### PR TITLE
Generate calico manifests from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,7 +375,7 @@ generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 		rbac:roleName=manager-role
 
 .PHONY: generate-flavors ## Generate template flavors
-generate-flavors: $(KUSTOMIZE)
+generate-flavors: $(KUSTOMIZE) generate-addons
 	./hack/gen-flavors.sh
 
 .PHONY: generate-e2e-templates ## Generate Azure infrastructure templates for the v1alpha4 CAPI test suite.
@@ -394,6 +394,8 @@ generate-e2e-templates: $(KUSTOMIZE)
 .PHONY: generate-addons
 generate-addons:
 	$(KUSTOMIZE) build $(ADDONS_DIR)/metrics-server > $(ADDONS_DIR)/metrics-server/metrics-server.yaml
+	$(KUSTOMIZE) build $(ADDONS_DIR)/calico > $(ADDONS_DIR)/calico.yaml
+	$(KUSTOMIZE) build $(ADDONS_DIR)/calico-ipv6 > $(ADDONS_DIR)/calico-ipv6.yaml
 
 ## --------------------------------------
 ## Docker

--- a/templates/addons/calico-ipv6.yaml
+++ b/templates/addons/calico-ipv6.yaml
@@ -3676,7 +3676,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.20.3
+        image: docker.io/calico/kube-controllers:v3.20.4
         livenessProbe:
           exec:
             command:
@@ -3743,7 +3743,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/typha:v3.20.3
+        image: docker.io/calico/typha:v3.20.4
         livenessProbe:
           httpGet:
             host: localhost
@@ -3857,7 +3857,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.20.3
+        image: docker.io/calico/node:v3.20.4
         lifecycle:
           preStop:
             exec:
@@ -3932,7 +3932,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.20.3
+        image: docker.io/calico/cni:v3.20.4
         name: install-cni
         securityContext:
           privileged: true
@@ -3941,7 +3941,7 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/cni/net.d
           name: cni-net-dir
-      - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+      - image: docker.io/calico/pod2daemon-flexvol:v3.20.4
         name: flexvol-driver
         securityContext:
           privileged: true

--- a/templates/addons/calico-ipv6.yaml
+++ b/templates/addons/calico-ipv6.yaml
@@ -1,19 +1,3597 @@
----
-# Source: calico/templates/calico-config.yaml
-# This ConfigMap is used to configure a self-hosted Calico installation.
-kind: ConfigMap
-apiVersion: v1
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
 metadata:
-  name: calico-config
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPConfiguration
+    listKind: BGPConfigurationList
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: BGPConfiguration contains the configuration for any BGP routing.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPConfigurationSpec contains the values of the BGP configuration.
+            properties:
+              asNumber:
+                description: 'ASNumber is the default AS number used by a node. [Default:
+                  64512]'
+                format: int32
+                type: integer
+              communities:
+                description: Communities is a list of BGP community values and their
+                  arbitrary names for tagging routes.
+                items:
+                  description: Community contains standard or large community value
+                    and its name.
+                  properties:
+                    name:
+                      description: Name given to community value.
+                      type: string
+                    value:
+                      description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                        For standard community use `aa:nn` format, where `aa` and
+                        `nn` are 16 bit number. For large community use `aa:nn:mm`
+                        format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                        `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                      pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                      type: string
+                  type: object
+                type: array
+              listenPort:
+                description: ListenPort is the port where BGP protocol should listen.
+                  Defaults to 179
+                maximum: 65535
+                minimum: 1
+                type: integer
+              logSeverityScreen:
+                description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: INFO]'
+                type: string
+              nodeToNodeMeshEnabled:
+                description: 'NodeToNodeMeshEnabled sets whether full node to node
+                  BGP mesh is enabled. [Default: true]'
+                type: boolean
+              prefixAdvertisements:
+                description: PrefixAdvertisements contains per-prefix advertisement
+                  configuration.
+                items:
+                  description: PrefixAdvertisement configures advertisement properties
+                    for the specified CIDR.
+                  properties:
+                    cidr:
+                      description: CIDR for which properties should be advertised.
+                      type: string
+                    communities:
+                      description: Communities can be list of either community names
+                        already defined in `Specs.Communities` or community value
+                        of format `aa:nn` or `aa:nn:mm`. For standard community use
+                        `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                        large community use `aa:nn:mm` format, where `aa`, `nn` and
+                        `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                        `mm` are per-AS identifier.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              serviceClusterIPs:
+                description: ServiceClusterIPs are the CIDR blocks from which service
+                  cluster IPs are allocated. If specified, Calico will advertise these
+                  blocks, as well as any cluster IPs within them.
+                items:
+                  description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                    CIDR block.
+                  properties:
+                    cidr:
+                      type: string
+                  type: object
+                type: array
+              serviceExternalIPs:
+                description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                  Service External IPs. Kubernetes Service ExternalIPs will only be
+                  advertised if they are within one of these blocks.
+                items:
+                  description: ServiceExternalIPBlock represents a single allowed
+                    External IP CIDR block.
+                  properties:
+                    cidr:
+                      type: string
+                  type: object
+                type: array
+              serviceLoadBalancerIPs:
+                description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                  Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                  IPs will only be advertised if they are within one of these blocks.
+                items:
+                  description: ServiceLoadBalancerIPBlock represents a single allowed
+                    LoadBalancer IP CIDR block.
+                  properties:
+                    cidr:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bgppeers.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPPeer
+    listKind: BGPPeerList
+    plural: bgppeers
+    singular: bgppeer
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPPeerSpec contains the specification for a BGPPeer resource.
+            properties:
+              asNumber:
+                description: The AS Number of the peer.
+                format: int32
+                type: integer
+              keepOriginalNextHop:
+                description: Option to keep the original nexthop field when routes
+                  are sent to a BGP Peer. Setting "true" configures the selected BGP
+                  Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                  in the specific branch of the Node on "bird.cfg".
+                type: boolean
+              maxRestartTime:
+                description: Time to allow for software restart.  When specified,
+                  this is configured as the graceful restart timeout.  When not specified,
+                  the BIRD default of 120s is used.
+                type: string
+              node:
+                description: The node name identifying the Calico node instance that
+                  is targeted by this peer. If this is not set, and no nodeSelector
+                  is specified, then this BGP peer selects all nodes in the cluster.
+                type: string
+              nodeSelector:
+                description: Selector for the nodes that should have this peering.  When
+                  this is set, the Node field must be empty.
+                type: string
+              password:
+                description: Optional BGP password for the peerings generated by this
+                  BGPPeer resource.
+                properties:
+                  secretKeyRef:
+                    description: Selects a key of a secret in the node pod's namespace.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                type: object
+              peerIP:
+                description: The IP address of the peer followed by an optional port
+                  number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                  or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                  and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                  set in BGPConfiguration, then we use that port to peer.
+                type: string
+              peerSelector:
+                description: Selector for the remote nodes to peer with.  When this
+                  is set, the PeerIP and ASNumber fields must be empty.  For each
+                  peering between the local node and selected remote nodes, we configure
+                  an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                  and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                  remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                  or the global default if that is not set.
+                type: string
+              sourceAddress:
+                description: Specifies whether and how to configure a source address
+                  for the peerings generated by this BGPPeer resource.  Default value
+                  "UseNodeIP" means to configure the node IP as the source address.  "None"
+                  means not to configure a source address.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: blockaffinities.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BlockAffinity
+    listKind: BlockAffinityList
+    plural: blockaffinities
+    singular: blockaffinity
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BlockAffinitySpec contains the specification for a BlockAffinity
+              resource.
+            properties:
+              cidr:
+                type: string
+              deleted:
+                description: Deleted indicates that this block affinity is being deleted.
+                  This field is a string for compatibility with older releases that
+                  mistakenly treat this field as a string.
+                type: string
+              node:
+                type: string
+              state:
+                type: string
+            required:
+            - cidr
+            - deleted
+            - node
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: ClusterInformation
+    listKind: ClusterInformationList
+    plural: clusterinformations
+    singular: clusterinformation
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterInformation contains the cluster specific information.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterInformationSpec contains the values of describing
+              the cluster.
+            properties:
+              calicoVersion:
+                description: CalicoVersion is the version of Calico that the cluster
+                  is running
+                type: string
+              clusterGUID:
+                description: ClusterGUID is the GUID of the cluster
+                type: string
+              clusterType:
+                description: ClusterType describes the type of the cluster
+                type: string
+              datastoreReady:
+                description: DatastoreReady is used during significant datastore migrations
+                  to signal to components such as Felix that it should wait before
+                  accessing the datastore.
+                type: boolean
+              variant:
+                description: Variant declares which variant of Calico should be active.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: FelixConfiguration
+    listKind: FelixConfigurationList
+    plural: felixconfigurations
+    singular: felixconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Felix Configuration contains the configuration for Felix.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FelixConfigurationSpec contains the values of the Felix configuration.
+            properties:
+              allowIPIPPacketsFromWorkloads:
+                description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                  will add a rule to drop IPIP encapsulated traffic from workloads
+                  [Default: false]'
+                type: boolean
+              allowVXLANPacketsFromWorkloads:
+                description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                  will add a rule to drop VXLAN encapsulated traffic from workloads
+                  [Default: false]'
+                type: boolean
+              awsSrcDstCheck:
+                description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                  value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                  DoNothing]'
+                enum:
+                - DoNothing
+                - Enable
+                - Disable
+                type: string
+              bpfConnectTimeLoadBalancingEnabled:
+                description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                  controls whether Felix installs the connection-time load balancer.  The
+                  connect-time load balancer is required for the host to be able to
+                  reach Kubernetes services and it improves the performance of pod-to-service
+                  connections.  The only reason to disable it is for debugging purposes.  [Default:
+                  true]'
+                type: boolean
+              bpfDataIfacePattern:
+                description: BPFDataIfacePattern is a regular expression that controls
+                  which interfaces Felix should attach BPF programs to in order to
+                  catch traffic to/from the network.  This needs to match the interfaces
+                  that Calico workload traffic flows over as well as any interfaces
+                  that handle incoming traffic to nodeports and services from outside
+                  the cluster.  It should not match the workload interfaces (usually
+                  named cali...).
+                type: string
+              bpfDisableUnprivileged:
+                description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                  sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                  users cannot access Calico''s BPF maps and cannot insert their own
+                  BPF programs to interfere with Calico''s. [Default: true]'
+                type: boolean
+              bpfEnabled:
+                description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                  [Default: false]'
+                type: boolean
+              bpfExtToServiceConnmark:
+                description: 'BPFExtToServiceConnmark in BPF mode, controls a 32bit
+                  mark that is set on connections from an external client to a local
+                  service. This mark allows us to control how packets of that connection
+                  are routed within the host and how is routing intepreted by RPF
+                  check. [Default: 0]'
+                type: integer
+              bpfExternalServiceMode:
+                description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                  from outside the cluster to services (node ports and cluster IPs)
+                  are forwarded to remote workloads.  If set to "Tunnel" then both
+                  request and response traffic is tunneled to the remote node.  If
+                  set to "DSR", the request traffic is tunneled but the response traffic
+                  is sent directly from the remote node.  In "DSR" mode, the remote
+                  node appears to use the IP of the ingress node; this requires a
+                  permissive L2 network.  [Default: Tunnel]'
+                type: string
+              bpfKubeProxyEndpointSlicesEnabled:
+                description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                  whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                type: boolean
+              bpfKubeProxyIptablesCleanupEnabled:
+                description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                  mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                  iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                  true]'
+                type: boolean
+              bpfKubeProxyMinSyncPeriod:
+                description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                  minimum time between updates to the dataplane for Felix''s embedded
+                  kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                  reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                type: string
+              bpfLogLevel:
+                description: 'BPFLogLevel controls the log level of the BPF programs
+                  when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                  logs are emitted to the BPF trace pipe, accessible with the command
+                  `tc exec bpf debug`. [Default: Off].'
+                type: string
+              chainInsertMode:
+                description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                  top-level iptables chains by inserting a rule at the top of the
+                  chain or by appending a rule at the bottom. insert is the safe default
+                  since it prevents Calico''s rules from being bypassed. If you switch
+                  to append mode, be sure that the other rules in the chains signal
+                  acceptance by falling through to the Calico rules, otherwise the
+                  Calico policy will be bypassed. [Default: insert]'
+                type: string
+              dataplaneDriver:
+                type: string
+              debugDisableLogDropping:
+                type: boolean
+              debugMemoryProfilePath:
+                type: string
+              debugSimulateCalcGraphHangAfter:
+                type: string
+              debugSimulateDataplaneHangAfter:
+                type: string
+              defaultEndpointToHostAction:
+                description: 'DefaultEndpointToHostAction controls what happens to
+                  traffic that goes from a workload endpoint to the host itself (after
+                  the traffic hits the endpoint egress policy). By default Calico
+                  blocks traffic from workload endpoints to the host itself with an
+                  iptables "DROP" action. If you want to allow some or all traffic
+                  from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                  RETURN if you have your own rules in the iptables "INPUT" chain;
+                  Calico will insert its rules at the top of that chain, then "RETURN"
+                  packets to the "INPUT" chain once it has completed processing workload
+                  endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                  from workloads after processing workload endpoint egress policy.
+                  [Default: Drop]'
+                type: string
+              deviceRouteProtocol:
+                description: This defines the route protocol added to programmed device
+                  routes, by default this will be RTPROT_BOOT when left blank.
+                type: integer
+              deviceRouteSourceAddress:
+                description: This is the source address to use on programmed device
+                  routes. By default the source address is left blank, leaving the
+                  kernel to choose the source address used.
+                type: string
+              disableConntrackInvalidCheck:
+                type: boolean
+              endpointReportingDelay:
+                type: string
+              endpointReportingEnabled:
+                type: boolean
+              externalNodesList:
+                description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                  which may source tunnel traffic and have the tunneled traffic be
+                  accepted at calico nodes.
+                items:
+                  type: string
+                type: array
+              failsafeInboundHostPorts:
+                description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                  and CIDRs that Felix will allow incoming traffic to host endpoints
+                  on irrespective of the security policy. This is useful to avoid
+                  accidentally cutting off a host with incorrect configuration. For
+                  back-compatibility, if the protocol is not specified, it defaults
+                  to "tcp". If a CIDR is not specified, it will allow traffic from
+                  all addresses. To disable all inbound host ports, use the value
+                  none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                  udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                items:
+                  description: ProtoPort is combination of protocol, port, and CIDR.
+                    Protocol and port must be specified.
+                  properties:
+                    net:
+                      type: string
+                    port:
+                      type: integer
+                    protocol:
+                      type: string
+                  required:
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              failsafeOutboundHostPorts:
+                description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                  and CIDRs that Felix will allow outgoing traffic from host endpoints
+                  to irrespective of the security policy. This is useful to avoid
+                  accidentally cutting off a host with incorrect configuration. For
+                  back-compatibility, if the protocol is not specified, it defaults
+                  to "tcp". If a CIDR is not specified, it will allow traffic from
+                  all addresses. To disable all outbound host ports, use the value
+                  none. The default value opens etcd''s standard ports to ensure that
+                  Felix does not get cut off from etcd as well as allowing DHCP and
+                  DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                  tcp:6667, udp:53, udp:67]'
+                items:
+                  description: ProtoPort is combination of protocol, port, and CIDR.
+                    Protocol and port must be specified.
+                  properties:
+                    net:
+                      type: string
+                    port:
+                      type: integer
+                    protocol:
+                      type: string
+                  required:
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              featureDetectOverride:
+                description: FeatureDetectOverride is used to override the feature
+                  detection. Values are specified in a comma separated list with no
+                  spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                  "true" or "false" will force the feature, empty or omitted values
+                  are auto-detected.
+                type: string
+              genericXDPEnabled:
+                description: 'GenericXDPEnabled enables Generic XDP so network cards
+                  that don''t support XDP offload or driver modes can use XDP. This
+                  is not recommended since it doesn''t provide better performance
+                  than iptables. [Default: false]'
+                type: boolean
+              healthEnabled:
+                type: boolean
+              healthHost:
+                type: string
+              healthPort:
+                type: integer
+              interfaceExclude:
+                description: 'InterfaceExclude is a comma-separated list of interfaces
+                  that Felix should exclude when monitoring for host endpoints. The
+                  default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                  interface, which is used internally by kube-proxy. If you want to
+                  exclude multiple interface names using a single value, the list
+                  supports regular expressions. For regular expressions you must wrap
+                  the value with ''/''. For example having values ''/^kube/,veth1''
+                  will exclude all interfaces that begin with ''kube'' and also the
+                  interface ''veth1''. [Default: kube-ipvs0]'
+                type: string
+              interfacePrefix:
+                description: 'InterfacePrefix is the interface name prefix that identifies
+                  workload endpoints and so distinguishes them from host endpoint
+                  interfaces. Note: in environments other than bare metal, the orchestrators
+                  configure this appropriately. For example our Kubernetes and Docker
+                  integrations set the ''cali'' value, and our OpenStack integration
+                  sets the ''tap'' value. [Default: cali]'
+                type: string
+              interfaceRefreshInterval:
+                description: InterfaceRefreshInterval is the period at which Felix
+                  rescans local interfaces to verify their state. The rescan can be
+                  disabled by setting the interval to 0.
+                type: string
+              ipipEnabled:
+                type: boolean
+              ipipMTU:
+                description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                  Configuring MTU [Default: 1440]'
+                type: integer
+              ipsetsRefreshInterval:
+                description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                  all iptables state to ensure that no other process has accidentally
+                  broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                  90s]'
+                type: string
+              iptablesBackend:
+                description: IptablesBackend specifies which backend of iptables will
+                  be used. The default is legacy.
+                type: string
+              iptablesFilterAllowAction:
+                type: string
+              iptablesLockFilePath:
+                description: 'IptablesLockFilePath is the location of the iptables
+                  lock file. You may need to change this if the lock file is not in
+                  its standard location (for example if you have mapped it into Felix''s
+                  container at a different path). [Default: /run/xtables.lock]'
+                type: string
+              iptablesLockProbeInterval:
+                description: 'IptablesLockProbeInterval is the time that Felix will
+                  wait between attempts to acquire the iptables lock if it is not
+                  available. Lower values make Felix more responsive when the lock
+                  is contended, but use more CPU. [Default: 50ms]'
+                type: string
+              iptablesLockTimeout:
+                description: 'IptablesLockTimeout is the time that Felix will wait
+                  for the iptables lock, or 0, to disable. To use this feature, Felix
+                  must share the iptables lock file with all other processes that
+                  also take the lock. When running Felix inside a container, this
+                  requires the /run directory of the host to be mounted into the calico/node
+                  or calico/felix container. [Default: 0s disabled]'
+                type: string
+              iptablesMangleAllowAction:
+                type: string
+              iptablesMarkMask:
+                description: 'IptablesMarkMask is the mask that Felix selects its
+                  IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                  at least 8 bits set, none of which clash with any other mark bits
+                  in use on the system. [Default: 0xff000000]'
+                format: int32
+                type: integer
+              iptablesNATOutgoingInterfaceFilter:
+                type: string
+              iptablesPostWriteCheckInterval:
+                description: 'IptablesPostWriteCheckInterval is the period after Felix
+                  has done a write to the dataplane that it schedules an extra read
+                  back in order to check the write was not clobbered by another process.
+                  This should only occur if another application on the system doesn''t
+                  respect the iptables lock. [Default: 1s]'
+                type: string
+              iptablesRefreshInterval:
+                description: 'IptablesRefreshInterval is the period at which Felix
+                  re-checks the IP sets in the dataplane to ensure that no other process
+                  has accidentally broken Calico''s rules. Set to 0 to disable IP
+                  sets refresh. Note: the default for this value is lower than the
+                  other refresh intervals as a workaround for a Linux kernel bug that
+                  was fixed in kernel version 4.11. If you are using v4.11 or greater
+                  you may want to set this to, a higher value to reduce Felix CPU
+                  usage. [Default: 10s]'
+                type: string
+              ipv6Support:
+                type: boolean
+              kubeNodePortRanges:
+                description: 'KubeNodePortRanges holds list of port ranges used for
+                  service node ports. Only used if felix detects kube-proxy running
+                  in ipvs mode. Felix uses these ranges to separate host and workload
+                  traffic. [Default: 30000:32767].'
+                items:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^.*
+                  x-kubernetes-int-or-string: true
+                type: array
+              logFilePath:
+                description: 'LogFilePath is the full path to the Felix log. Set to
+                  none to disable file logging. [Default: /var/log/calico/felix.log]'
+                type: string
+              logPrefix:
+                description: 'LogPrefix is the log prefix that Felix uses when rendering
+                  LOG rules. [Default: calico-packet]'
+                type: string
+              logSeverityFile:
+                description: 'LogSeverityFile is the log severity above which logs
+                  are sent to the log file. [Default: Info]'
+                type: string
+              logSeverityScreen:
+                description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: Info]'
+                type: string
+              logSeveritySys:
+                description: 'LogSeveritySys is the log severity above which logs
+                  are sent to the syslog. Set to None for no logging to syslog. [Default:
+                  Info]'
+                type: string
+              maxIpsetSize:
+                type: integer
+              metadataAddr:
+                description: 'MetadataAddr is the IP address or domain name of the
+                  server that can answer VM queries for cloud-init metadata. In OpenStack,
+                  this corresponds to the machine running nova-api (or in Ubuntu,
+                  nova-api-metadata). A value of none (case insensitive) means that
+                  Felix should not set up any NAT rule for the metadata path. [Default:
+                  127.0.0.1]'
+                type: string
+              metadataPort:
+                description: 'MetadataPort is the port of the metadata server. This,
+                  combined with global.MetadataAddr (if not ''None''), is used to
+                  set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                  In most cases this should not need to be changed [Default: 8775].'
+                type: integer
+              mtuIfacePattern:
+                description: MTUIfacePattern is a regular expression that controls
+                  which interfaces Felix should scan in order to calculate the host's
+                  MTU. This should not match workload interfaces (usually named cali...).
+                type: string
+              natOutgoingAddress:
+                description: NATOutgoingAddress specifies an address to use when performing
+                  source NAT for traffic in a natOutgoing pool that is leaving the
+                  network. By default the address used is an address on the interface
+                  the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                type: string
+              natPortRange:
+                anyOf:
+                - type: integer
+                - type: string
+                description: NATPortRange specifies the range of ports that is used
+                  for port mapping when doing outgoing NAT. When unset the default
+                  behavior of the network stack is used.
+                pattern: ^.*
+                x-kubernetes-int-or-string: true
+              netlinkTimeout:
+                type: string
+              openstackRegion:
+                description: 'OpenstackRegion is the name of the region that a particular
+                  Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                  this must be configured somehow for each Felix (here in the datamodel,
+                  or in felix.cfg or the environment on each compute node), and must
+                  match the [calico] openstack_region value configured in neutron.conf
+                  on each node. [Default: Empty]'
+                type: string
+              policySyncPathPrefix:
+                description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                  policy changes to external services, like Application layer policy.
+                  [Default: Empty]'
+                type: string
+              prometheusGoMetricsEnabled:
+                description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                  collection, which the Prometheus client does by default, when set
+                  to false. This reduces the number of metrics reported, reducing
+                  Prometheus load. [Default: true]'
+                type: boolean
+              prometheusMetricsEnabled:
+                description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                  server in Felix if set to true. [Default: false]'
+                type: boolean
+              prometheusMetricsHost:
+                description: 'PrometheusMetricsHost is the host that the Prometheus
+                  metrics server should bind to. [Default: empty]'
+                type: string
+              prometheusMetricsPort:
+                description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                  metrics server should bind to. [Default: 9091]'
+                type: integer
+              prometheusProcessMetricsEnabled:
+                description: 'PrometheusProcessMetricsEnabled disables process metrics
+                  collection, which the Prometheus client does by default, when set
+                  to false. This reduces the number of metrics reported, reducing
+                  Prometheus load. [Default: true]'
+                type: boolean
+              prometheusWireGuardMetricsEnabled:
+                description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                  metrics collection, which the Prometheus client does by default,
+                  when set to false. This reduces the number of metrics reported,
+                  reducing Prometheus load. [Default: true]'
+                type: boolean
+              removeExternalRoutes:
+                description: Whether or not to remove device routes that have not
+                  been programmed by Felix. Disabling this will allow external applications
+                  to also add device routes. This is enabled by default which means
+                  we will remove externally added routes.
+                type: boolean
+              reportingInterval:
+                description: 'ReportingInterval is the interval at which Felix reports
+                  its status into the datastore or 0 to disable. Must be non-zero
+                  in OpenStack deployments. [Default: 30s]'
+                type: string
+              reportingTTL:
+                description: 'ReportingTTL is the time-to-live setting for process-wide
+                  status reports. [Default: 90s]'
+                type: string
+              routeRefreshInterval:
+                description: 'RouteRefreshInterval is the period at which Felix re-checks
+                  the routes in the dataplane to ensure that no other process has
+                  accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                  [Default: 90s]'
+                type: string
+              routeSource:
+                description: 'RouteSource configures where Felix gets its routing
+                  information. - WorkloadIPs: use workload endpoints to construct
+                  routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                type: string
+              routeTableRange:
+                description: Calico programs additional Linux route tables for various
+                  purposes.  RouteTableRange specifies the indices of the route tables
+                  that Calico should use.
+                properties:
+                  max:
+                    type: integer
+                  min:
+                    type: integer
+                required:
+                - max
+                - min
+                type: object
+              serviceLoopPrevention:
+                description: 'When service IP advertisement is enabled, prevent routing
+                  loops to service IPs that are not in use, by dropping or rejecting
+                  packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                  in which case such routing loops continue to be allowed. [Default:
+                  Drop]'
+                type: string
+              sidecarAccelerationEnabled:
+                description: 'SidecarAccelerationEnabled enables experimental sidecar
+                  acceleration [Default: false]'
+                type: boolean
+              usageReportingEnabled:
+                description: 'UsageReportingEnabled reports anonymous Calico version
+                  number and cluster size to projectcalico.org. Logs warnings returned
+                  by the usage server. For example, if a significant security vulnerability
+                  has been discovered in the version of Calico being used. [Default:
+                  true]'
+                type: boolean
+              usageReportingInitialDelay:
+                description: 'UsageReportingInitialDelay controls the minimum delay
+                  before Felix makes a report. [Default: 300s]'
+                type: string
+              usageReportingInterval:
+                description: 'UsageReportingInterval controls the interval at which
+                  Felix makes reports. [Default: 86400s]'
+                type: string
+              useInternalDataplaneDriver:
+                type: boolean
+              vxlanEnabled:
+                type: boolean
+              vxlanMTU:
+                description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                  Configuring MTU [Default: 1440]'
+                type: integer
+              vxlanPort:
+                type: integer
+              vxlanVNI:
+                type: integer
+              wireguardEnabled:
+                description: 'WireguardEnabled controls whether Wireguard is enabled.
+                  [Default: false]'
+                type: boolean
+              wireguardHostEncryptionEnabled:
+                description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                  host-to-host encryption is enabled. [Default: false]'
+                type: boolean
+              wireguardInterfaceName:
+                description: 'WireguardInterfaceName specifies the name to use for
+                  the Wireguard interface. [Default: wg.calico]'
+                type: string
+              wireguardListeningPort:
+                description: 'WireguardListeningPort controls the listening port used
+                  by Wireguard. [Default: 51820]'
+                type: integer
+              wireguardMTU:
+                description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                  See Configuring MTU [Default: 1420]'
+                type: integer
+              wireguardRoutingRulePriority:
+                description: 'WireguardRoutingRulePriority controls the priority value
+                  to use for the Wireguard routing rule. [Default: 99]'
+                type: integer
+              xdpEnabled:
+                description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                  incoming deny rules. [Default: true]'
+                type: boolean
+              xdpRefreshInterval:
+                description: 'XDPRefreshInterval is the period at which Felix re-checks
+                  all XDP state to ensure that no other process has accidentally broken
+                  Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                  refresh. [Default: 90s]'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkPolicy
+    listKind: GlobalNetworkPolicyList
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              applyOnForward:
+                description: ApplyOnForward indicates to apply the rules in this policy
+                  on forward traffic.
+                type: boolean
+              doNotTrack:
+                description: DoNotTrack indicates whether packets matched by the rules
+                  in this policy should go through the data plane's connection tracking,
+                  such as Linux conntrack.  If True, the rules in this policy are
+                  applied before any data plane connection tracking, and packets allowed
+                  by this policy are marked as not to be tracked.
+                type: boolean
+              egress:
+                description: The ordered set of egress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                description: The ordered set of ingress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              namespaceSelector:
+                description: NamespaceSelector is an optional field for an expression
+                  used to select a pod based on namespaces.
+                type: string
+              order:
+                description: Order is an optional field that specifies the order in
+                  which the policy is applied. Policies with higher "order" are applied
+                  after those with lower order.  If the order is omitted, it may be
+                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                  with identical order will be applied in alphanumerical order based
+                  on the Policy "Name".
+                type: number
+              preDNAT:
+                description: PreDNAT indicates to apply the rules in this policy before
+                  any DNAT.
+                type: boolean
+              selector:
+                description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                type: string
+              serviceAccountSelector:
+                description: ServiceAccountSelector is an optional field for an expression
+                  used to select a pod based on service accounts.
+                type: string
+              types:
+                description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress rules are present in the policy.  The
+                  default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                  (including the case where there are   also no Ingress rules) \n
+                  - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                  rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                  both Ingress and Egress rules. \n When the policy is read back again,
+                  Types will always be one of these values, never empty or nil."
+                items:
+                  description: PolicyType enumerates the possible values of the PolicySpec
+                    Types field.
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkSet
+    listKind: GlobalNetworkSetList
+    plural: globalnetworksets
+    singular: globalnetworkset
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+          that share labels to allow rules to refer to them via selectors.  The labels
+          of GlobalNetworkSet are not namespaced.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+              resource.
+            properties:
+              nets:
+                description: The list of IP networks that belong to this set.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: HostEndpoint
+    listKind: HostEndpointList
+    plural: hostendpoints
+    singular: hostendpoint
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HostEndpointSpec contains the specification for a HostEndpoint
+              resource.
+            properties:
+              expectedIPs:
+                description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                  If \"InterfaceName\" is not present, Calico will look for an interface
+                  matching any of the IPs in the list and apply policy to that. Note:
+                  \tWhen using the selector match criteria in an ingress or egress
+                  security Policy \tor Profile, Calico converts the selector into
+                  a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                  is used for that purpose. (If only the interface \tname is specified,
+                  Calico does not learn the IPs of the interface for use in match
+                  \tcriteria.)"
+                items:
+                  type: string
+                type: array
+              interfaceName:
+                description: "Either \"*\", or the name of a specific Linux interface
+                  to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                  governs all traffic to, from or through the default network namespace
+                  of the host named by the \"Node\" field; entering and leaving that
+                  namespace via any interface, including those from/to non-host-networked
+                  local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                  only governs traffic that enters or leaves the host through the
+                  specific interface named by InterfaceName, or - when InterfaceName
+                  is empty - through the specific interface that has one of the IPs
+                  in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                  one expected IP must be specified.  Only external interfaces (such
+                  as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                  to protect traffic through a specific local workload interface.
+                  \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                  initially just pre-DNAT policy.  Please check Calico documentation
+                  for the latest position."
+                type: string
+              node:
+                description: The node name identifying the Calico node instance.
+                type: string
+              ports:
+                description: Ports contains the endpoint's named ports, which may
+                  be referenced in security policy rules.
+                items:
+                  properties:
+                    name:
+                      type: string
+                    port:
+                      type: integer
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              profiles:
+                description: A list of identifiers of security Profile objects that
+                  apply to this endpoint. Each profile is applied in the order that
+                  they appear in this list.  Profile rules are applied after the selector-based
+                  security policy.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMBlock
+    listKind: IPAMBlockList
+    plural: ipamblocks
+    singular: ipamblock
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMBlockSpec contains the specification for an IPAMBlock
+              resource.
+            properties:
+              affinity:
+                type: string
+              allocations:
+                items:
+                  nullable: true
+                  type: integer
+                type: array
+              attributes:
+                items:
+                  properties:
+                    handle_id:
+                      type: string
+                    secondary:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                type: array
+              cidr:
+                type: string
+              deleted:
+                type: boolean
+              strictAffinity:
+                type: boolean
+              unallocated:
+                items:
+                  type: integer
+                type: array
+            required:
+            - allocations
+            - attributes
+            - cidr
+            - strictAffinity
+            - unallocated
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamconfigs.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMConfig
+    listKind: IPAMConfigList
+    plural: ipamconfigs
+    singular: ipamconfig
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMConfigSpec contains the specification for an IPAMConfig
+              resource.
+            properties:
+              autoAllocateBlocks:
+                type: boolean
+              maxBlocksPerHost:
+                description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                  that can be affine to each host.
+                type: integer
+              strictAffinity:
+                type: boolean
+            required:
+            - autoAllocateBlocks
+            - strictAffinity
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamhandles.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMHandle
+    listKind: IPAMHandleList
+    plural: ipamhandles
+    singular: ipamhandle
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMHandleSpec contains the specification for an IPAMHandle
+              resource.
+            properties:
+              block:
+                additionalProperties:
+                  type: integer
+                type: object
+              deleted:
+                type: boolean
+              handleID:
+                type: string
+            required:
+            - block
+            - handleID
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPPool
+    listKind: IPPoolList
+    plural: ippools
+    singular: ippool
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPPoolSpec contains the specification for an IPPool resource.
+            properties:
+              blockSize:
+                description: The block size to use for IP address assignments from
+                  this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                type: integer
+              cidr:
+                description: The pool CIDR.
+                type: string
+              disabled:
+                description: When disabled is true, Calico IPAM will not assign addresses
+                  from this pool.
+                type: boolean
+              ipip:
+                description: 'Deprecated: this field is only used for APIv1 backwards
+                  compatibility. Setting this field is not allowed, this field is
+                  for internal use only.'
+                properties:
+                  enabled:
+                    description: When enabled is true, ipip tunneling will be used
+                      to deliver packets to destinations within this pool.
+                    type: boolean
+                  mode:
+                    description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                      mode of "always" will also use IPIP tunneling for routing to
+                      destination IP addresses within this pool.  A mode of "cross-subnet"
+                      will only use IPIP tunneling when the destination node is on
+                      a different subnet to the originating node.  The default value
+                      (if not specified) is "always".
+                    type: string
+                type: object
+              ipipMode:
+                description: Contains configuration for IPIP tunneling for this pool.
+                  If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                  is disabled).
+                type: string
+              nat-outgoing:
+                description: 'Deprecated: this field is only used for APIv1 backwards
+                  compatibility. Setting this field is not allowed, this field is
+                  for internal use only.'
+                type: boolean
+              natOutgoing:
+                description: When nat-outgoing is true, packets sent from Calico networked
+                  containers in this pool to destinations outside of this pool will
+                  be masqueraded.
+                type: boolean
+              nodeSelector:
+                description: Allows IPPool to allocate for a specific node by label
+                  selector.
+                type: string
+              vxlanMode:
+                description: Contains configuration for VXLAN tunneling for this pool.
+                  If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                  tunneling is disabled).
+                type: string
+            required:
+            - cidr
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kubecontrollersconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: KubeControllersConfiguration
+    listKind: KubeControllersConfigurationList
+    plural: kubecontrollersconfigurations
+    singular: kubecontrollersconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeControllersConfigurationSpec contains the values of the
+              Kubernetes controllers configuration.
+            properties:
+              controllers:
+                description: Controllers enables and configures individual Kubernetes
+                  controllers
+                properties:
+                  namespace:
+                    description: Namespace enables and configures the namespace controller.
+                      Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                  node:
+                    description: Node enables and configures the node controller.
+                      Enabled by default, set to nil to disable.
+                    properties:
+                      hostEndpoint:
+                        description: HostEndpoint controls syncing nodes to host endpoints.
+                          Disabled by default, set to nil to disable.
+                        properties:
+                          autoCreate:
+                            description: 'AutoCreate enables automatic creation of
+                              host endpoints for every node. [Default: Disabled]'
+                            type: string
+                        type: object
+                      leakGracePeriod:
+                        description: 'LeakGracePeriod is the period used by the controller
+                          to determine if an IP address has been leaked. Set to 0
+                          to disable IP garbage collection. [Default: 15m]'
+                        type: string
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                      syncLabels:
+                        description: 'SyncLabels controls whether to copy Kubernetes
+                          node labels to Calico nodes. [Default: Enabled]'
+                        type: string
+                    type: object
+                  policy:
+                    description: Policy enables and configures the policy controller.
+                      Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                  serviceAccount:
+                    description: ServiceAccount enables and configures the service
+                      account controller. Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                  workloadEndpoint:
+                    description: WorkloadEndpoint enables and configures the workload
+                      endpoint controller. Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                type: object
+              etcdV3CompactionPeriod:
+                description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                  compaction requests. Set to 0 to disable. [Default: 10m]'
+                type: string
+              healthChecks:
+                description: 'HealthChecks enables or disables support for health
+                  checks [Default: Enabled]'
+                type: string
+              logSeverityScreen:
+                description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: Info]'
+                type: string
+              prometheusMetricsPort:
+                description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                  metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                type: integer
+            required:
+            - controllers
+            type: object
+          status:
+            description: KubeControllersConfigurationStatus represents the status
+              of the configuration. It's useful for admins to be able to see the actual
+              config that was applied, which can be modified by environment variables
+              on the kube-controllers process.
+            properties:
+              environmentVars:
+                additionalProperties:
+                  type: string
+                description: EnvironmentVars contains the environment variables on
+                  the kube-controllers that influenced the RunningConfig.
+                type: object
+              runningConfig:
+                description: RunningConfig contains the effective config that is running
+                  in the kube-controllers pod, after merging the API resource with
+                  any environment variables.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace
+                          controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host
+                              endpoints. Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation
+                                  of host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the
+                              controller to determine if an IP address has been leaked.
+                              Set to 0 to disable IP garbage collection. [Default:
+                              15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which
+                      logs are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default:
+                      9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              egress:
+                description: The ordered set of egress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                description: The ordered set of ingress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              order:
+                description: Order is an optional field that specifies the order in
+                  which the policy is applied. Policies with higher "order" are applied
+                  after those with lower order.  If the order is omitted, it may be
+                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                  with identical order will be applied in alphanumerical order based
+                  on the Policy "Name".
+                type: number
+              selector:
+                description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                type: string
+              serviceAccountSelector:
+                description: ServiceAccountSelector is an optional field for an expression
+                  used to select a pod based on service accounts.
+                type: string
+              types:
+                description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress are present in the policy.  The default
+                  is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                  the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                  ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                  PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                  \n When the policy is read back again, Types will always be one
+                  of these values, never empty or nil."
+                items:
+                  description: PolicyType enumerates the possible values of the PolicySpec
+                    Types field.
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networksets.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkSet
+    listKind: NetworkSetList
+    plural: networksets
+    singular: networkset
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkSetSpec contains the specification for a NetworkSet
+              resource.
+            properties:
+              nets:
+                description: The list of IP networks that belong to this set.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-kube-controllers
   namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: calico-kube-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - ippools
+  verbs:
+  - list
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - blockaffinities
+  - ipamblocks
+  - ipamhandles
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - watch
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - hostendpoints
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - clusterinformations
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - kubecontrollersconfigurations
+  verbs:
+  - get
+  - create
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: calico-node
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  - serviceaccounts
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - patch
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - globalfelixconfigs
+  - felixconfigurations
+  - bgppeers
+  - globalbgpconfigs
+  - bgpconfigurations
+  - ippools
+  - ipamblocks
+  - globalnetworkpolicies
+  - globalnetworksets
+  - networkpolicies
+  - networksets
+  - clusterinformations
+  - hostendpoints
+  - blockaffinities
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - ippools
+  - felixconfigurations
+  - clusterinformations
+  verbs:
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - bgpconfigurations
+  - bgppeers
+  verbs:
+  - create
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-kube-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-kube-controllers
+subjects:
+- kind: ServiceAccount
+  name: calico-kube-controllers
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system
+---
+apiVersion: v1
 data:
-  # Typha is disabled.
-  typha_service_name: "none"
-  # Configure the backend to use.
-  calico_backend: "none"
-
-  # The CNI network configuration to install on each node. The special
-  # values in this config will be automatically populated.
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
@@ -48,3952 +3626,37 @@ data:
         }
       ]
     }
-
----
-# Source: calico/templates/kdd-crds.yaml
-
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+  typha_service_name: calico-typha
+  veth_mtu: "1350"
+kind: ConfigMap
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: bgpconfigurations.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: BGPConfiguration
-    listKind: BGPConfigurationList
-    plural: bgpconfigurations
-    singular: bgpconfiguration
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: BGPConfiguration contains the configuration for any BGP routing.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: BGPConfigurationSpec contains the values of the BGP configuration.
-              properties:
-                asNumber:
-                  description: 'ASNumber is the default AS number used by a node. [Default:
-                  64512]'
-                  format: int32
-                  type: integer
-                communities:
-                  description: Communities is a list of BGP community values and their
-                    arbitrary names for tagging routes.
-                  items:
-                    description: Community contains standard or large community value
-                      and its name.
-                    properties:
-                      name:
-                        description: Name given to community value.
-                        type: string
-                      value:
-                        description: Value must be of format `aa:nn` or `aa:nn:mm`.
-                          For standard community use `aa:nn` format, where `aa` and
-                          `nn` are 16 bit number. For large community use `aa:nn:mm`
-                          format, where `aa`, `nn` and `mm` are 32 bit number. Where,
-                          `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
-                        pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
-                        type: string
-                    type: object
-                  type: array
-                listenPort:
-                  description: ListenPort is the port where BGP protocol should listen.
-                    Defaults to 179
-                  maximum: 65535
-                  minimum: 1
-                  type: integer
-                logSeverityScreen:
-                  description: 'LogSeverityScreen is the log severity above which logs
-                  are sent to the stdout. [Default: INFO]'
-                  type: string
-                nodeToNodeMeshEnabled:
-                  description: 'NodeToNodeMeshEnabled sets whether full node to node
-                  BGP mesh is enabled. [Default: true]'
-                  type: boolean
-                prefixAdvertisements:
-                  description: PrefixAdvertisements contains per-prefix advertisement
-                    configuration.
-                  items:
-                    description: PrefixAdvertisement configures advertisement properties
-                      for the specified CIDR.
-                    properties:
-                      cidr:
-                        description: CIDR for which properties should be advertised.
-                        type: string
-                      communities:
-                        description: Communities can be list of either community names
-                          already defined in `Specs.Communities` or community value
-                          of format `aa:nn` or `aa:nn:mm`. For standard community use
-                          `aa:nn` format, where `aa` and `nn` are 16 bit number. For
-                          large community use `aa:nn:mm` format, where `aa`, `nn` and
-                          `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
-                          `mm` are per-AS identifier.
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  type: array
-                serviceClusterIPs:
-                  description: ServiceClusterIPs are the CIDR blocks from which service
-                    cluster IPs are allocated. If specified, Calico will advertise these
-                    blocks, as well as any cluster IPs within them.
-                  items:
-                    description: ServiceClusterIPBlock represents a single allowed ClusterIP
-                      CIDR block.
-                    properties:
-                      cidr:
-                        type: string
-                    type: object
-                  type: array
-                serviceExternalIPs:
-                  description: ServiceExternalIPs are the CIDR blocks for Kubernetes
-                    Service External IPs. Kubernetes Service ExternalIPs will only be
-                    advertised if they are within one of these blocks.
-                  items:
-                    description: ServiceExternalIPBlock represents a single allowed
-                      External IP CIDR block.
-                    properties:
-                      cidr:
-                        type: string
-                    type: object
-                  type: array
-                serviceLoadBalancerIPs:
-                  description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
-                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
-                    IPs will only be advertised if they are within one of these blocks.
-                  items:
-                    description: ServiceLoadBalancerIPBlock represents a single allowed
-                      LoadBalancer IP CIDR block.
-                    properties:
-                      cidr:
-                        type: string
-                    type: object
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: bgppeers.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: BGPPeer
-    listKind: BGPPeerList
-    plural: bgppeers
-    singular: bgppeer
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: BGPPeerSpec contains the specification for a BGPPeer resource.
-              properties:
-                asNumber:
-                  description: The AS Number of the peer.
-                  format: int32
-                  type: integer
-                keepOriginalNextHop:
-                  description: Option to keep the original nexthop field when routes
-                    are sent to a BGP Peer. Setting "true" configures the selected BGP
-                    Peers node to use the "next hop keep;" instead of "next hop self;"(default)
-                    in the specific branch of the Node on "bird.cfg".
-                  type: boolean
-                maxRestartTime:
-                  description: Time to allow for software restart.  When specified, this
-                    is configured as the graceful restart timeout.  When not specified,
-                    the BIRD default of 120s is used.
-                  type: string
-                node:
-                  description: The node name identifying the Calico node instance that
-                    is targeted by this peer. If this is not set, and no nodeSelector
-                    is specified, then this BGP peer selects all nodes in the cluster.
-                  type: string
-                nodeSelector:
-                  description: Selector for the nodes that should have this peering.  When
-                    this is set, the Node field must be empty.
-                  type: string
-                password:
-                  description: Optional BGP password for the peerings generated by this
-                    BGPPeer resource.
-                  properties:
-                    secretKeyRef:
-                      description: Selects a key of a secret in the node pod's namespace.
-                      properties:
-                        key:
-                          description: The key of the secret to select from.  Must be
-                            a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                        optional:
-                          description: Specify whether the Secret or its key must be
-                            defined
-                          type: boolean
-                      required:
-                        - key
-                      type: object
-                  type: object
-                peerIP:
-                  description: The IP address of the peer followed by an optional port
-                    number to peer with. If port number is given, format should be `[<IPv6>]:port`
-                    or `<IPv4>:<port>` for IPv4. If optional port number is not set,
-                    and this peer IP and ASNumber belongs to a calico/node with ListenPort
-                    set in BGPConfiguration, then we use that port to peer.
-                  type: string
-                peerSelector:
-                  description: Selector for the remote nodes to peer with.  When this
-                    is set, the PeerIP and ASNumber fields must be empty.  For each
-                    peering between the local node and selected remote nodes, we configure
-                    an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
-                    and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
-                    remote AS number comes from the remote node’s NodeBGPSpec.ASNumber,
-                    or the global default if that is not set.
-                  type: string
-                sourceAddress:
-                  description: Specifies whether and how to configure a source address
-                    for the peerings generated by this BGPPeer resource.  Default value
-                    "UseNodeIP" means to configure the node IP as the source address.  "None"
-                    means not to configure a source address.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: blockaffinities.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: BlockAffinity
-    listKind: BlockAffinityList
-    plural: blockaffinities
-    singular: blockaffinity
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: BlockAffinitySpec contains the specification for a BlockAffinity
-                resource.
-              properties:
-                cidr:
-                  type: string
-                deleted:
-                  description: Deleted indicates that this block affinity is being deleted.
-                    This field is a string for compatibility with older releases that
-                    mistakenly treat this field as a string.
-                  type: string
-                node:
-                  type: string
-                state:
-                  type: string
-              required:
-                - cidr
-                - deleted
-                - node
-                - state
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: clusterinformations.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: ClusterInformation
-    listKind: ClusterInformationList
-    plural: clusterinformations
-    singular: clusterinformation
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: ClusterInformation contains the cluster specific information.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ClusterInformationSpec contains the values of describing
-                the cluster.
-              properties:
-                calicoVersion:
-                  description: CalicoVersion is the version of Calico that the cluster
-                    is running
-                  type: string
-                clusterGUID:
-                  description: ClusterGUID is the GUID of the cluster
-                  type: string
-                clusterType:
-                  description: ClusterType describes the type of the cluster
-                  type: string
-                datastoreReady:
-                  description: DatastoreReady is used during significant datastore migrations
-                    to signal to components such as Felix that it should wait before
-                    accessing the datastore.
-                  type: boolean
-                variant:
-                  description: Variant declares which variant of Calico should be active.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: felixconfigurations.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: FelixConfiguration
-    listKind: FelixConfigurationList
-    plural: felixconfigurations
-    singular: felixconfiguration
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: Felix Configuration contains the configuration for Felix.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: FelixConfigurationSpec contains the values of the Felix configuration.
-              properties:
-                allowIPIPPacketsFromWorkloads:
-                  description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
-                  will add a rule to drop IPIP encapsulated traffic from workloads
-                  [Default: false]'
-                  type: boolean
-                allowVXLANPacketsFromWorkloads:
-                  description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
-                  will add a rule to drop VXLAN encapsulated traffic from workloads
-                  [Default: false]'
-                  type: boolean
-                awsSrcDstCheck:
-                  description: 'Set source-destination-check on AWS EC2 instances. Accepted
-                  value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
-                  DoNothing]'
-                  enum:
-                    - DoNothing
-                    - Enable
-                    - Disable
-                  type: string
-                bpfConnectTimeLoadBalancingEnabled:
-                  description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
-                  controls whether Felix installs the connection-time load balancer.  The
-                  connect-time load balancer is required for the host to be able to
-                  reach Kubernetes services and it improves the performance of pod-to-service
-                  connections.  The only reason to disable it is for debugging purposes.  [Default:
-                  true]'
-                  type: boolean
-                bpfDataIfacePattern:
-                  description: 'BPFDataIfacePattern is a regular expression that controls
-                  which interfaces Felix should attach BPF programs to in order to
-                  catch traffic to/from the network.  This needs to match the interfaces
-                  that Calico workload traffic flows over as well as any interfaces
-                  that handle incoming traffic to nodeports and services from outside
-                  the cluster.  It should not match the workload interfaces (usually
-                  named cali...). [Default: ^(en.*|eth.*|tunl0$)]'
-                  type: string
-                bpfDisableUnprivileged:
-                  description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
-                  sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
-                  users cannot access Calico''s BPF maps and cannot insert their own
-                  BPF programs to interfere with Calico''s. [Default: true]'
-                  type: boolean
-                bpfEnabled:
-                  description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
-                  [Default: false]'
-                  type: boolean
-                bpfExtToServiceConnmark:
-                  description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit
-                    mark that is set on connections from an external client to a local
-                    service. This mark allows us to control how packets of that connection
-                    are routed within the host and how is routing intepreted by RPF
-                    check. [Default: 0]'
-                  type: integer
-                bpfExternalServiceMode:
-                  description: 'BPFExternalServiceMode in BPF mode, controls how connections
-                  from outside the cluster to services (node ports and cluster IPs)
-                  are forwarded to remote workloads.  If set to "Tunnel" then both
-                  request and response traffic is tunneled to the remote node.  If
-                  set to "DSR", the request traffic is tunneled but the response traffic
-                  is sent directly from the remote node.  In "DSR" mode, the remote
-                  node appears to use the IP of the ingress node; this requires a
-                  permissive L2 network.  [Default: Tunnel]'
-                  type: string
-                bpfKubeProxyEndpointSlicesEnabled:
-                  description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
-                    whether Felix's embedded kube-proxy accepts EndpointSlices or not.
-                  type: boolean
-                bpfKubeProxyIptablesCleanupEnabled:
-                  description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
-                  mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
-                  iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
-                  true]'
-                  type: boolean
-                bpfKubeProxyMinSyncPeriod:
-                  description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
-                  minimum time between updates to the dataplane for Felix''s embedded
-                  kube-proxy.  Lower values give reduced set-up latency.  Higher values
-                  reduce Felix CPU usage by batching up more work.  [Default: 1s]'
-                  type: string
-                bpfLogLevel:
-                  description: 'BPFLogLevel controls the log level of the BPF programs
-                  when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
-                  logs are emitted to the BPF trace pipe, accessible with the command
-                  `tc exec bpf debug`. [Default: Off].'
-                  type: string
-                chainInsertMode:
-                  description: 'ChainInsertMode controls whether Felix hooks the kernel’s
-                  top-level iptables chains by inserting a rule at the top of the
-                  chain or by appending a rule at the bottom. insert is the safe default
-                  since it prevents Calico’s rules from being bypassed. If you switch
-                  to append mode, be sure that the other rules in the chains signal
-                  acceptance by falling through to the Calico rules, otherwise the
-                  Calico policy will be bypassed. [Default: insert]'
-                  type: string
-                dataplaneDriver:
-                  type: string
-                debugDisableLogDropping:
-                  type: boolean
-                debugMemoryProfilePath:
-                  type: string
-                debugSimulateCalcGraphHangAfter:
-                  type: string
-                debugSimulateDataplaneHangAfter:
-                  type: string
-                defaultEndpointToHostAction:
-                  description: 'DefaultEndpointToHostAction controls what happens to
-                  traffic that goes from a workload endpoint to the host itself (after
-                  the traffic hits the endpoint egress policy). By default Calico
-                  blocks traffic from workload endpoints to the host itself with an
-                  iptables “DROP” action. If you want to allow some or all traffic
-                  from endpoint to host, set this parameter to RETURN or ACCEPT. Use
-                  RETURN if you have your own rules in the iptables “INPUT” chain;
-                  Calico will insert its rules at the top of that chain, then “RETURN”
-                  packets to the “INPUT” chain once it has completed processing workload
-                  endpoint egress policy. Use ACCEPT to unconditionally accept packets
-                  from workloads after processing workload endpoint egress policy.
-                  [Default: Drop]'
-                  type: string
-                deviceRouteProtocol:
-                  description: This defines the route protocol added to programmed device
-                    routes, by default this will be RTPROT_BOOT when left blank.
-                  type: integer
-                deviceRouteSourceAddress:
-                  description: This is the source address to use on programmed device
-                    routes. By default the source address is left blank, leaving the
-                    kernel to choose the source address used.
-                  type: string
-                disableConntrackInvalidCheck:
-                  type: boolean
-                endpointReportingDelay:
-                  type: string
-                endpointReportingEnabled:
-                  type: boolean
-                externalNodesList:
-                  description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
-                    which may source tunnel traffic and have the tunneled traffic be
-                    accepted at calico nodes.
-                  items:
-                    type: string
-                  type: array
-                failsafeInboundHostPorts:
-                  description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
-                    and CIDRs that Felix will allow incoming traffic to host endpoints
-                    on irrespective of the security policy. This is useful to avoid
-                    accidentally cutting off a host with incorrect configuration. For
-                    back-compatibility, if the protocol is not specified, it defaults
-                    to "tcp". If a CIDR is not specified, it will allow traffic from
-                    all addresses. To disable all inbound host ports, use the value
-                    none. The default value allows ssh access and DHCP. [Default: tcp:22,
-                    udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
-                  items:
-                    description: ProtoPort is combination of protocol, port, and CIDR.
-                      Protocol and port must be specified.
-                    properties:
-                      net:
-                        type: string
-                      port:
-                        type: integer
-                      protocol:
-                        type: string
-                    required:
-                      - port
-                      - protocol
-                    type: object
-                  type: array
-                failsafeOutboundHostPorts:
-                  description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
-                    and CIDRs that Felix will allow outgoing traffic from host endpoints
-                    to irrespective of the security policy. This is useful to avoid
-                    accidentally cutting off a host with incorrect configuration. For
-                    back-compatibility, if the protocol is not specified, it defaults
-                    to "tcp". If a CIDR is not specified, it will allow traffic from
-                    all addresses. To disable all outbound host ports, use the value
-                    none. The default value opens etcd''s standard ports to ensure that
-                    Felix does not get cut off from etcd as well as allowing DHCP and
-                    DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
-                    tcp:6667, udp:53, udp:67]'
-                  items:
-                    description: ProtoPort is combination of protocol, port, and CIDR.
-                      Protocol and port must be specified.
-                    properties:
-                      net:
-                        type: string
-                      port:
-                        type: integer
-                      protocol:
-                        type: string
-                    required:
-                      - port
-                      - protocol
-                    type: object
-                  type: array
-                featureDetectOverride:
-                  description: FeatureDetectOverride is used to override the feature
-                    detection. Values are specified in a comma separated list with no
-                    spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
-                    "true" or "false" will force the feature, empty or omitted values
-                    are auto-detected.
-                  type: string
-                genericXDPEnabled:
-                  description: 'GenericXDPEnabled enables Generic XDP so network cards
-                  that don''t support XDP offload or driver modes can use XDP. This
-                  is not recommended since it doesn''t provide better performance
-                  than iptables. [Default: false]'
-                  type: boolean
-                healthEnabled:
-                  type: boolean
-                healthHost:
-                  type: string
-                healthPort:
-                  type: integer
-                interfaceExclude:
-                  description: 'InterfaceExclude is a comma-separated list of interfaces
-                  that Felix should exclude when monitoring for host endpoints. The
-                  default value ensures that Felix ignores Kubernetes'' IPVS dummy
-                  interface, which is used internally by kube-proxy. If you want to
-                  exclude multiple interface names using a single value, the list
-                  supports regular expressions. For regular expressions you must wrap
-                  the value with ''/''. For example having values ''/^kube/,veth1''
-                  will exclude all interfaces that begin with ''kube'' and also the
-                  interface ''veth1''. [Default: kube-ipvs0]'
-                  type: string
-                interfacePrefix:
-                  description: 'InterfacePrefix is the interface name prefix that identifies
-                  workload endpoints and so distinguishes them from host endpoint
-                  interfaces. Note: in environments other than bare metal, the orchestrators
-                  configure this appropriately. For example our Kubernetes and Docker
-                  integrations set the ‘cali’ value, and our OpenStack integration
-                  sets the ‘tap’ value. [Default: cali]'
-                  type: string
-                interfaceRefreshInterval:
-                  description: InterfaceRefreshInterval is the period at which Felix
-                    rescans local interfaces to verify their state. The rescan can be
-                    disabled by setting the interval to 0.
-                  type: string
-                ipipEnabled:
-                  type: boolean
-                ipipMTU:
-                  description: 'IPIPMTU is the MTU to set on the tunnel device. See
-                  Configuring MTU [Default: 1440]'
-                  type: integer
-                ipsetsRefreshInterval:
-                  description: 'IpsetsRefreshInterval is the period at which Felix re-checks
-                  all iptables state to ensure that no other process has accidentally
-                  broken Calico’s rules. Set to 0 to disable iptables refresh. [Default:
-                  90s]'
-                  type: string
-                iptablesBackend:
-                  description: IptablesBackend specifies which backend of iptables will
-                    be used. The default is legacy.
-                  type: string
-                iptablesFilterAllowAction:
-                  type: string
-                iptablesLockFilePath:
-                  description: 'IptablesLockFilePath is the location of the iptables
-                  lock file. You may need to change this if the lock file is not in
-                  its standard location (for example if you have mapped it into Felix’s
-                  container at a different path). [Default: /run/xtables.lock]'
-                  type: string
-                iptablesLockProbeInterval:
-                  description: 'IptablesLockProbeInterval is the time that Felix will
-                  wait between attempts to acquire the iptables lock if it is not
-                  available. Lower values make Felix more responsive when the lock
-                  is contended, but use more CPU. [Default: 50ms]'
-                  type: string
-                iptablesLockTimeout:
-                  description: 'IptablesLockTimeout is the time that Felix will wait
-                  for the iptables lock, or 0, to disable. To use this feature, Felix
-                  must share the iptables lock file with all other processes that
-                  also take the lock. When running Felix inside a container, this
-                  requires the /run directory of the host to be mounted into the calico/node
-                  or calico/felix container. [Default: 0s disabled]'
-                  type: string
-                iptablesMangleAllowAction:
-                  type: string
-                iptablesMarkMask:
-                  description: 'IptablesMarkMask is the mask that Felix selects its
-                  IPTables Mark bits from. Should be a 32 bit hexadecimal number with
-                  at least 8 bits set, none of which clash with any other mark bits
-                  in use on the system. [Default: 0xff000000]'
-                  format: int32
-                  type: integer
-                iptablesNATOutgoingInterfaceFilter:
-                  type: string
-                iptablesPostWriteCheckInterval:
-                  description: 'IptablesPostWriteCheckInterval is the period after Felix
-                  has done a write to the dataplane that it schedules an extra read
-                  back in order to check the write was not clobbered by another process.
-                  This should only occur if another application on the system doesn’t
-                  respect the iptables lock. [Default: 1s]'
-                  type: string
-                iptablesRefreshInterval:
-                  description: 'IptablesRefreshInterval is the period at which Felix
-                    re-checks the IP sets in the dataplane to ensure that no other process
-                    has accidentally broken Calico''s rules. Set to 0 to disable IP
-                    sets refresh. Note: the default for this value is lower than the
-                    other refresh intervals as a workaround for a Linux kernel bug that
-                    was fixed in kernel version 4.11. If you are using v4.11 or greater
-                    you may want to set this to, a higher value to reduce Felix CPU
-                    usage. [Default: 10s]'
-                  type: string
-                ipv6Support:
-                  type: boolean
-                kubeNodePortRanges:
-                  description: 'KubeNodePortRanges holds list of port ranges used for
-                  service node ports. Only used if felix detects kube-proxy running
-                  in ipvs mode. Felix uses these ranges to separate host and workload
-                  traffic. [Default: 30000:32767].'
-                  items:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    pattern: ^.*
-                    x-kubernetes-int-or-string: true
-                  type: array
-                logFilePath:
-                  description: 'LogFilePath is the full path to the Felix log. Set to
-                  none to disable file logging. [Default: /var/log/calico/felix.log]'
-                  type: string
-                logPrefix:
-                  description: 'LogPrefix is the log prefix that Felix uses when rendering
-                  LOG rules. [Default: calico-packet]'
-                  type: string
-                logSeverityFile:
-                  description: 'LogSeverityFile is the log severity above which logs
-                  are sent to the log file. [Default: Info]'
-                  type: string
-                logSeverityScreen:
-                  description: 'LogSeverityScreen is the log severity above which logs
-                  are sent to the stdout. [Default: Info]'
-                  type: string
-                logSeveritySys:
-                  description: 'LogSeveritySys is the log severity above which logs
-                  are sent to the syslog. Set to None for no logging to syslog. [Default:
-                  Info]'
-                  type: string
-                maxIpsetSize:
-                  type: integer
-                metadataAddr:
-                  description: 'MetadataAddr is the IP address or domain name of the
-                  server that can answer VM queries for cloud-init metadata. In OpenStack,
-                  this corresponds to the machine running nova-api (or in Ubuntu,
-                  nova-api-metadata). A value of none (case insensitive) means that
-                  Felix should not set up any NAT rule for the metadata path. [Default:
-                  127.0.0.1]'
-                  type: string
-                metadataPort:
-                  description: 'MetadataPort is the port of the metadata server. This,
-                  combined with global.MetadataAddr (if not ‘None’), is used to set
-                  up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
-                  In most cases this should not need to be changed [Default: 8775].'
-                  type: integer
-                mtuIfacePattern:
-                  description: MTUIfacePattern is a regular expression that controls
-                    which interfaces Felix should scan in order to calculate the host's
-                    MTU. This should not match workload interfaces (usually named cali...).
-                  type: string
-                natOutgoingAddress:
-                  description: NATOutgoingAddress specifies an address to use when performing
-                    source NAT for traffic in a natOutgoing pool that is leaving the
-                    network. By default the address used is an address on the interface
-                    the traffic is leaving on (ie it uses the iptables MASQUERADE target)
-                  type: string
-                natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
-                  description: NATPortRange specifies the range of ports that is used
-                    for port mapping when doing outgoing NAT. When unset the default
-                    behavior of the network stack is used.
-                  pattern: ^.*
-                  x-kubernetes-int-or-string: true
-                netlinkTimeout:
-                  type: string
-                openstackRegion:
-                  description: 'OpenstackRegion is the name of the region that a particular
-                  Felix belongs to. In a multi-region Calico/OpenStack deployment,
-                  this must be configured somehow for each Felix (here in the datamodel,
-                  or in felix.cfg or the environment on each compute node), and must
-                  match the [calico] openstack_region value configured in neutron.conf
-                  on each node. [Default: Empty]'
-                  type: string
-                policySyncPathPrefix:
-                  description: 'PolicySyncPathPrefix is used to by Felix to communicate
-                  policy changes to external services, like Application layer policy.
-                  [Default: Empty]'
-                  type: string
-                prometheusGoMetricsEnabled:
-                  description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
-                  collection, which the Prometheus client does by default, when set
-                  to false. This reduces the number of metrics reported, reducing
-                  Prometheus load. [Default: true]'
-                  type: boolean
-                prometheusMetricsEnabled:
-                  description: 'PrometheusMetricsEnabled enables the Prometheus metrics
-                  server in Felix if set to true. [Default: false]'
-                  type: boolean
-                prometheusMetricsHost:
-                  description: 'PrometheusMetricsHost is the host that the Prometheus
-                  metrics server should bind to. [Default: empty]'
-                  type: string
-                prometheusMetricsPort:
-                  description: 'PrometheusMetricsPort is the TCP port that the Prometheus
-                  metrics server should bind to. [Default: 9091]'
-                  type: integer
-                prometheusProcessMetricsEnabled:
-                  description: 'PrometheusProcessMetricsEnabled disables process metrics
-                  collection, which the Prometheus client does by default, when set
-                  to false. This reduces the number of metrics reported, reducing
-                  Prometheus load. [Default: true]'
-                  type: boolean
-                removeExternalRoutes:
-                  description: Whether or not to remove device routes that have not
-                    been programmed by Felix. Disabling this will allow external applications
-                    to also add device routes. This is enabled by default which means
-                    we will remove externally added routes.
-                  type: boolean
-                reportingInterval:
-                  description: 'ReportingInterval is the interval at which Felix reports
-                  its status into the datastore or 0 to disable. Must be non-zero
-                  in OpenStack deployments. [Default: 30s]'
-                  type: string
-                reportingTTL:
-                  description: 'ReportingTTL is the time-to-live setting for process-wide
-                  status reports. [Default: 90s]'
-                  type: string
-                routeRefreshInterval:
-                  description: 'RouterefreshInterval is the period at which Felix re-checks
-                  the routes in the dataplane to ensure that no other process has
-                  accidentally broken Calico’s rules. Set to 0 to disable route refresh.
-                  [Default: 90s]'
-                  type: string
-                routeSource:
-                  description: 'RouteSource configures where Felix gets its routing
-                  information. - WorkloadIPs: use workload endpoints to construct
-                  routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
-                  type: string
-                routeTableRange:
-                  description: Calico programs additional Linux route tables for various
-                    purposes.  RouteTableRange specifies the indices of the route tables
-                    that Calico should use.
-                  properties:
-                    max:
-                      type: integer
-                    min:
-                      type: integer
-                  required:
-                    - max
-                    - min
-                  type: object
-                serviceLoopPrevention:
-                  description: 'When service IP advertisement is enabled, prevent routing
-                    loops to service IPs that are not in use, by dropping or rejecting
-                    packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
-                    in which case such routing loops continue to be allowed. [Default:
-                    Drop]'
-                  type: string
-                sidecarAccelerationEnabled:
-                  description: 'SidecarAccelerationEnabled enables experimental sidecar
-                  acceleration [Default: false]'
-                  type: boolean
-                usageReportingEnabled:
-                  description: 'UsageReportingEnabled reports anonymous Calico version
-                  number and cluster size to projectcalico.org. Logs warnings returned
-                  by the usage server. For example, if a significant security vulnerability
-                  has been discovered in the version of Calico being used. [Default:
-                  true]'
-                  type: boolean
-                usageReportingInitialDelay:
-                  description: 'UsageReportingInitialDelay controls the minimum delay
-                  before Felix makes a report. [Default: 300s]'
-                  type: string
-                usageReportingInterval:
-                  description: 'UsageReportingInterval controls the interval at which
-                  Felix makes reports. [Default: 86400s]'
-                  type: string
-                useInternalDataplaneDriver:
-                  type: boolean
-                vxlanEnabled:
-                  type: boolean
-                vxlanMTU:
-                  description: 'VXLANMTU is the MTU to set on the tunnel device. See
-                  Configuring MTU [Default: 1440]'
-                  type: integer
-                vxlanPort:
-                  type: integer
-                vxlanVNI:
-                  type: integer
-                wireguardEnabled:
-                  description: 'WireguardEnabled controls whether Wireguard is enabled.
-                  [Default: false]'
-                  type: boolean
-                wireguardInterfaceName:
-                  description: 'WireguardInterfaceName specifies the name to use for
-                  the Wireguard interface. [Default: wg.calico]'
-                  type: string
-                wireguardListeningPort:
-                  description: 'WireguardListeningPort controls the listening port used
-                  by Wireguard. [Default: 51820]'
-                  type: integer
-                wireguardMTU:
-                  description: 'WireguardMTU controls the MTU on the Wireguard interface.
-                  See Configuring MTU [Default: 1420]'
-                  type: integer
-                wireguardRoutingRulePriority:
-                  description: 'WireguardRoutingRulePriority controls the priority value
-                  to use for the Wireguard routing rule. [Default: 99]'
-                  type: integer
-                xdpEnabled:
-                  description: 'XDPEnabled enables XDP acceleration for suitable untracked
-                  incoming deny rules. [Default: true]'
-                  type: boolean
-                xdpRefreshInterval:
-                  description: 'XDPRefreshInterval is the period at which Felix re-checks
-                  all XDP state to ensure that no other process has accidentally broken
-                  Calico''s BPF maps or attached programs. Set to 0 to disable XDP
-                  refresh. [Default: 90s]'
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: globalnetworkpolicies.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: GlobalNetworkPolicy
-    listKind: GlobalNetworkPolicyList
-    plural: globalnetworkpolicies
-    singular: globalnetworkpolicy
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                applyOnForward:
-                  description: ApplyOnForward indicates to apply the rules in this policy
-                    on forward traffic.
-                  type: boolean
-                doNotTrack:
-                  description: DoNotTrack indicates whether packets matched by the rules
-                    in this policy should go through the data plane's connection tracking,
-                    such as Linux conntrack.  If True, the rules in this policy are
-                    applied before any data plane connection tracking, and packets allowed
-                    by this policy are marked as not to be tracked.
-                  type: boolean
-                egress:
-                  description: The ordered set of egress rules.  Each rule contains
-                    a set of packet match criteria and a corresponding action to apply.
-                  items:
-                    description: "A Rule encapsulates a set of match criteria and an
-                    action.  Both selector-based security Policy and security Profiles
-                    reference rules - separated out as a list of rules for both ingress
-                    and egress packet matching. \n Each positive match criteria has
-                    a negated version, prefixed with ”Not”. All the match criteria
-                    within a rule must be satisfied for a packet to match. A single
-                    rule can contain the positive and negative version of a match
-                    and both must be satisfied for the rule to match."
-                    properties:
-                      action:
-                        type: string
-                      destination:
-                        description: Destination contains the match criteria that apply
-                          to destination entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                      http:
-                        description: HTTP contains match criteria that apply to HTTP
-                          requests.
-                        properties:
-                          methods:
-                            description: Methods is an optional field that restricts
-                              the rule to apply only to HTTP requests that use one of
-                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                              methods are OR'd together.
-                            items:
-                              type: string
-                            type: array
-                          paths:
-                            description: 'Paths is an optional field that restricts
-                            the rule to apply to HTTP requests that use one of the
-                            listed HTTP Paths. Multiple paths are OR''d together.
-                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                            ONLY specify either a `exact` or a `prefix` match. The
-                            validator will check for it.'
-                            items:
-                              description: 'HTTPPath specifies an HTTP path to match.
-                              It may be either of the form: exact: <path>: which matches
-                              the path exactly or prefix: <path-prefix>: which matches
-                              the path prefix'
-                              properties:
-                                exact:
-                                  type: string
-                                prefix:
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      icmp:
-                        description: ICMP is an optional field that restricts the rule
-                          to apply to a specific type and code of ICMP traffic.  This
-                          should only be specified if the Protocol field is set to "ICMP"
-                          or "ICMPv6".
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      ipVersion:
-                        description: IPVersion is an optional field that restricts the
-                          rule to only match a specific IP version.
-                        type: integer
-                      metadata:
-                        description: Metadata contains additional information for this
-                          rule
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations is a set of key value pairs that
-                              give extra information about the rule
-                            type: object
-                        type: object
-                      notICMP:
-                        description: NotICMP is the negated version of the ICMP field.
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: NotProtocol is the negated version of the Protocol
-                          field.
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: "Protocol is an optional field that restricts the
-                        rule to only apply to traffic of a specific IP protocol. Required
-                        if any of the EntityRules contain Ports (because ports only
-                        apply to certain protocols). \n Must be one of these string
-                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                        \"UDPLite\" or an integer in the range 1-255."
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      source:
-                        description: Source contains the match criteria that apply to
-                          source entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                    required:
-                      - action
-                    type: object
-                  type: array
-                ingress:
-                  description: The ordered set of ingress rules.  Each rule contains
-                    a set of packet match criteria and a corresponding action to apply.
-                  items:
-                    description: "A Rule encapsulates a set of match criteria and an
-                    action.  Both selector-based security Policy and security Profiles
-                    reference rules - separated out as a list of rules for both ingress
-                    and egress packet matching. \n Each positive match criteria has
-                    a negated version, prefixed with ”Not”. All the match criteria
-                    within a rule must be satisfied for a packet to match. A single
-                    rule can contain the positive and negative version of a match
-                    and both must be satisfied for the rule to match."
-                    properties:
-                      action:
-                        type: string
-                      destination:
-                        description: Destination contains the match criteria that apply
-                          to destination entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                      http:
-                        description: HTTP contains match criteria that apply to HTTP
-                          requests.
-                        properties:
-                          methods:
-                            description: Methods is an optional field that restricts
-                              the rule to apply only to HTTP requests that use one of
-                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                              methods are OR'd together.
-                            items:
-                              type: string
-                            type: array
-                          paths:
-                            description: 'Paths is an optional field that restricts
-                            the rule to apply to HTTP requests that use one of the
-                            listed HTTP Paths. Multiple paths are OR''d together.
-                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                            ONLY specify either a `exact` or a `prefix` match. The
-                            validator will check for it.'
-                            items:
-                              description: 'HTTPPath specifies an HTTP path to match.
-                              It may be either of the form: exact: <path>: which matches
-                              the path exactly or prefix: <path-prefix>: which matches
-                              the path prefix'
-                              properties:
-                                exact:
-                                  type: string
-                                prefix:
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      icmp:
-                        description: ICMP is an optional field that restricts the rule
-                          to apply to a specific type and code of ICMP traffic.  This
-                          should only be specified if the Protocol field is set to "ICMP"
-                          or "ICMPv6".
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      ipVersion:
-                        description: IPVersion is an optional field that restricts the
-                          rule to only match a specific IP version.
-                        type: integer
-                      metadata:
-                        description: Metadata contains additional information for this
-                          rule
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations is a set of key value pairs that
-                              give extra information about the rule
-                            type: object
-                        type: object
-                      notICMP:
-                        description: NotICMP is the negated version of the ICMP field.
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: NotProtocol is the negated version of the Protocol
-                          field.
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: "Protocol is an optional field that restricts the
-                        rule to only apply to traffic of a specific IP protocol. Required
-                        if any of the EntityRules contain Ports (because ports only
-                        apply to certain protocols). \n Must be one of these string
-                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                        \"UDPLite\" or an integer in the range 1-255."
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      source:
-                        description: Source contains the match criteria that apply to
-                          source entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                    required:
-                      - action
-                    type: object
-                  type: array
-                namespaceSelector:
-                  description: NamespaceSelector is an optional field for an expression
-                    used to select a pod based on namespaces.
-                  type: string
-                order:
-                  description: Order is an optional field that specifies the order in
-                    which the policy is applied. Policies with higher "order" are applied
-                    after those with lower order.  If the order is omitted, it may be
-                    considered to be "infinite" - i.e. the policy will be applied last.  Policies
-                    with identical order will be applied in alphanumerical order based
-                    on the Policy "Name".
-                  type: number
-                preDNAT:
-                  description: PreDNAT indicates to apply the rules in this policy before
-                    any DNAT.
-                  type: boolean
-                selector:
-                  description: "The selector is an expression used to pick pick out
-                  the endpoints that the policy should be applied to. \n Selector
-                  expressions follow this syntax: \n \tlabel == \"string_literal\"
-                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
-                  \  ->  not equal; also matches if label is not present \tlabel in
-                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
-                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
-                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
-                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
-                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
-                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
-                  or the empty selector -> matches all endpoints. \n Label names are
-                  allowed to contain alphanumerics, -, _ and /. String literals are
-                  more permissive but they do not support escape characters. \n Examples
-                  (with made-up labels): \n \ttype == \"webserver\" && deployment
-                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
-                  \"dev\" \t! has(label_name)"
-                  type: string
-                serviceAccountSelector:
-                  description: ServiceAccountSelector is an optional field for an expression
-                    used to select a pod based on service accounts.
-                  type: string
-                types:
-                  description: "Types indicates whether this policy applies to ingress,
-                  or to egress, or to both.  When not explicitly specified (and so
-                  the value on creation is empty or nil), Calico defaults Types according
-                  to what Ingress and Egress rules are present in the policy.  The
-                  default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
-                  (including the case where there are   also no Ingress rules) \n
-                  - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
-                  rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
-                  both Ingress and Egress rules. \n When the policy is read back again,
-                  Types will always be one of these values, never empty or nil."
-                  items:
-                    description: PolicyType enumerates the possible values of the PolicySpec
-                      Types field.
-                    type: string
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: globalnetworksets.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: GlobalNetworkSet
-    listKind: GlobalNetworkSetList
-    plural: globalnetworksets
-    singular: globalnetworkset
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
-            that share labels to allow rules to refer to them via selectors.  The labels
-            of GlobalNetworkSet are not namespaced.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: GlobalNetworkSetSpec contains the specification for a NetworkSet
-                resource.
-              properties:
-                nets:
-                  description: The list of IP networks that belong to this set.
-                  items:
-                    type: string
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: hostendpoints.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: HostEndpoint
-    listKind: HostEndpointList
-    plural: hostendpoints
-    singular: hostendpoint
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: HostEndpointSpec contains the specification for a HostEndpoint
-                resource.
-              properties:
-                expectedIPs:
-                  description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
-                  If \"InterfaceName\" is not present, Calico will look for an interface
-                  matching any of the IPs in the list and apply policy to that. Note:
-                  \tWhen using the selector match criteria in an ingress or egress
-                  security Policy \tor Profile, Calico converts the selector into
-                  a set of IP addresses. For host \tendpoints, the ExpectedIPs field
-                  is used for that purpose. (If only the interface \tname is specified,
-                  Calico does not learn the IPs of the interface for use in match
-                  \tcriteria.)"
-                  items:
-                    type: string
-                  type: array
-                interfaceName:
-                  description: "Either \"*\", or the name of a specific Linux interface
-                  to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
-                  governs all traffic to, from or through the default network namespace
-                  of the host named by the \"Node\" field; entering and leaving that
-                  namespace via any interface, including those from/to non-host-networked
-                  local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
-                  only governs traffic that enters or leaves the host through the
-                  specific interface named by InterfaceName, or - when InterfaceName
-                  is empty - through the specific interface that has one of the IPs
-                  in ExpectedIPs. Therefore, when InterfaceName is empty, at least
-                  one expected IP must be specified.  Only external interfaces (such
-                  as “eth0”) are supported here; it isn't possible for a HostEndpoint
-                  to protect traffic through a specific local workload interface.
-                  \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
-                  initially just pre-DNAT policy.  Please check Calico documentation
-                  for the latest position."
-                  type: string
-                node:
-                  description: The node name identifying the Calico node instance.
-                  type: string
-                ports:
-                  description: Ports contains the endpoint's named ports, which may
-                    be referenced in security policy rules.
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      port:
-                        type: integer
-                      protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                    required:
-                      - name
-                      - port
-                      - protocol
-                    type: object
-                  type: array
-                profiles:
-                  description: A list of identifiers of security Profile objects that
-                    apply to this endpoint. Each profile is applied in the order that
-                    they appear in this list.  Profile rules are applied after the selector-based
-                    security policy.
-                  items:
-                    type: string
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: ipamblocks.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: IPAMBlock
-    listKind: IPAMBlockList
-    plural: ipamblocks
-    singular: ipamblock
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: IPAMBlockSpec contains the specification for an IPAMBlock
-                resource.
-              properties:
-                affinity:
-                  type: string
-                allocations:
-                  items:
-                    type: integer
-                    # TODO: This nullable is manually added in. We should update controller-gen
-                    # to handle []*int properly itself.
-                    nullable: true
-                  type: array
-                attributes:
-                  items:
-                    properties:
-                      handle_id:
-                        type: string
-                      secondary:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
-                  type: array
-                cidr:
-                  type: string
-                deleted:
-                  type: boolean
-                strictAffinity:
-                  type: boolean
-                unallocated:
-                  items:
-                    type: integer
-                  type: array
-              required:
-                - allocations
-                - attributes
-                - cidr
-                - strictAffinity
-                - unallocated
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: ipamconfigs.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: IPAMConfig
-    listKind: IPAMConfigList
-    plural: ipamconfigs
-    singular: ipamconfig
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: IPAMConfigSpec contains the specification for an IPAMConfig
-                resource.
-              properties:
-                autoAllocateBlocks:
-                  type: boolean
-                maxBlocksPerHost:
-                  description: MaxBlocksPerHost, if non-zero, is the max number of blocks
-                    that can be affine to each host.
-                  type: integer
-                strictAffinity:
-                  type: boolean
-              required:
-                - autoAllocateBlocks
-                - strictAffinity
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: ipamhandles.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: IPAMHandle
-    listKind: IPAMHandleList
-    plural: ipamhandles
-    singular: ipamhandle
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: IPAMHandleSpec contains the specification for an IPAMHandle
-                resource.
-              properties:
-                block:
-                  additionalProperties:
-                    type: integer
-                  type: object
-                deleted:
-                  type: boolean
-                handleID:
-                  type: string
-              required:
-                - block
-                - handleID
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: ippools.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: IPPool
-    listKind: IPPoolList
-    plural: ippools
-    singular: ippool
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: IPPoolSpec contains the specification for an IPPool resource.
-              properties:
-                blockSize:
-                  description: The block size to use for IP address assignments from
-                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.
-                  type: integer
-                cidr:
-                  description: The pool CIDR.
-                  type: string
-                disabled:
-                  description: When disabled is true, Calico IPAM will not assign addresses
-                    from this pool.
-                  type: boolean
-                ipip:
-                  description: 'Deprecated: this field is only used for APIv1 backwards
-                  compatibility. Setting this field is not allowed, this field is
-                  for internal use only.'
-                  properties:
-                    enabled:
-                      description: When enabled is true, ipip tunneling will be used
-                        to deliver packets to destinations within this pool.
-                      type: boolean
-                    mode:
-                      description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
-                        mode of "always" will also use IPIP tunneling for routing to
-                        destination IP addresses within this pool.  A mode of "cross-subnet"
-                        will only use IPIP tunneling when the destination node is on
-                        a different subnet to the originating node.  The default value
-                        (if not specified) is "always".
-                      type: string
-                  type: object
-                ipipMode:
-                  description: Contains configuration for IPIP tunneling for this pool.
-                    If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
-                    is disabled).
-                  type: string
-                nat-outgoing:
-                  description: 'Deprecated: this field is only used for APIv1 backwards
-                  compatibility. Setting this field is not allowed, this field is
-                  for internal use only.'
-                  type: boolean
-                natOutgoing:
-                  description: When nat-outgoing is true, packets sent from Calico networked
-                    containers in this pool to destinations outside of this pool will
-                    be masqueraded.
-                  type: boolean
-                nodeSelector:
-                  description: Allows IPPool to allocate for a specific node by label
-                    selector.
-                  type: string
-                vxlanMode:
-                  description: Contains configuration for VXLAN tunneling for this pool.
-                    If not specified, then this is defaulted to "Never" (i.e. VXLAN
-                    tunneling is disabled).
-                  type: string
-              required:
-                - cidr
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: kubecontrollersconfigurations.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: KubeControllersConfiguration
-    listKind: KubeControllersConfigurationList
-    plural: kubecontrollersconfigurations
-    singular: kubecontrollersconfiguration
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KubeControllersConfigurationSpec contains the values of the
-                Kubernetes controllers configuration.
-              properties:
-                controllers:
-                  description: Controllers enables and configures individual Kubernetes
-                    controllers
-                  properties:
-                    namespace:
-                      description: Namespace enables and configures the namespace controller.
-                        Enabled by default, set to nil to disable.
-                      properties:
-                        reconcilerPeriod:
-                          description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                          type: string
-                      type: object
-                    node:
-                      description: Node enables and configures the node controller.
-                        Enabled by default, set to nil to disable.
-                      properties:
-                        hostEndpoint:
-                          description: HostEndpoint controls syncing nodes to host endpoints.
-                            Disabled by default, set to nil to disable.
-                          properties:
-                            autoCreate:
-                              description: 'AutoCreate enables automatic creation of
-                              host endpoints for every node. [Default: Disabled]'
-                              type: string
-                          type: object
-                        reconcilerPeriod:
-                          description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                          type: string
-                        syncLabels:
-                          description: 'SyncLabels controls whether to copy Kubernetes
-                          node labels to Calico nodes. [Default: Enabled]'
-                          type: string
-                      type: object
-                    policy:
-                      description: Policy enables and configures the policy controller.
-                        Enabled by default, set to nil to disable.
-                      properties:
-                        reconcilerPeriod:
-                          description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                          type: string
-                      type: object
-                    serviceAccount:
-                      description: ServiceAccount enables and configures the service
-                        account controller. Enabled by default, set to nil to disable.
-                      properties:
-                        reconcilerPeriod:
-                          description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                          type: string
-                      type: object
-                    workloadEndpoint:
-                      description: WorkloadEndpoint enables and configures the workload
-                        endpoint controller. Enabled by default, set to nil to disable.
-                      properties:
-                        reconcilerPeriod:
-                          description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                          type: string
-                      type: object
-                  type: object
-                etcdV3CompactionPeriod:
-                  description: 'EtcdV3CompactionPeriod is the period between etcdv3
-                  compaction requests. Set to 0 to disable. [Default: 10m]'
-                  type: string
-                healthChecks:
-                  description: 'HealthChecks enables or disables support for health
-                  checks [Default: Enabled]'
-                  type: string
-                logSeverityScreen:
-                  description: 'LogSeverityScreen is the log severity above which logs
-                  are sent to the stdout. [Default: Info]'
-                  type: string
-                prometheusMetricsPort:
-                  description: 'PrometheusMetricsPort is the TCP port that the Prometheus
-                    metrics server should bind to. Set to 0 to disable. [Default: 9094]'
-                  type: integer
-              required:
-                - controllers
-              type: object
-            status:
-              description: KubeControllersConfigurationStatus represents the status
-                of the configuration. It's useful for admins to be able to see the actual
-                config that was applied, which can be modified by environment variables
-                on the kube-controllers process.
-              properties:
-                environmentVars:
-                  additionalProperties:
-                    type: string
-                  description: EnvironmentVars contains the environment variables on
-                    the kube-controllers that influenced the RunningConfig.
-                  type: object
-                runningConfig:
-                  description: RunningConfig contains the effective config that is running
-                    in the kube-controllers pod, after merging the API resource with
-                    any environment variables.
-                  properties:
-                    controllers:
-                      description: Controllers enables and configures individual Kubernetes
-                        controllers
-                      properties:
-                        namespace:
-                          description: Namespace enables and configures the namespace
-                            controller. Enabled by default, set to nil to disable.
-                          properties:
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                              type: string
-                          type: object
-                        node:
-                          description: Node enables and configures the node controller.
-                            Enabled by default, set to nil to disable.
-                          properties:
-                            hostEndpoint:
-                              description: HostEndpoint controls syncing nodes to host
-                                endpoints. Disabled by default, set to nil to disable.
-                              properties:
-                                autoCreate:
-                                  description: 'AutoCreate enables automatic creation
-                                  of host endpoints for every node. [Default: Disabled]'
-                                  type: string
-                              type: object
-                            leakGracePeriod:
-                              description: 'LeakGracePeriod is the period used by the
-                                controller to determine if an IP address has been leaked.
-                                Set to 0 to disable IP garbage collection. [Default:
-                                15m]'
-                              type: string
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                              type: string
-                            syncLabels:
-                              description: 'SyncLabels controls whether to copy Kubernetes
-                              node labels to Calico nodes. [Default: Enabled]'
-                              type: string
-                          type: object
-                        policy:
-                          description: Policy enables and configures the policy controller.
-                            Enabled by default, set to nil to disable.
-                          properties:
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                              type: string
-                          type: object
-                        serviceAccount:
-                          description: ServiceAccount enables and configures the service
-                            account controller. Enabled by default, set to nil to disable.
-                          properties:
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                              type: string
-                          type: object
-                        workloadEndpoint:
-                          description: WorkloadEndpoint enables and configures the workload
-                            endpoint controller. Enabled by default, set to nil to disable.
-                          properties:
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                              type: string
-                          type: object
-                      type: object
-                    etcdV3CompactionPeriod:
-                      description: 'EtcdV3CompactionPeriod is the period between etcdv3
-                      compaction requests. Set to 0 to disable. [Default: 10m]'
-                      type: string
-                    healthChecks:
-                      description: 'HealthChecks enables or disables support for health
-                      checks [Default: Enabled]'
-                      type: string
-                    logSeverityScreen:
-                      description: 'LogSeverityScreen is the log severity above which
-                      logs are sent to the stdout. [Default: Info]'
-                      type: string
-                    prometheusMetricsPort:
-                      description: 'PrometheusMetricsPort is the TCP port that the Prometheus
-                        metrics server should bind to. Set to 0 to disable. [Default:
-                        9094]'
-                      type: integer
-                  required:
-                    - controllers
-                  type: object
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: networkpolicies.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: NetworkPolicy
-    listKind: NetworkPolicyList
-    plural: networkpolicies
-    singular: networkpolicy
-  scope: Namespaced
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                egress:
-                  description: The ordered set of egress rules.  Each rule contains
-                    a set of packet match criteria and a corresponding action to apply.
-                  items:
-                    description: "A Rule encapsulates a set of match criteria and an
-                    action.  Both selector-based security Policy and security Profiles
-                    reference rules - separated out as a list of rules for both ingress
-                    and egress packet matching. \n Each positive match criteria has
-                    a negated version, prefixed with ”Not”. All the match criteria
-                    within a rule must be satisfied for a packet to match. A single
-                    rule can contain the positive and negative version of a match
-                    and both must be satisfied for the rule to match."
-                    properties:
-                      action:
-                        type: string
-                      destination:
-                        description: Destination contains the match criteria that apply
-                          to destination entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                      http:
-                        description: HTTP contains match criteria that apply to HTTP
-                          requests.
-                        properties:
-                          methods:
-                            description: Methods is an optional field that restricts
-                              the rule to apply only to HTTP requests that use one of
-                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                              methods are OR'd together.
-                            items:
-                              type: string
-                            type: array
-                          paths:
-                            description: 'Paths is an optional field that restricts
-                            the rule to apply to HTTP requests that use one of the
-                            listed HTTP Paths. Multiple paths are OR''d together.
-                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                            ONLY specify either a `exact` or a `prefix` match. The
-                            validator will check for it.'
-                            items:
-                              description: 'HTTPPath specifies an HTTP path to match.
-                              It may be either of the form: exact: <path>: which matches
-                              the path exactly or prefix: <path-prefix>: which matches
-                              the path prefix'
-                              properties:
-                                exact:
-                                  type: string
-                                prefix:
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      icmp:
-                        description: ICMP is an optional field that restricts the rule
-                          to apply to a specific type and code of ICMP traffic.  This
-                          should only be specified if the Protocol field is set to "ICMP"
-                          or "ICMPv6".
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      ipVersion:
-                        description: IPVersion is an optional field that restricts the
-                          rule to only match a specific IP version.
-                        type: integer
-                      metadata:
-                        description: Metadata contains additional information for this
-                          rule
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations is a set of key value pairs that
-                              give extra information about the rule
-                            type: object
-                        type: object
-                      notICMP:
-                        description: NotICMP is the negated version of the ICMP field.
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: NotProtocol is the negated version of the Protocol
-                          field.
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: "Protocol is an optional field that restricts the
-                        rule to only apply to traffic of a specific IP protocol. Required
-                        if any of the EntityRules contain Ports (because ports only
-                        apply to certain protocols). \n Must be one of these string
-                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                        \"UDPLite\" or an integer in the range 1-255."
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      source:
-                        description: Source contains the match criteria that apply to
-                          source entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                    required:
-                      - action
-                    type: object
-                  type: array
-                ingress:
-                  description: The ordered set of ingress rules.  Each rule contains
-                    a set of packet match criteria and a corresponding action to apply.
-                  items:
-                    description: "A Rule encapsulates a set of match criteria and an
-                    action.  Both selector-based security Policy and security Profiles
-                    reference rules - separated out as a list of rules for both ingress
-                    and egress packet matching. \n Each positive match criteria has
-                    a negated version, prefixed with ”Not”. All the match criteria
-                    within a rule must be satisfied for a packet to match. A single
-                    rule can contain the positive and negative version of a match
-                    and both must be satisfied for the rule to match."
-                    properties:
-                      action:
-                        type: string
-                      destination:
-                        description: Destination contains the match criteria that apply
-                          to destination entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                      http:
-                        description: HTTP contains match criteria that apply to HTTP
-                          requests.
-                        properties:
-                          methods:
-                            description: Methods is an optional field that restricts
-                              the rule to apply only to HTTP requests that use one of
-                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                              methods are OR'd together.
-                            items:
-                              type: string
-                            type: array
-                          paths:
-                            description: 'Paths is an optional field that restricts
-                            the rule to apply to HTTP requests that use one of the
-                            listed HTTP Paths. Multiple paths are OR''d together.
-                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                            ONLY specify either a `exact` or a `prefix` match. The
-                            validator will check for it.'
-                            items:
-                              description: 'HTTPPath specifies an HTTP path to match.
-                              It may be either of the form: exact: <path>: which matches
-                              the path exactly or prefix: <path-prefix>: which matches
-                              the path prefix'
-                              properties:
-                                exact:
-                                  type: string
-                                prefix:
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      icmp:
-                        description: ICMP is an optional field that restricts the rule
-                          to apply to a specific type and code of ICMP traffic.  This
-                          should only be specified if the Protocol field is set to "ICMP"
-                          or "ICMPv6".
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      ipVersion:
-                        description: IPVersion is an optional field that restricts the
-                          rule to only match a specific IP version.
-                        type: integer
-                      metadata:
-                        description: Metadata contains additional information for this
-                          rule
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations is a set of key value pairs that
-                              give extra information about the rule
-                            type: object
-                        type: object
-                      notICMP:
-                        description: NotICMP is the negated version of the ICMP field.
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: NotProtocol is the negated version of the Protocol
-                          field.
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: "Protocol is an optional field that restricts the
-                        rule to only apply to traffic of a specific IP protocol. Required
-                        if any of the EntityRules contain Ports (because ports only
-                        apply to certain protocols). \n Must be one of these string
-                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                        \"UDPLite\" or an integer in the range 1-255."
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      source:
-                        description: Source contains the match criteria that apply to
-                          source entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                    required:
-                      - action
-                    type: object
-                  type: array
-                order:
-                  description: Order is an optional field that specifies the order in
-                    which the policy is applied. Policies with higher "order" are applied
-                    after those with lower order.  If the order is omitted, it may be
-                    considered to be "infinite" - i.e. the policy will be applied last.  Policies
-                    with identical order will be applied in alphanumerical order based
-                    on the Policy "Name".
-                  type: number
-                selector:
-                  description: "The selector is an expression used to pick pick out
-                  the endpoints that the policy should be applied to. \n Selector
-                  expressions follow this syntax: \n \tlabel == \"string_literal\"
-                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
-                  \  ->  not equal; also matches if label is not present \tlabel in
-                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
-                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
-                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
-                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
-                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
-                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
-                  or the empty selector -> matches all endpoints. \n Label names are
-                  allowed to contain alphanumerics, -, _ and /. String literals are
-                  more permissive but they do not support escape characters. \n Examples
-                  (with made-up labels): \n \ttype == \"webserver\" && deployment
-                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
-                  \"dev\" \t! has(label_name)"
-                  type: string
-                serviceAccountSelector:
-                  description: ServiceAccountSelector is an optional field for an expression
-                    used to select a pod based on service accounts.
-                  type: string
-                types:
-                  description: "Types indicates whether this policy applies to ingress,
-                  or to egress, or to both.  When not explicitly specified (and so
-                  the value on creation is empty or nil), Calico defaults Types according
-                  to what Ingress and Egress are present in the policy.  The default
-                  is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
-                  the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
-                  ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
-                  PolicyTypeEgress ], if there are both Ingress and Egress rules.
-                  \n When the policy is read back again, Types will always be one
-                  of these values, never empty or nil."
-                  items:
-                    description: PolicyType enumerates the possible values of the PolicySpec
-                      Types field.
-                    type: string
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: networksets.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: NetworkSet
-    listKind: NetworkSetList
-    plural: networksets
-    singular: networkset
-  scope: Namespaced
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: NetworkSetSpec contains the specification for a NetworkSet
-                resource.
-              properties:
-                nets:
-                  description: The list of IP networks that belong to this set.
-                  items:
-                    type: string
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
----
-# Source: calico/templates/calico-kube-controllers-rbac.yaml
-
-# Include a clusterrole for the kube-controllers component,
-# and bind it to the calico-kube-controllers serviceaccount.
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: calico-kube-controllers
-rules:
-  # Nodes are watched to monitor for deletions.
-  - apiGroups: [""]
-    resources:
-      - nodes
-    verbs:
-      - watch
-      - list
-      - get
-  # Pods are watched to check for existence as part of IPAM controller.
-  - apiGroups: [""]
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
-  # IPAM resources are manipulated when nodes are deleted.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - ippools
-    verbs:
-      - list
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - blockaffinities
-      - ipamblocks
-      - ipamhandles
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - watch
-  # kube-controllers manages hostendpoints.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - hostendpoints
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-  # Needs access to update clusterinformations.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - clusterinformations
-    verbs:
-      - get
-      - create
-      - update
-  # KubeControllersConfiguration is where it gets its config
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - kubecontrollersconfigurations
-    verbs:
-      # read its own config
-      - get
-      # create a default if none exists
-      - create
-      # update status
-      - update
-      # watch for changes
-      - watch
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: calico-kube-controllers
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: calico-kube-controllers
-subjects:
-  - kind: ServiceAccount
-    name: calico-kube-controllers
-    namespace: kube-system
----
-
----
-# Source: calico/templates/calico-node-rbac.yaml
-# Include a clusterrole for the calico-node DaemonSet,
-# and bind it to the calico-node serviceaccount.
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: calico-node
-rules:
-  # The CNI plugin needs to get pods, nodes, and namespaces.
-  - apiGroups: [""]
-    resources:
-      - pods
-      - nodes
-      - namespaces
-    verbs:
-      - get
-  # EndpointSlices are used for Service-based network policy rule
-  # enforcement.
-  - apiGroups: ["discovery.k8s.io"]
-    resources:
-      - endpointslices
-    verbs:
-      - watch
-      - list
-  - apiGroups: [""]
-    resources:
-      - endpoints
-      - services
-    verbs:
-      # Used to discover service IPs for advertisement.
-      - watch
-      - list
-      # Used to discover Typhas.
-      - get
-  # Pod CIDR auto-detection on kubeadm needs access to config maps.
-  - apiGroups: [""]
-    resources:
-      - configmaps
-    verbs:
-      - get
-  - apiGroups: [""]
-    resources:
-      - nodes/status
-    verbs:
-      # Needed for clearing NodeNetworkUnavailable flag.
-      - patch
-      # Calico stores some configuration information in node annotations.
-      - update
-  # Watch for changes to Kubernetes NetworkPolicies.
-  - apiGroups: ["networking.k8s.io"]
-    resources:
-      - networkpolicies
-    verbs:
-      - watch
-      - list
-  # Used by Calico for policy information.
-  - apiGroups: [""]
-    resources:
-      - pods
-      - namespaces
-      - serviceaccounts
-    verbs:
-      - list
-      - watch
-  # The CNI plugin patches pods/status.
-  - apiGroups: [""]
-    resources:
-      - pods/status
-    verbs:
-      - patch
-  # Calico monitors various CRDs for config.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - globalfelixconfigs
-      - felixconfigurations
-      - bgppeers
-      - globalbgpconfigs
-      - bgpconfigurations
-      - ippools
-      - ipamblocks
-      - globalnetworkpolicies
-      - globalnetworksets
-      - networkpolicies
-      - networksets
-      - clusterinformations
-      - hostendpoints
-      - blockaffinities
-    verbs:
-      - get
-      - list
-      - watch
-  # Calico must create and update some CRDs on startup.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - ippools
-      - felixconfigurations
-      - clusterinformations
-    verbs:
-      - create
-      - update
-  # Calico stores some configuration information on the node.
-  - apiGroups: [""]
-    resources:
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-  # These permissions are only required for upgrade from v2.6, and can
-  # be removed after upgrade or on fresh installations.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - bgpconfigurations
-      - bgppeers
-    verbs:
-      - create
-      - update
-  # These permissions are required for Calico CNI to perform IPAM allocations.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - blockaffinities
-      - ipamblocks
-      - ipamhandles
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - ipamconfigs
-    verbs:
-      - get
-  # Block affinities must also be watchable by confd for route aggregation.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - blockaffinities
-    verbs:
-      - watch
-  # The Calico IPAM migration needs to get daemonsets. These permissions can be
-  # removed if not upgrading from an installation using host-local IPAM.
-  - apiGroups: ["apps"]
-    resources:
-      - daemonsets
-    verbs:
-      - get
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: calico-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: calico-node
-subjects:
-  - kind: ServiceAccount
-    name: calico-node
-    namespace: kube-system
-
----
-# Source: calico/templates/calico-node.yaml
-# This manifest installs the calico-node container, as well
-# as the CNI plugins and network config on
-# each master and worker node in a Kubernetes cluster.
-kind: DaemonSet
-apiVersion: apps/v1
-metadata:
-  name: calico-node
+  name: calico-config
   namespace: kube-system
-  labels:
-    k8s-app: calico-node
-spec:
-  selector:
-    matchLabels:
-      k8s-app: calico-node
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-  template:
-    metadata:
-      labels:
-        k8s-app: calico-node
-    spec:
-      nodeSelector:
-        kubernetes.io/os: linux
-      hostNetwork: true
-      tolerations:
-        # Make sure calico-node gets scheduled on all nodes.
-        - effect: NoSchedule
-          operator: Exists
-        # Mark the pod as a critical add-on for rescheduling.
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
-      serviceAccountName: calico-node
-      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
-      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
-      terminationGracePeriodSeconds: 0
-      priorityClassName: system-node-critical
-      initContainers:
-        # This container installs the CNI binaries
-        # and CNI network config file on each node.
-        - name: install-cni
-          image: calico/cni:v3.20.0
-          command: ["/opt/cni/bin/install"]
-          env:
-            # Name of the CNI config file to create.
-            - name: CNI_CONF_NAME
-              value: "10-calico.conflist"
-            # The CNI network config to install on each node.
-            - name: CNI_NETWORK_CONFIG
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: cni_network_config
-            # Set the hostname based on the k8s node name.
-            - name: KUBERNETES_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            # Prevents the container from sleeping forever.
-            - name: SLEEP
-              value: "false"
-          volumeMounts:
-            - mountPath: /host/opt/cni/bin
-              name: cni-bin-dir
-            - mountPath: /host/etc/cni/net.d
-              name: cni-net-dir
-          securityContext:
-            privileged: true
-        # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
-        # to communicate with Felix over the Policy Sync API.
-        - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.20.0
-          volumeMounts:
-            - name: flexvol-driver-host
-              mountPath: /host/driver
-          securityContext:
-            privileged: true
-      containers:
-        # Runs calico-node container on each Kubernetes node. This
-        # container programs network policy and routes on each
-        # host.
-        - name: calico-node
-          image: calico/node:v3.20.0
-          env:
-            # Use Kubernetes API as the backing datastore.
-            - name: DATASTORE_TYPE
-              value: "kubernetes"
-            # Wait for the datastore.
-            - name: WAIT_FOR_DATASTORE
-              value: "true"
-            # Set based on the k8s node name.
-            - name: NODENAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            # Choose the backend to use.
-            - name: CALICO_NETWORKING_BACKEND
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: calico_backend
-            # Cluster type to identify the deployment type
-            - name: CLUSTER_TYPE
-              value: "k8s"
-            # Enable or Disable VXLAN on the default IP pool.
-            - name: CALICO_IPV4POOL_VXLAN
-              value: "Never"
-            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
-            # chosen from this range. Changing this value after installation will have
-            # no effect. This should fall within `--cluster-cidr`.
-            # - name: CALICO_IPV4POOL_CIDR
-            #   value: "192.168.0.0/16"
-            # https://docs.projectcalico.org/reference/public-cloud/azure#azure-user-defined-routes
-            - name: CALICO_IPv6POOL_CIDR
-              value: "2001:1234:5678:9a40::/58"
-            - name: IP6
-              value: "autodetect"
-            # Disable file logging so `kubectl logs` works.
-            - name: CALICO_DISABLE_FILE_LOGGING
-              value: "true"
-            # Set Felix endpoint to host default action to ACCEPT.
-            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-              value: "ACCEPT"
-            # Disable IPv6 on Kubernetes.
-            - name: FELIX_IPV6SUPPORT
-              value: "true"
-            - name: FELIX_FEATUREDETECTOVERRIDE
-              value: "ChecksumOffloadBroken=true"
-            - name: FELIX_HEALTHENABLED
-              value: "true"
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: 250m
-          livenessProbe:
-            exec:
-              command:
-                - /bin/calico-node
-                - -felix-live
-            periodSeconds: 10
-            initialDelaySeconds: 10
-            failureThreshold: 6
-          readinessProbe:
-            exec:
-              command:
-                - /bin/calico-node
-                - -felix-ready
-            periodSeconds: 10
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: lib-modules
-              readOnly: true
-            - mountPath: /run/xtables.lock
-              name: xtables-lock
-              readOnly: false
-            - mountPath: /var/run/calico
-              name: var-run-calico
-              readOnly: false
-            - mountPath: /var/lib/calico
-              name: var-lib-calico
-              readOnly: false
-            - name: policysync
-              mountPath: /var/run/nodeagent
-            # For eBPF mode, we need to be able to mount the BPF filesystem at /sys/fs/bpf so we mount in the
-            # parent directory.
-            - name: sysfs
-              mountPath: /sys/fs/
-              # Bidirectional means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to the host.
-              # If the host is known to mount that filesystem already then Bidirectional can be omitted.
-              mountPropagation: Bidirectional
-            - name: cni-log-dir
-              mountPath: /var/log/calico/cni
-              readOnly: true
-      volumes:
-        # Used by calico-node.
-        - name: lib-modules
-          hostPath:
-            path: /lib/modules
-        - name: var-run-calico
-          hostPath:
-            path: /var/run/calico
-        - name: var-lib-calico
-          hostPath:
-            path: /var/lib/calico
-        - name: xtables-lock
-          hostPath:
-            path: /run/xtables.lock
-            type: FileOrCreate
-        - name: sysfs
-          hostPath:
-            path: /sys/fs/
-            type: DirectoryOrCreate
-        # Used to install CNI.
-        - name: cni-bin-dir
-          hostPath:
-            path: /opt/cni/bin
-        - name: cni-net-dir
-          hostPath:
-            path: /etc/cni/net.d
-        # Used to access CNI logs.
-        - name: cni-log-dir
-          hostPath:
-            path: /var/log/calico/cni
-        # Mount in the directory for host-local IPAM allocations. This is
-        # used when upgrading from host-local to calico-ipam, and can be removed
-        # if not using the upgrade-ipam init container.
-        - name: host-local-net-dir
-          hostPath:
-            path: /var/lib/cni/networks
-        # Used to create per-pod Unix Domain Sockets
-        - name: policysync
-          hostPath:
-            type: DirectoryOrCreate
-            path: /var/run/nodeagent
-        # Used to install Flex Volume Driver
-        - name: flexvol-driver-host
-          hostPath:
-            type: DirectoryOrCreate
-            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
 ---
-
 apiVersion: v1
-kind: ServiceAccount
+kind: Service
 metadata:
-  name: calico-node
+  labels:
+    k8s-app: calico-typha
+  name: calico-typha
   namespace: kube-system
-
+spec:
+  ports:
+  - name: calico-typha
+    port: 5473
+    protocol: TCP
+    targetPort: calico-typha
+  selector:
+    k8s-app: calico-typha
 ---
-# Source: calico/templates/calico-kube-controllers.yaml
-# See https://github.com/projectcalico/kube-controllers
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: calico-kube-controllers
-  namespace: kube-system
   labels:
     k8s-app: calico-kube-controllers
+  name: calico-kube-controllers
+  namespace: kube-system
 spec:
-  # The controllers can only have a single active instance.
   replicas: 1
   selector:
     matchLabels:
@@ -4002,75 +3665,337 @@ spec:
     type: Recreate
   template:
     metadata:
-      name: calico-kube-controllers
-      namespace: kube-system
       labels:
         k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
     spec:
+      containers:
+      - env:
+        - name: ENABLED_CONTROLLERS
+          value: node
+        - name: DATASTORE_TYPE
+          value: kubernetes
+        image: docker.io/calico/kube-controllers:v3.20.3
+        livenessProbe:
+          exec:
+            command:
+            - /usr/bin/check-status
+            - -l
+          failureThreshold: 6
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 10
+        name: calico-kube-controllers
+        readinessProbe:
+          exec:
+            command:
+            - /usr/bin/check-status
+            - -r
+          periodSeconds: 10
       nodeSelector:
         kubernetes.io/os: linux
-      tolerations:
-        # Mark the pod as a critical add-on for rescheduling.
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
-      serviceAccountName: calico-kube-controllers
       priorityClassName: system-cluster-critical
-      containers:
-        - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.20.0
-          env:
-            # Choose which controllers to run.
-            - name: ENABLED_CONTROLLERS
-              value: node
-            - name: DATASTORE_TYPE
-              value: kubernetes
-          livenessProbe:
-            exec:
-              command:
-              - /usr/bin/check-status
-              - -l
-            periodSeconds: 10
-            initialDelaySeconds: 10
-            failureThreshold: 6
-            timeoutSeconds: 10
-          readinessProbe:
-            exec:
-              command:
-                - /usr/bin/check-status
-                - -r
-            periodSeconds: 10
-
+      serviceAccountName: calico-kube-controllers
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
 ---
-
-apiVersion: v1
-kind: ServiceAccount
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: calico-kube-controllers
+  labels:
+    k8s-app: calico-typha
+  name: calico-typha
   namespace: kube-system
-
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      k8s-app: calico-typha
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        k8s-app: calico-typha
+    spec:
+      containers:
+      - env:
+        - name: TYPHA_LOGSEVERITYSCREEN
+          value: info
+        - name: TYPHA_LOGFILEPATH
+          value: none
+        - name: TYPHA_LOGSEVERITYSYS
+          value: none
+        - name: TYPHA_CONNECTIONREBALANCINGMODE
+          value: kubernetes
+        - name: TYPHA_DATASTORETYPE
+          value: kubernetes
+        - name: TYPHA_HEALTHENABLED
+          value: "true"
+        - name: USE_POD_CIDR
+          value: "true"
+        envFrom:
+        - configMapRef:
+            name: kubernetes-services-endpoint
+            optional: true
+        image: docker.io/calico/typha:v3.20.3
+        livenessProbe:
+          httpGet:
+            host: localhost
+            path: /liveness
+            port: 9098
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+        name: calico-typha
+        ports:
+        - containerPort: 5473
+          name: calico-typha
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            host: localhost
+            path: /readiness
+            port: 9098
+          periodSeconds: 10
+          timeoutSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      securityContext:
+        fsGroup: 65534
+      serviceAccountName: calico-node
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
 ---
-
-# This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
-
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: calico-kube-controllers
-  namespace: kube-system
   labels:
     k8s-app: calico-kube-controllers
+  name: calico-kube-controllers
+  namespace: kube-system
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
       k8s-app: calico-kube-controllers
 ---
-# Source: calico/templates/calico-etcd-secrets.yaml
-
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    k8s-app: calico-typha
+  name: calico-typha
+  namespace: kube-system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-typha
 ---
-# Source: calico/templates/calico-typha.yaml
-
----
-# Source: calico/templates/configure-canal.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: calico-node
+  name: calico-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+    spec:
+      containers:
+      - env:
+        - name: CALICO_IPv6POOL_CIDR
+          value: 2001:1234:5678:9a40::/58
+        - name: IP6
+          value: autodetect
+        - name: FELIX_IPV6SUPPORT
+          value: "true"
+        - name: DATASTORE_TYPE
+          value: kubernetes
+        - name: USE_POD_CIDR
+          value: "true"
+        - name: FELIX_TYPHAK8SSERVICENAME
+          valueFrom:
+            configMapKeyRef:
+              key: typha_service_name
+              name: calico-config
+        - name: WAIT_FOR_DATASTORE
+          value: "true"
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CALICO_NETWORKING_BACKEND
+          value: none
+        - name: CLUSTER_TYPE
+          value: k8s
+        - name: CALICO_DISABLE_FILE_LOGGING
+          value: "true"
+        - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+          value: ACCEPT
+        - name: FELIX_HEALTHENABLED
+          value: "true"
+        envFrom:
+        - configMapRef:
+            name: kubernetes-services-endpoint
+            optional: true
+        image: docker.io/calico/node:v3.20.3
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/calico-node
+              - -shutdown
+        livenessProbe:
+          exec:
+            command:
+            - /bin/calico-node
+            - -felix-live
+          failureThreshold: 6
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 10
+        name: calico-node
+        readinessProbe:
+          exec:
+            command:
+            - /bin/calico-node
+            - -felix-ready
+          periodSeconds: 10
+          timeoutSeconds: 10
+        resources:
+          requests:
+            cpu: 250m
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/etc/cni/net.d
+          name: cni-net-dir
+          readOnly: false
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+          readOnly: false
+        - mountPath: /var/run/calico
+          name: var-run-calico
+          readOnly: false
+        - mountPath: /var/lib/calico
+          name: var-lib-calico
+          readOnly: false
+        - mountPath: /var/run/nodeagent
+          name: policysync
+        - mountPath: /sys/fs/
+          mountPropagation: Bidirectional
+          name: sysfs
+        - mountPath: /var/log/calico/cni
+          name: cni-log-dir
+          readOnly: true
+      hostNetwork: true
+      initContainers:
+      - command:
+        - /opt/cni/bin/install
+        env:
+        - name: CNI_CONF_NAME
+          value: 10-calico.conflist
+        - name: CNI_NETWORK_CONFIG
+          valueFrom:
+            configMapKeyRef:
+              key: cni_network_config
+              name: calico-config
+        - name: KUBERNETES_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: SLEEP
+          value: "false"
+        envFrom:
+        - configMapRef:
+            name: kubernetes-services-endpoint
+            optional: true
+        image: docker.io/calico/cni:v3.20.3
+        name: install-cni
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /host/etc/cni/net.d
+          name: cni-net-dir
+      - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+        name: flexvol-driver
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/driver
+          name: flexvol-driver-host
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      serviceAccountName: calico-node
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /lib/modules
+        name: lib-modules
+      - hostPath:
+          path: /var/run/calico
+        name: var-run-calico
+      - hostPath:
+          path: /var/lib/calico
+        name: var-lib-calico
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
+      - hostPath:
+          path: /sys/fs/
+          type: DirectoryOrCreate
+        name: sysfs
+      - hostPath:
+          path: /opt/cni/bin
+        name: cni-bin-dir
+      - hostPath:
+          path: /etc/cni/net.d
+        name: cni-net-dir
+      - hostPath:
+          path: /var/log/calico/cni
+        name: cni-log-dir
+      - hostPath:
+          path: /var/run/nodeagent
+          type: DirectoryOrCreate
+        name: policysync
+      - hostPath:
+          path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+          type: DirectoryOrCreate
+        name: flexvol-driver-host
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/templates/addons/calico-ipv6/kustomization.yaml
+++ b/templates/addons/calico-ipv6/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - https://docs.projectcalico.org/v3.20/manifests/calico-policy-only.yaml
+patchesStrategicMerge:
+    - patches/azure-mtu.yaml
+patches:
+- target: 
+    group: apps
+    version: v1
+    kind: DaemonSet
+    name: calico-node
+    namespace: kube-system
+  path: patches/calico-node.yaml

--- a/templates/addons/calico-ipv6/patches/azure-mtu.yaml
+++ b/templates/addons/calico-ipv6/patches/azure-mtu.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # On Azure, the underlying network has an MTU of 1400, even though the network interface will have an MTU of 1500.
+  # We set this value to 1350 for “physical network MTU size minus 50” since we use VXLAN, which uses a 50-byte header.
+  # If enabling Wireguard, this value should be changed to 1340 (Wireguard uses a 60-byte header).
+  # https://docs.projectcalico.org/networking/mtu#determine-mtu-size
+  veth_mtu: "1350"

--- a/templates/addons/calico-ipv6/patches/calico-node.yaml
+++ b/templates/addons/calico-ipv6/patches/calico-node.yaml
@@ -1,0 +1,18 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: calico-node
+        env:
+        # https://docs.projectcalico.org/reference/public-cloud/azure#azure-user-defined-routes
+        - name: CALICO_IPv6POOL_CIDR
+          value: "2001:1234:5678:9a40::/58"
+        - name: IP6	
+          value: "autodetect"
+        - name: FELIX_IPV6SUPPORT	
+          value: "true"

--- a/templates/addons/calico.yaml
+++ b/templates/addons/calico.yaml
@@ -3690,7 +3690,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.20.3
+        image: docker.io/calico/kube-controllers:v3.20.4
         livenessProbe:
           exec:
             command:
@@ -3800,7 +3800,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.20.3
+        image: docker.io/calico/node:v3.20.4
         lifecycle:
           preStop:
             exec:
@@ -3872,7 +3872,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.20.3
+        image: docker.io/calico/cni:v3.20.4
         name: upgrade-ipam
         securityContext:
           privileged: true
@@ -3906,7 +3906,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.20.3
+        image: docker.io/calico/cni:v3.20.4
         name: install-cni
         securityContext:
           privileged: true
@@ -3915,7 +3915,7 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/cni/net.d
           name: cni-net-dir
-      - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+      - image: docker.io/calico/pod2daemon-flexvol:v3.20.4
         name: flexvol-driver
         securityContext:
           privileged: true

--- a/templates/addons/calico.yaml
+++ b/templates/addons/calico.yaml
@@ -1,24 +1,3628 @@
----
-# Source: calico/templates/calico-config.yaml
-# This ConfigMap is used to configure a self-hosted Calico installation.
-kind: ConfigMap
-apiVersion: v1
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
 metadata:
-  name: calico-config
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPConfiguration
+    listKind: BGPConfigurationList
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: BGPConfiguration contains the configuration for any BGP routing.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPConfigurationSpec contains the values of the BGP configuration.
+            properties:
+              asNumber:
+                description: 'ASNumber is the default AS number used by a node. [Default:
+                  64512]'
+                format: int32
+                type: integer
+              communities:
+                description: Communities is a list of BGP community values and their
+                  arbitrary names for tagging routes.
+                items:
+                  description: Community contains standard or large community value
+                    and its name.
+                  properties:
+                    name:
+                      description: Name given to community value.
+                      type: string
+                    value:
+                      description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                        For standard community use `aa:nn` format, where `aa` and
+                        `nn` are 16 bit number. For large community use `aa:nn:mm`
+                        format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                        `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                      pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                      type: string
+                  type: object
+                type: array
+              listenPort:
+                description: ListenPort is the port where BGP protocol should listen.
+                  Defaults to 179
+                maximum: 65535
+                minimum: 1
+                type: integer
+              logSeverityScreen:
+                description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: INFO]'
+                type: string
+              nodeToNodeMeshEnabled:
+                description: 'NodeToNodeMeshEnabled sets whether full node to node
+                  BGP mesh is enabled. [Default: true]'
+                type: boolean
+              prefixAdvertisements:
+                description: PrefixAdvertisements contains per-prefix advertisement
+                  configuration.
+                items:
+                  description: PrefixAdvertisement configures advertisement properties
+                    for the specified CIDR.
+                  properties:
+                    cidr:
+                      description: CIDR for which properties should be advertised.
+                      type: string
+                    communities:
+                      description: Communities can be list of either community names
+                        already defined in `Specs.Communities` or community value
+                        of format `aa:nn` or `aa:nn:mm`. For standard community use
+                        `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                        large community use `aa:nn:mm` format, where `aa`, `nn` and
+                        `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                        `mm` are per-AS identifier.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              serviceClusterIPs:
+                description: ServiceClusterIPs are the CIDR blocks from which service
+                  cluster IPs are allocated. If specified, Calico will advertise these
+                  blocks, as well as any cluster IPs within them.
+                items:
+                  description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                    CIDR block.
+                  properties:
+                    cidr:
+                      type: string
+                  type: object
+                type: array
+              serviceExternalIPs:
+                description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                  Service External IPs. Kubernetes Service ExternalIPs will only be
+                  advertised if they are within one of these blocks.
+                items:
+                  description: ServiceExternalIPBlock represents a single allowed
+                    External IP CIDR block.
+                  properties:
+                    cidr:
+                      type: string
+                  type: object
+                type: array
+              serviceLoadBalancerIPs:
+                description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                  Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                  IPs will only be advertised if they are within one of these blocks.
+                items:
+                  description: ServiceLoadBalancerIPBlock represents a single allowed
+                    LoadBalancer IP CIDR block.
+                  properties:
+                    cidr:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bgppeers.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPPeer
+    listKind: BGPPeerList
+    plural: bgppeers
+    singular: bgppeer
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPPeerSpec contains the specification for a BGPPeer resource.
+            properties:
+              asNumber:
+                description: The AS Number of the peer.
+                format: int32
+                type: integer
+              keepOriginalNextHop:
+                description: Option to keep the original nexthop field when routes
+                  are sent to a BGP Peer. Setting "true" configures the selected BGP
+                  Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                  in the specific branch of the Node on "bird.cfg".
+                type: boolean
+              maxRestartTime:
+                description: Time to allow for software restart.  When specified,
+                  this is configured as the graceful restart timeout.  When not specified,
+                  the BIRD default of 120s is used.
+                type: string
+              node:
+                description: The node name identifying the Calico node instance that
+                  is targeted by this peer. If this is not set, and no nodeSelector
+                  is specified, then this BGP peer selects all nodes in the cluster.
+                type: string
+              nodeSelector:
+                description: Selector for the nodes that should have this peering.  When
+                  this is set, the Node field must be empty.
+                type: string
+              password:
+                description: Optional BGP password for the peerings generated by this
+                  BGPPeer resource.
+                properties:
+                  secretKeyRef:
+                    description: Selects a key of a secret in the node pod's namespace.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                type: object
+              peerIP:
+                description: The IP address of the peer followed by an optional port
+                  number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                  or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                  and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                  set in BGPConfiguration, then we use that port to peer.
+                type: string
+              peerSelector:
+                description: Selector for the remote nodes to peer with.  When this
+                  is set, the PeerIP and ASNumber fields must be empty.  For each
+                  peering between the local node and selected remote nodes, we configure
+                  an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                  and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                  remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                  or the global default if that is not set.
+                type: string
+              sourceAddress:
+                description: Specifies whether and how to configure a source address
+                  for the peerings generated by this BGPPeer resource.  Default value
+                  "UseNodeIP" means to configure the node IP as the source address.  "None"
+                  means not to configure a source address.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: blockaffinities.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BlockAffinity
+    listKind: BlockAffinityList
+    plural: blockaffinities
+    singular: blockaffinity
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BlockAffinitySpec contains the specification for a BlockAffinity
+              resource.
+            properties:
+              cidr:
+                type: string
+              deleted:
+                description: Deleted indicates that this block affinity is being deleted.
+                  This field is a string for compatibility with older releases that
+                  mistakenly treat this field as a string.
+                type: string
+              node:
+                type: string
+              state:
+                type: string
+            required:
+            - cidr
+            - deleted
+            - node
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: ClusterInformation
+    listKind: ClusterInformationList
+    plural: clusterinformations
+    singular: clusterinformation
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterInformation contains the cluster specific information.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterInformationSpec contains the values of describing
+              the cluster.
+            properties:
+              calicoVersion:
+                description: CalicoVersion is the version of Calico that the cluster
+                  is running
+                type: string
+              clusterGUID:
+                description: ClusterGUID is the GUID of the cluster
+                type: string
+              clusterType:
+                description: ClusterType describes the type of the cluster
+                type: string
+              datastoreReady:
+                description: DatastoreReady is used during significant datastore migrations
+                  to signal to components such as Felix that it should wait before
+                  accessing the datastore.
+                type: boolean
+              variant:
+                description: Variant declares which variant of Calico should be active.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: FelixConfiguration
+    listKind: FelixConfigurationList
+    plural: felixconfigurations
+    singular: felixconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Felix Configuration contains the configuration for Felix.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FelixConfigurationSpec contains the values of the Felix configuration.
+            properties:
+              allowIPIPPacketsFromWorkloads:
+                description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                  will add a rule to drop IPIP encapsulated traffic from workloads
+                  [Default: false]'
+                type: boolean
+              allowVXLANPacketsFromWorkloads:
+                description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                  will add a rule to drop VXLAN encapsulated traffic from workloads
+                  [Default: false]'
+                type: boolean
+              awsSrcDstCheck:
+                description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                  value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                  DoNothing]'
+                enum:
+                - DoNothing
+                - Enable
+                - Disable
+                type: string
+              bpfConnectTimeLoadBalancingEnabled:
+                description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                  controls whether Felix installs the connection-time load balancer.  The
+                  connect-time load balancer is required for the host to be able to
+                  reach Kubernetes services and it improves the performance of pod-to-service
+                  connections.  The only reason to disable it is for debugging purposes.  [Default:
+                  true]'
+                type: boolean
+              bpfDataIfacePattern:
+                description: BPFDataIfacePattern is a regular expression that controls
+                  which interfaces Felix should attach BPF programs to in order to
+                  catch traffic to/from the network.  This needs to match the interfaces
+                  that Calico workload traffic flows over as well as any interfaces
+                  that handle incoming traffic to nodeports and services from outside
+                  the cluster.  It should not match the workload interfaces (usually
+                  named cali...).
+                type: string
+              bpfDisableUnprivileged:
+                description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                  sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                  users cannot access Calico''s BPF maps and cannot insert their own
+                  BPF programs to interfere with Calico''s. [Default: true]'
+                type: boolean
+              bpfEnabled:
+                description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                  [Default: false]'
+                type: boolean
+              bpfExtToServiceConnmark:
+                description: 'BPFExtToServiceConnmark in BPF mode, controls a 32bit
+                  mark that is set on connections from an external client to a local
+                  service. This mark allows us to control how packets of that connection
+                  are routed within the host and how is routing intepreted by RPF
+                  check. [Default: 0]'
+                type: integer
+              bpfExternalServiceMode:
+                description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                  from outside the cluster to services (node ports and cluster IPs)
+                  are forwarded to remote workloads.  If set to "Tunnel" then both
+                  request and response traffic is tunneled to the remote node.  If
+                  set to "DSR", the request traffic is tunneled but the response traffic
+                  is sent directly from the remote node.  In "DSR" mode, the remote
+                  node appears to use the IP of the ingress node; this requires a
+                  permissive L2 network.  [Default: Tunnel]'
+                type: string
+              bpfKubeProxyEndpointSlicesEnabled:
+                description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                  whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                type: boolean
+              bpfKubeProxyIptablesCleanupEnabled:
+                description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                  mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                  iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                  true]'
+                type: boolean
+              bpfKubeProxyMinSyncPeriod:
+                description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                  minimum time between updates to the dataplane for Felix''s embedded
+                  kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                  reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                type: string
+              bpfLogLevel:
+                description: 'BPFLogLevel controls the log level of the BPF programs
+                  when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                  logs are emitted to the BPF trace pipe, accessible with the command
+                  `tc exec bpf debug`. [Default: Off].'
+                type: string
+              chainInsertMode:
+                description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                  top-level iptables chains by inserting a rule at the top of the
+                  chain or by appending a rule at the bottom. insert is the safe default
+                  since it prevents Calico''s rules from being bypassed. If you switch
+                  to append mode, be sure that the other rules in the chains signal
+                  acceptance by falling through to the Calico rules, otherwise the
+                  Calico policy will be bypassed. [Default: insert]'
+                type: string
+              dataplaneDriver:
+                type: string
+              debugDisableLogDropping:
+                type: boolean
+              debugMemoryProfilePath:
+                type: string
+              debugSimulateCalcGraphHangAfter:
+                type: string
+              debugSimulateDataplaneHangAfter:
+                type: string
+              defaultEndpointToHostAction:
+                description: 'DefaultEndpointToHostAction controls what happens to
+                  traffic that goes from a workload endpoint to the host itself (after
+                  the traffic hits the endpoint egress policy). By default Calico
+                  blocks traffic from workload endpoints to the host itself with an
+                  iptables "DROP" action. If you want to allow some or all traffic
+                  from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                  RETURN if you have your own rules in the iptables "INPUT" chain;
+                  Calico will insert its rules at the top of that chain, then "RETURN"
+                  packets to the "INPUT" chain once it has completed processing workload
+                  endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                  from workloads after processing workload endpoint egress policy.
+                  [Default: Drop]'
+                type: string
+              deviceRouteProtocol:
+                description: This defines the route protocol added to programmed device
+                  routes, by default this will be RTPROT_BOOT when left blank.
+                type: integer
+              deviceRouteSourceAddress:
+                description: This is the source address to use on programmed device
+                  routes. By default the source address is left blank, leaving the
+                  kernel to choose the source address used.
+                type: string
+              disableConntrackInvalidCheck:
+                type: boolean
+              endpointReportingDelay:
+                type: string
+              endpointReportingEnabled:
+                type: boolean
+              externalNodesList:
+                description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                  which may source tunnel traffic and have the tunneled traffic be
+                  accepted at calico nodes.
+                items:
+                  type: string
+                type: array
+              failsafeInboundHostPorts:
+                description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                  and CIDRs that Felix will allow incoming traffic to host endpoints
+                  on irrespective of the security policy. This is useful to avoid
+                  accidentally cutting off a host with incorrect configuration. For
+                  back-compatibility, if the protocol is not specified, it defaults
+                  to "tcp". If a CIDR is not specified, it will allow traffic from
+                  all addresses. To disable all inbound host ports, use the value
+                  none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                  udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                items:
+                  description: ProtoPort is combination of protocol, port, and CIDR.
+                    Protocol and port must be specified.
+                  properties:
+                    net:
+                      type: string
+                    port:
+                      type: integer
+                    protocol:
+                      type: string
+                  required:
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              failsafeOutboundHostPorts:
+                description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                  and CIDRs that Felix will allow outgoing traffic from host endpoints
+                  to irrespective of the security policy. This is useful to avoid
+                  accidentally cutting off a host with incorrect configuration. For
+                  back-compatibility, if the protocol is not specified, it defaults
+                  to "tcp". If a CIDR is not specified, it will allow traffic from
+                  all addresses. To disable all outbound host ports, use the value
+                  none. The default value opens etcd''s standard ports to ensure that
+                  Felix does not get cut off from etcd as well as allowing DHCP and
+                  DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                  tcp:6667, udp:53, udp:67]'
+                items:
+                  description: ProtoPort is combination of protocol, port, and CIDR.
+                    Protocol and port must be specified.
+                  properties:
+                    net:
+                      type: string
+                    port:
+                      type: integer
+                    protocol:
+                      type: string
+                  required:
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              featureDetectOverride:
+                description: FeatureDetectOverride is used to override the feature
+                  detection. Values are specified in a comma separated list with no
+                  spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                  "true" or "false" will force the feature, empty or omitted values
+                  are auto-detected.
+                type: string
+              genericXDPEnabled:
+                description: 'GenericXDPEnabled enables Generic XDP so network cards
+                  that don''t support XDP offload or driver modes can use XDP. This
+                  is not recommended since it doesn''t provide better performance
+                  than iptables. [Default: false]'
+                type: boolean
+              healthEnabled:
+                type: boolean
+              healthHost:
+                type: string
+              healthPort:
+                type: integer
+              interfaceExclude:
+                description: 'InterfaceExclude is a comma-separated list of interfaces
+                  that Felix should exclude when monitoring for host endpoints. The
+                  default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                  interface, which is used internally by kube-proxy. If you want to
+                  exclude multiple interface names using a single value, the list
+                  supports regular expressions. For regular expressions you must wrap
+                  the value with ''/''. For example having values ''/^kube/,veth1''
+                  will exclude all interfaces that begin with ''kube'' and also the
+                  interface ''veth1''. [Default: kube-ipvs0]'
+                type: string
+              interfacePrefix:
+                description: 'InterfacePrefix is the interface name prefix that identifies
+                  workload endpoints and so distinguishes them from host endpoint
+                  interfaces. Note: in environments other than bare metal, the orchestrators
+                  configure this appropriately. For example our Kubernetes and Docker
+                  integrations set the ''cali'' value, and our OpenStack integration
+                  sets the ''tap'' value. [Default: cali]'
+                type: string
+              interfaceRefreshInterval:
+                description: InterfaceRefreshInterval is the period at which Felix
+                  rescans local interfaces to verify their state. The rescan can be
+                  disabled by setting the interval to 0.
+                type: string
+              ipipEnabled:
+                type: boolean
+              ipipMTU:
+                description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                  Configuring MTU [Default: 1440]'
+                type: integer
+              ipsetsRefreshInterval:
+                description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                  all iptables state to ensure that no other process has accidentally
+                  broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                  90s]'
+                type: string
+              iptablesBackend:
+                description: IptablesBackend specifies which backend of iptables will
+                  be used. The default is legacy.
+                type: string
+              iptablesFilterAllowAction:
+                type: string
+              iptablesLockFilePath:
+                description: 'IptablesLockFilePath is the location of the iptables
+                  lock file. You may need to change this if the lock file is not in
+                  its standard location (for example if you have mapped it into Felix''s
+                  container at a different path). [Default: /run/xtables.lock]'
+                type: string
+              iptablesLockProbeInterval:
+                description: 'IptablesLockProbeInterval is the time that Felix will
+                  wait between attempts to acquire the iptables lock if it is not
+                  available. Lower values make Felix more responsive when the lock
+                  is contended, but use more CPU. [Default: 50ms]'
+                type: string
+              iptablesLockTimeout:
+                description: 'IptablesLockTimeout is the time that Felix will wait
+                  for the iptables lock, or 0, to disable. To use this feature, Felix
+                  must share the iptables lock file with all other processes that
+                  also take the lock. When running Felix inside a container, this
+                  requires the /run directory of the host to be mounted into the calico/node
+                  or calico/felix container. [Default: 0s disabled]'
+                type: string
+              iptablesMangleAllowAction:
+                type: string
+              iptablesMarkMask:
+                description: 'IptablesMarkMask is the mask that Felix selects its
+                  IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                  at least 8 bits set, none of which clash with any other mark bits
+                  in use on the system. [Default: 0xff000000]'
+                format: int32
+                type: integer
+              iptablesNATOutgoingInterfaceFilter:
+                type: string
+              iptablesPostWriteCheckInterval:
+                description: 'IptablesPostWriteCheckInterval is the period after Felix
+                  has done a write to the dataplane that it schedules an extra read
+                  back in order to check the write was not clobbered by another process.
+                  This should only occur if another application on the system doesn''t
+                  respect the iptables lock. [Default: 1s]'
+                type: string
+              iptablesRefreshInterval:
+                description: 'IptablesRefreshInterval is the period at which Felix
+                  re-checks the IP sets in the dataplane to ensure that no other process
+                  has accidentally broken Calico''s rules. Set to 0 to disable IP
+                  sets refresh. Note: the default for this value is lower than the
+                  other refresh intervals as a workaround for a Linux kernel bug that
+                  was fixed in kernel version 4.11. If you are using v4.11 or greater
+                  you may want to set this to, a higher value to reduce Felix CPU
+                  usage. [Default: 10s]'
+                type: string
+              ipv6Support:
+                type: boolean
+              kubeNodePortRanges:
+                description: 'KubeNodePortRanges holds list of port ranges used for
+                  service node ports. Only used if felix detects kube-proxy running
+                  in ipvs mode. Felix uses these ranges to separate host and workload
+                  traffic. [Default: 30000:32767].'
+                items:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^.*
+                  x-kubernetes-int-or-string: true
+                type: array
+              logFilePath:
+                description: 'LogFilePath is the full path to the Felix log. Set to
+                  none to disable file logging. [Default: /var/log/calico/felix.log]'
+                type: string
+              logPrefix:
+                description: 'LogPrefix is the log prefix that Felix uses when rendering
+                  LOG rules. [Default: calico-packet]'
+                type: string
+              logSeverityFile:
+                description: 'LogSeverityFile is the log severity above which logs
+                  are sent to the log file. [Default: Info]'
+                type: string
+              logSeverityScreen:
+                description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: Info]'
+                type: string
+              logSeveritySys:
+                description: 'LogSeveritySys is the log severity above which logs
+                  are sent to the syslog. Set to None for no logging to syslog. [Default:
+                  Info]'
+                type: string
+              maxIpsetSize:
+                type: integer
+              metadataAddr:
+                description: 'MetadataAddr is the IP address or domain name of the
+                  server that can answer VM queries for cloud-init metadata. In OpenStack,
+                  this corresponds to the machine running nova-api (or in Ubuntu,
+                  nova-api-metadata). A value of none (case insensitive) means that
+                  Felix should not set up any NAT rule for the metadata path. [Default:
+                  127.0.0.1]'
+                type: string
+              metadataPort:
+                description: 'MetadataPort is the port of the metadata server. This,
+                  combined with global.MetadataAddr (if not ''None''), is used to
+                  set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                  In most cases this should not need to be changed [Default: 8775].'
+                type: integer
+              mtuIfacePattern:
+                description: MTUIfacePattern is a regular expression that controls
+                  which interfaces Felix should scan in order to calculate the host's
+                  MTU. This should not match workload interfaces (usually named cali...).
+                type: string
+              natOutgoingAddress:
+                description: NATOutgoingAddress specifies an address to use when performing
+                  source NAT for traffic in a natOutgoing pool that is leaving the
+                  network. By default the address used is an address on the interface
+                  the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                type: string
+              natPortRange:
+                anyOf:
+                - type: integer
+                - type: string
+                description: NATPortRange specifies the range of ports that is used
+                  for port mapping when doing outgoing NAT. When unset the default
+                  behavior of the network stack is used.
+                pattern: ^.*
+                x-kubernetes-int-or-string: true
+              netlinkTimeout:
+                type: string
+              openstackRegion:
+                description: 'OpenstackRegion is the name of the region that a particular
+                  Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                  this must be configured somehow for each Felix (here in the datamodel,
+                  or in felix.cfg or the environment on each compute node), and must
+                  match the [calico] openstack_region value configured in neutron.conf
+                  on each node. [Default: Empty]'
+                type: string
+              policySyncPathPrefix:
+                description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                  policy changes to external services, like Application layer policy.
+                  [Default: Empty]'
+                type: string
+              prometheusGoMetricsEnabled:
+                description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                  collection, which the Prometheus client does by default, when set
+                  to false. This reduces the number of metrics reported, reducing
+                  Prometheus load. [Default: true]'
+                type: boolean
+              prometheusMetricsEnabled:
+                description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                  server in Felix if set to true. [Default: false]'
+                type: boolean
+              prometheusMetricsHost:
+                description: 'PrometheusMetricsHost is the host that the Prometheus
+                  metrics server should bind to. [Default: empty]'
+                type: string
+              prometheusMetricsPort:
+                description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                  metrics server should bind to. [Default: 9091]'
+                type: integer
+              prometheusProcessMetricsEnabled:
+                description: 'PrometheusProcessMetricsEnabled disables process metrics
+                  collection, which the Prometheus client does by default, when set
+                  to false. This reduces the number of metrics reported, reducing
+                  Prometheus load. [Default: true]'
+                type: boolean
+              prometheusWireGuardMetricsEnabled:
+                description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                  metrics collection, which the Prometheus client does by default,
+                  when set to false. This reduces the number of metrics reported,
+                  reducing Prometheus load. [Default: true]'
+                type: boolean
+              removeExternalRoutes:
+                description: Whether or not to remove device routes that have not
+                  been programmed by Felix. Disabling this will allow external applications
+                  to also add device routes. This is enabled by default which means
+                  we will remove externally added routes.
+                type: boolean
+              reportingInterval:
+                description: 'ReportingInterval is the interval at which Felix reports
+                  its status into the datastore or 0 to disable. Must be non-zero
+                  in OpenStack deployments. [Default: 30s]'
+                type: string
+              reportingTTL:
+                description: 'ReportingTTL is the time-to-live setting for process-wide
+                  status reports. [Default: 90s]'
+                type: string
+              routeRefreshInterval:
+                description: 'RouteRefreshInterval is the period at which Felix re-checks
+                  the routes in the dataplane to ensure that no other process has
+                  accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                  [Default: 90s]'
+                type: string
+              routeSource:
+                description: 'RouteSource configures where Felix gets its routing
+                  information. - WorkloadIPs: use workload endpoints to construct
+                  routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                type: string
+              routeTableRange:
+                description: Calico programs additional Linux route tables for various
+                  purposes.  RouteTableRange specifies the indices of the route tables
+                  that Calico should use.
+                properties:
+                  max:
+                    type: integer
+                  min:
+                    type: integer
+                required:
+                - max
+                - min
+                type: object
+              serviceLoopPrevention:
+                description: 'When service IP advertisement is enabled, prevent routing
+                  loops to service IPs that are not in use, by dropping or rejecting
+                  packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                  in which case such routing loops continue to be allowed. [Default:
+                  Drop]'
+                type: string
+              sidecarAccelerationEnabled:
+                description: 'SidecarAccelerationEnabled enables experimental sidecar
+                  acceleration [Default: false]'
+                type: boolean
+              usageReportingEnabled:
+                description: 'UsageReportingEnabled reports anonymous Calico version
+                  number and cluster size to projectcalico.org. Logs warnings returned
+                  by the usage server. For example, if a significant security vulnerability
+                  has been discovered in the version of Calico being used. [Default:
+                  true]'
+                type: boolean
+              usageReportingInitialDelay:
+                description: 'UsageReportingInitialDelay controls the minimum delay
+                  before Felix makes a report. [Default: 300s]'
+                type: string
+              usageReportingInterval:
+                description: 'UsageReportingInterval controls the interval at which
+                  Felix makes reports. [Default: 86400s]'
+                type: string
+              useInternalDataplaneDriver:
+                type: boolean
+              vxlanEnabled:
+                type: boolean
+              vxlanMTU:
+                description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                  Configuring MTU [Default: 1440]'
+                type: integer
+              vxlanPort:
+                type: integer
+              vxlanVNI:
+                type: integer
+              wireguardEnabled:
+                description: 'WireguardEnabled controls whether Wireguard is enabled.
+                  [Default: false]'
+                type: boolean
+              wireguardHostEncryptionEnabled:
+                description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                  host-to-host encryption is enabled. [Default: false]'
+                type: boolean
+              wireguardInterfaceName:
+                description: 'WireguardInterfaceName specifies the name to use for
+                  the Wireguard interface. [Default: wg.calico]'
+                type: string
+              wireguardListeningPort:
+                description: 'WireguardListeningPort controls the listening port used
+                  by Wireguard. [Default: 51820]'
+                type: integer
+              wireguardMTU:
+                description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                  See Configuring MTU [Default: 1420]'
+                type: integer
+              wireguardRoutingRulePriority:
+                description: 'WireguardRoutingRulePriority controls the priority value
+                  to use for the Wireguard routing rule. [Default: 99]'
+                type: integer
+              xdpEnabled:
+                description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                  incoming deny rules. [Default: true]'
+                type: boolean
+              xdpRefreshInterval:
+                description: 'XDPRefreshInterval is the period at which Felix re-checks
+                  all XDP state to ensure that no other process has accidentally broken
+                  Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                  refresh. [Default: 90s]'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkPolicy
+    listKind: GlobalNetworkPolicyList
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              applyOnForward:
+                description: ApplyOnForward indicates to apply the rules in this policy
+                  on forward traffic.
+                type: boolean
+              doNotTrack:
+                description: DoNotTrack indicates whether packets matched by the rules
+                  in this policy should go through the data plane's connection tracking,
+                  such as Linux conntrack.  If True, the rules in this policy are
+                  applied before any data plane connection tracking, and packets allowed
+                  by this policy are marked as not to be tracked.
+                type: boolean
+              egress:
+                description: The ordered set of egress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                description: The ordered set of ingress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              namespaceSelector:
+                description: NamespaceSelector is an optional field for an expression
+                  used to select a pod based on namespaces.
+                type: string
+              order:
+                description: Order is an optional field that specifies the order in
+                  which the policy is applied. Policies with higher "order" are applied
+                  after those with lower order.  If the order is omitted, it may be
+                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                  with identical order will be applied in alphanumerical order based
+                  on the Policy "Name".
+                type: number
+              preDNAT:
+                description: PreDNAT indicates to apply the rules in this policy before
+                  any DNAT.
+                type: boolean
+              selector:
+                description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                type: string
+              serviceAccountSelector:
+                description: ServiceAccountSelector is an optional field for an expression
+                  used to select a pod based on service accounts.
+                type: string
+              types:
+                description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress rules are present in the policy.  The
+                  default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                  (including the case where there are   also no Ingress rules) \n
+                  - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                  rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                  both Ingress and Egress rules. \n When the policy is read back again,
+                  Types will always be one of these values, never empty or nil."
+                items:
+                  description: PolicyType enumerates the possible values of the PolicySpec
+                    Types field.
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkSet
+    listKind: GlobalNetworkSetList
+    plural: globalnetworksets
+    singular: globalnetworkset
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+          that share labels to allow rules to refer to them via selectors.  The labels
+          of GlobalNetworkSet are not namespaced.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+              resource.
+            properties:
+              nets:
+                description: The list of IP networks that belong to this set.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: HostEndpoint
+    listKind: HostEndpointList
+    plural: hostendpoints
+    singular: hostendpoint
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HostEndpointSpec contains the specification for a HostEndpoint
+              resource.
+            properties:
+              expectedIPs:
+                description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                  If \"InterfaceName\" is not present, Calico will look for an interface
+                  matching any of the IPs in the list and apply policy to that. Note:
+                  \tWhen using the selector match criteria in an ingress or egress
+                  security Policy \tor Profile, Calico converts the selector into
+                  a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                  is used for that purpose. (If only the interface \tname is specified,
+                  Calico does not learn the IPs of the interface for use in match
+                  \tcriteria.)"
+                items:
+                  type: string
+                type: array
+              interfaceName:
+                description: "Either \"*\", or the name of a specific Linux interface
+                  to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                  governs all traffic to, from or through the default network namespace
+                  of the host named by the \"Node\" field; entering and leaving that
+                  namespace via any interface, including those from/to non-host-networked
+                  local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                  only governs traffic that enters or leaves the host through the
+                  specific interface named by InterfaceName, or - when InterfaceName
+                  is empty - through the specific interface that has one of the IPs
+                  in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                  one expected IP must be specified.  Only external interfaces (such
+                  as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                  to protect traffic through a specific local workload interface.
+                  \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                  initially just pre-DNAT policy.  Please check Calico documentation
+                  for the latest position."
+                type: string
+              node:
+                description: The node name identifying the Calico node instance.
+                type: string
+              ports:
+                description: Ports contains the endpoint's named ports, which may
+                  be referenced in security policy rules.
+                items:
+                  properties:
+                    name:
+                      type: string
+                    port:
+                      type: integer
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              profiles:
+                description: A list of identifiers of security Profile objects that
+                  apply to this endpoint. Each profile is applied in the order that
+                  they appear in this list.  Profile rules are applied after the selector-based
+                  security policy.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMBlock
+    listKind: IPAMBlockList
+    plural: ipamblocks
+    singular: ipamblock
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMBlockSpec contains the specification for an IPAMBlock
+              resource.
+            properties:
+              affinity:
+                type: string
+              allocations:
+                items:
+                  nullable: true
+                  type: integer
+                type: array
+              attributes:
+                items:
+                  properties:
+                    handle_id:
+                      type: string
+                    secondary:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                type: array
+              cidr:
+                type: string
+              deleted:
+                type: boolean
+              strictAffinity:
+                type: boolean
+              unallocated:
+                items:
+                  type: integer
+                type: array
+            required:
+            - allocations
+            - attributes
+            - cidr
+            - strictAffinity
+            - unallocated
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamconfigs.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMConfig
+    listKind: IPAMConfigList
+    plural: ipamconfigs
+    singular: ipamconfig
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMConfigSpec contains the specification for an IPAMConfig
+              resource.
+            properties:
+              autoAllocateBlocks:
+                type: boolean
+              maxBlocksPerHost:
+                description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                  that can be affine to each host.
+                type: integer
+              strictAffinity:
+                type: boolean
+            required:
+            - autoAllocateBlocks
+            - strictAffinity
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamhandles.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMHandle
+    listKind: IPAMHandleList
+    plural: ipamhandles
+    singular: ipamhandle
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMHandleSpec contains the specification for an IPAMHandle
+              resource.
+            properties:
+              block:
+                additionalProperties:
+                  type: integer
+                type: object
+              deleted:
+                type: boolean
+              handleID:
+                type: string
+            required:
+            - block
+            - handleID
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPPool
+    listKind: IPPoolList
+    plural: ippools
+    singular: ippool
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPPoolSpec contains the specification for an IPPool resource.
+            properties:
+              blockSize:
+                description: The block size to use for IP address assignments from
+                  this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                type: integer
+              cidr:
+                description: The pool CIDR.
+                type: string
+              disabled:
+                description: When disabled is true, Calico IPAM will not assign addresses
+                  from this pool.
+                type: boolean
+              ipip:
+                description: 'Deprecated: this field is only used for APIv1 backwards
+                  compatibility. Setting this field is not allowed, this field is
+                  for internal use only.'
+                properties:
+                  enabled:
+                    description: When enabled is true, ipip tunneling will be used
+                      to deliver packets to destinations within this pool.
+                    type: boolean
+                  mode:
+                    description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                      mode of "always" will also use IPIP tunneling for routing to
+                      destination IP addresses within this pool.  A mode of "cross-subnet"
+                      will only use IPIP tunneling when the destination node is on
+                      a different subnet to the originating node.  The default value
+                      (if not specified) is "always".
+                    type: string
+                type: object
+              ipipMode:
+                description: Contains configuration for IPIP tunneling for this pool.
+                  If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                  is disabled).
+                type: string
+              nat-outgoing:
+                description: 'Deprecated: this field is only used for APIv1 backwards
+                  compatibility. Setting this field is not allowed, this field is
+                  for internal use only.'
+                type: boolean
+              natOutgoing:
+                description: When nat-outgoing is true, packets sent from Calico networked
+                  containers in this pool to destinations outside of this pool will
+                  be masqueraded.
+                type: boolean
+              nodeSelector:
+                description: Allows IPPool to allocate for a specific node by label
+                  selector.
+                type: string
+              vxlanMode:
+                description: Contains configuration for VXLAN tunneling for this pool.
+                  If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                  tunneling is disabled).
+                type: string
+            required:
+            - cidr
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kubecontrollersconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: KubeControllersConfiguration
+    listKind: KubeControllersConfigurationList
+    plural: kubecontrollersconfigurations
+    singular: kubecontrollersconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeControllersConfigurationSpec contains the values of the
+              Kubernetes controllers configuration.
+            properties:
+              controllers:
+                description: Controllers enables and configures individual Kubernetes
+                  controllers
+                properties:
+                  namespace:
+                    description: Namespace enables and configures the namespace controller.
+                      Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                  node:
+                    description: Node enables and configures the node controller.
+                      Enabled by default, set to nil to disable.
+                    properties:
+                      hostEndpoint:
+                        description: HostEndpoint controls syncing nodes to host endpoints.
+                          Disabled by default, set to nil to disable.
+                        properties:
+                          autoCreate:
+                            description: 'AutoCreate enables automatic creation of
+                              host endpoints for every node. [Default: Disabled]'
+                            type: string
+                        type: object
+                      leakGracePeriod:
+                        description: 'LeakGracePeriod is the period used by the controller
+                          to determine if an IP address has been leaked. Set to 0
+                          to disable IP garbage collection. [Default: 15m]'
+                        type: string
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                      syncLabels:
+                        description: 'SyncLabels controls whether to copy Kubernetes
+                          node labels to Calico nodes. [Default: Enabled]'
+                        type: string
+                    type: object
+                  policy:
+                    description: Policy enables and configures the policy controller.
+                      Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                  serviceAccount:
+                    description: ServiceAccount enables and configures the service
+                      account controller. Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                  workloadEndpoint:
+                    description: WorkloadEndpoint enables and configures the workload
+                      endpoint controller. Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                type: object
+              etcdV3CompactionPeriod:
+                description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                  compaction requests. Set to 0 to disable. [Default: 10m]'
+                type: string
+              healthChecks:
+                description: 'HealthChecks enables or disables support for health
+                  checks [Default: Enabled]'
+                type: string
+              logSeverityScreen:
+                description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: Info]'
+                type: string
+              prometheusMetricsPort:
+                description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                  metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                type: integer
+            required:
+            - controllers
+            type: object
+          status:
+            description: KubeControllersConfigurationStatus represents the status
+              of the configuration. It's useful for admins to be able to see the actual
+              config that was applied, which can be modified by environment variables
+              on the kube-controllers process.
+            properties:
+              environmentVars:
+                additionalProperties:
+                  type: string
+                description: EnvironmentVars contains the environment variables on
+                  the kube-controllers that influenced the RunningConfig.
+                type: object
+              runningConfig:
+                description: RunningConfig contains the effective config that is running
+                  in the kube-controllers pod, after merging the API resource with
+                  any environment variables.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace
+                          controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host
+                              endpoints. Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation
+                                  of host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the
+                              controller to determine if an IP address has been leaked.
+                              Set to 0 to disable IP garbage collection. [Default:
+                              15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which
+                      logs are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default:
+                      9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              egress:
+                description: The ordered set of egress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                description: The ordered set of ingress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              order:
+                description: Order is an optional field that specifies the order in
+                  which the policy is applied. Policies with higher "order" are applied
+                  after those with lower order.  If the order is omitted, it may be
+                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                  with identical order will be applied in alphanumerical order based
+                  on the Policy "Name".
+                type: number
+              selector:
+                description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                type: string
+              serviceAccountSelector:
+                description: ServiceAccountSelector is an optional field for an expression
+                  used to select a pod based on service accounts.
+                type: string
+              types:
+                description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress are present in the policy.  The default
+                  is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                  the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                  ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                  PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                  \n When the policy is read back again, Types will always be one
+                  of these values, never empty or nil."
+                items:
+                  description: PolicyType enumerates the possible values of the PolicySpec
+                    Types field.
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networksets.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkSet
+    listKind: NetworkSetList
+    plural: networksets
+    singular: networkset
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkSetSpec contains the specification for a NetworkSet
+              resource.
+            properties:
+              nets:
+                description: The list of IP networks that belong to this set.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-kube-controllers
   namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: calico-kube-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - ippools
+  verbs:
+  - list
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - blockaffinities
+  - ipamblocks
+  - ipamhandles
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - watch
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - hostendpoints
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - clusterinformations
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - kubecontrollersconfigurations
+  verbs:
+  - get
+  - create
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: calico-node
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  - serviceaccounts
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - patch
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - globalfelixconfigs
+  - felixconfigurations
+  - bgppeers
+  - globalbgpconfigs
+  - bgpconfigurations
+  - ippools
+  - ipamblocks
+  - globalnetworkpolicies
+  - globalnetworksets
+  - networkpolicies
+  - networksets
+  - clusterinformations
+  - hostendpoints
+  - blockaffinities
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - ippools
+  - felixconfigurations
+  - clusterinformations
+  verbs:
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - bgpconfigurations
+  - bgppeers
+  verbs:
+  - create
+  - update
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - blockaffinities
+  - ipamblocks
+  - ipamhandles
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - ipamconfigs
+  verbs:
+  - get
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - blockaffinities
+  verbs:
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-kube-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-kube-controllers
+subjects:
+- kind: ServiceAccount
+  name: calico-kube-controllers
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system
+---
+apiVersion: v1
 data:
-  # Typha is disabled.
-  typha_service_name: "none"
-  # Configure the backend to use.
-  calico_backend: "vxlan"
-  # On Azure, the underlying network has an MTU of 1400, even though the network interface will have an MTU of 1500.
-  # We set this value to 1350 for “physical network MTU size minus 50” since we use VXLAN, which uses a 50-byte header.
-  # If enabling Wireguard, this value should be changed to 1340 (Wireguard uses a 60-byte header).
-  # https://docs.projectcalico.org/networking/mtu#determine-mtu-size
-  veth_mtu: "1350"
-  
-  # The CNI network configuration to install on each node. The special
-  # values in this config will be automatically populated.
+  calico_backend: vxlan
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
@@ -52,4015 +3656,21 @@ data:
         }
       ]
     }
-
----
-# Source: calico/templates/kdd-crds.yaml
-
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+  typha_service_name: none
+  veth_mtu: "1350"
+kind: ConfigMap
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: bgpconfigurations.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: BGPConfiguration
-    listKind: BGPConfigurationList
-    plural: bgpconfigurations
-    singular: bgpconfiguration
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: BGPConfiguration contains the configuration for any BGP routing.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: BGPConfigurationSpec contains the values of the BGP configuration.
-              properties:
-                asNumber:
-                  description: 'ASNumber is the default AS number used by a node. [Default:
-                  64512]'
-                  format: int32
-                  type: integer
-                communities:
-                  description: Communities is a list of BGP community values and their
-                    arbitrary names for tagging routes.
-                  items:
-                    description: Community contains standard or large community value
-                      and its name.
-                    properties:
-                      name:
-                        description: Name given to community value.
-                        type: string
-                      value:
-                        description: Value must be of format `aa:nn` or `aa:nn:mm`.
-                          For standard community use `aa:nn` format, where `aa` and
-                          `nn` are 16 bit number. For large community use `aa:nn:mm`
-                          format, where `aa`, `nn` and `mm` are 32 bit number. Where,
-                          `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
-                        pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
-                        type: string
-                    type: object
-                  type: array
-                listenPort:
-                  description: ListenPort is the port where BGP protocol should listen.
-                    Defaults to 179
-                  maximum: 65535
-                  minimum: 1
-                  type: integer
-                logSeverityScreen:
-                  description: 'LogSeverityScreen is the log severity above which logs
-                  are sent to the stdout. [Default: INFO]'
-                  type: string
-                nodeToNodeMeshEnabled:
-                  description: 'NodeToNodeMeshEnabled sets whether full node to node
-                  BGP mesh is enabled. [Default: true]'
-                  type: boolean
-                prefixAdvertisements:
-                  description: PrefixAdvertisements contains per-prefix advertisement
-                    configuration.
-                  items:
-                    description: PrefixAdvertisement configures advertisement properties
-                      for the specified CIDR.
-                    properties:
-                      cidr:
-                        description: CIDR for which properties should be advertised.
-                        type: string
-                      communities:
-                        description: Communities can be list of either community names
-                          already defined in `Specs.Communities` or community value
-                          of format `aa:nn` or `aa:nn:mm`. For standard community use
-                          `aa:nn` format, where `aa` and `nn` are 16 bit number. For
-                          large community use `aa:nn:mm` format, where `aa`, `nn` and
-                          `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
-                          `mm` are per-AS identifier.
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  type: array
-                serviceClusterIPs:
-                  description: ServiceClusterIPs are the CIDR blocks from which service
-                    cluster IPs are allocated. If specified, Calico will advertise these
-                    blocks, as well as any cluster IPs within them.
-                  items:
-                    description: ServiceClusterIPBlock represents a single allowed ClusterIP
-                      CIDR block.
-                    properties:
-                      cidr:
-                        type: string
-                    type: object
-                  type: array
-                serviceExternalIPs:
-                  description: ServiceExternalIPs are the CIDR blocks for Kubernetes
-                    Service External IPs. Kubernetes Service ExternalIPs will only be
-                    advertised if they are within one of these blocks.
-                  items:
-                    description: ServiceExternalIPBlock represents a single allowed
-                      External IP CIDR block.
-                    properties:
-                      cidr:
-                        type: string
-                    type: object
-                  type: array
-                serviceLoadBalancerIPs:
-                  description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
-                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
-                    IPs will only be advertised if they are within one of these blocks.
-                  items:
-                    description: ServiceLoadBalancerIPBlock represents a single allowed
-                      LoadBalancer IP CIDR block.
-                    properties:
-                      cidr:
-                        type: string
-                    type: object
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: bgppeers.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: BGPPeer
-    listKind: BGPPeerList
-    plural: bgppeers
-    singular: bgppeer
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: BGPPeerSpec contains the specification for a BGPPeer resource.
-              properties:
-                asNumber:
-                  description: The AS Number of the peer.
-                  format: int32
-                  type: integer
-                keepOriginalNextHop:
-                  description: Option to keep the original nexthop field when routes
-                    are sent to a BGP Peer. Setting "true" configures the selected BGP
-                    Peers node to use the "next hop keep;" instead of "next hop self;"(default)
-                    in the specific branch of the Node on "bird.cfg".
-                  type: boolean
-                maxRestartTime:
-                  description: Time to allow for software restart.  When specified, this
-                    is configured as the graceful restart timeout.  When not specified,
-                    the BIRD default of 120s is used.
-                  type: string
-                node:
-                  description: The node name identifying the Calico node instance that
-                    is targeted by this peer. If this is not set, and no nodeSelector
-                    is specified, then this BGP peer selects all nodes in the cluster.
-                  type: string
-                nodeSelector:
-                  description: Selector for the nodes that should have this peering.  When
-                    this is set, the Node field must be empty.
-                  type: string
-                password:
-                  description: Optional BGP password for the peerings generated by this
-                    BGPPeer resource.
-                  properties:
-                    secretKeyRef:
-                      description: Selects a key of a secret in the node pod's namespace.
-                      properties:
-                        key:
-                          description: The key of the secret to select from.  Must be
-                            a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                        optional:
-                          description: Specify whether the Secret or its key must be
-                            defined
-                          type: boolean
-                      required:
-                        - key
-                      type: object
-                  type: object
-                peerIP:
-                  description: The IP address of the peer followed by an optional port
-                    number to peer with. If port number is given, format should be `[<IPv6>]:port`
-                    or `<IPv4>:<port>` for IPv4. If optional port number is not set,
-                    and this peer IP and ASNumber belongs to a calico/node with ListenPort
-                    set in BGPConfiguration, then we use that port to peer.
-                  type: string
-                peerSelector:
-                  description: Selector for the remote nodes to peer with.  When this
-                    is set, the PeerIP and ASNumber fields must be empty.  For each
-                    peering between the local node and selected remote nodes, we configure
-                    an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
-                    and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
-                    remote AS number comes from the remote node’s NodeBGPSpec.ASNumber,
-                    or the global default if that is not set.
-                  type: string
-                sourceAddress:
-                  description: Specifies whether and how to configure a source address
-                    for the peerings generated by this BGPPeer resource.  Default value
-                    "UseNodeIP" means to configure the node IP as the source address.  "None"
-                    means not to configure a source address.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: blockaffinities.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: BlockAffinity
-    listKind: BlockAffinityList
-    plural: blockaffinities
-    singular: blockaffinity
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: BlockAffinitySpec contains the specification for a BlockAffinity
-                resource.
-              properties:
-                cidr:
-                  type: string
-                deleted:
-                  description: Deleted indicates that this block affinity is being deleted.
-                    This field is a string for compatibility with older releases that
-                    mistakenly treat this field as a string.
-                  type: string
-                node:
-                  type: string
-                state:
-                  type: string
-              required:
-                - cidr
-                - deleted
-                - node
-                - state
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: clusterinformations.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: ClusterInformation
-    listKind: ClusterInformationList
-    plural: clusterinformations
-    singular: clusterinformation
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: ClusterInformation contains the cluster specific information.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ClusterInformationSpec contains the values of describing
-                the cluster.
-              properties:
-                calicoVersion:
-                  description: CalicoVersion is the version of Calico that the cluster
-                    is running
-                  type: string
-                clusterGUID:
-                  description: ClusterGUID is the GUID of the cluster
-                  type: string
-                clusterType:
-                  description: ClusterType describes the type of the cluster
-                  type: string
-                datastoreReady:
-                  description: DatastoreReady is used during significant datastore migrations
-                    to signal to components such as Felix that it should wait before
-                    accessing the datastore.
-                  type: boolean
-                variant:
-                  description: Variant declares which variant of Calico should be active.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: felixconfigurations.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: FelixConfiguration
-    listKind: FelixConfigurationList
-    plural: felixconfigurations
-    singular: felixconfiguration
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: Felix Configuration contains the configuration for Felix.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: FelixConfigurationSpec contains the values of the Felix configuration.
-              properties:
-                allowIPIPPacketsFromWorkloads:
-                  description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
-                  will add a rule to drop IPIP encapsulated traffic from workloads
-                  [Default: false]'
-                  type: boolean
-                allowVXLANPacketsFromWorkloads:
-                  description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
-                  will add a rule to drop VXLAN encapsulated traffic from workloads
-                  [Default: false]'
-                  type: boolean
-                awsSrcDstCheck:
-                  description: 'Set source-destination-check on AWS EC2 instances. Accepted
-                  value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
-                  DoNothing]'
-                  enum:
-                    - DoNothing
-                    - Enable
-                    - Disable
-                  type: string
-                bpfConnectTimeLoadBalancingEnabled:
-                  description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
-                  controls whether Felix installs the connection-time load balancer.  The
-                  connect-time load balancer is required for the host to be able to
-                  reach Kubernetes services and it improves the performance of pod-to-service
-                  connections.  The only reason to disable it is for debugging purposes.  [Default:
-                  true]'
-                  type: boolean
-                bpfDataIfacePattern:
-                  description: 'BPFDataIfacePattern is a regular expression that controls
-                  which interfaces Felix should attach BPF programs to in order to
-                  catch traffic to/from the network.  This needs to match the interfaces
-                  that Calico workload traffic flows over as well as any interfaces
-                  that handle incoming traffic to nodeports and services from outside
-                  the cluster.  It should not match the workload interfaces (usually
-                  named cali...). [Default: ^(en.*|eth.*|tunl0$)]'
-                  type: string
-                bpfDisableUnprivileged:
-                  description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
-                  sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
-                  users cannot access Calico''s BPF maps and cannot insert their own
-                  BPF programs to interfere with Calico''s. [Default: true]'
-                  type: boolean
-                bpfEnabled:
-                  description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
-                  [Default: false]'
-                  type: boolean
-                bpfExtToServiceConnmark:
-                  description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit
-                    mark that is set on connections from an external client to a local
-                    service. This mark allows us to control how packets of that connection
-                    are routed within the host and how is routing intepreted by RPF
-                    check. [Default: 0]'
-                  type: integer
-                bpfExternalServiceMode:
-                  description: 'BPFExternalServiceMode in BPF mode, controls how connections
-                  from outside the cluster to services (node ports and cluster IPs)
-                  are forwarded to remote workloads.  If set to "Tunnel" then both
-                  request and response traffic is tunneled to the remote node.  If
-                  set to "DSR", the request traffic is tunneled but the response traffic
-                  is sent directly from the remote node.  In "DSR" mode, the remote
-                  node appears to use the IP of the ingress node; this requires a
-                  permissive L2 network.  [Default: Tunnel]'
-                  type: string
-                bpfKubeProxyEndpointSlicesEnabled:
-                  description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
-                    whether Felix's embedded kube-proxy accepts EndpointSlices or not.
-                  type: boolean
-                bpfKubeProxyIptablesCleanupEnabled:
-                  description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
-                  mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
-                  iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
-                  true]'
-                  type: boolean
-                bpfKubeProxyMinSyncPeriod:
-                  description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
-                  minimum time between updates to the dataplane for Felix''s embedded
-                  kube-proxy.  Lower values give reduced set-up latency.  Higher values
-                  reduce Felix CPU usage by batching up more work.  [Default: 1s]'
-                  type: string
-                bpfLogLevel:
-                  description: 'BPFLogLevel controls the log level of the BPF programs
-                  when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
-                  logs are emitted to the BPF trace pipe, accessible with the command
-                  `tc exec bpf debug`. [Default: Off].'
-                  type: string
-                chainInsertMode:
-                  description: 'ChainInsertMode controls whether Felix hooks the kernel’s
-                  top-level iptables chains by inserting a rule at the top of the
-                  chain or by appending a rule at the bottom. insert is the safe default
-                  since it prevents Calico’s rules from being bypassed. If you switch
-                  to append mode, be sure that the other rules in the chains signal
-                  acceptance by falling through to the Calico rules, otherwise the
-                  Calico policy will be bypassed. [Default: insert]'
-                  type: string
-                dataplaneDriver:
-                  type: string
-                debugDisableLogDropping:
-                  type: boolean
-                debugMemoryProfilePath:
-                  type: string
-                debugSimulateCalcGraphHangAfter:
-                  type: string
-                debugSimulateDataplaneHangAfter:
-                  type: string
-                defaultEndpointToHostAction:
-                  description: 'DefaultEndpointToHostAction controls what happens to
-                  traffic that goes from a workload endpoint to the host itself (after
-                  the traffic hits the endpoint egress policy). By default Calico
-                  blocks traffic from workload endpoints to the host itself with an
-                  iptables “DROP” action. If you want to allow some or all traffic
-                  from endpoint to host, set this parameter to RETURN or ACCEPT. Use
-                  RETURN if you have your own rules in the iptables “INPUT” chain;
-                  Calico will insert its rules at the top of that chain, then “RETURN”
-                  packets to the “INPUT” chain once it has completed processing workload
-                  endpoint egress policy. Use ACCEPT to unconditionally accept packets
-                  from workloads after processing workload endpoint egress policy.
-                  [Default: Drop]'
-                  type: string
-                deviceRouteProtocol:
-                  description: This defines the route protocol added to programmed device
-                    routes, by default this will be RTPROT_BOOT when left blank.
-                  type: integer
-                deviceRouteSourceAddress:
-                  description: This is the source address to use on programmed device
-                    routes. By default the source address is left blank, leaving the
-                    kernel to choose the source address used.
-                  type: string
-                disableConntrackInvalidCheck:
-                  type: boolean
-                endpointReportingDelay:
-                  type: string
-                endpointReportingEnabled:
-                  type: boolean
-                externalNodesList:
-                  description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
-                    which may source tunnel traffic and have the tunneled traffic be
-                    accepted at calico nodes.
-                  items:
-                    type: string
-                  type: array
-                failsafeInboundHostPorts:
-                  description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
-                    and CIDRs that Felix will allow incoming traffic to host endpoints
-                    on irrespective of the security policy. This is useful to avoid
-                    accidentally cutting off a host with incorrect configuration. For
-                    back-compatibility, if the protocol is not specified, it defaults
-                    to "tcp". If a CIDR is not specified, it will allow traffic from
-                    all addresses. To disable all inbound host ports, use the value
-                    none. The default value allows ssh access and DHCP. [Default: tcp:22,
-                    udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
-                  items:
-                    description: ProtoPort is combination of protocol, port, and CIDR.
-                      Protocol and port must be specified.
-                    properties:
-                      net:
-                        type: string
-                      port:
-                        type: integer
-                      protocol:
-                        type: string
-                    required:
-                      - port
-                      - protocol
-                    type: object
-                  type: array
-                failsafeOutboundHostPorts:
-                  description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
-                    and CIDRs that Felix will allow outgoing traffic from host endpoints
-                    to irrespective of the security policy. This is useful to avoid
-                    accidentally cutting off a host with incorrect configuration. For
-                    back-compatibility, if the protocol is not specified, it defaults
-                    to "tcp". If a CIDR is not specified, it will allow traffic from
-                    all addresses. To disable all outbound host ports, use the value
-                    none. The default value opens etcd''s standard ports to ensure that
-                    Felix does not get cut off from etcd as well as allowing DHCP and
-                    DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
-                    tcp:6667, udp:53, udp:67]'
-                  items:
-                    description: ProtoPort is combination of protocol, port, and CIDR.
-                      Protocol and port must be specified.
-                    properties:
-                      net:
-                        type: string
-                      port:
-                        type: integer
-                      protocol:
-                        type: string
-                    required:
-                      - port
-                      - protocol
-                    type: object
-                  type: array
-                featureDetectOverride:
-                  description: FeatureDetectOverride is used to override the feature
-                    detection. Values are specified in a comma separated list with no
-                    spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
-                    "true" or "false" will force the feature, empty or omitted values
-                    are auto-detected.
-                  type: string
-                genericXDPEnabled:
-                  description: 'GenericXDPEnabled enables Generic XDP so network cards
-                  that don''t support XDP offload or driver modes can use XDP. This
-                  is not recommended since it doesn''t provide better performance
-                  than iptables. [Default: false]'
-                  type: boolean
-                healthEnabled:
-                  type: boolean
-                healthHost:
-                  type: string
-                healthPort:
-                  type: integer
-                interfaceExclude:
-                  description: 'InterfaceExclude is a comma-separated list of interfaces
-                  that Felix should exclude when monitoring for host endpoints. The
-                  default value ensures that Felix ignores Kubernetes'' IPVS dummy
-                  interface, which is used internally by kube-proxy. If you want to
-                  exclude multiple interface names using a single value, the list
-                  supports regular expressions. For regular expressions you must wrap
-                  the value with ''/''. For example having values ''/^kube/,veth1''
-                  will exclude all interfaces that begin with ''kube'' and also the
-                  interface ''veth1''. [Default: kube-ipvs0]'
-                  type: string
-                interfacePrefix:
-                  description: 'InterfacePrefix is the interface name prefix that identifies
-                  workload endpoints and so distinguishes them from host endpoint
-                  interfaces. Note: in environments other than bare metal, the orchestrators
-                  configure this appropriately. For example our Kubernetes and Docker
-                  integrations set the ‘cali’ value, and our OpenStack integration
-                  sets the ‘tap’ value. [Default: cali]'
-                  type: string
-                interfaceRefreshInterval:
-                  description: InterfaceRefreshInterval is the period at which Felix
-                    rescans local interfaces to verify their state. The rescan can be
-                    disabled by setting the interval to 0.
-                  type: string
-                ipipEnabled:
-                  type: boolean
-                ipipMTU:
-                  description: 'IPIPMTU is the MTU to set on the tunnel device. See
-                  Configuring MTU [Default: 1440]'
-                  type: integer
-                ipsetsRefreshInterval:
-                  description: 'IpsetsRefreshInterval is the period at which Felix re-checks
-                  all iptables state to ensure that no other process has accidentally
-                  broken Calico’s rules. Set to 0 to disable iptables refresh. [Default:
-                  90s]'
-                  type: string
-                iptablesBackend:
-                  description: IptablesBackend specifies which backend of iptables will
-                    be used. The default is legacy.
-                  type: string
-                iptablesFilterAllowAction:
-                  type: string
-                iptablesLockFilePath:
-                  description: 'IptablesLockFilePath is the location of the iptables
-                  lock file. You may need to change this if the lock file is not in
-                  its standard location (for example if you have mapped it into Felix’s
-                  container at a different path). [Default: /run/xtables.lock]'
-                  type: string
-                iptablesLockProbeInterval:
-                  description: 'IptablesLockProbeInterval is the time that Felix will
-                  wait between attempts to acquire the iptables lock if it is not
-                  available. Lower values make Felix more responsive when the lock
-                  is contended, but use more CPU. [Default: 50ms]'
-                  type: string
-                iptablesLockTimeout:
-                  description: 'IptablesLockTimeout is the time that Felix will wait
-                  for the iptables lock, or 0, to disable. To use this feature, Felix
-                  must share the iptables lock file with all other processes that
-                  also take the lock. When running Felix inside a container, this
-                  requires the /run directory of the host to be mounted into the calico/node
-                  or calico/felix container. [Default: 0s disabled]'
-                  type: string
-                iptablesMangleAllowAction:
-                  type: string
-                iptablesMarkMask:
-                  description: 'IptablesMarkMask is the mask that Felix selects its
-                  IPTables Mark bits from. Should be a 32 bit hexadecimal number with
-                  at least 8 bits set, none of which clash with any other mark bits
-                  in use on the system. [Default: 0xff000000]'
-                  format: int32
-                  type: integer
-                iptablesNATOutgoingInterfaceFilter:
-                  type: string
-                iptablesPostWriteCheckInterval:
-                  description: 'IptablesPostWriteCheckInterval is the period after Felix
-                  has done a write to the dataplane that it schedules an extra read
-                  back in order to check the write was not clobbered by another process.
-                  This should only occur if another application on the system doesn’t
-                  respect the iptables lock. [Default: 1s]'
-                  type: string
-                iptablesRefreshInterval:
-                  description: 'IptablesRefreshInterval is the period at which Felix
-                    re-checks the IP sets in the dataplane to ensure that no other process
-                    has accidentally broken Calico''s rules. Set to 0 to disable IP
-                    sets refresh. Note: the default for this value is lower than the
-                    other refresh intervals as a workaround for a Linux kernel bug that
-                    was fixed in kernel version 4.11. If you are using v4.11 or greater
-                    you may want to set this to, a higher value to reduce Felix CPU
-                    usage. [Default: 10s]'
-                  type: string
-                ipv6Support:
-                  type: boolean
-                kubeNodePortRanges:
-                  description: 'KubeNodePortRanges holds list of port ranges used for
-                  service node ports. Only used if felix detects kube-proxy running
-                  in ipvs mode. Felix uses these ranges to separate host and workload
-                  traffic. [Default: 30000:32767].'
-                  items:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    pattern: ^.*
-                    x-kubernetes-int-or-string: true
-                  type: array
-                logFilePath:
-                  description: 'LogFilePath is the full path to the Felix log. Set to
-                  none to disable file logging. [Default: /var/log/calico/felix.log]'
-                  type: string
-                logPrefix:
-                  description: 'LogPrefix is the log prefix that Felix uses when rendering
-                  LOG rules. [Default: calico-packet]'
-                  type: string
-                logSeverityFile:
-                  description: 'LogSeverityFile is the log severity above which logs
-                  are sent to the log file. [Default: Info]'
-                  type: string
-                logSeverityScreen:
-                  description: 'LogSeverityScreen is the log severity above which logs
-                  are sent to the stdout. [Default: Info]'
-                  type: string
-                logSeveritySys:
-                  description: 'LogSeveritySys is the log severity above which logs
-                  are sent to the syslog. Set to None for no logging to syslog. [Default:
-                  Info]'
-                  type: string
-                maxIpsetSize:
-                  type: integer
-                metadataAddr:
-                  description: 'MetadataAddr is the IP address or domain name of the
-                  server that can answer VM queries for cloud-init metadata. In OpenStack,
-                  this corresponds to the machine running nova-api (or in Ubuntu,
-                  nova-api-metadata). A value of none (case insensitive) means that
-                  Felix should not set up any NAT rule for the metadata path. [Default:
-                  127.0.0.1]'
-                  type: string
-                metadataPort:
-                  description: 'MetadataPort is the port of the metadata server. This,
-                  combined with global.MetadataAddr (if not ‘None’), is used to set
-                  up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
-                  In most cases this should not need to be changed [Default: 8775].'
-                  type: integer
-                mtuIfacePattern:
-                  description: MTUIfacePattern is a regular expression that controls
-                    which interfaces Felix should scan in order to calculate the host's
-                    MTU. This should not match workload interfaces (usually named cali...).
-                  type: string
-                natOutgoingAddress:
-                  description: NATOutgoingAddress specifies an address to use when performing
-                    source NAT for traffic in a natOutgoing pool that is leaving the
-                    network. By default the address used is an address on the interface
-                    the traffic is leaving on (ie it uses the iptables MASQUERADE target)
-                  type: string
-                natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
-                  description: NATPortRange specifies the range of ports that is used
-                    for port mapping when doing outgoing NAT. When unset the default
-                    behavior of the network stack is used.
-                  pattern: ^.*
-                  x-kubernetes-int-or-string: true
-                netlinkTimeout:
-                  type: string
-                openstackRegion:
-                  description: 'OpenstackRegion is the name of the region that a particular
-                  Felix belongs to. In a multi-region Calico/OpenStack deployment,
-                  this must be configured somehow for each Felix (here in the datamodel,
-                  or in felix.cfg or the environment on each compute node), and must
-                  match the [calico] openstack_region value configured in neutron.conf
-                  on each node. [Default: Empty]'
-                  type: string
-                policySyncPathPrefix:
-                  description: 'PolicySyncPathPrefix is used to by Felix to communicate
-                  policy changes to external services, like Application layer policy.
-                  [Default: Empty]'
-                  type: string
-                prometheusGoMetricsEnabled:
-                  description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
-                  collection, which the Prometheus client does by default, when set
-                  to false. This reduces the number of metrics reported, reducing
-                  Prometheus load. [Default: true]'
-                  type: boolean
-                prometheusMetricsEnabled:
-                  description: 'PrometheusMetricsEnabled enables the Prometheus metrics
-                  server in Felix if set to true. [Default: false]'
-                  type: boolean
-                prometheusMetricsHost:
-                  description: 'PrometheusMetricsHost is the host that the Prometheus
-                  metrics server should bind to. [Default: empty]'
-                  type: string
-                prometheusMetricsPort:
-                  description: 'PrometheusMetricsPort is the TCP port that the Prometheus
-                  metrics server should bind to. [Default: 9091]'
-                  type: integer
-                prometheusProcessMetricsEnabled:
-                  description: 'PrometheusProcessMetricsEnabled disables process metrics
-                  collection, which the Prometheus client does by default, when set
-                  to false. This reduces the number of metrics reported, reducing
-                  Prometheus load. [Default: true]'
-                  type: boolean
-                removeExternalRoutes:
-                  description: Whether or not to remove device routes that have not
-                    been programmed by Felix. Disabling this will allow external applications
-                    to also add device routes. This is enabled by default which means
-                    we will remove externally added routes.
-                  type: boolean
-                reportingInterval:
-                  description: 'ReportingInterval is the interval at which Felix reports
-                  its status into the datastore or 0 to disable. Must be non-zero
-                  in OpenStack deployments. [Default: 30s]'
-                  type: string
-                reportingTTL:
-                  description: 'ReportingTTL is the time-to-live setting for process-wide
-                  status reports. [Default: 90s]'
-                  type: string
-                routeRefreshInterval:
-                  description: 'RouterefreshInterval is the period at which Felix re-checks
-                  the routes in the dataplane to ensure that no other process has
-                  accidentally broken Calico’s rules. Set to 0 to disable route refresh.
-                  [Default: 90s]'
-                  type: string
-                routeSource:
-                  description: 'RouteSource configures where Felix gets its routing
-                  information. - WorkloadIPs: use workload endpoints to construct
-                  routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
-                  type: string
-                routeTableRange:
-                  description: Calico programs additional Linux route tables for various
-                    purposes.  RouteTableRange specifies the indices of the route tables
-                    that Calico should use.
-                  properties:
-                    max:
-                      type: integer
-                    min:
-                      type: integer
-                  required:
-                    - max
-                    - min
-                  type: object
-                serviceLoopPrevention:
-                  description: 'When service IP advertisement is enabled, prevent routing
-                    loops to service IPs that are not in use, by dropping or rejecting
-                    packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
-                    in which case such routing loops continue to be allowed. [Default:
-                    Drop]'
-                  type: string
-                sidecarAccelerationEnabled:
-                  description: 'SidecarAccelerationEnabled enables experimental sidecar
-                  acceleration [Default: false]'
-                  type: boolean
-                usageReportingEnabled:
-                  description: 'UsageReportingEnabled reports anonymous Calico version
-                  number and cluster size to projectcalico.org. Logs warnings returned
-                  by the usage server. For example, if a significant security vulnerability
-                  has been discovered in the version of Calico being used. [Default:
-                  true]'
-                  type: boolean
-                usageReportingInitialDelay:
-                  description: 'UsageReportingInitialDelay controls the minimum delay
-                  before Felix makes a report. [Default: 300s]'
-                  type: string
-                usageReportingInterval:
-                  description: 'UsageReportingInterval controls the interval at which
-                  Felix makes reports. [Default: 86400s]'
-                  type: string
-                useInternalDataplaneDriver:
-                  type: boolean
-                vxlanEnabled:
-                  type: boolean
-                vxlanMTU:
-                  description: 'VXLANMTU is the MTU to set on the tunnel device. See
-                  Configuring MTU [Default: 1440]'
-                  type: integer
-                vxlanPort:
-                  type: integer
-                vxlanVNI:
-                  type: integer
-                wireguardEnabled:
-                  description: 'WireguardEnabled controls whether Wireguard is enabled.
-                  [Default: false]'
-                  type: boolean
-                wireguardInterfaceName:
-                  description: 'WireguardInterfaceName specifies the name to use for
-                  the Wireguard interface. [Default: wg.calico]'
-                  type: string
-                wireguardListeningPort:
-                  description: 'WireguardListeningPort controls the listening port used
-                  by Wireguard. [Default: 51820]'
-                  type: integer
-                wireguardMTU:
-                  description: 'WireguardMTU controls the MTU on the Wireguard interface.
-                  See Configuring MTU [Default: 1420]'
-                  type: integer
-                wireguardRoutingRulePriority:
-                  description: 'WireguardRoutingRulePriority controls the priority value
-                  to use for the Wireguard routing rule. [Default: 99]'
-                  type: integer
-                xdpEnabled:
-                  description: 'XDPEnabled enables XDP acceleration for suitable untracked
-                  incoming deny rules. [Default: true]'
-                  type: boolean
-                xdpRefreshInterval:
-                  description: 'XDPRefreshInterval is the period at which Felix re-checks
-                  all XDP state to ensure that no other process has accidentally broken
-                  Calico''s BPF maps or attached programs. Set to 0 to disable XDP
-                  refresh. [Default: 90s]'
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: globalnetworkpolicies.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: GlobalNetworkPolicy
-    listKind: GlobalNetworkPolicyList
-    plural: globalnetworkpolicies
-    singular: globalnetworkpolicy
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                applyOnForward:
-                  description: ApplyOnForward indicates to apply the rules in this policy
-                    on forward traffic.
-                  type: boolean
-                doNotTrack:
-                  description: DoNotTrack indicates whether packets matched by the rules
-                    in this policy should go through the data plane's connection tracking,
-                    such as Linux conntrack.  If True, the rules in this policy are
-                    applied before any data plane connection tracking, and packets allowed
-                    by this policy are marked as not to be tracked.
-                  type: boolean
-                egress:
-                  description: The ordered set of egress rules.  Each rule contains
-                    a set of packet match criteria and a corresponding action to apply.
-                  items:
-                    description: "A Rule encapsulates a set of match criteria and an
-                    action.  Both selector-based security Policy and security Profiles
-                    reference rules - separated out as a list of rules for both ingress
-                    and egress packet matching. \n Each positive match criteria has
-                    a negated version, prefixed with ”Not”. All the match criteria
-                    within a rule must be satisfied for a packet to match. A single
-                    rule can contain the positive and negative version of a match
-                    and both must be satisfied for the rule to match."
-                    properties:
-                      action:
-                        type: string
-                      destination:
-                        description: Destination contains the match criteria that apply
-                          to destination entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                      http:
-                        description: HTTP contains match criteria that apply to HTTP
-                          requests.
-                        properties:
-                          methods:
-                            description: Methods is an optional field that restricts
-                              the rule to apply only to HTTP requests that use one of
-                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                              methods are OR'd together.
-                            items:
-                              type: string
-                            type: array
-                          paths:
-                            description: 'Paths is an optional field that restricts
-                            the rule to apply to HTTP requests that use one of the
-                            listed HTTP Paths. Multiple paths are OR''d together.
-                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                            ONLY specify either a `exact` or a `prefix` match. The
-                            validator will check for it.'
-                            items:
-                              description: 'HTTPPath specifies an HTTP path to match.
-                              It may be either of the form: exact: <path>: which matches
-                              the path exactly or prefix: <path-prefix>: which matches
-                              the path prefix'
-                              properties:
-                                exact:
-                                  type: string
-                                prefix:
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      icmp:
-                        description: ICMP is an optional field that restricts the rule
-                          to apply to a specific type and code of ICMP traffic.  This
-                          should only be specified if the Protocol field is set to "ICMP"
-                          or "ICMPv6".
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      ipVersion:
-                        description: IPVersion is an optional field that restricts the
-                          rule to only match a specific IP version.
-                        type: integer
-                      metadata:
-                        description: Metadata contains additional information for this
-                          rule
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations is a set of key value pairs that
-                              give extra information about the rule
-                            type: object
-                        type: object
-                      notICMP:
-                        description: NotICMP is the negated version of the ICMP field.
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: NotProtocol is the negated version of the Protocol
-                          field.
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: "Protocol is an optional field that restricts the
-                        rule to only apply to traffic of a specific IP protocol. Required
-                        if any of the EntityRules contain Ports (because ports only
-                        apply to certain protocols). \n Must be one of these string
-                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                        \"UDPLite\" or an integer in the range 1-255."
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      source:
-                        description: Source contains the match criteria that apply to
-                          source entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                    required:
-                      - action
-                    type: object
-                  type: array
-                ingress:
-                  description: The ordered set of ingress rules.  Each rule contains
-                    a set of packet match criteria and a corresponding action to apply.
-                  items:
-                    description: "A Rule encapsulates a set of match criteria and an
-                    action.  Both selector-based security Policy and security Profiles
-                    reference rules - separated out as a list of rules for both ingress
-                    and egress packet matching. \n Each positive match criteria has
-                    a negated version, prefixed with ”Not”. All the match criteria
-                    within a rule must be satisfied for a packet to match. A single
-                    rule can contain the positive and negative version of a match
-                    and both must be satisfied for the rule to match."
-                    properties:
-                      action:
-                        type: string
-                      destination:
-                        description: Destination contains the match criteria that apply
-                          to destination entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                      http:
-                        description: HTTP contains match criteria that apply to HTTP
-                          requests.
-                        properties:
-                          methods:
-                            description: Methods is an optional field that restricts
-                              the rule to apply only to HTTP requests that use one of
-                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                              methods are OR'd together.
-                            items:
-                              type: string
-                            type: array
-                          paths:
-                            description: 'Paths is an optional field that restricts
-                            the rule to apply to HTTP requests that use one of the
-                            listed HTTP Paths. Multiple paths are OR''d together.
-                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                            ONLY specify either a `exact` or a `prefix` match. The
-                            validator will check for it.'
-                            items:
-                              description: 'HTTPPath specifies an HTTP path to match.
-                              It may be either of the form: exact: <path>: which matches
-                              the path exactly or prefix: <path-prefix>: which matches
-                              the path prefix'
-                              properties:
-                                exact:
-                                  type: string
-                                prefix:
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      icmp:
-                        description: ICMP is an optional field that restricts the rule
-                          to apply to a specific type and code of ICMP traffic.  This
-                          should only be specified if the Protocol field is set to "ICMP"
-                          or "ICMPv6".
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      ipVersion:
-                        description: IPVersion is an optional field that restricts the
-                          rule to only match a specific IP version.
-                        type: integer
-                      metadata:
-                        description: Metadata contains additional information for this
-                          rule
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations is a set of key value pairs that
-                              give extra information about the rule
-                            type: object
-                        type: object
-                      notICMP:
-                        description: NotICMP is the negated version of the ICMP field.
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: NotProtocol is the negated version of the Protocol
-                          field.
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: "Protocol is an optional field that restricts the
-                        rule to only apply to traffic of a specific IP protocol. Required
-                        if any of the EntityRules contain Ports (because ports only
-                        apply to certain protocols). \n Must be one of these string
-                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                        \"UDPLite\" or an integer in the range 1-255."
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      source:
-                        description: Source contains the match criteria that apply to
-                          source entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                    required:
-                      - action
-                    type: object
-                  type: array
-                namespaceSelector:
-                  description: NamespaceSelector is an optional field for an expression
-                    used to select a pod based on namespaces.
-                  type: string
-                order:
-                  description: Order is an optional field that specifies the order in
-                    which the policy is applied. Policies with higher "order" are applied
-                    after those with lower order.  If the order is omitted, it may be
-                    considered to be "infinite" - i.e. the policy will be applied last.  Policies
-                    with identical order will be applied in alphanumerical order based
-                    on the Policy "Name".
-                  type: number
-                preDNAT:
-                  description: PreDNAT indicates to apply the rules in this policy before
-                    any DNAT.
-                  type: boolean
-                selector:
-                  description: "The selector is an expression used to pick pick out
-                  the endpoints that the policy should be applied to. \n Selector
-                  expressions follow this syntax: \n \tlabel == \"string_literal\"
-                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
-                  \  ->  not equal; also matches if label is not present \tlabel in
-                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
-                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
-                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
-                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
-                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
-                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
-                  or the empty selector -> matches all endpoints. \n Label names are
-                  allowed to contain alphanumerics, -, _ and /. String literals are
-                  more permissive but they do not support escape characters. \n Examples
-                  (with made-up labels): \n \ttype == \"webserver\" && deployment
-                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
-                  \"dev\" \t! has(label_name)"
-                  type: string
-                serviceAccountSelector:
-                  description: ServiceAccountSelector is an optional field for an expression
-                    used to select a pod based on service accounts.
-                  type: string
-                types:
-                  description: "Types indicates whether this policy applies to ingress,
-                  or to egress, or to both.  When not explicitly specified (and so
-                  the value on creation is empty or nil), Calico defaults Types according
-                  to what Ingress and Egress rules are present in the policy.  The
-                  default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
-                  (including the case where there are   also no Ingress rules) \n
-                  - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
-                  rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
-                  both Ingress and Egress rules. \n When the policy is read back again,
-                  Types will always be one of these values, never empty or nil."
-                  items:
-                    description: PolicyType enumerates the possible values of the PolicySpec
-                      Types field.
-                    type: string
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: globalnetworksets.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: GlobalNetworkSet
-    listKind: GlobalNetworkSetList
-    plural: globalnetworksets
-    singular: globalnetworkset
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
-            that share labels to allow rules to refer to them via selectors.  The labels
-            of GlobalNetworkSet are not namespaced.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: GlobalNetworkSetSpec contains the specification for a NetworkSet
-                resource.
-              properties:
-                nets:
-                  description: The list of IP networks that belong to this set.
-                  items:
-                    type: string
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: hostendpoints.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: HostEndpoint
-    listKind: HostEndpointList
-    plural: hostendpoints
-    singular: hostendpoint
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: HostEndpointSpec contains the specification for a HostEndpoint
-                resource.
-              properties:
-                expectedIPs:
-                  description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
-                  If \"InterfaceName\" is not present, Calico will look for an interface
-                  matching any of the IPs in the list and apply policy to that. Note:
-                  \tWhen using the selector match criteria in an ingress or egress
-                  security Policy \tor Profile, Calico converts the selector into
-                  a set of IP addresses. For host \tendpoints, the ExpectedIPs field
-                  is used for that purpose. (If only the interface \tname is specified,
-                  Calico does not learn the IPs of the interface for use in match
-                  \tcriteria.)"
-                  items:
-                    type: string
-                  type: array
-                interfaceName:
-                  description: "Either \"*\", or the name of a specific Linux interface
-                  to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
-                  governs all traffic to, from or through the default network namespace
-                  of the host named by the \"Node\" field; entering and leaving that
-                  namespace via any interface, including those from/to non-host-networked
-                  local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
-                  only governs traffic that enters or leaves the host through the
-                  specific interface named by InterfaceName, or - when InterfaceName
-                  is empty - through the specific interface that has one of the IPs
-                  in ExpectedIPs. Therefore, when InterfaceName is empty, at least
-                  one expected IP must be specified.  Only external interfaces (such
-                  as “eth0”) are supported here; it isn't possible for a HostEndpoint
-                  to protect traffic through a specific local workload interface.
-                  \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
-                  initially just pre-DNAT policy.  Please check Calico documentation
-                  for the latest position."
-                  type: string
-                node:
-                  description: The node name identifying the Calico node instance.
-                  type: string
-                ports:
-                  description: Ports contains the endpoint's named ports, which may
-                    be referenced in security policy rules.
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      port:
-                        type: integer
-                      protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                    required:
-                      - name
-                      - port
-                      - protocol
-                    type: object
-                  type: array
-                profiles:
-                  description: A list of identifiers of security Profile objects that
-                    apply to this endpoint. Each profile is applied in the order that
-                    they appear in this list.  Profile rules are applied after the selector-based
-                    security policy.
-                  items:
-                    type: string
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: ipamblocks.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: IPAMBlock
-    listKind: IPAMBlockList
-    plural: ipamblocks
-    singular: ipamblock
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: IPAMBlockSpec contains the specification for an IPAMBlock
-                resource.
-              properties:
-                affinity:
-                  type: string
-                allocations:
-                  items:
-                    type: integer
-                    # TODO: This nullable is manually added in. We should update controller-gen
-                    # to handle []*int properly itself.
-                    nullable: true
-                  type: array
-                attributes:
-                  items:
-                    properties:
-                      handle_id:
-                        type: string
-                      secondary:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
-                  type: array
-                cidr:
-                  type: string
-                deleted:
-                  type: boolean
-                strictAffinity:
-                  type: boolean
-                unallocated:
-                  items:
-                    type: integer
-                  type: array
-              required:
-                - allocations
-                - attributes
-                - cidr
-                - strictAffinity
-                - unallocated
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: ipamconfigs.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: IPAMConfig
-    listKind: IPAMConfigList
-    plural: ipamconfigs
-    singular: ipamconfig
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: IPAMConfigSpec contains the specification for an IPAMConfig
-                resource.
-              properties:
-                autoAllocateBlocks:
-                  type: boolean
-                maxBlocksPerHost:
-                  description: MaxBlocksPerHost, if non-zero, is the max number of blocks
-                    that can be affine to each host.
-                  type: integer
-                strictAffinity:
-                  type: boolean
-              required:
-                - autoAllocateBlocks
-                - strictAffinity
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: ipamhandles.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: IPAMHandle
-    listKind: IPAMHandleList
-    plural: ipamhandles
-    singular: ipamhandle
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: IPAMHandleSpec contains the specification for an IPAMHandle
-                resource.
-              properties:
-                block:
-                  additionalProperties:
-                    type: integer
-                  type: object
-                deleted:
-                  type: boolean
-                handleID:
-                  type: string
-              required:
-                - block
-                - handleID
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: ippools.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: IPPool
-    listKind: IPPoolList
-    plural: ippools
-    singular: ippool
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: IPPoolSpec contains the specification for an IPPool resource.
-              properties:
-                blockSize:
-                  description: The block size to use for IP address assignments from
-                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.
-                  type: integer
-                cidr:
-                  description: The pool CIDR.
-                  type: string
-                disabled:
-                  description: When disabled is true, Calico IPAM will not assign addresses
-                    from this pool.
-                  type: boolean
-                ipip:
-                  description: 'Deprecated: this field is only used for APIv1 backwards
-                  compatibility. Setting this field is not allowed, this field is
-                  for internal use only.'
-                  properties:
-                    enabled:
-                      description: When enabled is true, ipip tunneling will be used
-                        to deliver packets to destinations within this pool.
-                      type: boolean
-                    mode:
-                      description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
-                        mode of "always" will also use IPIP tunneling for routing to
-                        destination IP addresses within this pool.  A mode of "cross-subnet"
-                        will only use IPIP tunneling when the destination node is on
-                        a different subnet to the originating node.  The default value
-                        (if not specified) is "always".
-                      type: string
-                  type: object
-                ipipMode:
-                  description: Contains configuration for IPIP tunneling for this pool.
-                    If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
-                    is disabled).
-                  type: string
-                nat-outgoing:
-                  description: 'Deprecated: this field is only used for APIv1 backwards
-                  compatibility. Setting this field is not allowed, this field is
-                  for internal use only.'
-                  type: boolean
-                natOutgoing:
-                  description: When nat-outgoing is true, packets sent from Calico networked
-                    containers in this pool to destinations outside of this pool will
-                    be masqueraded.
-                  type: boolean
-                nodeSelector:
-                  description: Allows IPPool to allocate for a specific node by label
-                    selector.
-                  type: string
-                vxlanMode:
-                  description: Contains configuration for VXLAN tunneling for this pool.
-                    If not specified, then this is defaulted to "Never" (i.e. VXLAN
-                    tunneling is disabled).
-                  type: string
-              required:
-                - cidr
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: kubecontrollersconfigurations.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: KubeControllersConfiguration
-    listKind: KubeControllersConfigurationList
-    plural: kubecontrollersconfigurations
-    singular: kubecontrollersconfiguration
-  scope: Cluster
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KubeControllersConfigurationSpec contains the values of the
-                Kubernetes controllers configuration.
-              properties:
-                controllers:
-                  description: Controllers enables and configures individual Kubernetes
-                    controllers
-                  properties:
-                    namespace:
-                      description: Namespace enables and configures the namespace controller.
-                        Enabled by default, set to nil to disable.
-                      properties:
-                        reconcilerPeriod:
-                          description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                          type: string
-                      type: object
-                    node:
-                      description: Node enables and configures the node controller.
-                        Enabled by default, set to nil to disable.
-                      properties:
-                        hostEndpoint:
-                          description: HostEndpoint controls syncing nodes to host endpoints.
-                            Disabled by default, set to nil to disable.
-                          properties:
-                            autoCreate:
-                              description: 'AutoCreate enables automatic creation of
-                              host endpoints for every node. [Default: Disabled]'
-                              type: string
-                          type: object
-                        reconcilerPeriod:
-                          description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                          type: string
-                        syncLabels:
-                          description: 'SyncLabels controls whether to copy Kubernetes
-                          node labels to Calico nodes. [Default: Enabled]'
-                          type: string
-                      type: object
-                    policy:
-                      description: Policy enables and configures the policy controller.
-                        Enabled by default, set to nil to disable.
-                      properties:
-                        reconcilerPeriod:
-                          description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                          type: string
-                      type: object
-                    serviceAccount:
-                      description: ServiceAccount enables and configures the service
-                        account controller. Enabled by default, set to nil to disable.
-                      properties:
-                        reconcilerPeriod:
-                          description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                          type: string
-                      type: object
-                    workloadEndpoint:
-                      description: WorkloadEndpoint enables and configures the workload
-                        endpoint controller. Enabled by default, set to nil to disable.
-                      properties:
-                        reconcilerPeriod:
-                          description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                          type: string
-                      type: object
-                  type: object
-                etcdV3CompactionPeriod:
-                  description: 'EtcdV3CompactionPeriod is the period between etcdv3
-                  compaction requests. Set to 0 to disable. [Default: 10m]'
-                  type: string
-                healthChecks:
-                  description: 'HealthChecks enables or disables support for health
-                  checks [Default: Enabled]'
-                  type: string
-                logSeverityScreen:
-                  description: 'LogSeverityScreen is the log severity above which logs
-                  are sent to the stdout. [Default: Info]'
-                  type: string
-                prometheusMetricsPort:
-                  description: 'PrometheusMetricsPort is the TCP port that the Prometheus
-                    metrics server should bind to. Set to 0 to disable. [Default: 9094]'
-                  type: integer
-              required:
-                - controllers
-              type: object
-            status:
-              description: KubeControllersConfigurationStatus represents the status
-                of the configuration. It's useful for admins to be able to see the actual
-                config that was applied, which can be modified by environment variables
-                on the kube-controllers process.
-              properties:
-                environmentVars:
-                  additionalProperties:
-                    type: string
-                  description: EnvironmentVars contains the environment variables on
-                    the kube-controllers that influenced the RunningConfig.
-                  type: object
-                runningConfig:
-                  description: RunningConfig contains the effective config that is running
-                    in the kube-controllers pod, after merging the API resource with
-                    any environment variables.
-                  properties:
-                    controllers:
-                      description: Controllers enables and configures individual Kubernetes
-                        controllers
-                      properties:
-                        namespace:
-                          description: Namespace enables and configures the namespace
-                            controller. Enabled by default, set to nil to disable.
-                          properties:
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                              type: string
-                          type: object
-                        node:
-                          description: Node enables and configures the node controller.
-                            Enabled by default, set to nil to disable.
-                          properties:
-                            hostEndpoint:
-                              description: HostEndpoint controls syncing nodes to host
-                                endpoints. Disabled by default, set to nil to disable.
-                              properties:
-                                autoCreate:
-                                  description: 'AutoCreate enables automatic creation
-                                  of host endpoints for every node. [Default: Disabled]'
-                                  type: string
-                              type: object
-                            leakGracePeriod:
-                              description: 'LeakGracePeriod is the period used by the
-                                controller to determine if an IP address has been leaked.
-                                Set to 0 to disable IP garbage collection. [Default:
-                                15m]'
-                              type: string
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                              type: string
-                            syncLabels:
-                              description: 'SyncLabels controls whether to copy Kubernetes
-                              node labels to Calico nodes. [Default: Enabled]'
-                              type: string
-                          type: object
-                        policy:
-                          description: Policy enables and configures the policy controller.
-                            Enabled by default, set to nil to disable.
-                          properties:
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                              type: string
-                          type: object
-                        serviceAccount:
-                          description: ServiceAccount enables and configures the service
-                            account controller. Enabled by default, set to nil to disable.
-                          properties:
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                              type: string
-                          type: object
-                        workloadEndpoint:
-                          description: WorkloadEndpoint enables and configures the workload
-                            endpoint controller. Enabled by default, set to nil to disable.
-                          properties:
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                              type: string
-                          type: object
-                      type: object
-                    etcdV3CompactionPeriod:
-                      description: 'EtcdV3CompactionPeriod is the period between etcdv3
-                      compaction requests. Set to 0 to disable. [Default: 10m]'
-                      type: string
-                    healthChecks:
-                      description: 'HealthChecks enables or disables support for health
-                      checks [Default: Enabled]'
-                      type: string
-                    logSeverityScreen:
-                      description: 'LogSeverityScreen is the log severity above which
-                      logs are sent to the stdout. [Default: Info]'
-                      type: string
-                    prometheusMetricsPort:
-                      description: 'PrometheusMetricsPort is the TCP port that the Prometheus
-                        metrics server should bind to. Set to 0 to disable. [Default:
-                        9094]'
-                      type: integer
-                  required:
-                    - controllers
-                  type: object
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: networkpolicies.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: NetworkPolicy
-    listKind: NetworkPolicyList
-    plural: networkpolicies
-    singular: networkpolicy
-  scope: Namespaced
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                egress:
-                  description: The ordered set of egress rules.  Each rule contains
-                    a set of packet match criteria and a corresponding action to apply.
-                  items:
-                    description: "A Rule encapsulates a set of match criteria and an
-                    action.  Both selector-based security Policy and security Profiles
-                    reference rules - separated out as a list of rules for both ingress
-                    and egress packet matching. \n Each positive match criteria has
-                    a negated version, prefixed with ”Not”. All the match criteria
-                    within a rule must be satisfied for a packet to match. A single
-                    rule can contain the positive and negative version of a match
-                    and both must be satisfied for the rule to match."
-                    properties:
-                      action:
-                        type: string
-                      destination:
-                        description: Destination contains the match criteria that apply
-                          to destination entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                      http:
-                        description: HTTP contains match criteria that apply to HTTP
-                          requests.
-                        properties:
-                          methods:
-                            description: Methods is an optional field that restricts
-                              the rule to apply only to HTTP requests that use one of
-                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                              methods are OR'd together.
-                            items:
-                              type: string
-                            type: array
-                          paths:
-                            description: 'Paths is an optional field that restricts
-                            the rule to apply to HTTP requests that use one of the
-                            listed HTTP Paths. Multiple paths are OR''d together.
-                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                            ONLY specify either a `exact` or a `prefix` match. The
-                            validator will check for it.'
-                            items:
-                              description: 'HTTPPath specifies an HTTP path to match.
-                              It may be either of the form: exact: <path>: which matches
-                              the path exactly or prefix: <path-prefix>: which matches
-                              the path prefix'
-                              properties:
-                                exact:
-                                  type: string
-                                prefix:
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      icmp:
-                        description: ICMP is an optional field that restricts the rule
-                          to apply to a specific type and code of ICMP traffic.  This
-                          should only be specified if the Protocol field is set to "ICMP"
-                          or "ICMPv6".
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      ipVersion:
-                        description: IPVersion is an optional field that restricts the
-                          rule to only match a specific IP version.
-                        type: integer
-                      metadata:
-                        description: Metadata contains additional information for this
-                          rule
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations is a set of key value pairs that
-                              give extra information about the rule
-                            type: object
-                        type: object
-                      notICMP:
-                        description: NotICMP is the negated version of the ICMP field.
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: NotProtocol is the negated version of the Protocol
-                          field.
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: "Protocol is an optional field that restricts the
-                        rule to only apply to traffic of a specific IP protocol. Required
-                        if any of the EntityRules contain Ports (because ports only
-                        apply to certain protocols). \n Must be one of these string
-                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                        \"UDPLite\" or an integer in the range 1-255."
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      source:
-                        description: Source contains the match criteria that apply to
-                          source entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                    required:
-                      - action
-                    type: object
-                  type: array
-                ingress:
-                  description: The ordered set of ingress rules.  Each rule contains
-                    a set of packet match criteria and a corresponding action to apply.
-                  items:
-                    description: "A Rule encapsulates a set of match criteria and an
-                    action.  Both selector-based security Policy and security Profiles
-                    reference rules - separated out as a list of rules for both ingress
-                    and egress packet matching. \n Each positive match criteria has
-                    a negated version, prefixed with ”Not”. All the match criteria
-                    within a rule must be satisfied for a packet to match. A single
-                    rule can contain the positive and negative version of a match
-                    and both must be satisfied for the rule to match."
-                    properties:
-                      action:
-                        type: string
-                      destination:
-                        description: Destination contains the match criteria that apply
-                          to destination entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                      http:
-                        description: HTTP contains match criteria that apply to HTTP
-                          requests.
-                        properties:
-                          methods:
-                            description: Methods is an optional field that restricts
-                              the rule to apply only to HTTP requests that use one of
-                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                              methods are OR'd together.
-                            items:
-                              type: string
-                            type: array
-                          paths:
-                            description: 'Paths is an optional field that restricts
-                            the rule to apply to HTTP requests that use one of the
-                            listed HTTP Paths. Multiple paths are OR''d together.
-                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                            ONLY specify either a `exact` or a `prefix` match. The
-                            validator will check for it.'
-                            items:
-                              description: 'HTTPPath specifies an HTTP path to match.
-                              It may be either of the form: exact: <path>: which matches
-                              the path exactly or prefix: <path-prefix>: which matches
-                              the path prefix'
-                              properties:
-                                exact:
-                                  type: string
-                                prefix:
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      icmp:
-                        description: ICMP is an optional field that restricts the rule
-                          to apply to a specific type and code of ICMP traffic.  This
-                          should only be specified if the Protocol field is set to "ICMP"
-                          or "ICMPv6".
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      ipVersion:
-                        description: IPVersion is an optional field that restricts the
-                          rule to only match a specific IP version.
-                        type: integer
-                      metadata:
-                        description: Metadata contains additional information for this
-                          rule
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations is a set of key value pairs that
-                              give extra information about the rule
-                            type: object
-                        type: object
-                      notICMP:
-                        description: NotICMP is the negated version of the ICMP field.
-                        properties:
-                          code:
-                            description: Match on a specific ICMP code.  If specified,
-                              the Type value must also be specified. This is a technical
-                              limitation imposed by the kernel’s iptables firewall,
-                              which Calico uses to enforce the rule.
-                            type: integer
-                          type:
-                            description: Match on a specific ICMP type.  For example
-                              a value of 8 refers to ICMP Echo Request (i.e. pings).
-                            type: integer
-                        type: object
-                      notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: NotProtocol is the negated version of the Protocol
-                          field.
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: "Protocol is an optional field that restricts the
-                        rule to only apply to traffic of a specific IP protocol. Required
-                        if any of the EntityRules contain Ports (because ports only
-                        apply to certain protocols). \n Must be one of these string
-                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                        \"UDPLite\" or an integer in the range 1-255."
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      source:
-                        description: Source contains the match criteria that apply to
-                          source entity.
-                        properties:
-                          namespaceSelector:
-                            description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                            type: string
-                          nets:
-                            description: Nets is an optional field that restricts the
-                              rule to only apply to traffic that originates from (or
-                              terminates at) IP addresses in any of the given subnets.
-                            items:
-                              type: string
-                            type: array
-                          notNets:
-                            description: NotNets is the negated version of the Nets
-                              field.
-                            items:
-                              type: string
-                            type: array
-                          notPorts:
-                            description: NotPorts is the negated version of the Ports
-                              field. Since only some protocols have ports, if any ports
-                              are specified it requires the Protocol match in the Rule
-                              to be set to "TCP" or "UDP".
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          notSelector:
-                            description: NotSelector is the negated version of the Selector
-                              field.  See Selector field for subtleties with negated
-                              selectors.
-                            type: string
-                          ports:
-                            description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                            items:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^.*
-                              x-kubernetes-int-or-string: true
-                            type: array
-                          selector:
-                            description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                            type: string
-                          serviceAccounts:
-                            description: ServiceAccounts is an optional field that restricts
-                              the rule to only apply to traffic that originates from
-                              (or terminates at) a pod running as a matching service
-                              account.
-                            properties:
-                              names:
-                                description: Names is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account whose name is in the list.
-                                items:
-                                  type: string
-                                type: array
-                              selector:
-                                description: Selector is an optional field that restricts
-                                  the rule to only apply to traffic that originates
-                                  from (or terminates at) a pod running as a service
-                                  account that matches the given label selector. If
-                                  both Names and Selector are specified then they are
-                                  AND'ed.
-                                type: string
-                            type: object
-                          services:
-                            description: "Services is an optional field that contains
-                              options for matching Kubernetes Services. If specified,
-                              only traffic that originates from or terminates at endpoints
-                              within the selected service(s) will be matched, and only
-                              to/from each endpoint's port. \n Services cannot be specified
-                              on the same rule as Selector, NotSelector, NamespaceSelector,
-                              Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                              Only valid on egress rules."
-                            properties:
-                              name:
-                                description: Name specifies the name of a Kubernetes
-                                  Service to match.
-                                type: string
-                              namespace:
-                                description: Namespace specifies the namespace of the
-                                  given Service. If left empty, the rule will match
-                                  within this policy's namespace.
-                                type: string
-                            type: object
-                        type: object
-                    required:
-                      - action
-                    type: object
-                  type: array
-                order:
-                  description: Order is an optional field that specifies the order in
-                    which the policy is applied. Policies with higher "order" are applied
-                    after those with lower order.  If the order is omitted, it may be
-                    considered to be "infinite" - i.e. the policy will be applied last.  Policies
-                    with identical order will be applied in alphanumerical order based
-                    on the Policy "Name".
-                  type: number
-                selector:
-                  description: "The selector is an expression used to pick pick out
-                  the endpoints that the policy should be applied to. \n Selector
-                  expressions follow this syntax: \n \tlabel == \"string_literal\"
-                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
-                  \  ->  not equal; also matches if label is not present \tlabel in
-                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
-                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
-                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
-                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
-                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
-                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
-                  or the empty selector -> matches all endpoints. \n Label names are
-                  allowed to contain alphanumerics, -, _ and /. String literals are
-                  more permissive but they do not support escape characters. \n Examples
-                  (with made-up labels): \n \ttype == \"webserver\" && deployment
-                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
-                  \"dev\" \t! has(label_name)"
-                  type: string
-                serviceAccountSelector:
-                  description: ServiceAccountSelector is an optional field for an expression
-                    used to select a pod based on service accounts.
-                  type: string
-                types:
-                  description: "Types indicates whether this policy applies to ingress,
-                  or to egress, or to both.  When not explicitly specified (and so
-                  the value on creation is empty or nil), Calico defaults Types according
-                  to what Ingress and Egress are present in the policy.  The default
-                  is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
-                  the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
-                  ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
-                  PolicyTypeEgress ], if there are both Ingress and Egress rules.
-                  \n When the policy is read back again, Types will always be one
-                  of these values, never empty or nil."
-                  items:
-                    description: PolicyType enumerates the possible values of the PolicySpec
-                      Types field.
-                    type: string
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
-  name: networksets.crd.projectcalico.org
-spec:
-  group: crd.projectcalico.org
-  names:
-    kind: NetworkSet
-    listKind: NetworkSetList
-    plural: networksets
-    singular: networkset
-  scope: Namespaced
-  versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: NetworkSetSpec contains the specification for a NetworkSet
-                resource.
-              properties:
-                nets:
-                  description: The list of IP networks that belong to this set.
-                  items:
-                    type: string
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
----
-# Source: calico/templates/calico-kube-controllers-rbac.yaml
-
-# Include a clusterrole for the kube-controllers component,
-# and bind it to the calico-kube-controllers serviceaccount.
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: calico-kube-controllers
-rules:
-  # Nodes are watched to monitor for deletions.
-  - apiGroups: [""]
-    resources:
-      - nodes
-    verbs:
-      - watch
-      - list
-      - get
-  # Pods are watched to check for existence as part of IPAM controller.
-  - apiGroups: [""]
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
-  # IPAM resources are manipulated when nodes are deleted.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - ippools
-    verbs:
-      - list
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - blockaffinities
-      - ipamblocks
-      - ipamhandles
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - watch
-  # kube-controllers manages hostendpoints.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - hostendpoints
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-  # Needs access to update clusterinformations.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - clusterinformations
-    verbs:
-      - get
-      - create
-      - update
-  # KubeControllersConfiguration is where it gets its config
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - kubecontrollersconfigurations
-    verbs:
-      # read its own config
-      - get
-      # create a default if none exists
-      - create
-      # update status
-      - update
-      # watch for changes
-      - watch
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: calico-kube-controllers
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: calico-kube-controllers
-subjects:
-  - kind: ServiceAccount
-    name: calico-kube-controllers
-    namespace: kube-system
----
-
----
-# Source: calico/templates/calico-node-rbac.yaml
-# Include a clusterrole for the calico-node DaemonSet,
-# and bind it to the calico-node serviceaccount.
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: calico-node
-rules:
-  # The CNI plugin needs to get pods, nodes, and namespaces.
-  - apiGroups: [""]
-    resources:
-      - pods
-      - nodes
-      - namespaces
-    verbs:
-      - get
-  # EndpointSlices are used for Service-based network policy rule
-  # enforcement.
-  - apiGroups: ["discovery.k8s.io"]
-    resources:
-      - endpointslices
-    verbs:
-      - watch
-      - list
-  - apiGroups: [""]
-    resources:
-      - endpoints
-      - services
-    verbs:
-      # Used to discover service IPs for advertisement.
-      - watch
-      - list
-      # Used to discover Typhas.
-      - get
-  # Pod CIDR auto-detection on kubeadm needs access to config maps.
-  - apiGroups: [""]
-    resources:
-      - configmaps
-    verbs:
-      - get
-  - apiGroups: [""]
-    resources:
-      - nodes/status
-    verbs:
-      # Needed for clearing NodeNetworkUnavailable flag.
-      - patch
-      # Calico stores some configuration information in node annotations.
-      - update
-  # Watch for changes to Kubernetes NetworkPolicies.
-  - apiGroups: ["networking.k8s.io"]
-    resources:
-      - networkpolicies
-    verbs:
-      - watch
-      - list
-  # Used by Calico for policy information.
-  - apiGroups: [""]
-    resources:
-      - pods
-      - namespaces
-      - serviceaccounts
-    verbs:
-      - list
-      - watch
-  # The CNI plugin patches pods/status.
-  - apiGroups: [""]
-    resources:
-      - pods/status
-    verbs:
-      - patch
-  # Calico monitors various CRDs for config.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - globalfelixconfigs
-      - felixconfigurations
-      - bgppeers
-      - globalbgpconfigs
-      - bgpconfigurations
-      - ippools
-      - ipamblocks
-      - globalnetworkpolicies
-      - globalnetworksets
-      - networkpolicies
-      - networksets
-      - clusterinformations
-      - hostendpoints
-      - blockaffinities
-    verbs:
-      - get
-      - list
-      - watch
-  # Calico must create and update some CRDs on startup.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - ippools
-      - felixconfigurations
-      - clusterinformations
-    verbs:
-      - create
-      - update
-  # Calico stores some configuration information on the node.
-  - apiGroups: [""]
-    resources:
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-  # These permissions are only required for upgrade from v2.6, and can
-  # be removed after upgrade or on fresh installations.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - bgpconfigurations
-      - bgppeers
-    verbs:
-      - create
-      - update
-  # These permissions are required for Calico CNI to perform IPAM allocations.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - blockaffinities
-      - ipamblocks
-      - ipamhandles
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - ipamconfigs
-    verbs:
-      - get
-  # Block affinities must also be watchable by confd for route aggregation.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - blockaffinities
-    verbs:
-      - watch
-  # The Calico IPAM migration needs to get daemonsets. These permissions can be
-  # removed if not upgrading from an installation using host-local IPAM.
-  - apiGroups: ["apps"]
-    resources:
-      - daemonsets
-    verbs:
-      - get
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: calico-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: calico-node
-subjects:
-  - kind: ServiceAccount
-    name: calico-node
-    namespace: kube-system
-
----
-# Source: calico/templates/calico-node.yaml
-# This manifest installs the calico-node container, as well
-# as the CNI plugins and network config on
-# each master and worker node in a Kubernetes cluster.
-kind: DaemonSet
-apiVersion: apps/v1
-metadata:
-  name: calico-node
+  name: calico-config
   namespace: kube-system
-  labels:
-    k8s-app: calico-node
-spec:
-  selector:
-    matchLabels:
-      k8s-app: calico-node
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-  template:
-    metadata:
-      labels:
-        k8s-app: calico-node
-    spec:
-      nodeSelector:
-        kubernetes.io/os: linux
-      hostNetwork: true
-      tolerations:
-        # Make sure calico-node gets scheduled on all nodes.
-        - effect: NoSchedule
-          operator: Exists
-        # Mark the pod as a critical add-on for rescheduling.
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
-      serviceAccountName: calico-node
-      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
-      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
-      terminationGracePeriodSeconds: 0
-      priorityClassName: system-node-critical
-      initContainers:
-        # This container performs upgrade from host-local IPAM to calico-ipam.
-        # It can be deleted if this is a fresh installation, or if you have already
-        # upgraded to use calico-ipam.
-        - name: upgrade-ipam
-          image: calico/cni:v3.20.0
-          command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
-          envFrom:
-            - configMapRef:
-                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
-                name: kubernetes-services-endpoint
-                optional: true
-          env:
-            - name: KUBERNETES_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: CALICO_NETWORKING_BACKEND
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: calico_backend
-          volumeMounts:
-            - mountPath: /var/lib/cni/networks
-              name: host-local-net-dir
-            - mountPath: /host/opt/cni/bin
-              name: cni-bin-dir
-          securityContext:
-            privileged: true
-        # This container installs the CNI binaries
-        # and CNI network config file on each node.
-        - name: install-cni
-          image: calico/cni:v3.20.0
-          command: ["/opt/cni/bin/install"]
-          envFrom:
-            - configMapRef:
-                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
-                name: kubernetes-services-endpoint
-                optional: true
-          env:
-            # Name of the CNI config file to create.
-            - name: CNI_CONF_NAME
-              value: "10-calico.conflist"
-            # The CNI network config to install on each node.
-            - name: CNI_NETWORK_CONFIG
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: cni_network_config
-            # Set the hostname based on the k8s node name.
-            - name: KUBERNETES_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            # CNI MTU Config variable
-            - name: CNI_MTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-            # Prevents the container from sleeping forever.
-            - name: SLEEP
-              value: "false"
-          volumeMounts:
-            - mountPath: /host/opt/cni/bin
-              name: cni-bin-dir
-            - mountPath: /host/etc/cni/net.d
-              name: cni-net-dir
-          securityContext:
-            privileged: true
-        # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
-        # to communicate with Felix over the Policy Sync API.
-        - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.20.0
-          volumeMounts:
-            - name: flexvol-driver-host
-              mountPath: /host/driver
-          securityContext:
-            privileged: true
-      containers:
-        # Runs calico-node container on each Kubernetes node. This
-        # container programs network policy and routes on each
-        # host.
-        - name: calico-node
-          image: calico/node:v3.20.0
-          envFrom:
-            - configMapRef:
-                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
-                name: kubernetes-services-endpoint
-                optional: true
-          env:
-            # Use Kubernetes API as the backing datastore.
-            - name: DATASTORE_TYPE
-              value: "kubernetes"
-            # Wait for the datastore.
-            - name: WAIT_FOR_DATASTORE
-              value: "true"
-            # Set based on the k8s node name.
-            - name: NODENAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            # Choose the backend to use.
-            - name: CALICO_NETWORKING_BACKEND
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: calico_backend
-            # Cluster type to identify the deployment type
-            - name: CLUSTER_TYPE
-              value: "k8s,bgp"
-            # Auto-detect the BGP IP address.
-            - name: IP
-              value: "autodetect"
-            # Enable VXLAN
-            - name: CALICO_IPV4POOL_VXLAN
-              value: "Always"
-            # Set MTU for tunnel device used if ipip is enabled
-            - name: FELIX_IPINIPMTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-            # Set MTU for the VXLAN tunnel device.
-            - name: FELIX_VXLANMTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-            # Set MTU for the Wireguard tunnel device.
-            - name: FELIX_WIREGUARDMTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
-            # chosen from this range. Changing this value after installation will have
-            # no effect. This should fall within `--cluster-cidr`.
-            # - name: CALICO_IPV4POOL_CIDR
-            #   value: "192.168.0.0/16"
-            # Disable file logging so `kubectl logs` works.
-            - name: CALICO_DISABLE_FILE_LOGGING
-              value: "true"
-            # Set Felix endpoint to host default action to ACCEPT.
-            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-              value: "ACCEPT"
-            # Disable IPv6 on Kubernetes.
-            - name: FELIX_IPV6SUPPORT
-              value: "false"
-            - name: FELIX_FEATUREDETECTOVERRIDE
-              value: "ChecksumOffloadBroken=true"
-            - name: FELIX_HEALTHENABLED
-              value: "true"
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: 250m
-          livenessProbe:
-            exec:
-              command:
-                - /bin/calico-node
-                - -felix-live
-            periodSeconds: 10
-            initialDelaySeconds: 10
-            failureThreshold: 6
-          readinessProbe:
-            exec:
-              command:
-                - /bin/calico-node
-                - -felix-ready
-            periodSeconds: 10
-          volumeMounts:
-            - mountPath: /host/etc/cni/net.d
-              name: cni-net-dir
-              readOnly: false
-            - mountPath: /lib/modules
-              name: lib-modules
-              readOnly: true
-            - mountPath: /run/xtables.lock
-              name: xtables-lock
-              readOnly: false
-            - mountPath: /var/run/calico
-              name: var-run-calico
-              readOnly: false
-            - mountPath: /var/lib/calico
-              name: var-lib-calico
-              readOnly: false
-            - name: policysync
-              mountPath: /var/run/nodeagent
-            # For eBPF mode, we need to be able to mount the BPF filesystem at /sys/fs/bpf so we mount in the
-            # parent directory.
-            - name: sysfs
-              mountPath: /sys/fs/
-              # Bidirectional means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to the host.
-              # If the host is known to mount that filesystem already then Bidirectional can be omitted.
-              mountPropagation: Bidirectional
-            - name: cni-log-dir
-              mountPath: /var/log/calico/cni
-              readOnly: true
-      volumes:
-        # Used by calico-node.
-        - name: lib-modules
-          hostPath:
-            path: /lib/modules
-        - name: var-run-calico
-          hostPath:
-            path: /var/run/calico
-        - name: var-lib-calico
-          hostPath:
-            path: /var/lib/calico
-        - name: xtables-lock
-          hostPath:
-            path: /run/xtables.lock
-            type: FileOrCreate
-        - name: sysfs
-          hostPath:
-            path: /sys/fs/
-            type: DirectoryOrCreate
-        # Used to install CNI.
-        - name: cni-bin-dir
-          hostPath:
-            path: /opt/cni/bin
-        - name: cni-net-dir
-          hostPath:
-            path: /etc/cni/net.d
-        # Used to access CNI logs.
-        - name: cni-log-dir
-          hostPath:
-            path: /var/log/calico/cni
-        # Mount in the directory for host-local IPAM allocations. This is
-        # used when upgrading from host-local to calico-ipam, and can be removed
-        # if not using the upgrade-ipam init container.
-        - name: host-local-net-dir
-          hostPath:
-            path: /var/lib/cni/networks
-        # Used to create per-pod Unix Domain Sockets
-        - name: policysync
-          hostPath:
-            type: DirectoryOrCreate
-            path: /var/run/nodeagent
-        # Used to install Flex Volume Driver
-        - name: flexvol-driver-host
-          hostPath:
-            type: DirectoryOrCreate
-            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
 ---
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: calico-node
-  namespace: kube-system
-
----
-# Source: calico/templates/calico-kube-controllers.yaml
-# See https://github.com/projectcalico/kube-controllers
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: calico-kube-controllers
-  namespace: kube-system
   labels:
     k8s-app: calico-kube-controllers
+  name: calico-kube-controllers
+  namespace: kube-system
 spec:
-  # The controllers can only have a single active instance.
   replicas: 1
   selector:
     matchLabels:
@@ -4069,75 +3679,300 @@ spec:
     type: Recreate
   template:
     metadata:
-      name: calico-kube-controllers
-      namespace: kube-system
       labels:
         k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
     spec:
+      containers:
+      - env:
+        - name: ENABLED_CONTROLLERS
+          value: node
+        - name: DATASTORE_TYPE
+          value: kubernetes
+        image: docker.io/calico/kube-controllers:v3.20.3
+        livenessProbe:
+          exec:
+            command:
+            - /usr/bin/check-status
+            - -l
+          failureThreshold: 6
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 10
+        name: calico-kube-controllers
+        readinessProbe:
+          exec:
+            command:
+            - /usr/bin/check-status
+            - -r
+          periodSeconds: 10
       nodeSelector:
         kubernetes.io/os: linux
-      tolerations:
-        # Mark the pod as a critical add-on for rescheduling.
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
-      serviceAccountName: calico-kube-controllers
       priorityClassName: system-cluster-critical
-      containers:
-        - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.20.0
-          env:
-            # Choose which controllers to run.
-            - name: ENABLED_CONTROLLERS
-              value: node
-            - name: DATASTORE_TYPE
-              value: kubernetes
-          livenessProbe:
-            exec:
-              command:
-              - /usr/bin/check-status
-              - -l
-            periodSeconds: 10
-            initialDelaySeconds: 10
-            failureThreshold: 6
-            timeoutSeconds: 10
-          readinessProbe:
-            exec:
-              command:
-                - /usr/bin/check-status
-                - -r
-            periodSeconds: 10
-
+      serviceAccountName: calico-kube-controllers
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
 ---
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: calico-kube-controllers
-  namespace: kube-system
-
----
-
-# This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
-
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: calico-kube-controllers
-  namespace: kube-system
   labels:
     k8s-app: calico-kube-controllers
+  name: calico-kube-controllers
+  namespace: kube-system
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
       k8s-app: calico-kube-controllers
 ---
-# Source: calico/templates/calico-etcd-secrets.yaml
-
----
-# Source: calico/templates/calico-typha.yaml
-
----
-# Source: calico/templates/configure-canal.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: calico-node
+  name: calico-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+    spec:
+      containers:
+      - env:
+        - name: FELIX_FEATUREDETECTOVERRIDE
+          value: ChecksumOffloadBroken=true
+        - name: CALICO_IPV4POOL_VXLAN
+          value: Always
+        - name: DATASTORE_TYPE
+          value: kubernetes
+        - name: WAIT_FOR_DATASTORE
+          value: "true"
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CALICO_NETWORKING_BACKEND
+          valueFrom:
+            configMapKeyRef:
+              key: calico_backend
+              name: calico-config
+        - name: CLUSTER_TYPE
+          value: k8s,bgp
+        - name: IP
+          value: autodetect
+        - name: CALICO_IPV4POOL_IPIP
+          value: Never
+        - name: FELIX_IPINIPMTU
+          valueFrom:
+            configMapKeyRef:
+              key: veth_mtu
+              name: calico-config
+        - name: FELIX_VXLANMTU
+          valueFrom:
+            configMapKeyRef:
+              key: veth_mtu
+              name: calico-config
+        - name: FELIX_WIREGUARDMTU
+          valueFrom:
+            configMapKeyRef:
+              key: veth_mtu
+              name: calico-config
+        - name: FELIX_AWSSRCDSTCHECK
+          value: Disable
+        - name: CALICO_DISABLE_FILE_LOGGING
+          value: "true"
+        - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+          value: ACCEPT
+        - name: FELIX_IPV6SUPPORT
+          value: "false"
+        - name: FELIX_HEALTHENABLED
+          value: "true"
+        envFrom:
+        - configMapRef:
+            name: kubernetes-services-endpoint
+            optional: true
+        image: docker.io/calico/node:v3.20.3
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/calico-node
+              - -shutdown
+        livenessProbe:
+          exec:
+            command:
+            - /bin/calico-node
+            - -felix-live
+          failureThreshold: 6
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 10
+        name: calico-node
+        readinessProbe:
+          exec:
+            command:
+            - /bin/calico-node
+            - -felix-ready
+          periodSeconds: 10
+          timeoutSeconds: 10
+        resources:
+          requests:
+            cpu: 250m
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/etc/cni/net.d
+          name: cni-net-dir
+          readOnly: false
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+          readOnly: false
+        - mountPath: /var/run/calico
+          name: var-run-calico
+          readOnly: false
+        - mountPath: /var/lib/calico
+          name: var-lib-calico
+          readOnly: false
+        - mountPath: /var/run/nodeagent
+          name: policysync
+        - mountPath: /sys/fs/
+          mountPropagation: Bidirectional
+          name: sysfs
+        - mountPath: /var/log/calico/cni
+          name: cni-log-dir
+          readOnly: true
+      hostNetwork: true
+      initContainers:
+      - command:
+        - /opt/cni/bin/calico-ipam
+        - -upgrade
+        env:
+        - name: KUBERNETES_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CALICO_NETWORKING_BACKEND
+          valueFrom:
+            configMapKeyRef:
+              key: calico_backend
+              name: calico-config
+        envFrom:
+        - configMapRef:
+            name: kubernetes-services-endpoint
+            optional: true
+        image: docker.io/calico/cni:v3.20.3
+        name: upgrade-ipam
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/cni/networks
+          name: host-local-net-dir
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+      - command:
+        - /opt/cni/bin/install
+        env:
+        - name: CNI_CONF_NAME
+          value: 10-calico.conflist
+        - name: CNI_NETWORK_CONFIG
+          valueFrom:
+            configMapKeyRef:
+              key: cni_network_config
+              name: calico-config
+        - name: KUBERNETES_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CNI_MTU
+          valueFrom:
+            configMapKeyRef:
+              key: veth_mtu
+              name: calico-config
+        - name: SLEEP
+          value: "false"
+        envFrom:
+        - configMapRef:
+            name: kubernetes-services-endpoint
+            optional: true
+        image: docker.io/calico/cni:v3.20.3
+        name: install-cni
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /host/etc/cni/net.d
+          name: cni-net-dir
+      - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+        name: flexvol-driver
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/driver
+          name: flexvol-driver-host
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      serviceAccountName: calico-node
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /lib/modules
+        name: lib-modules
+      - hostPath:
+          path: /var/run/calico
+        name: var-run-calico
+      - hostPath:
+          path: /var/lib/calico
+        name: var-lib-calico
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
+      - hostPath:
+          path: /sys/fs/
+          type: DirectoryOrCreate
+        name: sysfs
+      - hostPath:
+          path: /opt/cni/bin
+        name: cni-bin-dir
+      - hostPath:
+          path: /etc/cni/net.d
+        name: cni-net-dir
+      - hostPath:
+          path: /var/log/calico/cni
+        name: cni-log-dir
+      - hostPath:
+          path: /var/lib/cni/networks
+        name: host-local-net-dir
+      - hostPath:
+          path: /var/run/nodeagent
+          type: DirectoryOrCreate
+        name: policysync
+      - hostPath:
+          path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+          type: DirectoryOrCreate
+        name: flexvol-driver-host
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/templates/addons/calico/kustomization.yaml
+++ b/templates/addons/calico/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - https://docs.projectcalico.org/v3.20/manifests/calico-vxlan.yaml
+patchesStrategicMerge:
+    - patches/azure-mtu.yaml
+patches:
+- path: patches/calico-node.yaml
+  target:
+    kind: DaemonSet

--- a/templates/addons/calico/patches/azure-mtu.yaml
+++ b/templates/addons/calico/patches/azure-mtu.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # On Azure, the underlying network has an MTU of 1400, even though the network interface will have an MTU of 1500.
+  # We set this value to 1350 for “physical network MTU size minus 50” since we use VXLAN, which uses a 50-byte header.
+  # If enabling Wireguard, this value should be changed to 1340 (Wireguard uses a 60-byte header).
+  # https://docs.projectcalico.org/networking/mtu#determine-mtu-size
+  veth_mtu: "1350"

--- a/templates/addons/calico/patches/calico-node.yaml
+++ b/templates/addons/calico/patches/calico-node.yaml
@@ -1,0 +1,17 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: calico-node
+        env:
+        # https://github.com/projectcalico/calico/issues/4865
+        - name: FELIX_FEATUREDETECTOVERRIDE	
+          value: "ChecksumOffloadBroken=true"
+        - name: CALICO_IPV4POOL_VXLAN	
+          value: "Always"
+

--- a/templates/addons/windows/calico/calico.yaml
+++ b/templates/addons/windows/calico/calico.yaml
@@ -163,7 +163,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: sigwindowstools/calico-install:v3.20.0-hostprocess
+          image: sigwindowstools/calico-install:v3.20.4-hostprocess
           args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1"]
           imagePullPolicy: Always
           env:
@@ -205,7 +205,7 @@ spec:
               runAsUserName: "NT AUTHORITY\\system"
       containers:
       - name: calico-node-startup
-        image: sigwindowstools/calico-node:v3.20.0-hostprocess
+        image: sigwindowstools/calico-node:v3.20.4-hostprocess
         args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1"]
         workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/"
         imagePullPolicy: Always
@@ -232,7 +232,7 @@ spec:
         - name: VXLAN_VNI
           value: "4096"
       - name: calico-node-felix
-        image: sigwindowstools/calico-node:v3.20.0-hostprocess
+        image: sigwindowstools/calico-node:v3.20.4-hostprocess
         args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1"]
         imagePullPolicy: Always
         workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/"

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -4268,7 +4268,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.20.3
+            image: docker.io/calico/kube-controllers:v3.20.4
             livenessProbe:
               exec:
                 command:
@@ -4378,7 +4378,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.20.3
+            image: docker.io/calico/node:v3.20.4
             lifecycle:
               preStop:
                 exec:
@@ -4450,7 +4450,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: upgrade-ipam
             securityContext:
               privileged: true
@@ -4484,7 +4484,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: install-cni
             securityContext:
               privileged: true
@@ -4493,7 +4493,7 @@ data:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.4
             name: flexvol-driver
             securityContext:
               privileged: true
@@ -4601,7 +4601,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.20.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.20.4-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -4620,7 +4620,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.20.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.20.4-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -4631,7 +4631,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.20.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.20.4-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -575,2440 +575,3985 @@ data:
     \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
     kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
     \   type: RollingUpdate\n"
-  resources: "---\n# Source: calico/templates/calico-config.yaml\n# This ConfigMap
-    is used to configure a self-hosted Calico installation.\nkind: ConfigMap\napiVersion:
-    v1\nmetadata:\n  name: calico-config\n  namespace: kube-system\ndata:\n  # Typha
-    is disabled.\n  typha_service_name: \"none\"\n  # Configure the backend to use.\n
-    \ calico_backend: \"vxlan\"\n  # On Azure, the underlying network has an MTU of
-    1400, even though the network interface will have an MTU of 1500.\n  # We set
-    this value to 1350 for “physical network MTU size minus 50” since we use VXLAN,
-    which uses a 50-byte header.\n  # If enabling Wireguard, this value should be
-    changed to 1340 (Wireguard uses a 60-byte header).\n  # https://docs.projectcalico.org/networking/mtu#determine-mtu-size\n
-    \ veth_mtu: \"1350\"\n  \n  # The CNI network configuration to install on each
-    node. The special\n  # values in this config will be automatically populated.\n
-    \ cni_network_config: |-\n    {\n      \"name\": \"k8s-pod-network\",\n      \"cniVersion\":
-    \"0.3.1\",\n      \"plugins\": [\n        {\n          \"type\": \"calico\",\n
-    \         \"log_level\": \"info\",\n          \"log_file_path\": \"/var/log/calico/cni/cni.log\",\n
-    \         \"datastore_type\": \"kubernetes\",\n          \"nodename\": \"__KUBERNETES_NODE_NAME__\",\n
-    \         \"mtu\": __CNI_MTU__,\n          \"ipam\": {\n              \"type\":
-    \"calico-ipam\"\n          },\n          \"policy\": {\n              \"type\":
-    \"k8s\"\n          },\n          \"kubernetes\": {\n              \"kubeconfig\":
-    \"__KUBECONFIG_FILEPATH__\"\n          }\n        },\n        {\n          \"type\":
-    \"portmap\",\n          \"snat\": true,\n          \"capabilities\": {\"portMappings\":
-    true}\n        },\n        {\n          \"type\": \"bandwidth\",\n          \"capabilities\":
-    {\"bandwidth\": true}\n        }\n      ]\n    }\n\n---\n# Source: calico/templates/kdd-crds.yaml\n\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: bgpconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPConfiguration\n    listKind: BGPConfigurationList\n    plural:
-    bgpconfigurations\n    singular: bgpconfiguration\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    BGPConfiguration contains the configuration for any BGP routing.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPConfigurationSpec contains the
-    values of the BGP configuration.\n              properties:\n                asNumber:\n
-    \                 description: 'ASNumber is the default AS number used by a node.
-    [Default:\n                  64512]'\n                  format: int32\n                  type:
-    integer\n                communities:\n                  description: Communities
-    is a list of BGP community values and their\n                    arbitrary names
-    for tagging routes.\n                  items:\n                    description:
-    Community contains standard or large community value\n                      and
-    its name.\n                    properties:\n                      name:\n                        description:
-    Name given to community value.\n                        type: string\n                      value:\n
-    \                       description: Value must be of format `aa:nn` or `aa:nn:mm`.\n
-    \                         For standard community use `aa:nn` format, where `aa`
-    and\n                          `nn` are 16 bit number. For large community use
-    `aa:nn:mm`\n                          format, where `aa`, `nn` and `mm` are 32
-    bit number. Where,\n                          `aa` is an AS Number, `nn` and `mm`
-    are per-AS identifier.\n                        pattern: ^(\\d+):(\\d+)$|^(\\d+):(\\d+):(\\d+)$\n
-    \                       type: string\n                    type: object\n                  type:
-    array\n                listenPort:\n                  description: ListenPort
-    is the port where BGP protocol should listen.\n                    Defaults to
-    179\n                  maximum: 65535\n                  minimum: 1\n                  type:
-    integer\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: INFO]'\n                  type: string\n                nodeToNodeMeshEnabled:\n
-    \                 description: 'NodeToNodeMeshEnabled sets whether full node to
-    node\n                  BGP mesh is enabled. [Default: true]'\n                  type:
-    boolean\n                prefixAdvertisements:\n                  description:
-    PrefixAdvertisements contains per-prefix advertisement\n                    configuration.\n
-    \                 items:\n                    description: PrefixAdvertisement
-    configures advertisement properties\n                      for the specified CIDR.\n
-    \                   properties:\n                      cidr:\n                        description:
-    CIDR for which properties should be advertised.\n                        type:
-    string\n                      communities:\n                        description:
-    Communities can be list of either community names\n                          already
-    defined in `Specs.Communities` or community value\n                          of
-    format `aa:nn` or `aa:nn:mm`. For standard community use\n                          `aa:nn`
-    format, where `aa` and `nn` are 16 bit number. For\n                          large
-    community use `aa:nn:mm` format, where `aa`, `nn` and\n                          `mm`
-    are 32 bit number. Where,`aa` is an AS Number, `nn` and\n                          `mm`
-    are per-AS identifier.\n                        items:\n                          type:
-    string\n                        type: array\n                    type: object\n
-    \                 type: array\n                serviceClusterIPs:\n                  description:
-    ServiceClusterIPs are the CIDR blocks from which service\n                    cluster
-    IPs are allocated. If specified, Calico will advertise these\n                    blocks,
-    as well as any cluster IPs within them.\n                  items:\n                    description:
-    ServiceClusterIPBlock represents a single allowed ClusterIP\n                      CIDR
-    block.\n                    properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n                serviceExternalIPs:\n
-    \                 description: ServiceExternalIPs are the CIDR blocks for Kubernetes\n
-    \                   Service External IPs. Kubernetes Service ExternalIPs will
-    only be\n                    advertised if they are within one of these blocks.\n
-    \                 items:\n                    description: ServiceExternalIPBlock
-    represents a single allowed\n                      External IP CIDR block.\n                    properties:\n
-    \                     cidr:\n                        type: string\n                    type:
-    object\n                  type: array\n                serviceLoadBalancerIPs:\n
-    \                 description: ServiceLoadBalancerIPs are the CIDR blocks for
-    Kubernetes\n                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress\n
-    \                   IPs will only be advertised if they are within one of these
-    blocks.\n                  items:\n                    description: ServiceLoadBalancerIPBlock
-    represents a single allowed\n                      LoadBalancer IP CIDR block.\n
-    \                   properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: bgppeers.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPPeer\n    listKind: BGPPeerList\n    plural: bgppeers\n
-    \   singular: bgppeer\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPPeerSpec contains the specification
-    for a BGPPeer resource.\n              properties:\n                asNumber:\n
-    \                 description: The AS Number of the peer.\n                  format:
-    int32\n                  type: integer\n                keepOriginalNextHop:\n
-    \                 description: Option to keep the original nexthop field when
-    routes\n                    are sent to a BGP Peer. Setting \"true\" configures
-    the selected BGP\n                    Peers node to use the \"next hop keep;\"
-    instead of \"next hop self;\"(default)\n                    in the specific branch
-    of the Node on \"bird.cfg\".\n                  type: boolean\n                maxRestartTime:\n
-    \                 description: Time to allow for software restart.  When specified,
-    this\n                    is configured as the graceful restart timeout.  When
-    not specified,\n                    the BIRD default of 120s is used.\n                  type:
-    string\n                node:\n                  description: The node name identifying
-    the Calico node instance that\n                    is targeted by this peer. If
-    this is not set, and no nodeSelector\n                    is specified, then this
-    BGP peer selects all nodes in the cluster.\n                  type: string\n                nodeSelector:\n
-    \                 description: Selector for the nodes that should have this peering.
-    \ When\n                    this is set, the Node field must be empty.\n                  type:
-    string\n                password:\n                  description: Optional BGP
-    password for the peerings generated by this\n                    BGPPeer resource.\n
-    \                 properties:\n                    secretKeyRef:\n                      description:
-    Selects a key of a secret in the node pod's namespace.\n                      properties:\n
-    \                       key:\n                          description: The key of
-    the secret to select from.  Must be\n                            a valid secret
-    key.\n                          type: string\n                        name:\n
-    \                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n
-    \                         TODO: Add other useful fields. apiVersion, kind, uid?'\n
-    \                         type: string\n                        optional:\n                          description:
-    Specify whether the Secret or its key must be\n                            defined\n
-    \                         type: boolean\n                      required:\n                        -
-    key\n                      type: object\n                  type: object\n                peerIP:\n
-    \                 description: The IP address of the peer followed by an optional
-    port\n                    number to peer with. If port number is given, format
-    should be `[<IPv6>]:port`\n                    or `<IPv4>:<port>` for IPv4. If
-    optional port number is not set,\n                    and this peer IP and ASNumber
-    belongs to a calico/node with ListenPort\n                    set in BGPConfiguration,
-    then we use that port to peer.\n                  type: string\n                peerSelector:\n
-    \                 description: Selector for the remote nodes to peer with.  When
-    this\n                    is set, the PeerIP and ASNumber fields must be empty.
-    \ For each\n                    peering between the local node and selected remote
-    nodes, we configure\n                    an IPv4 peering if both ends have NodeBGPSpec.IPv4Address
-    specified,\n                    and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address
-    specified.  The\n                    remote AS number comes from the remote node’s
-    NodeBGPSpec.ASNumber,\n                    or the global default if that is not
-    set.\n                  type: string\n                sourceAddress:\n                  description:
-    Specifies whether and how to configure a source address\n                    for
-    the peerings generated by this BGPPeer resource.  Default value\n                    \"UseNodeIP\"
-    means to configure the node IP as the source address.  \"None\"\n                    means
-    not to configure a source address.\n                  type: string\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: blockaffinities.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BlockAffinity\n    listKind: BlockAffinityList\n    plural:
-    blockaffinities\n    singular: blockaffinity\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BlockAffinitySpec contains the specification
-    for a BlockAffinity\n                resource.\n              properties:\n                cidr:\n
-    \                 type: string\n                deleted:\n                  description:
-    Deleted indicates that this block affinity is being deleted.\n                    This
-    field is a string for compatibility with older releases that\n                    mistakenly
-    treat this field as a string.\n                  type: string\n                node:\n
-    \                 type: string\n                state:\n                  type:
-    string\n              required:\n                - cidr\n                - deleted\n
-    \               - node\n                - state\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: clusterinformations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: ClusterInformation\n    listKind: ClusterInformationList\n
-    \   plural: clusterinformations\n    singular: clusterinformation\n  scope: Cluster\n
-    \ versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    ClusterInformation contains the cluster specific information.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: ClusterInformationSpec contains
-    the values of describing\n                the cluster.\n              properties:\n
-    \               calicoVersion:\n                  description: CalicoVersion is
-    the version of Calico that the cluster\n                    is running\n                  type:
-    string\n                clusterGUID:\n                  description: ClusterGUID
-    is the GUID of the cluster\n                  type: string\n                clusterType:\n
-    \                 description: ClusterType describes the type of the cluster\n
-    \                 type: string\n                datastoreReady:\n                  description:
-    DatastoreReady is used during significant datastore migrations\n                    to
-    signal to components such as Felix that it should wait before\n                    accessing
-    the datastore.\n                  type: boolean\n                variant:\n                  description:
-    Variant declares which variant of Calico should be active.\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: felixconfigurations.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: FelixConfiguration\n    listKind:
-    FelixConfigurationList\n    plural: felixconfigurations\n    singular: felixconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         description: Felix Configuration contains the configuration for Felix.\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: FelixConfigurationSpec contains
-    the values of the Felix configuration.\n              properties:\n                allowIPIPPacketsFromWorkloads:\n
-    \                 description: 'AllowIPIPPacketsFromWorkloads controls whether
-    Felix\n                  will add a rule to drop IPIP encapsulated traffic from
-    workloads\n                  [Default: false]'\n                  type: boolean\n
-    \               allowVXLANPacketsFromWorkloads:\n                  description:
-    'AllowVXLANPacketsFromWorkloads controls whether Felix\n                  will
-    add a rule to drop VXLAN encapsulated traffic from workloads\n                  [Default:
-    false]'\n                  type: boolean\n                awsSrcDstCheck:\n                  description:
-    'Set source-destination-check on AWS EC2 instances. Accepted\n                  value
-    must be one of \"DoNothing\", \"Enabled\" or \"Disabled\". [Default:\n                  DoNothing]'\n
-    \                 enum:\n                    - DoNothing\n                    -
-    Enable\n                    - Disable\n                  type: string\n                bpfConnectTimeLoadBalancingEnabled:\n
-    \                 description: 'BPFConnectTimeLoadBalancingEnabled when in BPF
-    mode,\n                  controls whether Felix installs the connection-time load
-    balancer.  The\n                  connect-time load balancer is required for the
-    host to be able to\n                  reach Kubernetes services and it improves
-    the performance of pod-to-service\n                  connections.  The only reason
-    to disable it is for debugging purposes.  [Default:\n                  true]'\n
-    \                 type: boolean\n                bpfDataIfacePattern:\n                  description:
-    'BPFDataIfacePattern is a regular expression that controls\n                  which
-    interfaces Felix should attach BPF programs to in order to\n                  catch
-    traffic to/from the network.  This needs to match the interfaces\n                  that
-    Calico workload traffic flows over as well as any interfaces\n                  that
-    handle incoming traffic to nodeports and services from outside\n                  the
-    cluster.  It should not match the workload interfaces (usually\n                  named
-    cali...). [Default: ^(en.*|eth.*|tunl0$)]'\n                  type: string\n                bpfDisableUnprivileged:\n
-    \                 description: 'BPFDisableUnprivileged, if enabled, Felix sets
-    the kernel.unprivileged_bpf_disabled\n                  sysctl to disable unprivileged
-    use of BPF.  This ensures that unprivileged\n                  users cannot access
-    Calico''s BPF maps and cannot insert their own\n                  BPF programs
-    to interfere with Calico''s. [Default: true]'\n                  type: boolean\n
-    \               bpfEnabled:\n                  description: 'BPFEnabled, if enabled
-    Felix will use the BPF dataplane.\n                  [Default: false]'\n                  type:
-    boolean\n                bpfExtToServiceConnmark:\n                  description:
-    'BPFExtToServiceConnmark in BPF mode, control a 32bit\n                    mark
-    that is set on connections from an external client to a local\n                    service.
-    This mark allows us to control how packets of that connection\n                    are
-    routed within the host and how is routing intepreted by RPF\n                    check.
-    [Default: 0]'\n                  type: integer\n                bpfExternalServiceMode:\n
-    \                 description: 'BPFExternalServiceMode in BPF mode, controls how
-    connections\n                  from outside the cluster to services (node ports
-    and cluster IPs)\n                  are forwarded to remote workloads.  If set
-    to \"Tunnel\" then both\n                  request and response traffic is tunneled
-    to the remote node.  If\n                  set to \"DSR\", the request traffic
-    is tunneled but the response traffic\n                  is sent directly from
-    the remote node.  In \"DSR\" mode, the remote\n                  node appears
-    to use the IP of the ingress node; this requires a\n                  permissive
-    L2 network.  [Default: Tunnel]'\n                  type: string\n                bpfKubeProxyEndpointSlicesEnabled:\n
-    \                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode,
-    controls\n                    whether Felix's embedded kube-proxy accepts EndpointSlices
-    or not.\n                  type: boolean\n                bpfKubeProxyIptablesCleanupEnabled:\n
-    \                 description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled
-    in BPF\n                  mode, Felix will proactively clean up the upstream Kubernetes
-    kube-proxy''s\n                  iptables chains.  Should only be enabled if kube-proxy
-    is not running.  [Default:\n                  true]'\n                  type:
-    boolean\n                bpfKubeProxyMinSyncPeriod:\n                  description:
-    'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the\n                  minimum
-    time between updates to the dataplane for Felix''s embedded\n                  kube-proxy.
-    \ Lower values give reduced set-up latency.  Higher values\n                  reduce
-    Felix CPU usage by batching up more work.  [Default: 1s]'\n                  type:
-    string\n                bpfLogLevel:\n                  description: 'BPFLogLevel
-    controls the log level of the BPF programs\n                  when in BPF dataplane
-    mode.  One of \"Off\", \"Info\", or \"Debug\".  The\n                  logs are
-    emitted to the BPF trace pipe, accessible with the command\n                  `tc
-    exec bpf debug`. [Default: Off].'\n                  type: string\n                chainInsertMode:\n
-    \                 description: 'ChainInsertMode controls whether Felix hooks the
-    kernel’s\n                  top-level iptables chains by inserting a rule at the
-    top of the\n                  chain or by appending a rule at the bottom. insert
-    is the safe default\n                  since it prevents Calico’s rules from being
-    bypassed. If you switch\n                  to append mode, be sure that the other
-    rules in the chains signal\n                  acceptance by falling through to
-    the Calico rules, otherwise the\n                  Calico policy will be bypassed.
-    [Default: insert]'\n                  type: string\n                dataplaneDriver:\n
-    \                 type: string\n                debugDisableLogDropping:\n                  type:
-    boolean\n                debugMemoryProfilePath:\n                  type: string\n
-    \               debugSimulateCalcGraphHangAfter:\n                  type: string\n
-    \               debugSimulateDataplaneHangAfter:\n                  type: string\n
-    \               defaultEndpointToHostAction:\n                  description: 'DefaultEndpointToHostAction
-    controls what happens to\n                  traffic that goes from a workload
-    endpoint to the host itself (after\n                  the traffic hits the endpoint
-    egress policy). By default Calico\n                  blocks traffic from workload
-    endpoints to the host itself with an\n                  iptables “DROP” action.
-    If you want to allow some or all traffic\n                  from endpoint to host,
-    set this parameter to RETURN or ACCEPT. Use\n                  RETURN if you have
-    your own rules in the iptables “INPUT” chain;\n                  Calico will insert
-    its rules at the top of that chain, then “RETURN”\n                  packets to
-    the “INPUT” chain once it has completed processing workload\n                  endpoint
-    egress policy. Use ACCEPT to unconditionally accept packets\n                  from
-    workloads after processing workload endpoint egress policy.\n                  [Default:
-    Drop]'\n                  type: string\n                deviceRouteProtocol:\n
-    \                 description: This defines the route protocol added to programmed
-    device\n                    routes, by default this will be RTPROT_BOOT when left
-    blank.\n                  type: integer\n                deviceRouteSourceAddress:\n
-    \                 description: This is the source address to use on programmed
-    device\n                    routes. By default the source address is left blank,
-    leaving the\n                    kernel to choose the source address used.\n                  type:
-    string\n                disableConntrackInvalidCheck:\n                  type:
-    boolean\n                endpointReportingDelay:\n                  type: string\n
-    \               endpointReportingEnabled:\n                  type: boolean\n                externalNodesList:\n
-    \                 description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes\n
-    \                   which may source tunnel traffic and have the tunneled traffic
-    be\n                    accepted at calico nodes.\n                  items:\n
-    \                   type: string\n                  type: array\n                failsafeInboundHostPorts:\n
-    \                 description: 'FailsafeInboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow incoming traffic to
-    host endpoints\n                    on irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    inbound host ports, use the value\n                    none. The default value
-    allows ssh access and DHCP. [Default: tcp:22,\n                    udp:68, tcp:179,
-    tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'\n                  items:\n
-    \                   description: ProtoPort is combination of protocol, port, and
-    CIDR.\n                      Protocol and port must be specified.\n                    properties:\n
-    \                     net:\n                        type: string\n                      port:\n
-    \                       type: integer\n                      protocol:\n                        type:
-    string\n                    required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                failsafeOutboundHostPorts:\n
-    \                 description: 'FailsafeOutboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow outgoing traffic from
-    host endpoints\n                    to irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    outbound host ports, use the value\n                    none. The default value
-    opens etcd''s standard ports to ensure that\n                    Felix does not
-    get cut off from etcd as well as allowing DHCP and\n                    DNS. [Default:
-    tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,\n                    tcp:6667,
-    udp:53, udp:67]'\n                  items:\n                    description: ProtoPort
-    is combination of protocol, port, and CIDR.\n                      Protocol and
-    port must be specified.\n                    properties:\n                      net:\n
-    \                       type: string\n                      port:\n                        type:
-    integer\n                      protocol:\n                        type: string\n
-    \                   required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                featureDetectOverride:\n
-    \                 description: FeatureDetectOverride is used to override the feature\n
-    \                   detection. Values are specified in a comma separated list
-    with no\n                    spaces, example; \"SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=\".\n
-    \                   \"true\" or \"false\" will force the feature, empty or omitted
-    values\n                    are auto-detected.\n                  type: string\n
-    \               genericXDPEnabled:\n                  description: 'GenericXDPEnabled
-    enables Generic XDP so network cards\n                  that don''t support XDP
-    offload or driver modes can use XDP. This\n                  is not recommended
-    since it doesn''t provide better performance\n                  than iptables.
-    [Default: false]'\n                  type: boolean\n                healthEnabled:\n
-    \                 type: boolean\n                healthHost:\n                  type:
-    string\n                healthPort:\n                  type: integer\n                interfaceExclude:\n
-    \                 description: 'InterfaceExclude is a comma-separated list of
-    interfaces\n                  that Felix should exclude when monitoring for host
-    endpoints. The\n                  default value ensures that Felix ignores Kubernetes''
-    IPVS dummy\n                  interface, which is used internally by kube-proxy.
-    If you want to\n                  exclude multiple interface names using a single
-    value, the list\n                  supports regular expressions. For regular expressions
-    you must wrap\n                  the value with ''/''. For example having values
-    ''/^kube/,veth1''\n                  will exclude all interfaces that begin with
-    ''kube'' and also the\n                  interface ''veth1''. [Default: kube-ipvs0]'\n
-    \                 type: string\n                interfacePrefix:\n                  description:
-    'InterfacePrefix is the interface name prefix that identifies\n                  workload
-    endpoints and so distinguishes them from host endpoint\n                  interfaces.
-    Note: in environments other than bare metal, the orchestrators\n                  configure
-    this appropriately. For example our Kubernetes and Docker\n                  integrations
-    set the ‘cali’ value, and our OpenStack integration\n                  sets the
-    ‘tap’ value. [Default: cali]'\n                  type: string\n                interfaceRefreshInterval:\n
-    \                 description: InterfaceRefreshInterval is the period at which
-    Felix\n                    rescans local interfaces to verify their state. The
-    rescan can be\n                    disabled by setting the interval to 0.\n                  type:
-    string\n                ipipEnabled:\n                  type: boolean\n                ipipMTU:\n
-    \                 description: 'IPIPMTU is the MTU to set on the tunnel device.
-    See\n                  Configuring MTU [Default: 1440]'\n                  type:
-    integer\n                ipsetsRefreshInterval:\n                  description:
-    'IpsetsRefreshInterval is the period at which Felix re-checks\n                  all
-    iptables state to ensure that no other process has accidentally\n                  broken
-    Calico’s rules. Set to 0 to disable iptables refresh. [Default:\n                  90s]'\n
-    \                 type: string\n                iptablesBackend:\n                  description:
-    IptablesBackend specifies which backend of iptables will\n                    be
-    used. The default is legacy.\n                  type: string\n                iptablesFilterAllowAction:\n
-    \                 type: string\n                iptablesLockFilePath:\n                  description:
-    'IptablesLockFilePath is the location of the iptables\n                  lock
-    file. You may need to change this if the lock file is not in\n                  its
-    standard location (for example if you have mapped it into Felix’s\n                  container
-    at a different path). [Default: /run/xtables.lock]'\n                  type: string\n
-    \               iptablesLockProbeInterval:\n                  description: 'IptablesLockProbeInterval
-    is the time that Felix will\n                  wait between attempts to acquire
-    the iptables lock if it is not\n                  available. Lower values make
-    Felix more responsive when the lock\n                  is contended, but use more
-    CPU. [Default: 50ms]'\n                  type: string\n                iptablesLockTimeout:\n
-    \                 description: 'IptablesLockTimeout is the time that Felix will
-    wait\n                  for the iptables lock, or 0, to disable. To use this feature,
-    Felix\n                  must share the iptables lock file with all other processes
-    that\n                  also take the lock. When running Felix inside a container,
-    this\n                  requires the /run directory of the host to be mounted
-    into the calico/node\n                  or calico/felix container. [Default: 0s
-    disabled]'\n                  type: string\n                iptablesMangleAllowAction:\n
-    \                 type: string\n                iptablesMarkMask:\n                  description:
-    'IptablesMarkMask is the mask that Felix selects its\n                  IPTables
-    Mark bits from. Should be a 32 bit hexadecimal number with\n                  at
-    least 8 bits set, none of which clash with any other mark bits\n                  in
-    use on the system. [Default: 0xff000000]'\n                  format: int32\n                  type:
-    integer\n                iptablesNATOutgoingInterfaceFilter:\n                  type:
-    string\n                iptablesPostWriteCheckInterval:\n                  description:
-    'IptablesPostWriteCheckInterval is the period after Felix\n                  has
-    done a write to the dataplane that it schedules an extra read\n                  back
-    in order to check the write was not clobbered by another process.\n                  This
-    should only occur if another application on the system doesn’t\n                  respect
-    the iptables lock. [Default: 1s]'\n                  type: string\n                iptablesRefreshInterval:\n
-    \                 description: 'IptablesRefreshInterval is the period at which
-    Felix\n                    re-checks the IP sets in the dataplane to ensure that
-    no other process\n                    has accidentally broken Calico''s rules.
-    Set to 0 to disable IP\n                    sets refresh. Note: the default for
-    this value is lower than the\n                    other refresh intervals as a
-    workaround for a Linux kernel bug that\n                    was fixed in kernel
-    version 4.11. If you are using v4.11 or greater\n                    you may want
-    to set this to, a higher value to reduce Felix CPU\n                    usage.
-    [Default: 10s]'\n                  type: string\n                ipv6Support:\n
-    \                 type: boolean\n                kubeNodePortRanges:\n                  description:
-    'KubeNodePortRanges holds list of port ranges used for\n                  service
-    node ports. Only used if felix detects kube-proxy running\n                  in
-    ipvs mode. Felix uses these ranges to separate host and workload\n                  traffic.
-    [Default: 30000:32767].'\n                  items:\n                    anyOf:\n
-    \                     - type: integer\n                      - type: string\n
-    \                   pattern: ^.*\n                    x-kubernetes-int-or-string:
-    true\n                  type: array\n                logFilePath:\n                  description:
-    'LogFilePath is the full path to the Felix log. Set to\n                  none
-    to disable file logging. [Default: /var/log/calico/felix.log]'\n                  type:
-    string\n                logPrefix:\n                  description: 'LogPrefix
-    is the log prefix that Felix uses when rendering\n                  LOG rules.
-    [Default: calico-packet]'\n                  type: string\n                logSeverityFile:\n
-    \                 description: 'LogSeverityFile is the log severity above which
-    logs\n                  are sent to the log file. [Default: Info]'\n                  type:
-    string\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: Info]'\n                  type: string\n                logSeveritySys:\n
-    \                 description: 'LogSeveritySys is the log severity above which
-    logs\n                  are sent to the syslog. Set to None for no logging to
-    syslog. [Default:\n                  Info]'\n                  type: string\n
-    \               maxIpsetSize:\n                  type: integer\n                metadataAddr:\n
-    \                 description: 'MetadataAddr is the IP address or domain name
-    of the\n                  server that can answer VM queries for cloud-init metadata.
-    In OpenStack,\n                  this corresponds to the machine running nova-api
-    (or in Ubuntu,\n                  nova-api-metadata). A value of none (case insensitive)
-    means that\n                  Felix should not set up any NAT rule for the metadata
-    path. [Default:\n                  127.0.0.1]'\n                  type: string\n
-    \               metadataPort:\n                  description: 'MetadataPort is
-    the port of the metadata server. This,\n                  combined with global.MetadataAddr
-    (if not ‘None’), is used to set\n                  up a NAT rule, from 169.254.169.254:80
-    to MetadataAddr:MetadataPort.\n                  In most cases this should not
-    need to be changed [Default: 8775].'\n                  type: integer\n                mtuIfacePattern:\n
-    \                 description: MTUIfacePattern is a regular expression that controls\n
-    \                   which interfaces Felix should scan in order to calculate the
-    host's\n                    MTU. This should not match workload interfaces (usually
-    named cali...).\n                  type: string\n                natOutgoingAddress:\n
-    \                 description: NATOutgoingAddress specifies an address to use
-    when performing\n                    source NAT for traffic in a natOutgoing pool
-    that is leaving the\n                    network. By default the address used
-    is an address on the interface\n                    the traffic is leaving on
-    (ie it uses the iptables MASQUERADE target)\n                  type: string\n
-    \               natPortRange:\n                  anyOf:\n                    -
-    type: integer\n                    - type: string\n                  description:
-    NATPortRange specifies the range of ports that is used\n                    for
-    port mapping when doing outgoing NAT. When unset the default\n                    behavior
-    of the network stack is used.\n                  pattern: ^.*\n                  x-kubernetes-int-or-string:
-    true\n                netlinkTimeout:\n                  type: string\n                openstackRegion:\n
-    \                 description: 'OpenstackRegion is the name of the region that
-    a particular\n                  Felix belongs to. In a multi-region Calico/OpenStack
-    deployment,\n                  this must be configured somehow for each Felix
-    (here in the datamodel,\n                  or in felix.cfg or the environment
-    on each compute node), and must\n                  match the [calico] openstack_region
-    value configured in neutron.conf\n                  on each node. [Default: Empty]'\n
-    \                 type: string\n                policySyncPathPrefix:\n                  description:
-    'PolicySyncPathPrefix is used to by Felix to communicate\n                  policy
-    changes to external services, like Application layer policy.\n                  [Default:
-    Empty]'\n                  type: string\n                prometheusGoMetricsEnabled:\n
-    \                 description: 'PrometheusGoMetricsEnabled disables Go runtime
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                prometheusMetricsEnabled:\n                  description:
-    'PrometheusMetricsEnabled enables the Prometheus metrics\n                  server
-    in Felix if set to true. [Default: false]'\n                  type: boolean\n
-    \               prometheusMetricsHost:\n                  description: 'PrometheusMetricsHost
-    is the host that the Prometheus\n                  metrics server should bind
-    to. [Default: empty]'\n                  type: string\n                prometheusMetricsPort:\n
-    \                 description: 'PrometheusMetricsPort is the TCP port that the
-    Prometheus\n                  metrics server should bind to. [Default: 9091]'\n
-    \                 type: integer\n                prometheusProcessMetricsEnabled:\n
-    \                 description: 'PrometheusProcessMetricsEnabled disables process
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                removeExternalRoutes:\n                  description:
-    Whether or not to remove device routes that have not\n                    been
-    programmed by Felix. Disabling this will allow external applications\n                    to
-    also add device routes. This is enabled by default which means\n                    we
-    will remove externally added routes.\n                  type: boolean\n                reportingInterval:\n
-    \                 description: 'ReportingInterval is the interval at which Felix
-    reports\n                  its status into the datastore or 0 to disable. Must
-    be non-zero\n                  in OpenStack deployments. [Default: 30s]'\n                  type:
-    string\n                reportingTTL:\n                  description: 'ReportingTTL
-    is the time-to-live setting for process-wide\n                  status reports.
-    [Default: 90s]'\n                  type: string\n                routeRefreshInterval:\n
-    \                 description: 'RouterefreshInterval is the period at which Felix
-    re-checks\n                  the routes in the dataplane to ensure that no other
-    process has\n                  accidentally broken Calico’s rules. Set to 0 to
-    disable route refresh.\n                  [Default: 90s]'\n                  type:
-    string\n                routeSource:\n                  description: 'RouteSource
-    configures where Felix gets its routing\n                  information. - WorkloadIPs:
-    use workload endpoints to construct\n                  routes. - CalicoIPAM: the
-    default - use IPAM data to construct routes.'\n                  type: string\n
-    \               routeTableRange:\n                  description: Calico programs
-    additional Linux route tables for various\n                    purposes.  RouteTableRange
-    specifies the indices of the route tables\n                    that Calico should
-    use.\n                  properties:\n                    max:\n                      type:
-    integer\n                    min:\n                      type: integer\n                  required:\n
-    \                   - max\n                    - min\n                  type:
-    object\n                serviceLoopPrevention:\n                  description:
-    'When service IP advertisement is enabled, prevent routing\n                    loops
-    to service IPs that are not in use, by dropping or rejecting\n                    packets
-    that do not get DNAT''d by kube-proxy. Unless set to \"Disabled\",\n                    in
-    which case such routing loops continue to be allowed. [Default:\n                    Drop]'\n
-    \                 type: string\n                sidecarAccelerationEnabled:\n
-    \                 description: 'SidecarAccelerationEnabled enables experimental
-    sidecar\n                  acceleration [Default: false]'\n                  type:
-    boolean\n                usageReportingEnabled:\n                  description:
-    'UsageReportingEnabled reports anonymous Calico version\n                  number
-    and cluster size to projectcalico.org. Logs warnings returned\n                  by
-    the usage server. For example, if a significant security vulnerability\n                  has
-    been discovered in the version of Calico being used. [Default:\n                  true]'\n
-    \                 type: boolean\n                usageReportingInitialDelay:\n
-    \                 description: 'UsageReportingInitialDelay controls the minimum
-    delay\n                  before Felix makes a report. [Default: 300s]'\n                  type:
-    string\n                usageReportingInterval:\n                  description:
-    'UsageReportingInterval controls the interval at which\n                  Felix
-    makes reports. [Default: 86400s]'\n                  type: string\n                useInternalDataplaneDriver:\n
-    \                 type: boolean\n                vxlanEnabled:\n                  type:
-    boolean\n                vxlanMTU:\n                  description: 'VXLANMTU is
-    the MTU to set on the tunnel device. See\n                  Configuring MTU [Default:
-    1440]'\n                  type: integer\n                vxlanPort:\n                  type:
-    integer\n                vxlanVNI:\n                  type: integer\n                wireguardEnabled:\n
-    \                 description: 'WireguardEnabled controls whether Wireguard is
-    enabled.\n                  [Default: false]'\n                  type: boolean\n
-    \               wireguardInterfaceName:\n                  description: 'WireguardInterfaceName
-    specifies the name to use for\n                  the Wireguard interface. [Default:
-    wg.calico]'\n                  type: string\n                wireguardListeningPort:\n
-    \                 description: 'WireguardListeningPort controls the listening
-    port used\n                  by Wireguard. [Default: 51820]'\n                  type:
-    integer\n                wireguardMTU:\n                  description: 'WireguardMTU
-    controls the MTU on the Wireguard interface.\n                  See Configuring
-    MTU [Default: 1420]'\n                  type: integer\n                wireguardRoutingRulePriority:\n
-    \                 description: 'WireguardRoutingRulePriority controls the priority
-    value\n                  to use for the Wireguard routing rule. [Default: 99]'\n
-    \                 type: integer\n                xdpEnabled:\n                  description:
-    'XDPEnabled enables XDP acceleration for suitable untracked\n                  incoming
-    deny rules. [Default: true]'\n                  type: boolean\n                xdpRefreshInterval:\n
-    \                 description: 'XDPRefreshInterval is the period at which Felix
-    re-checks\n                  all XDP state to ensure that no other process has
-    accidentally broken\n                  Calico''s BPF maps or attached programs.
-    Set to 0 to disable XDP\n                  refresh. [Default: 90s]'\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: globalnetworkpolicies.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: GlobalNetworkPolicy\n    listKind:
-    GlobalNetworkPolicyList\n    plural: globalnetworkpolicies\n    singular: globalnetworkpolicy\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                applyOnForward:\n
-    \                 description: ApplyOnForward indicates to apply the rules in
-    this policy\n                    on forward traffic.\n                  type:
-    boolean\n                doNotTrack:\n                  description: DoNotTrack
-    indicates whether packets matched by the rules\n                    in this policy
-    should go through the data plane's connection tracking,\n                    such
-    as Linux conntrack.  If True, the rules in this policy are\n                    applied
-    before any data plane connection tracking, and packets allowed\n                    by
-    this policy are marked as not to be tracked.\n                  type: boolean\n
-    \               egress:\n                  description: The ordered set of egress
-    rules.  Each rule contains\n                    a set of packet match criteria
-    and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                namespaceSelector:\n                  description: NamespaceSelector
-    is an optional field for an expression\n                    used to select a pod
-    based on namespaces.\n                  type: string\n                order:\n
-    \                 description: Order is an optional field that specifies the order
-    in\n                    which the policy is applied. Policies with higher \"order\"
-    are applied\n                    after those with lower order.  If the order is
-    omitted, it may be\n                    considered to be \"infinite\" - i.e. the
-    policy will be applied last.  Policies\n                    with identical order
-    will be applied in alphanumerical order based\n                    on the Policy
-    \"Name\".\n                  type: number\n                preDNAT:\n                  description:
-    PreDNAT indicates to apply the rules in this policy before\n                    any
-    DNAT.\n                  type: boolean\n                selector:\n                  description:
-    \"The selector is an expression used to pick pick out\n                  the endpoints
-    that the policy should be applied to. \\n Selector\n                  expressions
-    follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n                  \\
-    ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel != \\\"string_literal\\\"\n
-    \                 \\  ->  not equal; also matches if label is not present \\tlabel
-    in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\", ... }  ->  true if the
-    value of label X is\n                  one of \\\"a\\\", \\\"b\\\", \\\"c\\\"
-    \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ... }  ->
-    \ true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress rules are present
-    in the policy.  The\n                  default is: \\n - [ PolicyTypeIngress ],
-    if there are no Egress rules\n                  (including the case where there
-    are   also no Ingress rules) \\n\n                  - [ PolicyTypeEgress ], if
-    there are Egress rules but no Ingress\n                  rules \\n - [ PolicyTypeIngress,
-    PolicyTypeEgress ], if there are\n                  both Ingress and Egress rules.
-    \\n When the policy is read back again,\n                  Types will always be
-    one of these values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: globalnetworksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: GlobalNetworkSet\n    listKind: GlobalNetworkSetList\n    plural:
-    globalnetworksets\n    singular: globalnetworkset\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs\n            that
-    share labels to allow rules to refer to them via selectors.  The labels\n            of
-    GlobalNetworkSet are not namespaced.\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: GlobalNetworkSetSpec contains the
-    specification for a NetworkSet\n                resource.\n              properties:\n
-    \               nets:\n                  description: The list of IP networks
-    that belong to this set.\n                  items:\n                    type:
-    string\n                  type: array\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: hostendpoints.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: HostEndpoint\n    listKind: HostEndpointList\n    plural:
-    hostendpoints\n    singular: hostendpoint\n  scope: Cluster\n  versions:\n    -
-    name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: HostEndpointSpec contains the specification
-    for a HostEndpoint\n                resource.\n              properties:\n                expectedIPs:\n
-    \                 description: \"The expected IP addresses (IPv4 and IPv6) of
-    the endpoint.\n                  If \\\"InterfaceName\\\" is not present, Calico
-    will look for an interface\n                  matching any of the IPs in the list
-    and apply policy to that. Note:\n                  \\tWhen using the selector
-    match criteria in an ingress or egress\n                  security Policy \\tor
-    Profile, Calico converts the selector into\n                  a set of IP addresses.
-    For host \\tendpoints, the ExpectedIPs field\n                  is used for that
-    purpose. (If only the interface \\tname is specified,\n                  Calico
-    does not learn the IPs of the interface for use in match\n                  \\tcriteria.)\"\n
-    \                 items:\n                    type: string\n                  type:
-    array\n                interfaceName:\n                  description: \"Either
-    \\\"*\\\", or the name of a specific Linux interface\n                  to apply
-    policy to; or empty.  \\\"*\\\" indicates that this HostEndpoint\n                  governs
-    all traffic to, from or through the default network namespace\n                  of
-    the host named by the \\\"Node\\\" field; entering and leaving that\n                  namespace
-    via any interface, including those from/to non-host-networked\n                  local
-    workloads. \\n If InterfaceName is not \\\"*\\\", this HostEndpoint\n                  only
-    governs traffic that enters or leaves the host through the\n                  specific
-    interface named by InterfaceName, or - when InterfaceName\n                  is
-    empty - through the specific interface that has one of the IPs\n                  in
-    ExpectedIPs. Therefore, when InterfaceName is empty, at least\n                  one
-    expected IP must be specified.  Only external interfaces (such\n                  as
-    “eth0”) are supported here; it isn't possible for a HostEndpoint\n                  to
-    protect traffic through a specific local workload interface.\n                  \\n
-    Note: Only some kinds of policy are implemented for \\\"*\\\" HostEndpoints;\n
-    \                 initially just pre-DNAT policy.  Please check Calico documentation\n
-    \                 for the latest position.\"\n                  type: string\n
-    \               node:\n                  description: The node name identifying
-    the Calico node instance.\n                  type: string\n                ports:\n
-    \                 description: Ports contains the endpoint's named ports, which
-    may\n                    be referenced in security policy rules.\n                  items:\n
-    \                   properties:\n                      name:\n                        type:
-    string\n                      port:\n                        type: integer\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                    required:\n                      - name\n                      -
-    port\n                      - protocol\n                    type: object\n                  type:
-    array\n                profiles:\n                  description: A list of identifiers
-    of security Profile objects that\n                    apply to this endpoint.
-    Each profile is applied in the order that\n                    they appear in
-    this list.  Profile rules are applied after the selector-based\n                    security
-    policy.\n                  items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: ipamblocks.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMBlock\n    listKind: IPAMBlockList\n
-    \   plural: ipamblocks\n    singular: ipamblock\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMBlockSpec contains the specification
-    for an IPAMBlock\n                resource.\n              properties:\n                affinity:\n
-    \                 type: string\n                allocations:\n                  items:\n
-    \                   type: integer\n                    # TODO: This nullable is
-    manually added in. We should update controller-gen\n                    # to handle
-    []*int properly itself.\n                    nullable: true\n                  type:
-    array\n                attributes:\n                  items:\n                    properties:\n
-    \                     handle_id:\n                        type: string\n                      secondary:\n
-    \                       additionalProperties:\n                          type:
-    string\n                        type: object\n                    type: object\n
-    \                 type: array\n                cidr:\n                  type:
-    string\n                deleted:\n                  type: boolean\n                strictAffinity:\n
-    \                 type: boolean\n                unallocated:\n                  items:\n
-    \                   type: integer\n                  type: array\n              required:\n
-    \               - allocations\n                - attributes\n                -
-    cidr\n                - strictAffinity\n                - unallocated\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMConfig\n    listKind: IPAMConfigList\n    plural: ipamconfigs\n
-    \   singular: ipamconfig\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMConfigSpec contains the specification
-    for an IPAMConfig\n                resource.\n              properties:\n                autoAllocateBlocks:\n
-    \                 type: boolean\n                maxBlocksPerHost:\n                  description:
-    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                    that
-    can be affine to each host.\n                  type: integer\n                strictAffinity:\n
-    \                 type: boolean\n              required:\n                - autoAllocateBlocks\n
-    \               - strictAffinity\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ipamhandles.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMHandle\n    listKind: IPAMHandleList\n    plural: ipamhandles\n
-    \   singular: ipamhandle\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMHandleSpec contains the specification
-    for an IPAMHandle\n                resource.\n              properties:\n                block:\n
-    \                 additionalProperties:\n                    type: integer\n                  type:
-    object\n                deleted:\n                  type: boolean\n                handleID:\n
-    \                 type: string\n              required:\n                - block\n
-    \               - handleID\n              type: object\n          type: object\n
-    \     served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ippools.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPPool\n    listKind: IPPoolList\n    plural: ippools\n    singular:
-    ippool\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPPoolSpec contains the specification
-    for an IPPool resource.\n              properties:\n                blockSize:\n
-    \                 description: The block size to use for IP address assignments
-    from\n                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.\n
-    \                 type: integer\n                cidr:\n                  description:
-    The pool CIDR.\n                  type: string\n                disabled:\n                  description:
-    When disabled is true, Calico IPAM will not assign addresses\n                    from
-    this pool.\n                  type: boolean\n                ipip:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  properties:\n                    enabled:\n                      description:
-    When enabled is true, ipip tunneling will be used\n                        to
-    deliver packets to destinations within this pool.\n                      type:
-    boolean\n                    mode:\n                      description: The IPIP
-    mode.  This can be one of \"always\" or \"cross-subnet\".  A\n                        mode
-    of \"always\" will also use IPIP tunneling for routing to\n                        destination
-    IP addresses within this pool.  A mode of \"cross-subnet\"\n                        will
-    only use IPIP tunneling when the destination node is on\n                        a
-    different subnet to the originating node.  The default value\n                        (if
-    not specified) is \"always\".\n                      type: string\n                  type:
-    object\n                ipipMode:\n                  description: Contains configuration
-    for IPIP tunneling for this pool.\n                    If not specified, then
-    this is defaulted to \"Never\" (i.e. IPIP tunneling\n                    is disabled).\n
-    \                 type: string\n                nat-outgoing:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  type: boolean\n                natOutgoing:\n                  description:
-    When nat-outgoing is true, packets sent from Calico networked\n                    containers
-    in this pool to destinations outside of this pool will\n                    be
-    masqueraded.\n                  type: boolean\n                nodeSelector:\n
-    \                 description: Allows IPPool to allocate for a specific node by
-    label\n                    selector.\n                  type: string\n                vxlanMode:\n
-    \                 description: Contains configuration for VXLAN tunneling for
-    this pool.\n                    If not specified, then this is defaulted to \"Never\"
-    (i.e. VXLAN\n                    tunneling is disabled).\n                  type:
-    string\n              required:\n                - cidr\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: kubecontrollersconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: KubeControllersConfiguration\n    listKind: KubeControllersConfigurationList\n
-    \   plural: kubecontrollersconfigurations\n    singular: kubecontrollersconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: KubeControllersConfigurationSpec
-    contains the values of the\n                Kubernetes controllers configuration.\n
-    \             properties:\n                controllers:\n                  description:
-    Controllers enables and configures individual Kubernetes\n                    controllers\n
-    \                 properties:\n                    namespace:\n                      description:
-    Namespace enables and configures the namespace controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   node:\n                      description: Node enables and
-    configures the node controller.\n                        Enabled by default, set
-    to nil to disable.\n                      properties:\n                        hostEndpoint:\n
-    \                         description: HostEndpoint controls syncing nodes to
-    host endpoints.\n                            Disabled by default, set to nil to
-    disable.\n                          properties:\n                            autoCreate:\n
-    \                             description: 'AutoCreate enables automatic creation
-    of\n                              host endpoints for every node. [Default: Disabled]'\n
-    \                             type: string\n                          type: object\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                       syncLabels:\n                          description: 'SyncLabels
-    controls whether to copy Kubernetes\n                          node labels to
-    Calico nodes. [Default: Enabled]'\n                          type: string\n                      type:
-    object\n                    policy:\n                      description: Policy
-    enables and configures the policy controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   serviceAccount:\n                      description: ServiceAccount
-    enables and configures the service\n                        account controller.
-    Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                    workloadEndpoint:\n                      description:
-    WorkloadEndpoint enables and configures the workload\n                        endpoint
-    controller. Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                  type: object\n                etcdV3CompactionPeriod:\n
-    \                 description: 'EtcdV3CompactionPeriod is the period between etcdv3\n
-    \                 compaction requests. Set to 0 to disable. [Default: 10m]'\n
-    \                 type: string\n                healthChecks:\n                  description:
-    'HealthChecks enables or disables support for health\n                  checks
-    [Default: Enabled]'\n                  type: string\n                logSeverityScreen:\n
-    \                 description: 'LogSeverityScreen is the log severity above which
-    logs\n                  are sent to the stdout. [Default: Info]'\n                  type:
-    string\n                prometheusMetricsPort:\n                  description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                    metrics
-    server should bind to. Set to 0 to disable. [Default: 9094]'\n                  type:
-    integer\n              required:\n                - controllers\n              type:
-    object\n            status:\n              description: KubeControllersConfigurationStatus
-    represents the status\n                of the configuration. It's useful for admins
-    to be able to see the actual\n                config that was applied, which can
-    be modified by environment variables\n                on the kube-controllers
-    process.\n              properties:\n                environmentVars:\n                  additionalProperties:\n
-    \                   type: string\n                  description: EnvironmentVars
-    contains the environment variables on\n                    the kube-controllers
-    that influenced the RunningConfig.\n                  type: object\n                runningConfig:\n
-    \                 description: RunningConfig contains the effective config that
-    is running\n                    in the kube-controllers pod, after merging the
-    API resource with\n                    any environment variables.\n                  properties:\n
-    \                   controllers:\n                      description: Controllers
-    enables and configures individual Kubernetes\n                        controllers\n
-    \                     properties:\n                        namespace:\n                          description:
-    Namespace enables and configures the namespace\n                            controller.
-    Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        node:\n
-    \                         description: Node enables and configures the node controller.\n
-    \                           Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           hostEndpoint:\n                              description:
-    HostEndpoint controls syncing nodes to host\n                                endpoints.
-    Disabled by default, set to nil to disable.\n                              properties:\n
-    \                               autoCreate:\n                                  description:
-    'AutoCreate enables automatic creation\n                                  of host
-    endpoints for every node. [Default: Disabled]'\n                                  type:
-    string\n                              type: object\n                            leakGracePeriod:\n
-    \                             description: 'LeakGracePeriod is the period used
-    by the\n                                controller to determine if an IP address
-    has been leaked.\n                                Set to 0 to disable IP garbage
-    collection. [Default:\n                                15m]'\n                              type:
-    string\n                            reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                            syncLabels:\n                              description:
-    'SyncLabels controls whether to copy Kubernetes\n                              node
-    labels to Calico nodes. [Default: Enabled]'\n                              type:
-    string\n                          type: object\n                        policy:\n
-    \                         description: Policy enables and configures the policy
-    controller.\n                            Enabled by default, set to nil to disable.\n
-    \                         properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        serviceAccount:\n
-    \                         description: ServiceAccount enables and configures the
-    service\n                            account controller. Enabled by default, set
-    to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        workloadEndpoint:\n
-    \                         description: WorkloadEndpoint enables and configures
-    the workload\n                            endpoint controller. Enabled by default,
-    set to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                      type: object\n
-    \                   etcdV3CompactionPeriod:\n                      description:
-    'EtcdV3CompactionPeriod is the period between etcdv3\n                      compaction
-    requests. Set to 0 to disable. [Default: 10m]'\n                      type: string\n
-    \                   healthChecks:\n                      description: 'HealthChecks
-    enables or disables support for health\n                      checks [Default:
-    Enabled]'\n                      type: string\n                    logSeverityScreen:\n
-    \                     description: 'LogSeverityScreen is the log severity above
-    which\n                      logs are sent to the stdout. [Default: Info]'\n                      type:
-    string\n                    prometheusMetricsPort:\n                      description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                        metrics
-    server should bind to. Set to 0 to disable. [Default:\n                        9094]'\n
-    \                     type: integer\n                  required:\n                    -
-    controllers\n                  type: object\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: networkpolicies.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkPolicy\n    listKind: NetworkPolicyList\n    plural:
-    networkpolicies\n    singular: networkpolicy\n  scope: Namespaced\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                egress:\n                  description:
-    The ordered set of egress rules.  Each rule contains\n                    a set
-    of packet match criteria and a corresponding action to apply.\n                  items:\n
-    \                   description: \"A Rule encapsulates a set of match criteria
-    and an\n                    action.  Both selector-based security Policy and security
-    Profiles\n                    reference rules - separated out as a list of rules
-    for both ingress\n                    and egress packet matching. \\n Each positive
-    match criteria has\n                    a negated version, prefixed with ”Not”.
-    All the match criteria\n                    within a rule must be satisfied for
-    a packet to match. A single\n                    rule can contain the positive
-    and negative version of a match\n                    and both must be satisfied
-    for the rule to match.\"\n                    properties:\n                      action:\n
-    \                       type: string\n                      destination:\n                        description:
-    Destination contains the match criteria that apply\n                          to
-    destination entity.\n                        properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                order:\n                  description: Order is an optional
-    field that specifies the order in\n                    which the policy is applied.
-    Policies with higher \"order\" are applied\n                    after those with
-    lower order.  If the order is omitted, it may be\n                    considered
-    to be \"infinite\" - i.e. the policy will be applied last.  Policies\n                    with
-    identical order will be applied in alphanumerical order based\n                    on
-    the Policy \"Name\".\n                  type: number\n                selector:\n
-    \                 description: \"The selector is an expression used to pick pick
-    out\n                  the endpoints that the policy should be applied to. \\n
-    Selector\n                  expressions follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n
-    \                 \\ ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel
-    != \\\"string_literal\\\"\n                  \\  ->  not equal; also matches if
-    label is not present \\tlabel in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\",
-    ... }  ->  true if the value of label X is\n                  one of \\\"a\\\",
-    \\\"b\\\", \\\"c\\\" \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ...
-    }  ->  true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress are present in the
-    policy.  The default\n                  is: \\n - [ PolicyTypeIngress ], if there
-    are no Egress rules (including\n                  the case where there are   also
-    no Ingress rules) \\n - [ PolicyTypeEgress\n                  ], if there are
-    Egress rules but no Ingress rules \\n - [ PolicyTypeIngress,\n                  PolicyTypeEgress
-    ], if there are both Ingress and Egress rules.\n                  \\n When the
-    policy is read back again, Types will always be one\n                  of these
-    values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: networksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkSet\n    listKind: NetworkSetList\n    plural: networksets\n
-    \   singular: networkset\n  scope: Namespaced\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          description: NetworkSet is the Namespaced-equivalent
-    of the GlobalNetworkSet.\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: NetworkSetSpec contains the specification
-    for a NetworkSet\n                resource.\n              properties:\n                nets:\n
-    \                 description: The list of IP networks that belong to this set.\n
-    \                 items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n---\n# Source: calico/templates/calico-kube-controllers-rbac.yaml\n\n#
-    Include a clusterrole for the kube-controllers component,\n# and bind it to the
-    calico-kube-controllers serviceaccount.\nkind: ClusterRole\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nrules:\n  # Nodes are watched to monitor for
-    deletions.\n  - apiGroups: [\"\"]\n    resources:\n      - nodes\n    verbs:\n
-    \     - watch\n      - list\n      - get\n  # Pods are watched to check for existence
-    as part of IPAM controller.\n  - apiGroups: [\"\"]\n    resources:\n      - pods\n
-    \   verbs:\n      - get\n      - list\n      - watch\n  # IPAM resources are manipulated
-    when nodes are deleted.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - ippools\n    verbs:\n      - list\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - blockaffinities\n      - ipamblocks\n      - ipamhandles\n
-    \   verbs:\n      - get\n      - list\n      - create\n      - update\n      -
-    delete\n      - watch\n  # kube-controllers manages hostendpoints.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - hostendpoints\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  #
-    Needs access to update clusterinformations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - clusterinformations\n    verbs:\n      - get\n      -
-    create\n      - update\n  # KubeControllersConfiguration is where it gets its
-    config\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - kubecontrollersconfigurations\n
-    \   verbs:\n      # read its own config\n      - get\n      # create a default
-    if none exists\n      - create\n      # update status\n      - update\n      #
-    watch for changes\n      - watch\n---\nkind: ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-kube-controllers\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-kube-controllers\n    namespace: kube-system\n---\n\n---\n# Source:
-    calico/templates/calico-node-rbac.yaml\n# Include a clusterrole for the calico-node
-    DaemonSet,\n# and bind it to the calico-node serviceaccount.\nkind: ClusterRole\napiVersion:
-    rbac.authorization.k8s.io/v1\nmetadata:\n  name: calico-node\nrules:\n  # The
-    CNI plugin needs to get pods, nodes, and namespaces.\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - pods\n      - nodes\n      - namespaces\n    verbs:\n
-    \     - get\n  # EndpointSlices are used for Service-based network policy rule\n
-    \ # enforcement.\n  - apiGroups: [\"discovery.k8s.io\"]\n    resources:\n      -
-    endpointslices\n    verbs:\n      - watch\n      - list\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - endpoints\n      - services\n    verbs:\n      # Used
-    to discover service IPs for advertisement.\n      - watch\n      - list\n      #
-    Used to discover Typhas.\n      - get\n  # Pod CIDR auto-detection on kubeadm
-    needs access to config maps.\n  - apiGroups: [\"\"]\n    resources:\n      - configmaps\n
-    \   verbs:\n      - get\n  - apiGroups: [\"\"]\n    resources:\n      - nodes/status\n
-    \   verbs:\n      # Needed for clearing NodeNetworkUnavailable flag.\n      -
-    patch\n      # Calico stores some configuration information in node annotations.\n
-    \     - update\n  # Watch for changes to Kubernetes NetworkPolicies.\n  - apiGroups:
-    [\"networking.k8s.io\"]\n    resources:\n      - networkpolicies\n    verbs:\n
-    \     - watch\n      - list\n  # Used by Calico for policy information.\n  - apiGroups:
-    [\"\"]\n    resources:\n      - pods\n      - namespaces\n      - serviceaccounts\n
-    \   verbs:\n      - list\n      - watch\n  # The CNI plugin patches pods/status.\n
-    \ - apiGroups: [\"\"]\n    resources:\n      - pods/status\n    verbs:\n      -
-    patch\n  # Calico monitors various CRDs for config.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - globalfelixconfigs\n      - felixconfigurations\n      -
-    bgppeers\n      - globalbgpconfigs\n      - bgpconfigurations\n      - ippools\n
-    \     - ipamblocks\n      - globalnetworkpolicies\n      - globalnetworksets\n
-    \     - networkpolicies\n      - networksets\n      - clusterinformations\n      -
-    hostendpoints\n      - blockaffinities\n    verbs:\n      - get\n      - list\n
-    \     - watch\n  # Calico must create and update some CRDs on startup.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - ippools\n      - felixconfigurations\n
-    \     - clusterinformations\n    verbs:\n      - create\n      - update\n  # Calico
-    stores some configuration information on the node.\n  - apiGroups: [\"\"]\n    resources:\n
-    \     - nodes\n    verbs:\n      - get\n      - list\n      - watch\n  # These
-    permissions are only required for upgrade from v2.6, and can\n  # be removed after
-    upgrade or on fresh installations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - bgpconfigurations\n      - bgppeers\n    verbs:\n      -
-    create\n      - update\n  # These permissions are required for Calico CNI to perform
-    IPAM allocations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n      - ipamblocks\n      - ipamhandles\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  -
-    apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - ipamconfigs\n
-    \   verbs:\n      - get\n  # Block affinities must also be watchable by confd
-    for route aggregation.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n    verbs:\n      - watch\n  # The Calico IPAM migration
-    needs to get daemonsets. These permissions can be\n  # removed if not upgrading
-    from an installation using host-local IPAM.\n  - apiGroups: [\"apps\"]\n    resources:\n
-    \     - daemonsets\n    verbs:\n      - get\n\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:
-    ClusterRoleBinding\nmetadata:\n  name: calico-node\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-node\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-node\n    namespace: kube-system\n\n---\n# Source: calico/templates/calico-node.yaml\n#
-    This manifest installs the calico-node container, as well\n# as the CNI plugins
-    and network config on\n# each master and worker node in a Kubernetes cluster.\nkind:
-    DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: calico-node\n  namespace: kube-system\n
-    \ labels:\n    k8s-app: calico-node\nspec:\n  selector:\n    matchLabels:\n      k8s-app:
-    calico-node\n  updateStrategy:\n    type: RollingUpdate\n    rollingUpdate:\n
-    \     maxUnavailable: 1\n  template:\n    metadata:\n      labels:\n        k8s-app:
-    calico-node\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n
-    \     hostNetwork: true\n      tolerations:\n        # Make sure calico-node gets
-    scheduled on all nodes.\n        - effect: NoSchedule\n          operator: Exists\n
-    \       # Mark the pod as a critical add-on for rescheduling.\n        - key:
-    CriticalAddonsOnly\n          operator: Exists\n        - effect: NoExecute\n
-    \         operator: Exists\n      serviceAccountName: calico-node\n      # Minimize
-    downtime during a rolling upgrade or deletion; tell Kubernetes to do a \"force\n
-    \     # deletion\": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.\n
-    \     terminationGracePeriodSeconds: 0\n      priorityClassName: system-node-critical\n
-    \     initContainers:\n        # This container performs upgrade from host-local
-    IPAM to calico-ipam.\n        # It can be deleted if this is a fresh installation,
-    or if you have already\n        # upgraded to use calico-ipam.\n        - name:
-    upgrade-ipam\n          image: calico/cni:v3.20.0\n          command: [\"/opt/cni/bin/calico-ipam\",
-    \"-upgrade\"]\n          envFrom:\n            - configMapRef:\n                #
-    Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for
-    eBPF mode.\n                name: kubernetes-services-endpoint\n                optional:
-    true\n          env:\n            - name: KUBERNETES_NODE_NAME\n              valueFrom:\n
-    \               fieldRef:\n                  fieldPath: spec.nodeName\n            -
-    name: CALICO_NETWORKING_BACKEND\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: calico_backend\n
-    \         volumeMounts:\n            - mountPath: /var/lib/cni/networks\n              name:
-    host-local-net-dir\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n          securityContext:\n            privileged: true\n        #
-    This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: calico/cni:v3.20.0\n
-    \         command: [\"/opt/cni/bin/install\"]\n          envFrom:\n            -
-    configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
-    to be overridden for eBPF mode.\n                name: kubernetes-services-endpoint\n
-    \               optional: true\n          env:\n            # Name of the CNI
-    config file to create.\n            - name: CNI_CONF_NAME\n              value:
-    \"10-calico.conflist\"\n            # The CNI network config to install on each
-    node.\n            - name: CNI_NETWORK_CONFIG\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: cni_network_config\n
-    \           # Set the hostname based on the k8s node name.\n            - name:
-    KUBERNETES_NODE_NAME\n              valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # CNI MTU Config variable\n            - name: CNI_MTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Prevents the container
-    from sleeping forever.\n            - name: SLEEP\n              value: \"false\"\n
-    \         volumeMounts:\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n            - mountPath: /host/etc/cni/net.d\n              name:
-    cni-net-dir\n          securityContext:\n            privileged: true\n        #
-    Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes\n
-    \       # to communicate with Felix over the Policy Sync API.\n        - name:
-    flexvol-driver\n          image: calico/pod2daemon-flexvol:v3.20.0\n          volumeMounts:\n
-    \           - name: flexvol-driver-host\n              mountPath: /host/driver\n
-    \         securityContext:\n            privileged: true\n      containers:\n
-    \       # Runs calico-node container on each Kubernetes node. This\n        #
-    container programs network policy and routes on each\n        # host.\n        -
-    name: calico-node\n          image: calico/node:v3.20.0\n          envFrom:\n
-    \           - configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and
-    KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.\n                name:
-    kubernetes-services-endpoint\n                optional: true\n          env:\n
-    \           # Use Kubernetes API as the backing datastore.\n            - name:
-    DATASTORE_TYPE\n              value: \"kubernetes\"\n            # Wait for the
-    datastore.\n            - name: WAIT_FOR_DATASTORE\n              value: \"true\"\n
-    \           # Set based on the k8s node name.\n            - name: NODENAME\n
-    \             valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # Choose the backend to use.\n            - name: CALICO_NETWORKING_BACKEND\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: calico_backend\n            # Cluster type
-    to identify the deployment type\n            - name: CLUSTER_TYPE\n              value:
-    \"k8s,bgp\"\n            # Auto-detect the BGP IP address.\n            - name:
-    IP\n              value: \"autodetect\"\n            # Enable VXLAN\n            -
-    name: CALICO_IPV4POOL_VXLAN\n              value: \"Always\"\n            # Set
-    MTU for tunnel device used if ipip is enabled\n            - name: FELIX_IPINIPMTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Set MTU for the
-    VXLAN tunnel device.\n            - name: FELIX_VXLANMTU\n              valueFrom:\n
-    \               configMapKeyRef:\n                  name: calico-config\n                  key:
-    veth_mtu\n            # Set MTU for the Wireguard tunnel device.\n            -
-    name: FELIX_WIREGUARDMTU\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: veth_mtu\n            #
-    The default IPv4 pool to create on startup if none exists. Pod IPs will be\n            #
-    chosen from this range. Changing this value after installation will have\n            #
-    no effect. This should fall within `--cluster-cidr`.\n            # - name: CALICO_IPV4POOL_CIDR\n
-    \           #   value: \"192.168.0.0/16\"\n            # Disable file logging
-    so `kubectl logs` works.\n            - name: CALICO_DISABLE_FILE_LOGGING\n              value:
-    \"true\"\n            # Set Felix endpoint to host default action to ACCEPT.\n
-    \           - name: FELIX_DEFAULTENDPOINTTOHOSTACTION\n              value: \"ACCEPT\"\n
-    \           # Disable IPv6 on Kubernetes.\n            - name: FELIX_IPV6SUPPORT\n
-    \             value: \"false\"\n            - name: FELIX_FEATUREDETECTOVERRIDE\n
-    \             value: \"ChecksumOffloadBroken=true\"\n            - name: FELIX_HEALTHENABLED\n
-    \             value: \"true\"\n          securityContext:\n            privileged:
-    true\n          resources:\n            requests:\n              cpu: 250m\n          livenessProbe:\n
-    \           exec:\n              command:\n                - /bin/calico-node\n
-    \               - -felix-live\n            periodSeconds: 10\n            initialDelaySeconds:
-    10\n            failureThreshold: 6\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /bin/calico-node\n                -
-    -felix-ready\n            periodSeconds: 10\n          volumeMounts:\n            -
-    mountPath: /host/etc/cni/net.d\n              name: cni-net-dir\n              readOnly:
-    false\n            - mountPath: /lib/modules\n              name: lib-modules\n
-    \             readOnly: true\n            - mountPath: /run/xtables.lock\n              name:
-    xtables-lock\n              readOnly: false\n            - mountPath: /var/run/calico\n
-    \             name: var-run-calico\n              readOnly: false\n            -
-    mountPath: /var/lib/calico\n              name: var-lib-calico\n              readOnly:
-    false\n            - name: policysync\n              mountPath: /var/run/nodeagent\n
-    \           # For eBPF mode, we need to be able to mount the BPF filesystem at
-    /sys/fs/bpf so we mount in the\n            # parent directory.\n            -
-    name: sysfs\n              mountPath: /sys/fs/\n              # Bidirectional
-    means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to
-    the host.\n              # If the host is known to mount that filesystem already
-    then Bidirectional can be omitted.\n              mountPropagation: Bidirectional\n
-    \           - name: cni-log-dir\n              mountPath: /var/log/calico/cni\n
-    \             readOnly: true\n      volumes:\n        # Used by calico-node.\n
-    \       - name: lib-modules\n          hostPath:\n            path: /lib/modules\n
-    \       - name: var-run-calico\n          hostPath:\n            path: /var/run/calico\n
-    \       - name: var-lib-calico\n          hostPath:\n            path: /var/lib/calico\n
-    \       - name: xtables-lock\n          hostPath:\n            path: /run/xtables.lock\n
-    \           type: FileOrCreate\n        - name: sysfs\n          hostPath:\n            path:
-    /sys/fs/\n            type: DirectoryOrCreate\n        # Used to install CNI.\n
-    \       - name: cni-bin-dir\n          hostPath:\n            path: /opt/cni/bin\n
-    \       - name: cni-net-dir\n          hostPath:\n            path: /etc/cni/net.d\n
-    \       # Used to access CNI logs.\n        - name: cni-log-dir\n          hostPath:\n
-    \           path: /var/log/calico/cni\n        # Mount in the directory for host-local
-    IPAM allocations. This is\n        # used when upgrading from host-local to calico-ipam,
-    and can be removed\n        # if not using the upgrade-ipam init container.\n
-    \       - name: host-local-net-dir\n          hostPath:\n            path: /var/lib/cni/networks\n
-    \       # Used to create per-pod Unix Domain Sockets\n        - name: policysync\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /var/run/nodeagent\n
-    \       # Used to install Flex Volume Driver\n        - name: flexvol-driver-host\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds\n---\n\napiVersion:
-    v1\nkind: ServiceAccount\nmetadata:\n  name: calico-node\n  namespace: kube-system\n\n---\n#
-    Source: calico/templates/calico-kube-controllers.yaml\n# See https://github.com/projectcalico/kube-controllers\napiVersion:
-    apps/v1\nkind: Deployment\nmetadata:\n  name: calico-kube-controllers\n  namespace:
-    kube-system\n  labels:\n    k8s-app: calico-kube-controllers\nspec:\n  # The controllers
-    can only have a single active instance.\n  replicas: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n  strategy:\n    type: Recreate\n  template:\n
-    \   metadata:\n      name: calico-kube-controllers\n      namespace: kube-system\n
-    \     labels:\n        k8s-app: calico-kube-controllers\n    spec:\n      nodeSelector:\n
-    \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
-    a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
-    Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
-    \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
-    \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
-    \         env:\n            # Choose which controllers to run.\n            -
-    name: ENABLED_CONTROLLERS\n              value: node\n            - name: DATASTORE_TYPE\n
-    \             value: kubernetes\n          livenessProbe:\n            exec:\n
-    \             command:\n              - /usr/bin/check-status\n              -
-    -l\n            periodSeconds: 10\n            initialDelaySeconds: 10\n            failureThreshold:
-    6\n            timeoutSeconds: 10\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /usr/bin/check-status\n                -
-    -r\n            periodSeconds: 10\n\n---\n\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n\n---\n\n# This manifest
-    creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler
-    to evict\n\napiVersion: policy/v1beta1\nkind: PodDisruptionBudget\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n  labels:\n    k8s-app:
-    calico-kube-controllers\nspec:\n  maxUnavailable: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n---\n# Source: calico/templates/calico-etcd-secrets.yaml\n\n---\n#
-    Source: calico/templates/calico-typha.yaml\n\n---\n# Source: calico/templates/configure-canal.yaml\n"
+  resources: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgpconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPConfiguration
+        listKind: BGPConfigurationList
+        plural: bgpconfigurations
+        singular: bgpconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: BGPConfiguration contains the configuration for any BGP routing.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPConfigurationSpec contains the values of the BGP configuration.
+                properties:
+                  asNumber:
+                    description: 'ASNumber is the default AS number used by a node. [Default:
+                      64512]'
+                    format: int32
+                    type: integer
+                  communities:
+                    description: Communities is a list of BGP community values and their
+                      arbitrary names for tagging routes.
+                    items:
+                      description: Community contains standard or large community value
+                        and its name.
+                      properties:
+                        name:
+                          description: Name given to community value.
+                          type: string
+                        value:
+                          description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                            For standard community use `aa:nn` format, where `aa` and
+                            `nn` are 16 bit number. For large community use `aa:nn:mm`
+                            format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                            `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                          pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                          type: string
+                      type: object
+                    type: array
+                  listenPort:
+                    description: ListenPort is the port where BGP protocol should listen.
+                      Defaults to 179
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: INFO]'
+                    type: string
+                  nodeToNodeMeshEnabled:
+                    description: 'NodeToNodeMeshEnabled sets whether full node to node
+                      BGP mesh is enabled. [Default: true]'
+                    type: boolean
+                  prefixAdvertisements:
+                    description: PrefixAdvertisements contains per-prefix advertisement
+                      configuration.
+                    items:
+                      description: PrefixAdvertisement configures advertisement properties
+                        for the specified CIDR.
+                      properties:
+                        cidr:
+                          description: CIDR for which properties should be advertised.
+                          type: string
+                        communities:
+                          description: Communities can be list of either community names
+                            already defined in `Specs.Communities` or community value
+                            of format `aa:nn` or `aa:nn:mm`. For standard community use
+                            `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                            large community use `aa:nn:mm` format, where `aa`, `nn` and
+                            `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                            `mm` are per-AS identifier.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  serviceClusterIPs:
+                    description: ServiceClusterIPs are the CIDR blocks from which service
+                      cluster IPs are allocated. If specified, Calico will advertise these
+                      blocks, as well as any cluster IPs within them.
+                    items:
+                      description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                        CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceExternalIPs:
+                    description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                      Service External IPs. Kubernetes Service ExternalIPs will only be
+                      advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceExternalIPBlock represents a single allowed
+                        External IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceLoadBalancerIPs:
+                    description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                      Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                      IPs will only be advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceLoadBalancerIPBlock represents a single allowed
+                        LoadBalancer IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgppeers.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPPeer
+        listKind: BGPPeerList
+        plural: bgppeers
+        singular: bgppeer
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPPeerSpec contains the specification for a BGPPeer resource.
+                properties:
+                  asNumber:
+                    description: The AS Number of the peer.
+                    format: int32
+                    type: integer
+                  keepOriginalNextHop:
+                    description: Option to keep the original nexthop field when routes
+                      are sent to a BGP Peer. Setting "true" configures the selected BGP
+                      Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                      in the specific branch of the Node on "bird.cfg".
+                    type: boolean
+                  maxRestartTime:
+                    description: Time to allow for software restart.  When specified,
+                      this is configured as the graceful restart timeout.  When not specified,
+                      the BIRD default of 120s is used.
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance that
+                      is targeted by this peer. If this is not set, and no nodeSelector
+                      is specified, then this BGP peer selects all nodes in the cluster.
+                    type: string
+                  nodeSelector:
+                    description: Selector for the nodes that should have this peering.  When
+                      this is set, the Node field must be empty.
+                    type: string
+                  password:
+                    description: Optional BGP password for the peerings generated by this
+                      BGPPeer resource.
+                    properties:
+                      secretKeyRef:
+                        description: Selects a key of a secret in the node pod's namespace.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be
+                              a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be
+                              defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  peerIP:
+                    description: The IP address of the peer followed by an optional port
+                      number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                      or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                      and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                      set in BGPConfiguration, then we use that port to peer.
+                    type: string
+                  peerSelector:
+                    description: Selector for the remote nodes to peer with.  When this
+                      is set, the PeerIP and ASNumber fields must be empty.  For each
+                      peering between the local node and selected remote nodes, we configure
+                      an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                      and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                      remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                      or the global default if that is not set.
+                    type: string
+                  sourceAddress:
+                    description: Specifies whether and how to configure a source address
+                      for the peerings generated by this BGPPeer resource.  Default value
+                      "UseNodeIP" means to configure the node IP as the source address.  "None"
+                      means not to configure a source address.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: blockaffinities.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BlockAffinity
+        listKind: BlockAffinityList
+        plural: blockaffinities
+        singular: blockaffinity
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BlockAffinitySpec contains the specification for a BlockAffinity
+                  resource.
+                properties:
+                  cidr:
+                    type: string
+                  deleted:
+                    description: Deleted indicates that this block affinity is being deleted.
+                      This field is a string for compatibility with older releases that
+                      mistakenly treat this field as a string.
+                    type: string
+                  node:
+                    type: string
+                  state:
+                    type: string
+                required:
+                - cidr
+                - deleted
+                - node
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: clusterinformations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: ClusterInformation
+        listKind: ClusterInformationList
+        plural: clusterinformations
+        singular: clusterinformation
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterInformation contains the cluster specific information.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterInformationSpec contains the values of describing
+                  the cluster.
+                properties:
+                  calicoVersion:
+                    description: CalicoVersion is the version of Calico that the cluster
+                      is running
+                    type: string
+                  clusterGUID:
+                    description: ClusterGUID is the GUID of the cluster
+                    type: string
+                  clusterType:
+                    description: ClusterType describes the type of the cluster
+                    type: string
+                  datastoreReady:
+                    description: DatastoreReady is used during significant datastore migrations
+                      to signal to components such as Felix that it should wait before
+                      accessing the datastore.
+                    type: boolean
+                  variant:
+                    description: Variant declares which variant of Calico should be active.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: felixconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: FelixConfiguration
+        listKind: FelixConfigurationList
+        plural: felixconfigurations
+        singular: felixconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: Felix Configuration contains the configuration for Felix.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: FelixConfigurationSpec contains the values of the Felix configuration.
+                properties:
+                  allowIPIPPacketsFromWorkloads:
+                    description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop IPIP encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  allowVXLANPacketsFromWorkloads:
+                    description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop VXLAN encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  awsSrcDstCheck:
+                    description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                      value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                      DoNothing]'
+                    enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                    type: string
+                  bpfConnectTimeLoadBalancingEnabled:
+                    description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                      controls whether Felix installs the connection-time load balancer.  The
+                      connect-time load balancer is required for the host to be able to
+                      reach Kubernetes services and it improves the performance of pod-to-service
+                      connections.  The only reason to disable it is for debugging purposes.  [Default:
+                      true]'
+                    type: boolean
+                  bpfDataIfacePattern:
+                    description: BPFDataIfacePattern is a regular expression that controls
+                      which interfaces Felix should attach BPF programs to in order to
+                      catch traffic to/from the network.  This needs to match the interfaces
+                      that Calico workload traffic flows over as well as any interfaces
+                      that handle incoming traffic to nodeports and services from outside
+                      the cluster.  It should not match the workload interfaces (usually
+                      named cali...).
+                    type: string
+                  bpfDisableUnprivileged:
+                    description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                      sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                      users cannot access Calico''s BPF maps and cannot insert their own
+                      BPF programs to interfere with Calico''s. [Default: true]'
+                    type: boolean
+                  bpfEnabled:
+                    description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                      [Default: false]'
+                    type: boolean
+                  bpfExtToServiceConnmark:
+                    description: 'BPFExtToServiceConnmark in BPF mode, controls a 32bit
+                      mark that is set on connections from an external client to a local
+                      service. This mark allows us to control how packets of that connection
+                      are routed within the host and how is routing intepreted by RPF
+                      check. [Default: 0]'
+                    type: integer
+                  bpfExternalServiceMode:
+                    description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                      from outside the cluster to services (node ports and cluster IPs)
+                      are forwarded to remote workloads.  If set to "Tunnel" then both
+                      request and response traffic is tunneled to the remote node.  If
+                      set to "DSR", the request traffic is tunneled but the response traffic
+                      is sent directly from the remote node.  In "DSR" mode, the remote
+                      node appears to use the IP of the ingress node; this requires a
+                      permissive L2 network.  [Default: Tunnel]'
+                    type: string
+                  bpfKubeProxyEndpointSlicesEnabled:
+                    description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                      whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                    type: boolean
+                  bpfKubeProxyIptablesCleanupEnabled:
+                    description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                      mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                      iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                      true]'
+                    type: boolean
+                  bpfKubeProxyMinSyncPeriod:
+                    description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                      minimum time between updates to the dataplane for Felix''s embedded
+                      kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                      reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                    type: string
+                  bpfLogLevel:
+                    description: 'BPFLogLevel controls the log level of the BPF programs
+                      when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                      logs are emitted to the BPF trace pipe, accessible with the command
+                      `tc exec bpf debug`. [Default: Off].'
+                    type: string
+                  chainInsertMode:
+                    description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                      top-level iptables chains by inserting a rule at the top of the
+                      chain or by appending a rule at the bottom. insert is the safe default
+                      since it prevents Calico''s rules from being bypassed. If you switch
+                      to append mode, be sure that the other rules in the chains signal
+                      acceptance by falling through to the Calico rules, otherwise the
+                      Calico policy will be bypassed. [Default: insert]'
+                    type: string
+                  dataplaneDriver:
+                    type: string
+                  debugDisableLogDropping:
+                    type: boolean
+                  debugMemoryProfilePath:
+                    type: string
+                  debugSimulateCalcGraphHangAfter:
+                    type: string
+                  debugSimulateDataplaneHangAfter:
+                    type: string
+                  defaultEndpointToHostAction:
+                    description: 'DefaultEndpointToHostAction controls what happens to
+                      traffic that goes from a workload endpoint to the host itself (after
+                      the traffic hits the endpoint egress policy). By default Calico
+                      blocks traffic from workload endpoints to the host itself with an
+                      iptables "DROP" action. If you want to allow some or all traffic
+                      from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                      RETURN if you have your own rules in the iptables "INPUT" chain;
+                      Calico will insert its rules at the top of that chain, then "RETURN"
+                      packets to the "INPUT" chain once it has completed processing workload
+                      endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                      from workloads after processing workload endpoint egress policy.
+                      [Default: Drop]'
+                    type: string
+                  deviceRouteProtocol:
+                    description: This defines the route protocol added to programmed device
+                      routes, by default this will be RTPROT_BOOT when left blank.
+                    type: integer
+                  deviceRouteSourceAddress:
+                    description: This is the source address to use on programmed device
+                      routes. By default the source address is left blank, leaving the
+                      kernel to choose the source address used.
+                    type: string
+                  disableConntrackInvalidCheck:
+                    type: boolean
+                  endpointReportingDelay:
+                    type: string
+                  endpointReportingEnabled:
+                    type: boolean
+                  externalNodesList:
+                    description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                      which may source tunnel traffic and have the tunneled traffic be
+                      accepted at calico nodes.
+                    items:
+                      type: string
+                    type: array
+                  failsafeInboundHostPorts:
+                    description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow incoming traffic to host endpoints
+                      on irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all inbound host ports, use the value
+                      none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                      udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  failsafeOutboundHostPorts:
+                    description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow outgoing traffic from host endpoints
+                      to irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all outbound host ports, use the value
+                      none. The default value opens etcd''s standard ports to ensure that
+                      Felix does not get cut off from etcd as well as allowing DHCP and
+                      DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                      tcp:6667, udp:53, udp:67]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  featureDetectOverride:
+                    description: FeatureDetectOverride is used to override the feature
+                      detection. Values are specified in a comma separated list with no
+                      spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                      "true" or "false" will force the feature, empty or omitted values
+                      are auto-detected.
+                    type: string
+                  genericXDPEnabled:
+                    description: 'GenericXDPEnabled enables Generic XDP so network cards
+                      that don''t support XDP offload or driver modes can use XDP. This
+                      is not recommended since it doesn''t provide better performance
+                      than iptables. [Default: false]'
+                    type: boolean
+                  healthEnabled:
+                    type: boolean
+                  healthHost:
+                    type: string
+                  healthPort:
+                    type: integer
+                  interfaceExclude:
+                    description: 'InterfaceExclude is a comma-separated list of interfaces
+                      that Felix should exclude when monitoring for host endpoints. The
+                      default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                      interface, which is used internally by kube-proxy. If you want to
+                      exclude multiple interface names using a single value, the list
+                      supports regular expressions. For regular expressions you must wrap
+                      the value with ''/''. For example having values ''/^kube/,veth1''
+                      will exclude all interfaces that begin with ''kube'' and also the
+                      interface ''veth1''. [Default: kube-ipvs0]'
+                    type: string
+                  interfacePrefix:
+                    description: 'InterfacePrefix is the interface name prefix that identifies
+                      workload endpoints and so distinguishes them from host endpoint
+                      interfaces. Note: in environments other than bare metal, the orchestrators
+                      configure this appropriately. For example our Kubernetes and Docker
+                      integrations set the ''cali'' value, and our OpenStack integration
+                      sets the ''tap'' value. [Default: cali]'
+                    type: string
+                  interfaceRefreshInterval:
+                    description: InterfaceRefreshInterval is the period at which Felix
+                      rescans local interfaces to verify their state. The rescan can be
+                      disabled by setting the interval to 0.
+                    type: string
+                  ipipEnabled:
+                    type: boolean
+                  ipipMTU:
+                    description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  ipsetsRefreshInterval:
+                    description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                      all iptables state to ensure that no other process has accidentally
+                      broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                      90s]'
+                    type: string
+                  iptablesBackend:
+                    description: IptablesBackend specifies which backend of iptables will
+                      be used. The default is legacy.
+                    type: string
+                  iptablesFilterAllowAction:
+                    type: string
+                  iptablesLockFilePath:
+                    description: 'IptablesLockFilePath is the location of the iptables
+                      lock file. You may need to change this if the lock file is not in
+                      its standard location (for example if you have mapped it into Felix''s
+                      container at a different path). [Default: /run/xtables.lock]'
+                    type: string
+                  iptablesLockProbeInterval:
+                    description: 'IptablesLockProbeInterval is the time that Felix will
+                      wait between attempts to acquire the iptables lock if it is not
+                      available. Lower values make Felix more responsive when the lock
+                      is contended, but use more CPU. [Default: 50ms]'
+                    type: string
+                  iptablesLockTimeout:
+                    description: 'IptablesLockTimeout is the time that Felix will wait
+                      for the iptables lock, or 0, to disable. To use this feature, Felix
+                      must share the iptables lock file with all other processes that
+                      also take the lock. When running Felix inside a container, this
+                      requires the /run directory of the host to be mounted into the calico/node
+                      or calico/felix container. [Default: 0s disabled]'
+                    type: string
+                  iptablesMangleAllowAction:
+                    type: string
+                  iptablesMarkMask:
+                    description: 'IptablesMarkMask is the mask that Felix selects its
+                      IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                      at least 8 bits set, none of which clash with any other mark bits
+                      in use on the system. [Default: 0xff000000]'
+                    format: int32
+                    type: integer
+                  iptablesNATOutgoingInterfaceFilter:
+                    type: string
+                  iptablesPostWriteCheckInterval:
+                    description: 'IptablesPostWriteCheckInterval is the period after Felix
+                      has done a write to the dataplane that it schedules an extra read
+                      back in order to check the write was not clobbered by another process.
+                      This should only occur if another application on the system doesn''t
+                      respect the iptables lock. [Default: 1s]'
+                    type: string
+                  iptablesRefreshInterval:
+                    description: 'IptablesRefreshInterval is the period at which Felix
+                      re-checks the IP sets in the dataplane to ensure that no other process
+                      has accidentally broken Calico''s rules. Set to 0 to disable IP
+                      sets refresh. Note: the default for this value is lower than the
+                      other refresh intervals as a workaround for a Linux kernel bug that
+                      was fixed in kernel version 4.11. If you are using v4.11 or greater
+                      you may want to set this to, a higher value to reduce Felix CPU
+                      usage. [Default: 10s]'
+                    type: string
+                  ipv6Support:
+                    type: boolean
+                  kubeNodePortRanges:
+                    description: 'KubeNodePortRanges holds list of port ranges used for
+                      service node ports. Only used if felix detects kube-proxy running
+                      in ipvs mode. Felix uses these ranges to separate host and workload
+                      traffic. [Default: 30000:32767].'
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  logFilePath:
+                    description: 'LogFilePath is the full path to the Felix log. Set to
+                      none to disable file logging. [Default: /var/log/calico/felix.log]'
+                    type: string
+                  logPrefix:
+                    description: 'LogPrefix is the log prefix that Felix uses when rendering
+                      LOG rules. [Default: calico-packet]'
+                    type: string
+                  logSeverityFile:
+                    description: 'LogSeverityFile is the log severity above which logs
+                      are sent to the log file. [Default: Info]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  logSeveritySys:
+                    description: 'LogSeveritySys is the log severity above which logs
+                      are sent to the syslog. Set to None for no logging to syslog. [Default:
+                      Info]'
+                    type: string
+                  maxIpsetSize:
+                    type: integer
+                  metadataAddr:
+                    description: 'MetadataAddr is the IP address or domain name of the
+                      server that can answer VM queries for cloud-init metadata. In OpenStack,
+                      this corresponds to the machine running nova-api (or in Ubuntu,
+                      nova-api-metadata). A value of none (case insensitive) means that
+                      Felix should not set up any NAT rule for the metadata path. [Default:
+                      127.0.0.1]'
+                    type: string
+                  metadataPort:
+                    description: 'MetadataPort is the port of the metadata server. This,
+                      combined with global.MetadataAddr (if not ''None''), is used to
+                      set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                      In most cases this should not need to be changed [Default: 8775].'
+                    type: integer
+                  mtuIfacePattern:
+                    description: MTUIfacePattern is a regular expression that controls
+                      which interfaces Felix should scan in order to calculate the host's
+                      MTU. This should not match workload interfaces (usually named cali...).
+                    type: string
+                  natOutgoingAddress:
+                    description: NATOutgoingAddress specifies an address to use when performing
+                      source NAT for traffic in a natOutgoing pool that is leaving the
+                      network. By default the address used is an address on the interface
+                      the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                    type: string
+                  natPortRange:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NATPortRange specifies the range of ports that is used
+                      for port mapping when doing outgoing NAT. When unset the default
+                      behavior of the network stack is used.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  netlinkTimeout:
+                    type: string
+                  openstackRegion:
+                    description: 'OpenstackRegion is the name of the region that a particular
+                      Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                      this must be configured somehow for each Felix (here in the datamodel,
+                      or in felix.cfg or the environment on each compute node), and must
+                      match the [calico] openstack_region value configured in neutron.conf
+                      on each node. [Default: Empty]'
+                    type: string
+                  policySyncPathPrefix:
+                    description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                      policy changes to external services, like Application layer policy.
+                      [Default: Empty]'
+                    type: string
+                  prometheusGoMetricsEnabled:
+                    description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusMetricsEnabled:
+                    description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                      server in Felix if set to true. [Default: false]'
+                    type: boolean
+                  prometheusMetricsHost:
+                    description: 'PrometheusMetricsHost is the host that the Prometheus
+                      metrics server should bind to. [Default: empty]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. [Default: 9091]'
+                    type: integer
+                  prometheusProcessMetricsEnabled:
+                    description: 'PrometheusProcessMetricsEnabled disables process metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusWireGuardMetricsEnabled:
+                    description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                      metrics collection, which the Prometheus client does by default,
+                      when set to false. This reduces the number of metrics reported,
+                      reducing Prometheus load. [Default: true]'
+                    type: boolean
+                  removeExternalRoutes:
+                    description: Whether or not to remove device routes that have not
+                      been programmed by Felix. Disabling this will allow external applications
+                      to also add device routes. This is enabled by default which means
+                      we will remove externally added routes.
+                    type: boolean
+                  reportingInterval:
+                    description: 'ReportingInterval is the interval at which Felix reports
+                      its status into the datastore or 0 to disable. Must be non-zero
+                      in OpenStack deployments. [Default: 30s]'
+                    type: string
+                  reportingTTL:
+                    description: 'ReportingTTL is the time-to-live setting for process-wide
+                      status reports. [Default: 90s]'
+                    type: string
+                  routeRefreshInterval:
+                    description: 'RouteRefreshInterval is the period at which Felix re-checks
+                      the routes in the dataplane to ensure that no other process has
+                      accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                      [Default: 90s]'
+                    type: string
+                  routeSource:
+                    description: 'RouteSource configures where Felix gets its routing
+                      information. - WorkloadIPs: use workload endpoints to construct
+                      routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                    type: string
+                  routeTableRange:
+                    description: Calico programs additional Linux route tables for various
+                      purposes.  RouteTableRange specifies the indices of the route tables
+                      that Calico should use.
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                    - max
+                    - min
+                    type: object
+                  serviceLoopPrevention:
+                    description: 'When service IP advertisement is enabled, prevent routing
+                      loops to service IPs that are not in use, by dropping or rejecting
+                      packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                      in which case such routing loops continue to be allowed. [Default:
+                      Drop]'
+                    type: string
+                  sidecarAccelerationEnabled:
+                    description: 'SidecarAccelerationEnabled enables experimental sidecar
+                      acceleration [Default: false]'
+                    type: boolean
+                  usageReportingEnabled:
+                    description: 'UsageReportingEnabled reports anonymous Calico version
+                      number and cluster size to projectcalico.org. Logs warnings returned
+                      by the usage server. For example, if a significant security vulnerability
+                      has been discovered in the version of Calico being used. [Default:
+                      true]'
+                    type: boolean
+                  usageReportingInitialDelay:
+                    description: 'UsageReportingInitialDelay controls the minimum delay
+                      before Felix makes a report. [Default: 300s]'
+                    type: string
+                  usageReportingInterval:
+                    description: 'UsageReportingInterval controls the interval at which
+                      Felix makes reports. [Default: 86400s]'
+                    type: string
+                  useInternalDataplaneDriver:
+                    type: boolean
+                  vxlanEnabled:
+                    type: boolean
+                  vxlanMTU:
+                    description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  vxlanPort:
+                    type: integer
+                  vxlanVNI:
+                    type: integer
+                  wireguardEnabled:
+                    description: 'WireguardEnabled controls whether Wireguard is enabled.
+                      [Default: false]'
+                    type: boolean
+                  wireguardHostEncryptionEnabled:
+                    description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                      host-to-host encryption is enabled. [Default: false]'
+                    type: boolean
+                  wireguardInterfaceName:
+                    description: 'WireguardInterfaceName specifies the name to use for
+                      the Wireguard interface. [Default: wg.calico]'
+                    type: string
+                  wireguardListeningPort:
+                    description: 'WireguardListeningPort controls the listening port used
+                      by Wireguard. [Default: 51820]'
+                    type: integer
+                  wireguardMTU:
+                    description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                      See Configuring MTU [Default: 1420]'
+                    type: integer
+                  wireguardRoutingRulePriority:
+                    description: 'WireguardRoutingRulePriority controls the priority value
+                      to use for the Wireguard routing rule. [Default: 99]'
+                    type: integer
+                  xdpEnabled:
+                    description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                      incoming deny rules. [Default: true]'
+                    type: boolean
+                  xdpRefreshInterval:
+                    description: 'XDPRefreshInterval is the period at which Felix re-checks
+                      all XDP state to ensure that no other process has accidentally broken
+                      Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                      refresh. [Default: 90s]'
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkPolicy
+        listKind: GlobalNetworkPolicyList
+        plural: globalnetworkpolicies
+        singular: globalnetworkpolicy
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  applyOnForward:
+                    description: ApplyOnForward indicates to apply the rules in this policy
+                      on forward traffic.
+                    type: boolean
+                  doNotTrack:
+                    description: DoNotTrack indicates whether packets matched by the rules
+                      in this policy should go through the data plane's connection tracking,
+                      such as Linux conntrack.  If True, the rules in this policy are
+                      applied before any data plane connection tracking, and packets allowed
+                      by this policy are marked as not to be tracked.
+                    type: boolean
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    description: NamespaceSelector is an optional field for an expression
+                      used to select a pod based on namespaces.
+                    type: string
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  preDNAT:
+                    description: PreDNAT indicates to apply the rules in this policy before
+                      any DNAT.
+                    type: boolean
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress rules are present in the policy.  The
+                      default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                      (including the case where there are   also no Ingress rules) \n
+                      - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                      rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                      both Ingress and Egress rules. \n When the policy is read back again,
+                      Types will always be one of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkSet
+        listKind: GlobalNetworkSetList
+        plural: globalnetworksets
+        singular: globalnetworkset
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+              that share labels to allow rules to refer to them via selectors.  The labels
+              of GlobalNetworkSet are not namespaced.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: hostendpoints.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: HostEndpoint
+        listKind: HostEndpointList
+        plural: hostendpoints
+        singular: hostendpoint
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: HostEndpointSpec contains the specification for a HostEndpoint
+                  resource.
+                properties:
+                  expectedIPs:
+                    description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                      If \"InterfaceName\" is not present, Calico will look for an interface
+                      matching any of the IPs in the list and apply policy to that. Note:
+                      \tWhen using the selector match criteria in an ingress or egress
+                      security Policy \tor Profile, Calico converts the selector into
+                      a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                      is used for that purpose. (If only the interface \tname is specified,
+                      Calico does not learn the IPs of the interface for use in match
+                      \tcriteria.)"
+                    items:
+                      type: string
+                    type: array
+                  interfaceName:
+                    description: "Either \"*\", or the name of a specific Linux interface
+                      to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                      governs all traffic to, from or through the default network namespace
+                      of the host named by the \"Node\" field; entering and leaving that
+                      namespace via any interface, including those from/to non-host-networked
+                      local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                      only governs traffic that enters or leaves the host through the
+                      specific interface named by InterfaceName, or - when InterfaceName
+                      is empty - through the specific interface that has one of the IPs
+                      in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                      one expected IP must be specified.  Only external interfaces (such
+                      as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                      to protect traffic through a specific local workload interface.
+                      \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                      initially just pre-DNAT policy.  Please check Calico documentation
+                      for the latest position."
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance.
+                    type: string
+                  ports:
+                    description: Ports contains the endpoint's named ports, which may
+                      be referenced in security policy rules.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  profiles:
+                    description: A list of identifiers of security Profile objects that
+                      apply to this endpoint. Each profile is applied in the order that
+                      they appear in this list.  Profile rules are applied after the selector-based
+                      security policy.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamblocks.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMBlock
+        listKind: IPAMBlockList
+        plural: ipamblocks
+        singular: ipamblock
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMBlockSpec contains the specification for an IPAMBlock
+                  resource.
+                properties:
+                  affinity:
+                    type: string
+                  allocations:
+                    items:
+                      nullable: true
+                      type: integer
+                    type: array
+                  attributes:
+                    items:
+                      properties:
+                        handle_id:
+                          type: string
+                        secondary:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    type: array
+                  cidr:
+                    type: string
+                  deleted:
+                    type: boolean
+                  strictAffinity:
+                    type: boolean
+                  unallocated:
+                    items:
+                      type: integer
+                    type: array
+                required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamconfigs.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMConfig
+        listKind: IPAMConfigList
+        plural: ipamconfigs
+        singular: ipamconfig
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMConfigSpec contains the specification for an IPAMConfig
+                  resource.
+                properties:
+                  autoAllocateBlocks:
+                    type: boolean
+                  maxBlocksPerHost:
+                    description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                      that can be affine to each host.
+                    type: integer
+                  strictAffinity:
+                    type: boolean
+                required:
+                - autoAllocateBlocks
+                - strictAffinity
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamhandles.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMHandle
+        listKind: IPAMHandleList
+        plural: ipamhandles
+        singular: ipamhandle
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMHandleSpec contains the specification for an IPAMHandle
+                  resource.
+                properties:
+                  block:
+                    additionalProperties:
+                      type: integer
+                    type: object
+                  deleted:
+                    type: boolean
+                  handleID:
+                    type: string
+                required:
+                - block
+                - handleID
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ippools.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPPool
+        listKind: IPPoolList
+        plural: ippools
+        singular: ippool
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPPoolSpec contains the specification for an IPPool resource.
+                properties:
+                  blockSize:
+                    description: The block size to use for IP address assignments from
+                      this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                    type: integer
+                  cidr:
+                    description: The pool CIDR.
+                    type: string
+                  disabled:
+                    description: When disabled is true, Calico IPAM will not assign addresses
+                      from this pool.
+                    type: boolean
+                  ipip:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    properties:
+                      enabled:
+                        description: When enabled is true, ipip tunneling will be used
+                          to deliver packets to destinations within this pool.
+                        type: boolean
+                      mode:
+                        description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                          mode of "always" will also use IPIP tunneling for routing to
+                          destination IP addresses within this pool.  A mode of "cross-subnet"
+                          will only use IPIP tunneling when the destination node is on
+                          a different subnet to the originating node.  The default value
+                          (if not specified) is "always".
+                        type: string
+                    type: object
+                  ipipMode:
+                    description: Contains configuration for IPIP tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                      is disabled).
+                    type: string
+                  nat-outgoing:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    type: boolean
+                  natOutgoing:
+                    description: When nat-outgoing is true, packets sent from Calico networked
+                      containers in this pool to destinations outside of this pool will
+                      be masqueraded.
+                    type: boolean
+                  nodeSelector:
+                    description: Allows IPPool to allocate for a specific node by label
+                      selector.
+                    type: string
+                  vxlanMode:
+                    description: Contains configuration for VXLAN tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                      tunneling is disabled).
+                    type: string
+                required:
+                - cidr
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubecontrollersconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: KubeControllersConfiguration
+        listKind: KubeControllersConfigurationList
+        plural: kubecontrollersconfigurations
+        singular: kubecontrollersconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeControllersConfigurationSpec contains the values of the
+                  Kubernetes controllers configuration.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host endpoints.
+                              Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation of
+                                  host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the controller
+                              to determine if an IP address has been leaked. Set to 0
+                              to disable IP garbage collection. [Default: 15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+              status:
+                description: KubeControllersConfigurationStatus represents the status
+                  of the configuration. It's useful for admins to be able to see the actual
+                  config that was applied, which can be modified by environment variables
+                  on the kube-controllers process.
+                properties:
+                  environmentVars:
+                    additionalProperties:
+                      type: string
+                    description: EnvironmentVars contains the environment variables on
+                      the kube-controllers that influenced the RunningConfig.
+                    type: object
+                  runningConfig:
+                    description: RunningConfig contains the effective config that is running
+                      in the kube-controllers pod, after merging the API resource with
+                      any environment variables.
+                    properties:
+                      controllers:
+                        description: Controllers enables and configures individual Kubernetes
+                          controllers
+                        properties:
+                          namespace:
+                            description: Namespace enables and configures the namespace
+                              controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          node:
+                            description: Node enables and configures the node controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              hostEndpoint:
+                                description: HostEndpoint controls syncing nodes to host
+                                  endpoints. Disabled by default, set to nil to disable.
+                                properties:
+                                  autoCreate:
+                                    description: 'AutoCreate enables automatic creation
+                                      of host endpoints for every node. [Default: Disabled]'
+                                    type: string
+                                type: object
+                              leakGracePeriod:
+                                description: 'LeakGracePeriod is the period used by the
+                                  controller to determine if an IP address has been leaked.
+                                  Set to 0 to disable IP garbage collection. [Default:
+                                  15m]'
+                                type: string
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                              syncLabels:
+                                description: 'SyncLabels controls whether to copy Kubernetes
+                                  node labels to Calico nodes. [Default: Enabled]'
+                                type: string
+                            type: object
+                          policy:
+                            description: Policy enables and configures the policy controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          serviceAccount:
+                            description: ServiceAccount enables and configures the service
+                              account controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          workloadEndpoint:
+                            description: WorkloadEndpoint enables and configures the workload
+                              endpoint controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                        type: object
+                      etcdV3CompactionPeriod:
+                        description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                          compaction requests. Set to 0 to disable. [Default: 10m]'
+                        type: string
+                      healthChecks:
+                        description: 'HealthChecks enables or disables support for health
+                          checks [Default: Enabled]'
+                        type: string
+                      logSeverityScreen:
+                        description: 'LogSeverityScreen is the log severity above which
+                          logs are sent to the stdout. [Default: Info]'
+                        type: string
+                      prometheusMetricsPort:
+                        description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                          metrics server should bind to. Set to 0 to disable. [Default:
+                          9094]'
+                        type: integer
+                    required:
+                    - controllers
+                    type: object
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkPolicy
+        listKind: NetworkPolicyList
+        plural: networkpolicies
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress are present in the policy.  The default
+                      is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                      the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                      ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                      PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                      \n When the policy is read back again, Types will always be one
+                      of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkSet
+        listKind: NetworkSetList
+        plural: networksets
+        singular: networkset
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: NetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-kube-controllers
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      verbs:
+      - list
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - hostendpoints
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - clusterinformations
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - kubecontrollersconfigurations
+      verbs:
+      - get
+      - create
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-node
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - namespaces
+      verbs:
+      - get
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - patch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - bgpconfigurations
+      - bgppeers
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ipamconfigs
+      verbs:
+      - get
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      verbs:
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - daemonsets
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-kube-controllers
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      calico_backend: vxlan
+      cni_network_config: |-
+        {
+          "name": "k8s-pod-network",
+          "cniVersion": "0.3.1",
+          "plugins": [
+            {
+              "type": "calico",
+              "log_level": "info",
+              "log_file_path": "/var/log/calico/cni/cni.log",
+              "datastore_type": "kubernetes",
+              "nodename": "__KUBERNETES_NODE_NAME__",
+              "mtu": __CNI_MTU__,
+              "ipam": {
+                  "type": "calico-ipam"
+              },
+              "policy": {
+                  "type": "k8s"
+              },
+              "kubernetes": {
+                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              }
+            },
+            {
+              "type": "portmap",
+              "snat": true,
+              "capabilities": {"portMappings": true}
+            },
+            {
+              "type": "bandwidth",
+              "capabilities": {"bandwidth": true}
+            }
+          ]
+        }
+      typha_service_name: none
+      veth_mtu: "1350"
+    kind: ConfigMap
+    metadata:
+      name: calico-config
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-kube-controllers
+          name: calico-kube-controllers
+          namespace: kube-system
+        spec:
+          containers:
+          - env:
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            image: docker.io/calico/kube-controllers:v3.20.3
+            livenessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -l
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-kube-controllers
+            readinessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -r
+              periodSeconds: 10
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: calico-kube-controllers
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: calico-node
+      name: calico-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+        spec:
+          containers:
+          - env:
+            - name: FELIX_FEATUREDETECTOVERRIDE
+              value: ChecksumOffloadBroken=true
+            - name: CALICO_IPV4POOL_VXLAN
+              value: Always
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            - name: CLUSTER_TYPE
+              value: k8s,bgp
+            - name: IP
+              value: autodetect
+            - name: CALICO_IPV4POOL_IPIP
+              value: Never
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_WIREGUARDMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_AWSSRCDSTCHECK
+              value: Disable
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: ACCEPT
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/node:v3.20.3
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -shutdown
+            livenessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-live
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-node
+            readinessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-ready
+              periodSeconds: 10
+              timeoutSeconds: 10
+            resources:
+              requests:
+                cpu: 250m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /var/run/nodeagent
+              name: policysync
+            - mountPath: /sys/fs/
+              mountPropagation: Bidirectional
+              name: sysfs
+            - mountPath: /var/log/calico/cni
+              name: cni-log-dir
+              readOnly: true
+          hostNetwork: true
+          initContainers:
+          - command:
+            - /opt/cni/bin/calico-ipam
+            - -upgrade
+            env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: upgrade-ipam
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          - command:
+            - /opt/cni/bin/install
+            env:
+            - name: CNI_CONF_NAME
+              value: 10-calico.conflist
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  key: cni_network_config
+                  name: calico-config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: SLEEP
+              value: "false"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: install-cni
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+            name: flexvol-driver
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/driver
+              name: flexvol-driver-host
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: calico-node
+          terminationGracePeriodSeconds: 0
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /lib/modules
+            name: lib-modules
+          - hostPath:
+              path: /var/run/calico
+            name: var-run-calico
+          - hostPath:
+              path: /var/lib/calico
+            name: var-lib-calico
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+          - hostPath:
+              path: /sys/fs/
+              type: DirectoryOrCreate
+            name: sysfs
+          - hostPath:
+              path: /opt/cni/bin
+            name: cni-bin-dir
+          - hostPath:
+              path: /etc/cni/net.d
+            name: cni-net-dir
+          - hostPath:
+              path: /var/log/calico/cni
+            name: cni-log-dir
+          - hostPath:
+              path: /var/lib/cni/networks
+            name: host-local-net-dir
+          - hostPath:
+              path: /var/run/nodeagent
+              type: DirectoryOrCreate
+            name: policysync
+          - hostPath:
+              path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+              type: DirectoryOrCreate
+            name: flexvol-driver-host
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
   windows-cni: "# strictAffinity required for windows\napiVersion: crd.projectcalico.org/v1\nkind:
     IPAMConfig\nmetadata:\n  name: default\nspec:\n  autoAllocateBlocks: true\n  strictAffinity:
     true\n---\nkind: ConfigMap\napiVersion: v1\nmetadata:\n  name: calico-static-rules\n

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -4268,7 +4268,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.20.3
+            image: docker.io/calico/kube-controllers:v3.20.4
             livenessProbe:
               exec:
                 command:
@@ -4378,7 +4378,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.20.3
+            image: docker.io/calico/node:v3.20.4
             lifecycle:
               preStop:
                 exec:
@@ -4450,7 +4450,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: upgrade-ipam
             securityContext:
               privileged: true
@@ -4484,7 +4484,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: install-cni
             securityContext:
               privileged: true
@@ -4493,7 +4493,7 @@ data:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.4
             name: flexvol-driver
             securityContext:
               privileged: true
@@ -4601,7 +4601,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.20.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.20.4-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -4620,7 +4620,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.20.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.20.4-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -4631,7 +4631,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.20.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.20.4-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -575,2440 +575,3985 @@ data:
     \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
     kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
     \   type: RollingUpdate\n"
-  resources: "---\n# Source: calico/templates/calico-config.yaml\n# This ConfigMap
-    is used to configure a self-hosted Calico installation.\nkind: ConfigMap\napiVersion:
-    v1\nmetadata:\n  name: calico-config\n  namespace: kube-system\ndata:\n  # Typha
-    is disabled.\n  typha_service_name: \"none\"\n  # Configure the backend to use.\n
-    \ calico_backend: \"vxlan\"\n  # On Azure, the underlying network has an MTU of
-    1400, even though the network interface will have an MTU of 1500.\n  # We set
-    this value to 1350 for “physical network MTU size minus 50” since we use VXLAN,
-    which uses a 50-byte header.\n  # If enabling Wireguard, this value should be
-    changed to 1340 (Wireguard uses a 60-byte header).\n  # https://docs.projectcalico.org/networking/mtu#determine-mtu-size\n
-    \ veth_mtu: \"1350\"\n  \n  # The CNI network configuration to install on each
-    node. The special\n  # values in this config will be automatically populated.\n
-    \ cni_network_config: |-\n    {\n      \"name\": \"k8s-pod-network\",\n      \"cniVersion\":
-    \"0.3.1\",\n      \"plugins\": [\n        {\n          \"type\": \"calico\",\n
-    \         \"log_level\": \"info\",\n          \"log_file_path\": \"/var/log/calico/cni/cni.log\",\n
-    \         \"datastore_type\": \"kubernetes\",\n          \"nodename\": \"__KUBERNETES_NODE_NAME__\",\n
-    \         \"mtu\": __CNI_MTU__,\n          \"ipam\": {\n              \"type\":
-    \"calico-ipam\"\n          },\n          \"policy\": {\n              \"type\":
-    \"k8s\"\n          },\n          \"kubernetes\": {\n              \"kubeconfig\":
-    \"__KUBECONFIG_FILEPATH__\"\n          }\n        },\n        {\n          \"type\":
-    \"portmap\",\n          \"snat\": true,\n          \"capabilities\": {\"portMappings\":
-    true}\n        },\n        {\n          \"type\": \"bandwidth\",\n          \"capabilities\":
-    {\"bandwidth\": true}\n        }\n      ]\n    }\n\n---\n# Source: calico/templates/kdd-crds.yaml\n\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: bgpconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPConfiguration\n    listKind: BGPConfigurationList\n    plural:
-    bgpconfigurations\n    singular: bgpconfiguration\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    BGPConfiguration contains the configuration for any BGP routing.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPConfigurationSpec contains the
-    values of the BGP configuration.\n              properties:\n                asNumber:\n
-    \                 description: 'ASNumber is the default AS number used by a node.
-    [Default:\n                  64512]'\n                  format: int32\n                  type:
-    integer\n                communities:\n                  description: Communities
-    is a list of BGP community values and their\n                    arbitrary names
-    for tagging routes.\n                  items:\n                    description:
-    Community contains standard or large community value\n                      and
-    its name.\n                    properties:\n                      name:\n                        description:
-    Name given to community value.\n                        type: string\n                      value:\n
-    \                       description: Value must be of format `aa:nn` or `aa:nn:mm`.\n
-    \                         For standard community use `aa:nn` format, where `aa`
-    and\n                          `nn` are 16 bit number. For large community use
-    `aa:nn:mm`\n                          format, where `aa`, `nn` and `mm` are 32
-    bit number. Where,\n                          `aa` is an AS Number, `nn` and `mm`
-    are per-AS identifier.\n                        pattern: ^(\\d+):(\\d+)$|^(\\d+):(\\d+):(\\d+)$\n
-    \                       type: string\n                    type: object\n                  type:
-    array\n                listenPort:\n                  description: ListenPort
-    is the port where BGP protocol should listen.\n                    Defaults to
-    179\n                  maximum: 65535\n                  minimum: 1\n                  type:
-    integer\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: INFO]'\n                  type: string\n                nodeToNodeMeshEnabled:\n
-    \                 description: 'NodeToNodeMeshEnabled sets whether full node to
-    node\n                  BGP mesh is enabled. [Default: true]'\n                  type:
-    boolean\n                prefixAdvertisements:\n                  description:
-    PrefixAdvertisements contains per-prefix advertisement\n                    configuration.\n
-    \                 items:\n                    description: PrefixAdvertisement
-    configures advertisement properties\n                      for the specified CIDR.\n
-    \                   properties:\n                      cidr:\n                        description:
-    CIDR for which properties should be advertised.\n                        type:
-    string\n                      communities:\n                        description:
-    Communities can be list of either community names\n                          already
-    defined in `Specs.Communities` or community value\n                          of
-    format `aa:nn` or `aa:nn:mm`. For standard community use\n                          `aa:nn`
-    format, where `aa` and `nn` are 16 bit number. For\n                          large
-    community use `aa:nn:mm` format, where `aa`, `nn` and\n                          `mm`
-    are 32 bit number. Where,`aa` is an AS Number, `nn` and\n                          `mm`
-    are per-AS identifier.\n                        items:\n                          type:
-    string\n                        type: array\n                    type: object\n
-    \                 type: array\n                serviceClusterIPs:\n                  description:
-    ServiceClusterIPs are the CIDR blocks from which service\n                    cluster
-    IPs are allocated. If specified, Calico will advertise these\n                    blocks,
-    as well as any cluster IPs within them.\n                  items:\n                    description:
-    ServiceClusterIPBlock represents a single allowed ClusterIP\n                      CIDR
-    block.\n                    properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n                serviceExternalIPs:\n
-    \                 description: ServiceExternalIPs are the CIDR blocks for Kubernetes\n
-    \                   Service External IPs. Kubernetes Service ExternalIPs will
-    only be\n                    advertised if they are within one of these blocks.\n
-    \                 items:\n                    description: ServiceExternalIPBlock
-    represents a single allowed\n                      External IP CIDR block.\n                    properties:\n
-    \                     cidr:\n                        type: string\n                    type:
-    object\n                  type: array\n                serviceLoadBalancerIPs:\n
-    \                 description: ServiceLoadBalancerIPs are the CIDR blocks for
-    Kubernetes\n                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress\n
-    \                   IPs will only be advertised if they are within one of these
-    blocks.\n                  items:\n                    description: ServiceLoadBalancerIPBlock
-    represents a single allowed\n                      LoadBalancer IP CIDR block.\n
-    \                   properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: bgppeers.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPPeer\n    listKind: BGPPeerList\n    plural: bgppeers\n
-    \   singular: bgppeer\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPPeerSpec contains the specification
-    for a BGPPeer resource.\n              properties:\n                asNumber:\n
-    \                 description: The AS Number of the peer.\n                  format:
-    int32\n                  type: integer\n                keepOriginalNextHop:\n
-    \                 description: Option to keep the original nexthop field when
-    routes\n                    are sent to a BGP Peer. Setting \"true\" configures
-    the selected BGP\n                    Peers node to use the \"next hop keep;\"
-    instead of \"next hop self;\"(default)\n                    in the specific branch
-    of the Node on \"bird.cfg\".\n                  type: boolean\n                maxRestartTime:\n
-    \                 description: Time to allow for software restart.  When specified,
-    this\n                    is configured as the graceful restart timeout.  When
-    not specified,\n                    the BIRD default of 120s is used.\n                  type:
-    string\n                node:\n                  description: The node name identifying
-    the Calico node instance that\n                    is targeted by this peer. If
-    this is not set, and no nodeSelector\n                    is specified, then this
-    BGP peer selects all nodes in the cluster.\n                  type: string\n                nodeSelector:\n
-    \                 description: Selector for the nodes that should have this peering.
-    \ When\n                    this is set, the Node field must be empty.\n                  type:
-    string\n                password:\n                  description: Optional BGP
-    password for the peerings generated by this\n                    BGPPeer resource.\n
-    \                 properties:\n                    secretKeyRef:\n                      description:
-    Selects a key of a secret in the node pod's namespace.\n                      properties:\n
-    \                       key:\n                          description: The key of
-    the secret to select from.  Must be\n                            a valid secret
-    key.\n                          type: string\n                        name:\n
-    \                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n
-    \                         TODO: Add other useful fields. apiVersion, kind, uid?'\n
-    \                         type: string\n                        optional:\n                          description:
-    Specify whether the Secret or its key must be\n                            defined\n
-    \                         type: boolean\n                      required:\n                        -
-    key\n                      type: object\n                  type: object\n                peerIP:\n
-    \                 description: The IP address of the peer followed by an optional
-    port\n                    number to peer with. If port number is given, format
-    should be `[<IPv6>]:port`\n                    or `<IPv4>:<port>` for IPv4. If
-    optional port number is not set,\n                    and this peer IP and ASNumber
-    belongs to a calico/node with ListenPort\n                    set in BGPConfiguration,
-    then we use that port to peer.\n                  type: string\n                peerSelector:\n
-    \                 description: Selector for the remote nodes to peer with.  When
-    this\n                    is set, the PeerIP and ASNumber fields must be empty.
-    \ For each\n                    peering between the local node and selected remote
-    nodes, we configure\n                    an IPv4 peering if both ends have NodeBGPSpec.IPv4Address
-    specified,\n                    and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address
-    specified.  The\n                    remote AS number comes from the remote node’s
-    NodeBGPSpec.ASNumber,\n                    or the global default if that is not
-    set.\n                  type: string\n                sourceAddress:\n                  description:
-    Specifies whether and how to configure a source address\n                    for
-    the peerings generated by this BGPPeer resource.  Default value\n                    \"UseNodeIP\"
-    means to configure the node IP as the source address.  \"None\"\n                    means
-    not to configure a source address.\n                  type: string\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: blockaffinities.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BlockAffinity\n    listKind: BlockAffinityList\n    plural:
-    blockaffinities\n    singular: blockaffinity\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BlockAffinitySpec contains the specification
-    for a BlockAffinity\n                resource.\n              properties:\n                cidr:\n
-    \                 type: string\n                deleted:\n                  description:
-    Deleted indicates that this block affinity is being deleted.\n                    This
-    field is a string for compatibility with older releases that\n                    mistakenly
-    treat this field as a string.\n                  type: string\n                node:\n
-    \                 type: string\n                state:\n                  type:
-    string\n              required:\n                - cidr\n                - deleted\n
-    \               - node\n                - state\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: clusterinformations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: ClusterInformation\n    listKind: ClusterInformationList\n
-    \   plural: clusterinformations\n    singular: clusterinformation\n  scope: Cluster\n
-    \ versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    ClusterInformation contains the cluster specific information.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: ClusterInformationSpec contains
-    the values of describing\n                the cluster.\n              properties:\n
-    \               calicoVersion:\n                  description: CalicoVersion is
-    the version of Calico that the cluster\n                    is running\n                  type:
-    string\n                clusterGUID:\n                  description: ClusterGUID
-    is the GUID of the cluster\n                  type: string\n                clusterType:\n
-    \                 description: ClusterType describes the type of the cluster\n
-    \                 type: string\n                datastoreReady:\n                  description:
-    DatastoreReady is used during significant datastore migrations\n                    to
-    signal to components such as Felix that it should wait before\n                    accessing
-    the datastore.\n                  type: boolean\n                variant:\n                  description:
-    Variant declares which variant of Calico should be active.\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: felixconfigurations.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: FelixConfiguration\n    listKind:
-    FelixConfigurationList\n    plural: felixconfigurations\n    singular: felixconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         description: Felix Configuration contains the configuration for Felix.\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: FelixConfigurationSpec contains
-    the values of the Felix configuration.\n              properties:\n                allowIPIPPacketsFromWorkloads:\n
-    \                 description: 'AllowIPIPPacketsFromWorkloads controls whether
-    Felix\n                  will add a rule to drop IPIP encapsulated traffic from
-    workloads\n                  [Default: false]'\n                  type: boolean\n
-    \               allowVXLANPacketsFromWorkloads:\n                  description:
-    'AllowVXLANPacketsFromWorkloads controls whether Felix\n                  will
-    add a rule to drop VXLAN encapsulated traffic from workloads\n                  [Default:
-    false]'\n                  type: boolean\n                awsSrcDstCheck:\n                  description:
-    'Set source-destination-check on AWS EC2 instances. Accepted\n                  value
-    must be one of \"DoNothing\", \"Enabled\" or \"Disabled\". [Default:\n                  DoNothing]'\n
-    \                 enum:\n                    - DoNothing\n                    -
-    Enable\n                    - Disable\n                  type: string\n                bpfConnectTimeLoadBalancingEnabled:\n
-    \                 description: 'BPFConnectTimeLoadBalancingEnabled when in BPF
-    mode,\n                  controls whether Felix installs the connection-time load
-    balancer.  The\n                  connect-time load balancer is required for the
-    host to be able to\n                  reach Kubernetes services and it improves
-    the performance of pod-to-service\n                  connections.  The only reason
-    to disable it is for debugging purposes.  [Default:\n                  true]'\n
-    \                 type: boolean\n                bpfDataIfacePattern:\n                  description:
-    'BPFDataIfacePattern is a regular expression that controls\n                  which
-    interfaces Felix should attach BPF programs to in order to\n                  catch
-    traffic to/from the network.  This needs to match the interfaces\n                  that
-    Calico workload traffic flows over as well as any interfaces\n                  that
-    handle incoming traffic to nodeports and services from outside\n                  the
-    cluster.  It should not match the workload interfaces (usually\n                  named
-    cali...). [Default: ^(en.*|eth.*|tunl0$)]'\n                  type: string\n                bpfDisableUnprivileged:\n
-    \                 description: 'BPFDisableUnprivileged, if enabled, Felix sets
-    the kernel.unprivileged_bpf_disabled\n                  sysctl to disable unprivileged
-    use of BPF.  This ensures that unprivileged\n                  users cannot access
-    Calico''s BPF maps and cannot insert their own\n                  BPF programs
-    to interfere with Calico''s. [Default: true]'\n                  type: boolean\n
-    \               bpfEnabled:\n                  description: 'BPFEnabled, if enabled
-    Felix will use the BPF dataplane.\n                  [Default: false]'\n                  type:
-    boolean\n                bpfExtToServiceConnmark:\n                  description:
-    'BPFExtToServiceConnmark in BPF mode, control a 32bit\n                    mark
-    that is set on connections from an external client to a local\n                    service.
-    This mark allows us to control how packets of that connection\n                    are
-    routed within the host and how is routing intepreted by RPF\n                    check.
-    [Default: 0]'\n                  type: integer\n                bpfExternalServiceMode:\n
-    \                 description: 'BPFExternalServiceMode in BPF mode, controls how
-    connections\n                  from outside the cluster to services (node ports
-    and cluster IPs)\n                  are forwarded to remote workloads.  If set
-    to \"Tunnel\" then both\n                  request and response traffic is tunneled
-    to the remote node.  If\n                  set to \"DSR\", the request traffic
-    is tunneled but the response traffic\n                  is sent directly from
-    the remote node.  In \"DSR\" mode, the remote\n                  node appears
-    to use the IP of the ingress node; this requires a\n                  permissive
-    L2 network.  [Default: Tunnel]'\n                  type: string\n                bpfKubeProxyEndpointSlicesEnabled:\n
-    \                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode,
-    controls\n                    whether Felix's embedded kube-proxy accepts EndpointSlices
-    or not.\n                  type: boolean\n                bpfKubeProxyIptablesCleanupEnabled:\n
-    \                 description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled
-    in BPF\n                  mode, Felix will proactively clean up the upstream Kubernetes
-    kube-proxy''s\n                  iptables chains.  Should only be enabled if kube-proxy
-    is not running.  [Default:\n                  true]'\n                  type:
-    boolean\n                bpfKubeProxyMinSyncPeriod:\n                  description:
-    'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the\n                  minimum
-    time between updates to the dataplane for Felix''s embedded\n                  kube-proxy.
-    \ Lower values give reduced set-up latency.  Higher values\n                  reduce
-    Felix CPU usage by batching up more work.  [Default: 1s]'\n                  type:
-    string\n                bpfLogLevel:\n                  description: 'BPFLogLevel
-    controls the log level of the BPF programs\n                  when in BPF dataplane
-    mode.  One of \"Off\", \"Info\", or \"Debug\".  The\n                  logs are
-    emitted to the BPF trace pipe, accessible with the command\n                  `tc
-    exec bpf debug`. [Default: Off].'\n                  type: string\n                chainInsertMode:\n
-    \                 description: 'ChainInsertMode controls whether Felix hooks the
-    kernel’s\n                  top-level iptables chains by inserting a rule at the
-    top of the\n                  chain or by appending a rule at the bottom. insert
-    is the safe default\n                  since it prevents Calico’s rules from being
-    bypassed. If you switch\n                  to append mode, be sure that the other
-    rules in the chains signal\n                  acceptance by falling through to
-    the Calico rules, otherwise the\n                  Calico policy will be bypassed.
-    [Default: insert]'\n                  type: string\n                dataplaneDriver:\n
-    \                 type: string\n                debugDisableLogDropping:\n                  type:
-    boolean\n                debugMemoryProfilePath:\n                  type: string\n
-    \               debugSimulateCalcGraphHangAfter:\n                  type: string\n
-    \               debugSimulateDataplaneHangAfter:\n                  type: string\n
-    \               defaultEndpointToHostAction:\n                  description: 'DefaultEndpointToHostAction
-    controls what happens to\n                  traffic that goes from a workload
-    endpoint to the host itself (after\n                  the traffic hits the endpoint
-    egress policy). By default Calico\n                  blocks traffic from workload
-    endpoints to the host itself with an\n                  iptables “DROP” action.
-    If you want to allow some or all traffic\n                  from endpoint to host,
-    set this parameter to RETURN or ACCEPT. Use\n                  RETURN if you have
-    your own rules in the iptables “INPUT” chain;\n                  Calico will insert
-    its rules at the top of that chain, then “RETURN”\n                  packets to
-    the “INPUT” chain once it has completed processing workload\n                  endpoint
-    egress policy. Use ACCEPT to unconditionally accept packets\n                  from
-    workloads after processing workload endpoint egress policy.\n                  [Default:
-    Drop]'\n                  type: string\n                deviceRouteProtocol:\n
-    \                 description: This defines the route protocol added to programmed
-    device\n                    routes, by default this will be RTPROT_BOOT when left
-    blank.\n                  type: integer\n                deviceRouteSourceAddress:\n
-    \                 description: This is the source address to use on programmed
-    device\n                    routes. By default the source address is left blank,
-    leaving the\n                    kernel to choose the source address used.\n                  type:
-    string\n                disableConntrackInvalidCheck:\n                  type:
-    boolean\n                endpointReportingDelay:\n                  type: string\n
-    \               endpointReportingEnabled:\n                  type: boolean\n                externalNodesList:\n
-    \                 description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes\n
-    \                   which may source tunnel traffic and have the tunneled traffic
-    be\n                    accepted at calico nodes.\n                  items:\n
-    \                   type: string\n                  type: array\n                failsafeInboundHostPorts:\n
-    \                 description: 'FailsafeInboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow incoming traffic to
-    host endpoints\n                    on irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    inbound host ports, use the value\n                    none. The default value
-    allows ssh access and DHCP. [Default: tcp:22,\n                    udp:68, tcp:179,
-    tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'\n                  items:\n
-    \                   description: ProtoPort is combination of protocol, port, and
-    CIDR.\n                      Protocol and port must be specified.\n                    properties:\n
-    \                     net:\n                        type: string\n                      port:\n
-    \                       type: integer\n                      protocol:\n                        type:
-    string\n                    required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                failsafeOutboundHostPorts:\n
-    \                 description: 'FailsafeOutboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow outgoing traffic from
-    host endpoints\n                    to irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    outbound host ports, use the value\n                    none. The default value
-    opens etcd''s standard ports to ensure that\n                    Felix does not
-    get cut off from etcd as well as allowing DHCP and\n                    DNS. [Default:
-    tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,\n                    tcp:6667,
-    udp:53, udp:67]'\n                  items:\n                    description: ProtoPort
-    is combination of protocol, port, and CIDR.\n                      Protocol and
-    port must be specified.\n                    properties:\n                      net:\n
-    \                       type: string\n                      port:\n                        type:
-    integer\n                      protocol:\n                        type: string\n
-    \                   required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                featureDetectOverride:\n
-    \                 description: FeatureDetectOverride is used to override the feature\n
-    \                   detection. Values are specified in a comma separated list
-    with no\n                    spaces, example; \"SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=\".\n
-    \                   \"true\" or \"false\" will force the feature, empty or omitted
-    values\n                    are auto-detected.\n                  type: string\n
-    \               genericXDPEnabled:\n                  description: 'GenericXDPEnabled
-    enables Generic XDP so network cards\n                  that don''t support XDP
-    offload or driver modes can use XDP. This\n                  is not recommended
-    since it doesn''t provide better performance\n                  than iptables.
-    [Default: false]'\n                  type: boolean\n                healthEnabled:\n
-    \                 type: boolean\n                healthHost:\n                  type:
-    string\n                healthPort:\n                  type: integer\n                interfaceExclude:\n
-    \                 description: 'InterfaceExclude is a comma-separated list of
-    interfaces\n                  that Felix should exclude when monitoring for host
-    endpoints. The\n                  default value ensures that Felix ignores Kubernetes''
-    IPVS dummy\n                  interface, which is used internally by kube-proxy.
-    If you want to\n                  exclude multiple interface names using a single
-    value, the list\n                  supports regular expressions. For regular expressions
-    you must wrap\n                  the value with ''/''. For example having values
-    ''/^kube/,veth1''\n                  will exclude all interfaces that begin with
-    ''kube'' and also the\n                  interface ''veth1''. [Default: kube-ipvs0]'\n
-    \                 type: string\n                interfacePrefix:\n                  description:
-    'InterfacePrefix is the interface name prefix that identifies\n                  workload
-    endpoints and so distinguishes them from host endpoint\n                  interfaces.
-    Note: in environments other than bare metal, the orchestrators\n                  configure
-    this appropriately. For example our Kubernetes and Docker\n                  integrations
-    set the ‘cali’ value, and our OpenStack integration\n                  sets the
-    ‘tap’ value. [Default: cali]'\n                  type: string\n                interfaceRefreshInterval:\n
-    \                 description: InterfaceRefreshInterval is the period at which
-    Felix\n                    rescans local interfaces to verify their state. The
-    rescan can be\n                    disabled by setting the interval to 0.\n                  type:
-    string\n                ipipEnabled:\n                  type: boolean\n                ipipMTU:\n
-    \                 description: 'IPIPMTU is the MTU to set on the tunnel device.
-    See\n                  Configuring MTU [Default: 1440]'\n                  type:
-    integer\n                ipsetsRefreshInterval:\n                  description:
-    'IpsetsRefreshInterval is the period at which Felix re-checks\n                  all
-    iptables state to ensure that no other process has accidentally\n                  broken
-    Calico’s rules. Set to 0 to disable iptables refresh. [Default:\n                  90s]'\n
-    \                 type: string\n                iptablesBackend:\n                  description:
-    IptablesBackend specifies which backend of iptables will\n                    be
-    used. The default is legacy.\n                  type: string\n                iptablesFilterAllowAction:\n
-    \                 type: string\n                iptablesLockFilePath:\n                  description:
-    'IptablesLockFilePath is the location of the iptables\n                  lock
-    file. You may need to change this if the lock file is not in\n                  its
-    standard location (for example if you have mapped it into Felix’s\n                  container
-    at a different path). [Default: /run/xtables.lock]'\n                  type: string\n
-    \               iptablesLockProbeInterval:\n                  description: 'IptablesLockProbeInterval
-    is the time that Felix will\n                  wait between attempts to acquire
-    the iptables lock if it is not\n                  available. Lower values make
-    Felix more responsive when the lock\n                  is contended, but use more
-    CPU. [Default: 50ms]'\n                  type: string\n                iptablesLockTimeout:\n
-    \                 description: 'IptablesLockTimeout is the time that Felix will
-    wait\n                  for the iptables lock, or 0, to disable. To use this feature,
-    Felix\n                  must share the iptables lock file with all other processes
-    that\n                  also take the lock. When running Felix inside a container,
-    this\n                  requires the /run directory of the host to be mounted
-    into the calico/node\n                  or calico/felix container. [Default: 0s
-    disabled]'\n                  type: string\n                iptablesMangleAllowAction:\n
-    \                 type: string\n                iptablesMarkMask:\n                  description:
-    'IptablesMarkMask is the mask that Felix selects its\n                  IPTables
-    Mark bits from. Should be a 32 bit hexadecimal number with\n                  at
-    least 8 bits set, none of which clash with any other mark bits\n                  in
-    use on the system. [Default: 0xff000000]'\n                  format: int32\n                  type:
-    integer\n                iptablesNATOutgoingInterfaceFilter:\n                  type:
-    string\n                iptablesPostWriteCheckInterval:\n                  description:
-    'IptablesPostWriteCheckInterval is the period after Felix\n                  has
-    done a write to the dataplane that it schedules an extra read\n                  back
-    in order to check the write was not clobbered by another process.\n                  This
-    should only occur if another application on the system doesn’t\n                  respect
-    the iptables lock. [Default: 1s]'\n                  type: string\n                iptablesRefreshInterval:\n
-    \                 description: 'IptablesRefreshInterval is the period at which
-    Felix\n                    re-checks the IP sets in the dataplane to ensure that
-    no other process\n                    has accidentally broken Calico''s rules.
-    Set to 0 to disable IP\n                    sets refresh. Note: the default for
-    this value is lower than the\n                    other refresh intervals as a
-    workaround for a Linux kernel bug that\n                    was fixed in kernel
-    version 4.11. If you are using v4.11 or greater\n                    you may want
-    to set this to, a higher value to reduce Felix CPU\n                    usage.
-    [Default: 10s]'\n                  type: string\n                ipv6Support:\n
-    \                 type: boolean\n                kubeNodePortRanges:\n                  description:
-    'KubeNodePortRanges holds list of port ranges used for\n                  service
-    node ports. Only used if felix detects kube-proxy running\n                  in
-    ipvs mode. Felix uses these ranges to separate host and workload\n                  traffic.
-    [Default: 30000:32767].'\n                  items:\n                    anyOf:\n
-    \                     - type: integer\n                      - type: string\n
-    \                   pattern: ^.*\n                    x-kubernetes-int-or-string:
-    true\n                  type: array\n                logFilePath:\n                  description:
-    'LogFilePath is the full path to the Felix log. Set to\n                  none
-    to disable file logging. [Default: /var/log/calico/felix.log]'\n                  type:
-    string\n                logPrefix:\n                  description: 'LogPrefix
-    is the log prefix that Felix uses when rendering\n                  LOG rules.
-    [Default: calico-packet]'\n                  type: string\n                logSeverityFile:\n
-    \                 description: 'LogSeverityFile is the log severity above which
-    logs\n                  are sent to the log file. [Default: Info]'\n                  type:
-    string\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: Info]'\n                  type: string\n                logSeveritySys:\n
-    \                 description: 'LogSeveritySys is the log severity above which
-    logs\n                  are sent to the syslog. Set to None for no logging to
-    syslog. [Default:\n                  Info]'\n                  type: string\n
-    \               maxIpsetSize:\n                  type: integer\n                metadataAddr:\n
-    \                 description: 'MetadataAddr is the IP address or domain name
-    of the\n                  server that can answer VM queries for cloud-init metadata.
-    In OpenStack,\n                  this corresponds to the machine running nova-api
-    (or in Ubuntu,\n                  nova-api-metadata). A value of none (case insensitive)
-    means that\n                  Felix should not set up any NAT rule for the metadata
-    path. [Default:\n                  127.0.0.1]'\n                  type: string\n
-    \               metadataPort:\n                  description: 'MetadataPort is
-    the port of the metadata server. This,\n                  combined with global.MetadataAddr
-    (if not ‘None’), is used to set\n                  up a NAT rule, from 169.254.169.254:80
-    to MetadataAddr:MetadataPort.\n                  In most cases this should not
-    need to be changed [Default: 8775].'\n                  type: integer\n                mtuIfacePattern:\n
-    \                 description: MTUIfacePattern is a regular expression that controls\n
-    \                   which interfaces Felix should scan in order to calculate the
-    host's\n                    MTU. This should not match workload interfaces (usually
-    named cali...).\n                  type: string\n                natOutgoingAddress:\n
-    \                 description: NATOutgoingAddress specifies an address to use
-    when performing\n                    source NAT for traffic in a natOutgoing pool
-    that is leaving the\n                    network. By default the address used
-    is an address on the interface\n                    the traffic is leaving on
-    (ie it uses the iptables MASQUERADE target)\n                  type: string\n
-    \               natPortRange:\n                  anyOf:\n                    -
-    type: integer\n                    - type: string\n                  description:
-    NATPortRange specifies the range of ports that is used\n                    for
-    port mapping when doing outgoing NAT. When unset the default\n                    behavior
-    of the network stack is used.\n                  pattern: ^.*\n                  x-kubernetes-int-or-string:
-    true\n                netlinkTimeout:\n                  type: string\n                openstackRegion:\n
-    \                 description: 'OpenstackRegion is the name of the region that
-    a particular\n                  Felix belongs to. In a multi-region Calico/OpenStack
-    deployment,\n                  this must be configured somehow for each Felix
-    (here in the datamodel,\n                  or in felix.cfg or the environment
-    on each compute node), and must\n                  match the [calico] openstack_region
-    value configured in neutron.conf\n                  on each node. [Default: Empty]'\n
-    \                 type: string\n                policySyncPathPrefix:\n                  description:
-    'PolicySyncPathPrefix is used to by Felix to communicate\n                  policy
-    changes to external services, like Application layer policy.\n                  [Default:
-    Empty]'\n                  type: string\n                prometheusGoMetricsEnabled:\n
-    \                 description: 'PrometheusGoMetricsEnabled disables Go runtime
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                prometheusMetricsEnabled:\n                  description:
-    'PrometheusMetricsEnabled enables the Prometheus metrics\n                  server
-    in Felix if set to true. [Default: false]'\n                  type: boolean\n
-    \               prometheusMetricsHost:\n                  description: 'PrometheusMetricsHost
-    is the host that the Prometheus\n                  metrics server should bind
-    to. [Default: empty]'\n                  type: string\n                prometheusMetricsPort:\n
-    \                 description: 'PrometheusMetricsPort is the TCP port that the
-    Prometheus\n                  metrics server should bind to. [Default: 9091]'\n
-    \                 type: integer\n                prometheusProcessMetricsEnabled:\n
-    \                 description: 'PrometheusProcessMetricsEnabled disables process
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                removeExternalRoutes:\n                  description:
-    Whether or not to remove device routes that have not\n                    been
-    programmed by Felix. Disabling this will allow external applications\n                    to
-    also add device routes. This is enabled by default which means\n                    we
-    will remove externally added routes.\n                  type: boolean\n                reportingInterval:\n
-    \                 description: 'ReportingInterval is the interval at which Felix
-    reports\n                  its status into the datastore or 0 to disable. Must
-    be non-zero\n                  in OpenStack deployments. [Default: 30s]'\n                  type:
-    string\n                reportingTTL:\n                  description: 'ReportingTTL
-    is the time-to-live setting for process-wide\n                  status reports.
-    [Default: 90s]'\n                  type: string\n                routeRefreshInterval:\n
-    \                 description: 'RouterefreshInterval is the period at which Felix
-    re-checks\n                  the routes in the dataplane to ensure that no other
-    process has\n                  accidentally broken Calico’s rules. Set to 0 to
-    disable route refresh.\n                  [Default: 90s]'\n                  type:
-    string\n                routeSource:\n                  description: 'RouteSource
-    configures where Felix gets its routing\n                  information. - WorkloadIPs:
-    use workload endpoints to construct\n                  routes. - CalicoIPAM: the
-    default - use IPAM data to construct routes.'\n                  type: string\n
-    \               routeTableRange:\n                  description: Calico programs
-    additional Linux route tables for various\n                    purposes.  RouteTableRange
-    specifies the indices of the route tables\n                    that Calico should
-    use.\n                  properties:\n                    max:\n                      type:
-    integer\n                    min:\n                      type: integer\n                  required:\n
-    \                   - max\n                    - min\n                  type:
-    object\n                serviceLoopPrevention:\n                  description:
-    'When service IP advertisement is enabled, prevent routing\n                    loops
-    to service IPs that are not in use, by dropping or rejecting\n                    packets
-    that do not get DNAT''d by kube-proxy. Unless set to \"Disabled\",\n                    in
-    which case such routing loops continue to be allowed. [Default:\n                    Drop]'\n
-    \                 type: string\n                sidecarAccelerationEnabled:\n
-    \                 description: 'SidecarAccelerationEnabled enables experimental
-    sidecar\n                  acceleration [Default: false]'\n                  type:
-    boolean\n                usageReportingEnabled:\n                  description:
-    'UsageReportingEnabled reports anonymous Calico version\n                  number
-    and cluster size to projectcalico.org. Logs warnings returned\n                  by
-    the usage server. For example, if a significant security vulnerability\n                  has
-    been discovered in the version of Calico being used. [Default:\n                  true]'\n
-    \                 type: boolean\n                usageReportingInitialDelay:\n
-    \                 description: 'UsageReportingInitialDelay controls the minimum
-    delay\n                  before Felix makes a report. [Default: 300s]'\n                  type:
-    string\n                usageReportingInterval:\n                  description:
-    'UsageReportingInterval controls the interval at which\n                  Felix
-    makes reports. [Default: 86400s]'\n                  type: string\n                useInternalDataplaneDriver:\n
-    \                 type: boolean\n                vxlanEnabled:\n                  type:
-    boolean\n                vxlanMTU:\n                  description: 'VXLANMTU is
-    the MTU to set on the tunnel device. See\n                  Configuring MTU [Default:
-    1440]'\n                  type: integer\n                vxlanPort:\n                  type:
-    integer\n                vxlanVNI:\n                  type: integer\n                wireguardEnabled:\n
-    \                 description: 'WireguardEnabled controls whether Wireguard is
-    enabled.\n                  [Default: false]'\n                  type: boolean\n
-    \               wireguardInterfaceName:\n                  description: 'WireguardInterfaceName
-    specifies the name to use for\n                  the Wireguard interface. [Default:
-    wg.calico]'\n                  type: string\n                wireguardListeningPort:\n
-    \                 description: 'WireguardListeningPort controls the listening
-    port used\n                  by Wireguard. [Default: 51820]'\n                  type:
-    integer\n                wireguardMTU:\n                  description: 'WireguardMTU
-    controls the MTU on the Wireguard interface.\n                  See Configuring
-    MTU [Default: 1420]'\n                  type: integer\n                wireguardRoutingRulePriority:\n
-    \                 description: 'WireguardRoutingRulePriority controls the priority
-    value\n                  to use for the Wireguard routing rule. [Default: 99]'\n
-    \                 type: integer\n                xdpEnabled:\n                  description:
-    'XDPEnabled enables XDP acceleration for suitable untracked\n                  incoming
-    deny rules. [Default: true]'\n                  type: boolean\n                xdpRefreshInterval:\n
-    \                 description: 'XDPRefreshInterval is the period at which Felix
-    re-checks\n                  all XDP state to ensure that no other process has
-    accidentally broken\n                  Calico''s BPF maps or attached programs.
-    Set to 0 to disable XDP\n                  refresh. [Default: 90s]'\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: globalnetworkpolicies.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: GlobalNetworkPolicy\n    listKind:
-    GlobalNetworkPolicyList\n    plural: globalnetworkpolicies\n    singular: globalnetworkpolicy\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                applyOnForward:\n
-    \                 description: ApplyOnForward indicates to apply the rules in
-    this policy\n                    on forward traffic.\n                  type:
-    boolean\n                doNotTrack:\n                  description: DoNotTrack
-    indicates whether packets matched by the rules\n                    in this policy
-    should go through the data plane's connection tracking,\n                    such
-    as Linux conntrack.  If True, the rules in this policy are\n                    applied
-    before any data plane connection tracking, and packets allowed\n                    by
-    this policy are marked as not to be tracked.\n                  type: boolean\n
-    \               egress:\n                  description: The ordered set of egress
-    rules.  Each rule contains\n                    a set of packet match criteria
-    and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                namespaceSelector:\n                  description: NamespaceSelector
-    is an optional field for an expression\n                    used to select a pod
-    based on namespaces.\n                  type: string\n                order:\n
-    \                 description: Order is an optional field that specifies the order
-    in\n                    which the policy is applied. Policies with higher \"order\"
-    are applied\n                    after those with lower order.  If the order is
-    omitted, it may be\n                    considered to be \"infinite\" - i.e. the
-    policy will be applied last.  Policies\n                    with identical order
-    will be applied in alphanumerical order based\n                    on the Policy
-    \"Name\".\n                  type: number\n                preDNAT:\n                  description:
-    PreDNAT indicates to apply the rules in this policy before\n                    any
-    DNAT.\n                  type: boolean\n                selector:\n                  description:
-    \"The selector is an expression used to pick pick out\n                  the endpoints
-    that the policy should be applied to. \\n Selector\n                  expressions
-    follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n                  \\
-    ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel != \\\"string_literal\\\"\n
-    \                 \\  ->  not equal; also matches if label is not present \\tlabel
-    in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\", ... }  ->  true if the
-    value of label X is\n                  one of \\\"a\\\", \\\"b\\\", \\\"c\\\"
-    \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ... }  ->
-    \ true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress rules are present
-    in the policy.  The\n                  default is: \\n - [ PolicyTypeIngress ],
-    if there are no Egress rules\n                  (including the case where there
-    are   also no Ingress rules) \\n\n                  - [ PolicyTypeEgress ], if
-    there are Egress rules but no Ingress\n                  rules \\n - [ PolicyTypeIngress,
-    PolicyTypeEgress ], if there are\n                  both Ingress and Egress rules.
-    \\n When the policy is read back again,\n                  Types will always be
-    one of these values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: globalnetworksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: GlobalNetworkSet\n    listKind: GlobalNetworkSetList\n    plural:
-    globalnetworksets\n    singular: globalnetworkset\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs\n            that
-    share labels to allow rules to refer to them via selectors.  The labels\n            of
-    GlobalNetworkSet are not namespaced.\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: GlobalNetworkSetSpec contains the
-    specification for a NetworkSet\n                resource.\n              properties:\n
-    \               nets:\n                  description: The list of IP networks
-    that belong to this set.\n                  items:\n                    type:
-    string\n                  type: array\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: hostendpoints.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: HostEndpoint\n    listKind: HostEndpointList\n    plural:
-    hostendpoints\n    singular: hostendpoint\n  scope: Cluster\n  versions:\n    -
-    name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: HostEndpointSpec contains the specification
-    for a HostEndpoint\n                resource.\n              properties:\n                expectedIPs:\n
-    \                 description: \"The expected IP addresses (IPv4 and IPv6) of
-    the endpoint.\n                  If \\\"InterfaceName\\\" is not present, Calico
-    will look for an interface\n                  matching any of the IPs in the list
-    and apply policy to that. Note:\n                  \\tWhen using the selector
-    match criteria in an ingress or egress\n                  security Policy \\tor
-    Profile, Calico converts the selector into\n                  a set of IP addresses.
-    For host \\tendpoints, the ExpectedIPs field\n                  is used for that
-    purpose. (If only the interface \\tname is specified,\n                  Calico
-    does not learn the IPs of the interface for use in match\n                  \\tcriteria.)\"\n
-    \                 items:\n                    type: string\n                  type:
-    array\n                interfaceName:\n                  description: \"Either
-    \\\"*\\\", or the name of a specific Linux interface\n                  to apply
-    policy to; or empty.  \\\"*\\\" indicates that this HostEndpoint\n                  governs
-    all traffic to, from or through the default network namespace\n                  of
-    the host named by the \\\"Node\\\" field; entering and leaving that\n                  namespace
-    via any interface, including those from/to non-host-networked\n                  local
-    workloads. \\n If InterfaceName is not \\\"*\\\", this HostEndpoint\n                  only
-    governs traffic that enters or leaves the host through the\n                  specific
-    interface named by InterfaceName, or - when InterfaceName\n                  is
-    empty - through the specific interface that has one of the IPs\n                  in
-    ExpectedIPs. Therefore, when InterfaceName is empty, at least\n                  one
-    expected IP must be specified.  Only external interfaces (such\n                  as
-    “eth0”) are supported here; it isn't possible for a HostEndpoint\n                  to
-    protect traffic through a specific local workload interface.\n                  \\n
-    Note: Only some kinds of policy are implemented for \\\"*\\\" HostEndpoints;\n
-    \                 initially just pre-DNAT policy.  Please check Calico documentation\n
-    \                 for the latest position.\"\n                  type: string\n
-    \               node:\n                  description: The node name identifying
-    the Calico node instance.\n                  type: string\n                ports:\n
-    \                 description: Ports contains the endpoint's named ports, which
-    may\n                    be referenced in security policy rules.\n                  items:\n
-    \                   properties:\n                      name:\n                        type:
-    string\n                      port:\n                        type: integer\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                    required:\n                      - name\n                      -
-    port\n                      - protocol\n                    type: object\n                  type:
-    array\n                profiles:\n                  description: A list of identifiers
-    of security Profile objects that\n                    apply to this endpoint.
-    Each profile is applied in the order that\n                    they appear in
-    this list.  Profile rules are applied after the selector-based\n                    security
-    policy.\n                  items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: ipamblocks.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMBlock\n    listKind: IPAMBlockList\n
-    \   plural: ipamblocks\n    singular: ipamblock\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMBlockSpec contains the specification
-    for an IPAMBlock\n                resource.\n              properties:\n                affinity:\n
-    \                 type: string\n                allocations:\n                  items:\n
-    \                   type: integer\n                    # TODO: This nullable is
-    manually added in. We should update controller-gen\n                    # to handle
-    []*int properly itself.\n                    nullable: true\n                  type:
-    array\n                attributes:\n                  items:\n                    properties:\n
-    \                     handle_id:\n                        type: string\n                      secondary:\n
-    \                       additionalProperties:\n                          type:
-    string\n                        type: object\n                    type: object\n
-    \                 type: array\n                cidr:\n                  type:
-    string\n                deleted:\n                  type: boolean\n                strictAffinity:\n
-    \                 type: boolean\n                unallocated:\n                  items:\n
-    \                   type: integer\n                  type: array\n              required:\n
-    \               - allocations\n                - attributes\n                -
-    cidr\n                - strictAffinity\n                - unallocated\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMConfig\n    listKind: IPAMConfigList\n    plural: ipamconfigs\n
-    \   singular: ipamconfig\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMConfigSpec contains the specification
-    for an IPAMConfig\n                resource.\n              properties:\n                autoAllocateBlocks:\n
-    \                 type: boolean\n                maxBlocksPerHost:\n                  description:
-    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                    that
-    can be affine to each host.\n                  type: integer\n                strictAffinity:\n
-    \                 type: boolean\n              required:\n                - autoAllocateBlocks\n
-    \               - strictAffinity\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ipamhandles.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMHandle\n    listKind: IPAMHandleList\n    plural: ipamhandles\n
-    \   singular: ipamhandle\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMHandleSpec contains the specification
-    for an IPAMHandle\n                resource.\n              properties:\n                block:\n
-    \                 additionalProperties:\n                    type: integer\n                  type:
-    object\n                deleted:\n                  type: boolean\n                handleID:\n
-    \                 type: string\n              required:\n                - block\n
-    \               - handleID\n              type: object\n          type: object\n
-    \     served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ippools.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPPool\n    listKind: IPPoolList\n    plural: ippools\n    singular:
-    ippool\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPPoolSpec contains the specification
-    for an IPPool resource.\n              properties:\n                blockSize:\n
-    \                 description: The block size to use for IP address assignments
-    from\n                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.\n
-    \                 type: integer\n                cidr:\n                  description:
-    The pool CIDR.\n                  type: string\n                disabled:\n                  description:
-    When disabled is true, Calico IPAM will not assign addresses\n                    from
-    this pool.\n                  type: boolean\n                ipip:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  properties:\n                    enabled:\n                      description:
-    When enabled is true, ipip tunneling will be used\n                        to
-    deliver packets to destinations within this pool.\n                      type:
-    boolean\n                    mode:\n                      description: The IPIP
-    mode.  This can be one of \"always\" or \"cross-subnet\".  A\n                        mode
-    of \"always\" will also use IPIP tunneling for routing to\n                        destination
-    IP addresses within this pool.  A mode of \"cross-subnet\"\n                        will
-    only use IPIP tunneling when the destination node is on\n                        a
-    different subnet to the originating node.  The default value\n                        (if
-    not specified) is \"always\".\n                      type: string\n                  type:
-    object\n                ipipMode:\n                  description: Contains configuration
-    for IPIP tunneling for this pool.\n                    If not specified, then
-    this is defaulted to \"Never\" (i.e. IPIP tunneling\n                    is disabled).\n
-    \                 type: string\n                nat-outgoing:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  type: boolean\n                natOutgoing:\n                  description:
-    When nat-outgoing is true, packets sent from Calico networked\n                    containers
-    in this pool to destinations outside of this pool will\n                    be
-    masqueraded.\n                  type: boolean\n                nodeSelector:\n
-    \                 description: Allows IPPool to allocate for a specific node by
-    label\n                    selector.\n                  type: string\n                vxlanMode:\n
-    \                 description: Contains configuration for VXLAN tunneling for
-    this pool.\n                    If not specified, then this is defaulted to \"Never\"
-    (i.e. VXLAN\n                    tunneling is disabled).\n                  type:
-    string\n              required:\n                - cidr\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: kubecontrollersconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: KubeControllersConfiguration\n    listKind: KubeControllersConfigurationList\n
-    \   plural: kubecontrollersconfigurations\n    singular: kubecontrollersconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: KubeControllersConfigurationSpec
-    contains the values of the\n                Kubernetes controllers configuration.\n
-    \             properties:\n                controllers:\n                  description:
-    Controllers enables and configures individual Kubernetes\n                    controllers\n
-    \                 properties:\n                    namespace:\n                      description:
-    Namespace enables and configures the namespace controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   node:\n                      description: Node enables and
-    configures the node controller.\n                        Enabled by default, set
-    to nil to disable.\n                      properties:\n                        hostEndpoint:\n
-    \                         description: HostEndpoint controls syncing nodes to
-    host endpoints.\n                            Disabled by default, set to nil to
-    disable.\n                          properties:\n                            autoCreate:\n
-    \                             description: 'AutoCreate enables automatic creation
-    of\n                              host endpoints for every node. [Default: Disabled]'\n
-    \                             type: string\n                          type: object\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                       syncLabels:\n                          description: 'SyncLabels
-    controls whether to copy Kubernetes\n                          node labels to
-    Calico nodes. [Default: Enabled]'\n                          type: string\n                      type:
-    object\n                    policy:\n                      description: Policy
-    enables and configures the policy controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   serviceAccount:\n                      description: ServiceAccount
-    enables and configures the service\n                        account controller.
-    Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                    workloadEndpoint:\n                      description:
-    WorkloadEndpoint enables and configures the workload\n                        endpoint
-    controller. Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                  type: object\n                etcdV3CompactionPeriod:\n
-    \                 description: 'EtcdV3CompactionPeriod is the period between etcdv3\n
-    \                 compaction requests. Set to 0 to disable. [Default: 10m]'\n
-    \                 type: string\n                healthChecks:\n                  description:
-    'HealthChecks enables or disables support for health\n                  checks
-    [Default: Enabled]'\n                  type: string\n                logSeverityScreen:\n
-    \                 description: 'LogSeverityScreen is the log severity above which
-    logs\n                  are sent to the stdout. [Default: Info]'\n                  type:
-    string\n                prometheusMetricsPort:\n                  description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                    metrics
-    server should bind to. Set to 0 to disable. [Default: 9094]'\n                  type:
-    integer\n              required:\n                - controllers\n              type:
-    object\n            status:\n              description: KubeControllersConfigurationStatus
-    represents the status\n                of the configuration. It's useful for admins
-    to be able to see the actual\n                config that was applied, which can
-    be modified by environment variables\n                on the kube-controllers
-    process.\n              properties:\n                environmentVars:\n                  additionalProperties:\n
-    \                   type: string\n                  description: EnvironmentVars
-    contains the environment variables on\n                    the kube-controllers
-    that influenced the RunningConfig.\n                  type: object\n                runningConfig:\n
-    \                 description: RunningConfig contains the effective config that
-    is running\n                    in the kube-controllers pod, after merging the
-    API resource with\n                    any environment variables.\n                  properties:\n
-    \                   controllers:\n                      description: Controllers
-    enables and configures individual Kubernetes\n                        controllers\n
-    \                     properties:\n                        namespace:\n                          description:
-    Namespace enables and configures the namespace\n                            controller.
-    Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        node:\n
-    \                         description: Node enables and configures the node controller.\n
-    \                           Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           hostEndpoint:\n                              description:
-    HostEndpoint controls syncing nodes to host\n                                endpoints.
-    Disabled by default, set to nil to disable.\n                              properties:\n
-    \                               autoCreate:\n                                  description:
-    'AutoCreate enables automatic creation\n                                  of host
-    endpoints for every node. [Default: Disabled]'\n                                  type:
-    string\n                              type: object\n                            leakGracePeriod:\n
-    \                             description: 'LeakGracePeriod is the period used
-    by the\n                                controller to determine if an IP address
-    has been leaked.\n                                Set to 0 to disable IP garbage
-    collection. [Default:\n                                15m]'\n                              type:
-    string\n                            reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                            syncLabels:\n                              description:
-    'SyncLabels controls whether to copy Kubernetes\n                              node
-    labels to Calico nodes. [Default: Enabled]'\n                              type:
-    string\n                          type: object\n                        policy:\n
-    \                         description: Policy enables and configures the policy
-    controller.\n                            Enabled by default, set to nil to disable.\n
-    \                         properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        serviceAccount:\n
-    \                         description: ServiceAccount enables and configures the
-    service\n                            account controller. Enabled by default, set
-    to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        workloadEndpoint:\n
-    \                         description: WorkloadEndpoint enables and configures
-    the workload\n                            endpoint controller. Enabled by default,
-    set to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                      type: object\n
-    \                   etcdV3CompactionPeriod:\n                      description:
-    'EtcdV3CompactionPeriod is the period between etcdv3\n                      compaction
-    requests. Set to 0 to disable. [Default: 10m]'\n                      type: string\n
-    \                   healthChecks:\n                      description: 'HealthChecks
-    enables or disables support for health\n                      checks [Default:
-    Enabled]'\n                      type: string\n                    logSeverityScreen:\n
-    \                     description: 'LogSeverityScreen is the log severity above
-    which\n                      logs are sent to the stdout. [Default: Info]'\n                      type:
-    string\n                    prometheusMetricsPort:\n                      description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                        metrics
-    server should bind to. Set to 0 to disable. [Default:\n                        9094]'\n
-    \                     type: integer\n                  required:\n                    -
-    controllers\n                  type: object\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: networkpolicies.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkPolicy\n    listKind: NetworkPolicyList\n    plural:
-    networkpolicies\n    singular: networkpolicy\n  scope: Namespaced\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                egress:\n                  description:
-    The ordered set of egress rules.  Each rule contains\n                    a set
-    of packet match criteria and a corresponding action to apply.\n                  items:\n
-    \                   description: \"A Rule encapsulates a set of match criteria
-    and an\n                    action.  Both selector-based security Policy and security
-    Profiles\n                    reference rules - separated out as a list of rules
-    for both ingress\n                    and egress packet matching. \\n Each positive
-    match criteria has\n                    a negated version, prefixed with ”Not”.
-    All the match criteria\n                    within a rule must be satisfied for
-    a packet to match. A single\n                    rule can contain the positive
-    and negative version of a match\n                    and both must be satisfied
-    for the rule to match.\"\n                    properties:\n                      action:\n
-    \                       type: string\n                      destination:\n                        description:
-    Destination contains the match criteria that apply\n                          to
-    destination entity.\n                        properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                order:\n                  description: Order is an optional
-    field that specifies the order in\n                    which the policy is applied.
-    Policies with higher \"order\" are applied\n                    after those with
-    lower order.  If the order is omitted, it may be\n                    considered
-    to be \"infinite\" - i.e. the policy will be applied last.  Policies\n                    with
-    identical order will be applied in alphanumerical order based\n                    on
-    the Policy \"Name\".\n                  type: number\n                selector:\n
-    \                 description: \"The selector is an expression used to pick pick
-    out\n                  the endpoints that the policy should be applied to. \\n
-    Selector\n                  expressions follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n
-    \                 \\ ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel
-    != \\\"string_literal\\\"\n                  \\  ->  not equal; also matches if
-    label is not present \\tlabel in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\",
-    ... }  ->  true if the value of label X is\n                  one of \\\"a\\\",
-    \\\"b\\\", \\\"c\\\" \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ...
-    }  ->  true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress are present in the
-    policy.  The default\n                  is: \\n - [ PolicyTypeIngress ], if there
-    are no Egress rules (including\n                  the case where there are   also
-    no Ingress rules) \\n - [ PolicyTypeEgress\n                  ], if there are
-    Egress rules but no Ingress rules \\n - [ PolicyTypeIngress,\n                  PolicyTypeEgress
-    ], if there are both Ingress and Egress rules.\n                  \\n When the
-    policy is read back again, Types will always be one\n                  of these
-    values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: networksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkSet\n    listKind: NetworkSetList\n    plural: networksets\n
-    \   singular: networkset\n  scope: Namespaced\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          description: NetworkSet is the Namespaced-equivalent
-    of the GlobalNetworkSet.\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: NetworkSetSpec contains the specification
-    for a NetworkSet\n                resource.\n              properties:\n                nets:\n
-    \                 description: The list of IP networks that belong to this set.\n
-    \                 items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n---\n# Source: calico/templates/calico-kube-controllers-rbac.yaml\n\n#
-    Include a clusterrole for the kube-controllers component,\n# and bind it to the
-    calico-kube-controllers serviceaccount.\nkind: ClusterRole\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nrules:\n  # Nodes are watched to monitor for
-    deletions.\n  - apiGroups: [\"\"]\n    resources:\n      - nodes\n    verbs:\n
-    \     - watch\n      - list\n      - get\n  # Pods are watched to check for existence
-    as part of IPAM controller.\n  - apiGroups: [\"\"]\n    resources:\n      - pods\n
-    \   verbs:\n      - get\n      - list\n      - watch\n  # IPAM resources are manipulated
-    when nodes are deleted.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - ippools\n    verbs:\n      - list\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - blockaffinities\n      - ipamblocks\n      - ipamhandles\n
-    \   verbs:\n      - get\n      - list\n      - create\n      - update\n      -
-    delete\n      - watch\n  # kube-controllers manages hostendpoints.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - hostendpoints\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  #
-    Needs access to update clusterinformations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - clusterinformations\n    verbs:\n      - get\n      -
-    create\n      - update\n  # KubeControllersConfiguration is where it gets its
-    config\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - kubecontrollersconfigurations\n
-    \   verbs:\n      # read its own config\n      - get\n      # create a default
-    if none exists\n      - create\n      # update status\n      - update\n      #
-    watch for changes\n      - watch\n---\nkind: ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-kube-controllers\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-kube-controllers\n    namespace: kube-system\n---\n\n---\n# Source:
-    calico/templates/calico-node-rbac.yaml\n# Include a clusterrole for the calico-node
-    DaemonSet,\n# and bind it to the calico-node serviceaccount.\nkind: ClusterRole\napiVersion:
-    rbac.authorization.k8s.io/v1\nmetadata:\n  name: calico-node\nrules:\n  # The
-    CNI plugin needs to get pods, nodes, and namespaces.\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - pods\n      - nodes\n      - namespaces\n    verbs:\n
-    \     - get\n  # EndpointSlices are used for Service-based network policy rule\n
-    \ # enforcement.\n  - apiGroups: [\"discovery.k8s.io\"]\n    resources:\n      -
-    endpointslices\n    verbs:\n      - watch\n      - list\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - endpoints\n      - services\n    verbs:\n      # Used
-    to discover service IPs for advertisement.\n      - watch\n      - list\n      #
-    Used to discover Typhas.\n      - get\n  # Pod CIDR auto-detection on kubeadm
-    needs access to config maps.\n  - apiGroups: [\"\"]\n    resources:\n      - configmaps\n
-    \   verbs:\n      - get\n  - apiGroups: [\"\"]\n    resources:\n      - nodes/status\n
-    \   verbs:\n      # Needed for clearing NodeNetworkUnavailable flag.\n      -
-    patch\n      # Calico stores some configuration information in node annotations.\n
-    \     - update\n  # Watch for changes to Kubernetes NetworkPolicies.\n  - apiGroups:
-    [\"networking.k8s.io\"]\n    resources:\n      - networkpolicies\n    verbs:\n
-    \     - watch\n      - list\n  # Used by Calico for policy information.\n  - apiGroups:
-    [\"\"]\n    resources:\n      - pods\n      - namespaces\n      - serviceaccounts\n
-    \   verbs:\n      - list\n      - watch\n  # The CNI plugin patches pods/status.\n
-    \ - apiGroups: [\"\"]\n    resources:\n      - pods/status\n    verbs:\n      -
-    patch\n  # Calico monitors various CRDs for config.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - globalfelixconfigs\n      - felixconfigurations\n      -
-    bgppeers\n      - globalbgpconfigs\n      - bgpconfigurations\n      - ippools\n
-    \     - ipamblocks\n      - globalnetworkpolicies\n      - globalnetworksets\n
-    \     - networkpolicies\n      - networksets\n      - clusterinformations\n      -
-    hostendpoints\n      - blockaffinities\n    verbs:\n      - get\n      - list\n
-    \     - watch\n  # Calico must create and update some CRDs on startup.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - ippools\n      - felixconfigurations\n
-    \     - clusterinformations\n    verbs:\n      - create\n      - update\n  # Calico
-    stores some configuration information on the node.\n  - apiGroups: [\"\"]\n    resources:\n
-    \     - nodes\n    verbs:\n      - get\n      - list\n      - watch\n  # These
-    permissions are only required for upgrade from v2.6, and can\n  # be removed after
-    upgrade or on fresh installations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - bgpconfigurations\n      - bgppeers\n    verbs:\n      -
-    create\n      - update\n  # These permissions are required for Calico CNI to perform
-    IPAM allocations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n      - ipamblocks\n      - ipamhandles\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  -
-    apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - ipamconfigs\n
-    \   verbs:\n      - get\n  # Block affinities must also be watchable by confd
-    for route aggregation.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n    verbs:\n      - watch\n  # The Calico IPAM migration
-    needs to get daemonsets. These permissions can be\n  # removed if not upgrading
-    from an installation using host-local IPAM.\n  - apiGroups: [\"apps\"]\n    resources:\n
-    \     - daemonsets\n    verbs:\n      - get\n\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:
-    ClusterRoleBinding\nmetadata:\n  name: calico-node\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-node\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-node\n    namespace: kube-system\n\n---\n# Source: calico/templates/calico-node.yaml\n#
-    This manifest installs the calico-node container, as well\n# as the CNI plugins
-    and network config on\n# each master and worker node in a Kubernetes cluster.\nkind:
-    DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: calico-node\n  namespace: kube-system\n
-    \ labels:\n    k8s-app: calico-node\nspec:\n  selector:\n    matchLabels:\n      k8s-app:
-    calico-node\n  updateStrategy:\n    type: RollingUpdate\n    rollingUpdate:\n
-    \     maxUnavailable: 1\n  template:\n    metadata:\n      labels:\n        k8s-app:
-    calico-node\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n
-    \     hostNetwork: true\n      tolerations:\n        # Make sure calico-node gets
-    scheduled on all nodes.\n        - effect: NoSchedule\n          operator: Exists\n
-    \       # Mark the pod as a critical add-on for rescheduling.\n        - key:
-    CriticalAddonsOnly\n          operator: Exists\n        - effect: NoExecute\n
-    \         operator: Exists\n      serviceAccountName: calico-node\n      # Minimize
-    downtime during a rolling upgrade or deletion; tell Kubernetes to do a \"force\n
-    \     # deletion\": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.\n
-    \     terminationGracePeriodSeconds: 0\n      priorityClassName: system-node-critical\n
-    \     initContainers:\n        # This container performs upgrade from host-local
-    IPAM to calico-ipam.\n        # It can be deleted if this is a fresh installation,
-    or if you have already\n        # upgraded to use calico-ipam.\n        - name:
-    upgrade-ipam\n          image: calico/cni:v3.20.0\n          command: [\"/opt/cni/bin/calico-ipam\",
-    \"-upgrade\"]\n          envFrom:\n            - configMapRef:\n                #
-    Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for
-    eBPF mode.\n                name: kubernetes-services-endpoint\n                optional:
-    true\n          env:\n            - name: KUBERNETES_NODE_NAME\n              valueFrom:\n
-    \               fieldRef:\n                  fieldPath: spec.nodeName\n            -
-    name: CALICO_NETWORKING_BACKEND\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: calico_backend\n
-    \         volumeMounts:\n            - mountPath: /var/lib/cni/networks\n              name:
-    host-local-net-dir\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n          securityContext:\n            privileged: true\n        #
-    This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: calico/cni:v3.20.0\n
-    \         command: [\"/opt/cni/bin/install\"]\n          envFrom:\n            -
-    configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
-    to be overridden for eBPF mode.\n                name: kubernetes-services-endpoint\n
-    \               optional: true\n          env:\n            # Name of the CNI
-    config file to create.\n            - name: CNI_CONF_NAME\n              value:
-    \"10-calico.conflist\"\n            # The CNI network config to install on each
-    node.\n            - name: CNI_NETWORK_CONFIG\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: cni_network_config\n
-    \           # Set the hostname based on the k8s node name.\n            - name:
-    KUBERNETES_NODE_NAME\n              valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # CNI MTU Config variable\n            - name: CNI_MTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Prevents the container
-    from sleeping forever.\n            - name: SLEEP\n              value: \"false\"\n
-    \         volumeMounts:\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n            - mountPath: /host/etc/cni/net.d\n              name:
-    cni-net-dir\n          securityContext:\n            privileged: true\n        #
-    Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes\n
-    \       # to communicate with Felix over the Policy Sync API.\n        - name:
-    flexvol-driver\n          image: calico/pod2daemon-flexvol:v3.20.0\n          volumeMounts:\n
-    \           - name: flexvol-driver-host\n              mountPath: /host/driver\n
-    \         securityContext:\n            privileged: true\n      containers:\n
-    \       # Runs calico-node container on each Kubernetes node. This\n        #
-    container programs network policy and routes on each\n        # host.\n        -
-    name: calico-node\n          image: calico/node:v3.20.0\n          envFrom:\n
-    \           - configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and
-    KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.\n                name:
-    kubernetes-services-endpoint\n                optional: true\n          env:\n
-    \           # Use Kubernetes API as the backing datastore.\n            - name:
-    DATASTORE_TYPE\n              value: \"kubernetes\"\n            # Wait for the
-    datastore.\n            - name: WAIT_FOR_DATASTORE\n              value: \"true\"\n
-    \           # Set based on the k8s node name.\n            - name: NODENAME\n
-    \             valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # Choose the backend to use.\n            - name: CALICO_NETWORKING_BACKEND\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: calico_backend\n            # Cluster type
-    to identify the deployment type\n            - name: CLUSTER_TYPE\n              value:
-    \"k8s,bgp\"\n            # Auto-detect the BGP IP address.\n            - name:
-    IP\n              value: \"autodetect\"\n            # Enable VXLAN\n            -
-    name: CALICO_IPV4POOL_VXLAN\n              value: \"Always\"\n            # Set
-    MTU for tunnel device used if ipip is enabled\n            - name: FELIX_IPINIPMTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Set MTU for the
-    VXLAN tunnel device.\n            - name: FELIX_VXLANMTU\n              valueFrom:\n
-    \               configMapKeyRef:\n                  name: calico-config\n                  key:
-    veth_mtu\n            # Set MTU for the Wireguard tunnel device.\n            -
-    name: FELIX_WIREGUARDMTU\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: veth_mtu\n            #
-    The default IPv4 pool to create on startup if none exists. Pod IPs will be\n            #
-    chosen from this range. Changing this value after installation will have\n            #
-    no effect. This should fall within `--cluster-cidr`.\n            # - name: CALICO_IPV4POOL_CIDR\n
-    \           #   value: \"192.168.0.0/16\"\n            # Disable file logging
-    so `kubectl logs` works.\n            - name: CALICO_DISABLE_FILE_LOGGING\n              value:
-    \"true\"\n            # Set Felix endpoint to host default action to ACCEPT.\n
-    \           - name: FELIX_DEFAULTENDPOINTTOHOSTACTION\n              value: \"ACCEPT\"\n
-    \           # Disable IPv6 on Kubernetes.\n            - name: FELIX_IPV6SUPPORT\n
-    \             value: \"false\"\n            - name: FELIX_FEATUREDETECTOVERRIDE\n
-    \             value: \"ChecksumOffloadBroken=true\"\n            - name: FELIX_HEALTHENABLED\n
-    \             value: \"true\"\n          securityContext:\n            privileged:
-    true\n          resources:\n            requests:\n              cpu: 250m\n          livenessProbe:\n
-    \           exec:\n              command:\n                - /bin/calico-node\n
-    \               - -felix-live\n            periodSeconds: 10\n            initialDelaySeconds:
-    10\n            failureThreshold: 6\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /bin/calico-node\n                -
-    -felix-ready\n            periodSeconds: 10\n          volumeMounts:\n            -
-    mountPath: /host/etc/cni/net.d\n              name: cni-net-dir\n              readOnly:
-    false\n            - mountPath: /lib/modules\n              name: lib-modules\n
-    \             readOnly: true\n            - mountPath: /run/xtables.lock\n              name:
-    xtables-lock\n              readOnly: false\n            - mountPath: /var/run/calico\n
-    \             name: var-run-calico\n              readOnly: false\n            -
-    mountPath: /var/lib/calico\n              name: var-lib-calico\n              readOnly:
-    false\n            - name: policysync\n              mountPath: /var/run/nodeagent\n
-    \           # For eBPF mode, we need to be able to mount the BPF filesystem at
-    /sys/fs/bpf so we mount in the\n            # parent directory.\n            -
-    name: sysfs\n              mountPath: /sys/fs/\n              # Bidirectional
-    means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to
-    the host.\n              # If the host is known to mount that filesystem already
-    then Bidirectional can be omitted.\n              mountPropagation: Bidirectional\n
-    \           - name: cni-log-dir\n              mountPath: /var/log/calico/cni\n
-    \             readOnly: true\n      volumes:\n        # Used by calico-node.\n
-    \       - name: lib-modules\n          hostPath:\n            path: /lib/modules\n
-    \       - name: var-run-calico\n          hostPath:\n            path: /var/run/calico\n
-    \       - name: var-lib-calico\n          hostPath:\n            path: /var/lib/calico\n
-    \       - name: xtables-lock\n          hostPath:\n            path: /run/xtables.lock\n
-    \           type: FileOrCreate\n        - name: sysfs\n          hostPath:\n            path:
-    /sys/fs/\n            type: DirectoryOrCreate\n        # Used to install CNI.\n
-    \       - name: cni-bin-dir\n          hostPath:\n            path: /opt/cni/bin\n
-    \       - name: cni-net-dir\n          hostPath:\n            path: /etc/cni/net.d\n
-    \       # Used to access CNI logs.\n        - name: cni-log-dir\n          hostPath:\n
-    \           path: /var/log/calico/cni\n        # Mount in the directory for host-local
-    IPAM allocations. This is\n        # used when upgrading from host-local to calico-ipam,
-    and can be removed\n        # if not using the upgrade-ipam init container.\n
-    \       - name: host-local-net-dir\n          hostPath:\n            path: /var/lib/cni/networks\n
-    \       # Used to create per-pod Unix Domain Sockets\n        - name: policysync\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /var/run/nodeagent\n
-    \       # Used to install Flex Volume Driver\n        - name: flexvol-driver-host\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds\n---\n\napiVersion:
-    v1\nkind: ServiceAccount\nmetadata:\n  name: calico-node\n  namespace: kube-system\n\n---\n#
-    Source: calico/templates/calico-kube-controllers.yaml\n# See https://github.com/projectcalico/kube-controllers\napiVersion:
-    apps/v1\nkind: Deployment\nmetadata:\n  name: calico-kube-controllers\n  namespace:
-    kube-system\n  labels:\n    k8s-app: calico-kube-controllers\nspec:\n  # The controllers
-    can only have a single active instance.\n  replicas: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n  strategy:\n    type: Recreate\n  template:\n
-    \   metadata:\n      name: calico-kube-controllers\n      namespace: kube-system\n
-    \     labels:\n        k8s-app: calico-kube-controllers\n    spec:\n      nodeSelector:\n
-    \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
-    a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
-    Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
-    \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
-    \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
-    \         env:\n            # Choose which controllers to run.\n            -
-    name: ENABLED_CONTROLLERS\n              value: node\n            - name: DATASTORE_TYPE\n
-    \             value: kubernetes\n          livenessProbe:\n            exec:\n
-    \             command:\n              - /usr/bin/check-status\n              -
-    -l\n            periodSeconds: 10\n            initialDelaySeconds: 10\n            failureThreshold:
-    6\n            timeoutSeconds: 10\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /usr/bin/check-status\n                -
-    -r\n            periodSeconds: 10\n\n---\n\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n\n---\n\n# This manifest
-    creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler
-    to evict\n\napiVersion: policy/v1beta1\nkind: PodDisruptionBudget\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n  labels:\n    k8s-app:
-    calico-kube-controllers\nspec:\n  maxUnavailable: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n---\n# Source: calico/templates/calico-etcd-secrets.yaml\n\n---\n#
-    Source: calico/templates/calico-typha.yaml\n\n---\n# Source: calico/templates/configure-canal.yaml\n"
+  resources: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgpconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPConfiguration
+        listKind: BGPConfigurationList
+        plural: bgpconfigurations
+        singular: bgpconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: BGPConfiguration contains the configuration for any BGP routing.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPConfigurationSpec contains the values of the BGP configuration.
+                properties:
+                  asNumber:
+                    description: 'ASNumber is the default AS number used by a node. [Default:
+                      64512]'
+                    format: int32
+                    type: integer
+                  communities:
+                    description: Communities is a list of BGP community values and their
+                      arbitrary names for tagging routes.
+                    items:
+                      description: Community contains standard or large community value
+                        and its name.
+                      properties:
+                        name:
+                          description: Name given to community value.
+                          type: string
+                        value:
+                          description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                            For standard community use `aa:nn` format, where `aa` and
+                            `nn` are 16 bit number. For large community use `aa:nn:mm`
+                            format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                            `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                          pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                          type: string
+                      type: object
+                    type: array
+                  listenPort:
+                    description: ListenPort is the port where BGP protocol should listen.
+                      Defaults to 179
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: INFO]'
+                    type: string
+                  nodeToNodeMeshEnabled:
+                    description: 'NodeToNodeMeshEnabled sets whether full node to node
+                      BGP mesh is enabled. [Default: true]'
+                    type: boolean
+                  prefixAdvertisements:
+                    description: PrefixAdvertisements contains per-prefix advertisement
+                      configuration.
+                    items:
+                      description: PrefixAdvertisement configures advertisement properties
+                        for the specified CIDR.
+                      properties:
+                        cidr:
+                          description: CIDR for which properties should be advertised.
+                          type: string
+                        communities:
+                          description: Communities can be list of either community names
+                            already defined in `Specs.Communities` or community value
+                            of format `aa:nn` or `aa:nn:mm`. For standard community use
+                            `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                            large community use `aa:nn:mm` format, where `aa`, `nn` and
+                            `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                            `mm` are per-AS identifier.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  serviceClusterIPs:
+                    description: ServiceClusterIPs are the CIDR blocks from which service
+                      cluster IPs are allocated. If specified, Calico will advertise these
+                      blocks, as well as any cluster IPs within them.
+                    items:
+                      description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                        CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceExternalIPs:
+                    description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                      Service External IPs. Kubernetes Service ExternalIPs will only be
+                      advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceExternalIPBlock represents a single allowed
+                        External IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceLoadBalancerIPs:
+                    description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                      Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                      IPs will only be advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceLoadBalancerIPBlock represents a single allowed
+                        LoadBalancer IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgppeers.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPPeer
+        listKind: BGPPeerList
+        plural: bgppeers
+        singular: bgppeer
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPPeerSpec contains the specification for a BGPPeer resource.
+                properties:
+                  asNumber:
+                    description: The AS Number of the peer.
+                    format: int32
+                    type: integer
+                  keepOriginalNextHop:
+                    description: Option to keep the original nexthop field when routes
+                      are sent to a BGP Peer. Setting "true" configures the selected BGP
+                      Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                      in the specific branch of the Node on "bird.cfg".
+                    type: boolean
+                  maxRestartTime:
+                    description: Time to allow for software restart.  When specified,
+                      this is configured as the graceful restart timeout.  When not specified,
+                      the BIRD default of 120s is used.
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance that
+                      is targeted by this peer. If this is not set, and no nodeSelector
+                      is specified, then this BGP peer selects all nodes in the cluster.
+                    type: string
+                  nodeSelector:
+                    description: Selector for the nodes that should have this peering.  When
+                      this is set, the Node field must be empty.
+                    type: string
+                  password:
+                    description: Optional BGP password for the peerings generated by this
+                      BGPPeer resource.
+                    properties:
+                      secretKeyRef:
+                        description: Selects a key of a secret in the node pod's namespace.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be
+                              a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be
+                              defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  peerIP:
+                    description: The IP address of the peer followed by an optional port
+                      number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                      or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                      and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                      set in BGPConfiguration, then we use that port to peer.
+                    type: string
+                  peerSelector:
+                    description: Selector for the remote nodes to peer with.  When this
+                      is set, the PeerIP and ASNumber fields must be empty.  For each
+                      peering between the local node and selected remote nodes, we configure
+                      an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                      and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                      remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                      or the global default if that is not set.
+                    type: string
+                  sourceAddress:
+                    description: Specifies whether and how to configure a source address
+                      for the peerings generated by this BGPPeer resource.  Default value
+                      "UseNodeIP" means to configure the node IP as the source address.  "None"
+                      means not to configure a source address.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: blockaffinities.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BlockAffinity
+        listKind: BlockAffinityList
+        plural: blockaffinities
+        singular: blockaffinity
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BlockAffinitySpec contains the specification for a BlockAffinity
+                  resource.
+                properties:
+                  cidr:
+                    type: string
+                  deleted:
+                    description: Deleted indicates that this block affinity is being deleted.
+                      This field is a string for compatibility with older releases that
+                      mistakenly treat this field as a string.
+                    type: string
+                  node:
+                    type: string
+                  state:
+                    type: string
+                required:
+                - cidr
+                - deleted
+                - node
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: clusterinformations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: ClusterInformation
+        listKind: ClusterInformationList
+        plural: clusterinformations
+        singular: clusterinformation
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterInformation contains the cluster specific information.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterInformationSpec contains the values of describing
+                  the cluster.
+                properties:
+                  calicoVersion:
+                    description: CalicoVersion is the version of Calico that the cluster
+                      is running
+                    type: string
+                  clusterGUID:
+                    description: ClusterGUID is the GUID of the cluster
+                    type: string
+                  clusterType:
+                    description: ClusterType describes the type of the cluster
+                    type: string
+                  datastoreReady:
+                    description: DatastoreReady is used during significant datastore migrations
+                      to signal to components such as Felix that it should wait before
+                      accessing the datastore.
+                    type: boolean
+                  variant:
+                    description: Variant declares which variant of Calico should be active.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: felixconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: FelixConfiguration
+        listKind: FelixConfigurationList
+        plural: felixconfigurations
+        singular: felixconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: Felix Configuration contains the configuration for Felix.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: FelixConfigurationSpec contains the values of the Felix configuration.
+                properties:
+                  allowIPIPPacketsFromWorkloads:
+                    description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop IPIP encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  allowVXLANPacketsFromWorkloads:
+                    description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop VXLAN encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  awsSrcDstCheck:
+                    description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                      value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                      DoNothing]'
+                    enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                    type: string
+                  bpfConnectTimeLoadBalancingEnabled:
+                    description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                      controls whether Felix installs the connection-time load balancer.  The
+                      connect-time load balancer is required for the host to be able to
+                      reach Kubernetes services and it improves the performance of pod-to-service
+                      connections.  The only reason to disable it is for debugging purposes.  [Default:
+                      true]'
+                    type: boolean
+                  bpfDataIfacePattern:
+                    description: BPFDataIfacePattern is a regular expression that controls
+                      which interfaces Felix should attach BPF programs to in order to
+                      catch traffic to/from the network.  This needs to match the interfaces
+                      that Calico workload traffic flows over as well as any interfaces
+                      that handle incoming traffic to nodeports and services from outside
+                      the cluster.  It should not match the workload interfaces (usually
+                      named cali...).
+                    type: string
+                  bpfDisableUnprivileged:
+                    description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                      sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                      users cannot access Calico''s BPF maps and cannot insert their own
+                      BPF programs to interfere with Calico''s. [Default: true]'
+                    type: boolean
+                  bpfEnabled:
+                    description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                      [Default: false]'
+                    type: boolean
+                  bpfExtToServiceConnmark:
+                    description: 'BPFExtToServiceConnmark in BPF mode, controls a 32bit
+                      mark that is set on connections from an external client to a local
+                      service. This mark allows us to control how packets of that connection
+                      are routed within the host and how is routing intepreted by RPF
+                      check. [Default: 0]'
+                    type: integer
+                  bpfExternalServiceMode:
+                    description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                      from outside the cluster to services (node ports and cluster IPs)
+                      are forwarded to remote workloads.  If set to "Tunnel" then both
+                      request and response traffic is tunneled to the remote node.  If
+                      set to "DSR", the request traffic is tunneled but the response traffic
+                      is sent directly from the remote node.  In "DSR" mode, the remote
+                      node appears to use the IP of the ingress node; this requires a
+                      permissive L2 network.  [Default: Tunnel]'
+                    type: string
+                  bpfKubeProxyEndpointSlicesEnabled:
+                    description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                      whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                    type: boolean
+                  bpfKubeProxyIptablesCleanupEnabled:
+                    description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                      mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                      iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                      true]'
+                    type: boolean
+                  bpfKubeProxyMinSyncPeriod:
+                    description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                      minimum time between updates to the dataplane for Felix''s embedded
+                      kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                      reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                    type: string
+                  bpfLogLevel:
+                    description: 'BPFLogLevel controls the log level of the BPF programs
+                      when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                      logs are emitted to the BPF trace pipe, accessible with the command
+                      `tc exec bpf debug`. [Default: Off].'
+                    type: string
+                  chainInsertMode:
+                    description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                      top-level iptables chains by inserting a rule at the top of the
+                      chain or by appending a rule at the bottom. insert is the safe default
+                      since it prevents Calico''s rules from being bypassed. If you switch
+                      to append mode, be sure that the other rules in the chains signal
+                      acceptance by falling through to the Calico rules, otherwise the
+                      Calico policy will be bypassed. [Default: insert]'
+                    type: string
+                  dataplaneDriver:
+                    type: string
+                  debugDisableLogDropping:
+                    type: boolean
+                  debugMemoryProfilePath:
+                    type: string
+                  debugSimulateCalcGraphHangAfter:
+                    type: string
+                  debugSimulateDataplaneHangAfter:
+                    type: string
+                  defaultEndpointToHostAction:
+                    description: 'DefaultEndpointToHostAction controls what happens to
+                      traffic that goes from a workload endpoint to the host itself (after
+                      the traffic hits the endpoint egress policy). By default Calico
+                      blocks traffic from workload endpoints to the host itself with an
+                      iptables "DROP" action. If you want to allow some or all traffic
+                      from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                      RETURN if you have your own rules in the iptables "INPUT" chain;
+                      Calico will insert its rules at the top of that chain, then "RETURN"
+                      packets to the "INPUT" chain once it has completed processing workload
+                      endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                      from workloads after processing workload endpoint egress policy.
+                      [Default: Drop]'
+                    type: string
+                  deviceRouteProtocol:
+                    description: This defines the route protocol added to programmed device
+                      routes, by default this will be RTPROT_BOOT when left blank.
+                    type: integer
+                  deviceRouteSourceAddress:
+                    description: This is the source address to use on programmed device
+                      routes. By default the source address is left blank, leaving the
+                      kernel to choose the source address used.
+                    type: string
+                  disableConntrackInvalidCheck:
+                    type: boolean
+                  endpointReportingDelay:
+                    type: string
+                  endpointReportingEnabled:
+                    type: boolean
+                  externalNodesList:
+                    description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                      which may source tunnel traffic and have the tunneled traffic be
+                      accepted at calico nodes.
+                    items:
+                      type: string
+                    type: array
+                  failsafeInboundHostPorts:
+                    description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow incoming traffic to host endpoints
+                      on irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all inbound host ports, use the value
+                      none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                      udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  failsafeOutboundHostPorts:
+                    description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow outgoing traffic from host endpoints
+                      to irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all outbound host ports, use the value
+                      none. The default value opens etcd''s standard ports to ensure that
+                      Felix does not get cut off from etcd as well as allowing DHCP and
+                      DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                      tcp:6667, udp:53, udp:67]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  featureDetectOverride:
+                    description: FeatureDetectOverride is used to override the feature
+                      detection. Values are specified in a comma separated list with no
+                      spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                      "true" or "false" will force the feature, empty or omitted values
+                      are auto-detected.
+                    type: string
+                  genericXDPEnabled:
+                    description: 'GenericXDPEnabled enables Generic XDP so network cards
+                      that don''t support XDP offload or driver modes can use XDP. This
+                      is not recommended since it doesn''t provide better performance
+                      than iptables. [Default: false]'
+                    type: boolean
+                  healthEnabled:
+                    type: boolean
+                  healthHost:
+                    type: string
+                  healthPort:
+                    type: integer
+                  interfaceExclude:
+                    description: 'InterfaceExclude is a comma-separated list of interfaces
+                      that Felix should exclude when monitoring for host endpoints. The
+                      default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                      interface, which is used internally by kube-proxy. If you want to
+                      exclude multiple interface names using a single value, the list
+                      supports regular expressions. For regular expressions you must wrap
+                      the value with ''/''. For example having values ''/^kube/,veth1''
+                      will exclude all interfaces that begin with ''kube'' and also the
+                      interface ''veth1''. [Default: kube-ipvs0]'
+                    type: string
+                  interfacePrefix:
+                    description: 'InterfacePrefix is the interface name prefix that identifies
+                      workload endpoints and so distinguishes them from host endpoint
+                      interfaces. Note: in environments other than bare metal, the orchestrators
+                      configure this appropriately. For example our Kubernetes and Docker
+                      integrations set the ''cali'' value, and our OpenStack integration
+                      sets the ''tap'' value. [Default: cali]'
+                    type: string
+                  interfaceRefreshInterval:
+                    description: InterfaceRefreshInterval is the period at which Felix
+                      rescans local interfaces to verify their state. The rescan can be
+                      disabled by setting the interval to 0.
+                    type: string
+                  ipipEnabled:
+                    type: boolean
+                  ipipMTU:
+                    description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  ipsetsRefreshInterval:
+                    description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                      all iptables state to ensure that no other process has accidentally
+                      broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                      90s]'
+                    type: string
+                  iptablesBackend:
+                    description: IptablesBackend specifies which backend of iptables will
+                      be used. The default is legacy.
+                    type: string
+                  iptablesFilterAllowAction:
+                    type: string
+                  iptablesLockFilePath:
+                    description: 'IptablesLockFilePath is the location of the iptables
+                      lock file. You may need to change this if the lock file is not in
+                      its standard location (for example if you have mapped it into Felix''s
+                      container at a different path). [Default: /run/xtables.lock]'
+                    type: string
+                  iptablesLockProbeInterval:
+                    description: 'IptablesLockProbeInterval is the time that Felix will
+                      wait between attempts to acquire the iptables lock if it is not
+                      available. Lower values make Felix more responsive when the lock
+                      is contended, but use more CPU. [Default: 50ms]'
+                    type: string
+                  iptablesLockTimeout:
+                    description: 'IptablesLockTimeout is the time that Felix will wait
+                      for the iptables lock, or 0, to disable. To use this feature, Felix
+                      must share the iptables lock file with all other processes that
+                      also take the lock. When running Felix inside a container, this
+                      requires the /run directory of the host to be mounted into the calico/node
+                      or calico/felix container. [Default: 0s disabled]'
+                    type: string
+                  iptablesMangleAllowAction:
+                    type: string
+                  iptablesMarkMask:
+                    description: 'IptablesMarkMask is the mask that Felix selects its
+                      IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                      at least 8 bits set, none of which clash with any other mark bits
+                      in use on the system. [Default: 0xff000000]'
+                    format: int32
+                    type: integer
+                  iptablesNATOutgoingInterfaceFilter:
+                    type: string
+                  iptablesPostWriteCheckInterval:
+                    description: 'IptablesPostWriteCheckInterval is the period after Felix
+                      has done a write to the dataplane that it schedules an extra read
+                      back in order to check the write was not clobbered by another process.
+                      This should only occur if another application on the system doesn''t
+                      respect the iptables lock. [Default: 1s]'
+                    type: string
+                  iptablesRefreshInterval:
+                    description: 'IptablesRefreshInterval is the period at which Felix
+                      re-checks the IP sets in the dataplane to ensure that no other process
+                      has accidentally broken Calico''s rules. Set to 0 to disable IP
+                      sets refresh. Note: the default for this value is lower than the
+                      other refresh intervals as a workaround for a Linux kernel bug that
+                      was fixed in kernel version 4.11. If you are using v4.11 or greater
+                      you may want to set this to, a higher value to reduce Felix CPU
+                      usage. [Default: 10s]'
+                    type: string
+                  ipv6Support:
+                    type: boolean
+                  kubeNodePortRanges:
+                    description: 'KubeNodePortRanges holds list of port ranges used for
+                      service node ports. Only used if felix detects kube-proxy running
+                      in ipvs mode. Felix uses these ranges to separate host and workload
+                      traffic. [Default: 30000:32767].'
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  logFilePath:
+                    description: 'LogFilePath is the full path to the Felix log. Set to
+                      none to disable file logging. [Default: /var/log/calico/felix.log]'
+                    type: string
+                  logPrefix:
+                    description: 'LogPrefix is the log prefix that Felix uses when rendering
+                      LOG rules. [Default: calico-packet]'
+                    type: string
+                  logSeverityFile:
+                    description: 'LogSeverityFile is the log severity above which logs
+                      are sent to the log file. [Default: Info]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  logSeveritySys:
+                    description: 'LogSeveritySys is the log severity above which logs
+                      are sent to the syslog. Set to None for no logging to syslog. [Default:
+                      Info]'
+                    type: string
+                  maxIpsetSize:
+                    type: integer
+                  metadataAddr:
+                    description: 'MetadataAddr is the IP address or domain name of the
+                      server that can answer VM queries for cloud-init metadata. In OpenStack,
+                      this corresponds to the machine running nova-api (or in Ubuntu,
+                      nova-api-metadata). A value of none (case insensitive) means that
+                      Felix should not set up any NAT rule for the metadata path. [Default:
+                      127.0.0.1]'
+                    type: string
+                  metadataPort:
+                    description: 'MetadataPort is the port of the metadata server. This,
+                      combined with global.MetadataAddr (if not ''None''), is used to
+                      set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                      In most cases this should not need to be changed [Default: 8775].'
+                    type: integer
+                  mtuIfacePattern:
+                    description: MTUIfacePattern is a regular expression that controls
+                      which interfaces Felix should scan in order to calculate the host's
+                      MTU. This should not match workload interfaces (usually named cali...).
+                    type: string
+                  natOutgoingAddress:
+                    description: NATOutgoingAddress specifies an address to use when performing
+                      source NAT for traffic in a natOutgoing pool that is leaving the
+                      network. By default the address used is an address on the interface
+                      the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                    type: string
+                  natPortRange:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NATPortRange specifies the range of ports that is used
+                      for port mapping when doing outgoing NAT. When unset the default
+                      behavior of the network stack is used.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  netlinkTimeout:
+                    type: string
+                  openstackRegion:
+                    description: 'OpenstackRegion is the name of the region that a particular
+                      Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                      this must be configured somehow for each Felix (here in the datamodel,
+                      or in felix.cfg or the environment on each compute node), and must
+                      match the [calico] openstack_region value configured in neutron.conf
+                      on each node. [Default: Empty]'
+                    type: string
+                  policySyncPathPrefix:
+                    description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                      policy changes to external services, like Application layer policy.
+                      [Default: Empty]'
+                    type: string
+                  prometheusGoMetricsEnabled:
+                    description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusMetricsEnabled:
+                    description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                      server in Felix if set to true. [Default: false]'
+                    type: boolean
+                  prometheusMetricsHost:
+                    description: 'PrometheusMetricsHost is the host that the Prometheus
+                      metrics server should bind to. [Default: empty]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. [Default: 9091]'
+                    type: integer
+                  prometheusProcessMetricsEnabled:
+                    description: 'PrometheusProcessMetricsEnabled disables process metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusWireGuardMetricsEnabled:
+                    description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                      metrics collection, which the Prometheus client does by default,
+                      when set to false. This reduces the number of metrics reported,
+                      reducing Prometheus load. [Default: true]'
+                    type: boolean
+                  removeExternalRoutes:
+                    description: Whether or not to remove device routes that have not
+                      been programmed by Felix. Disabling this will allow external applications
+                      to also add device routes. This is enabled by default which means
+                      we will remove externally added routes.
+                    type: boolean
+                  reportingInterval:
+                    description: 'ReportingInterval is the interval at which Felix reports
+                      its status into the datastore or 0 to disable. Must be non-zero
+                      in OpenStack deployments. [Default: 30s]'
+                    type: string
+                  reportingTTL:
+                    description: 'ReportingTTL is the time-to-live setting for process-wide
+                      status reports. [Default: 90s]'
+                    type: string
+                  routeRefreshInterval:
+                    description: 'RouteRefreshInterval is the period at which Felix re-checks
+                      the routes in the dataplane to ensure that no other process has
+                      accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                      [Default: 90s]'
+                    type: string
+                  routeSource:
+                    description: 'RouteSource configures where Felix gets its routing
+                      information. - WorkloadIPs: use workload endpoints to construct
+                      routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                    type: string
+                  routeTableRange:
+                    description: Calico programs additional Linux route tables for various
+                      purposes.  RouteTableRange specifies the indices of the route tables
+                      that Calico should use.
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                    - max
+                    - min
+                    type: object
+                  serviceLoopPrevention:
+                    description: 'When service IP advertisement is enabled, prevent routing
+                      loops to service IPs that are not in use, by dropping or rejecting
+                      packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                      in which case such routing loops continue to be allowed. [Default:
+                      Drop]'
+                    type: string
+                  sidecarAccelerationEnabled:
+                    description: 'SidecarAccelerationEnabled enables experimental sidecar
+                      acceleration [Default: false]'
+                    type: boolean
+                  usageReportingEnabled:
+                    description: 'UsageReportingEnabled reports anonymous Calico version
+                      number and cluster size to projectcalico.org. Logs warnings returned
+                      by the usage server. For example, if a significant security vulnerability
+                      has been discovered in the version of Calico being used. [Default:
+                      true]'
+                    type: boolean
+                  usageReportingInitialDelay:
+                    description: 'UsageReportingInitialDelay controls the minimum delay
+                      before Felix makes a report. [Default: 300s]'
+                    type: string
+                  usageReportingInterval:
+                    description: 'UsageReportingInterval controls the interval at which
+                      Felix makes reports. [Default: 86400s]'
+                    type: string
+                  useInternalDataplaneDriver:
+                    type: boolean
+                  vxlanEnabled:
+                    type: boolean
+                  vxlanMTU:
+                    description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  vxlanPort:
+                    type: integer
+                  vxlanVNI:
+                    type: integer
+                  wireguardEnabled:
+                    description: 'WireguardEnabled controls whether Wireguard is enabled.
+                      [Default: false]'
+                    type: boolean
+                  wireguardHostEncryptionEnabled:
+                    description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                      host-to-host encryption is enabled. [Default: false]'
+                    type: boolean
+                  wireguardInterfaceName:
+                    description: 'WireguardInterfaceName specifies the name to use for
+                      the Wireguard interface. [Default: wg.calico]'
+                    type: string
+                  wireguardListeningPort:
+                    description: 'WireguardListeningPort controls the listening port used
+                      by Wireguard. [Default: 51820]'
+                    type: integer
+                  wireguardMTU:
+                    description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                      See Configuring MTU [Default: 1420]'
+                    type: integer
+                  wireguardRoutingRulePriority:
+                    description: 'WireguardRoutingRulePriority controls the priority value
+                      to use for the Wireguard routing rule. [Default: 99]'
+                    type: integer
+                  xdpEnabled:
+                    description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                      incoming deny rules. [Default: true]'
+                    type: boolean
+                  xdpRefreshInterval:
+                    description: 'XDPRefreshInterval is the period at which Felix re-checks
+                      all XDP state to ensure that no other process has accidentally broken
+                      Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                      refresh. [Default: 90s]'
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkPolicy
+        listKind: GlobalNetworkPolicyList
+        plural: globalnetworkpolicies
+        singular: globalnetworkpolicy
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  applyOnForward:
+                    description: ApplyOnForward indicates to apply the rules in this policy
+                      on forward traffic.
+                    type: boolean
+                  doNotTrack:
+                    description: DoNotTrack indicates whether packets matched by the rules
+                      in this policy should go through the data plane's connection tracking,
+                      such as Linux conntrack.  If True, the rules in this policy are
+                      applied before any data plane connection tracking, and packets allowed
+                      by this policy are marked as not to be tracked.
+                    type: boolean
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    description: NamespaceSelector is an optional field for an expression
+                      used to select a pod based on namespaces.
+                    type: string
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  preDNAT:
+                    description: PreDNAT indicates to apply the rules in this policy before
+                      any DNAT.
+                    type: boolean
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress rules are present in the policy.  The
+                      default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                      (including the case where there are   also no Ingress rules) \n
+                      - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                      rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                      both Ingress and Egress rules. \n When the policy is read back again,
+                      Types will always be one of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkSet
+        listKind: GlobalNetworkSetList
+        plural: globalnetworksets
+        singular: globalnetworkset
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+              that share labels to allow rules to refer to them via selectors.  The labels
+              of GlobalNetworkSet are not namespaced.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: hostendpoints.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: HostEndpoint
+        listKind: HostEndpointList
+        plural: hostendpoints
+        singular: hostendpoint
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: HostEndpointSpec contains the specification for a HostEndpoint
+                  resource.
+                properties:
+                  expectedIPs:
+                    description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                      If \"InterfaceName\" is not present, Calico will look for an interface
+                      matching any of the IPs in the list and apply policy to that. Note:
+                      \tWhen using the selector match criteria in an ingress or egress
+                      security Policy \tor Profile, Calico converts the selector into
+                      a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                      is used for that purpose. (If only the interface \tname is specified,
+                      Calico does not learn the IPs of the interface for use in match
+                      \tcriteria.)"
+                    items:
+                      type: string
+                    type: array
+                  interfaceName:
+                    description: "Either \"*\", or the name of a specific Linux interface
+                      to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                      governs all traffic to, from or through the default network namespace
+                      of the host named by the \"Node\" field; entering and leaving that
+                      namespace via any interface, including those from/to non-host-networked
+                      local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                      only governs traffic that enters or leaves the host through the
+                      specific interface named by InterfaceName, or - when InterfaceName
+                      is empty - through the specific interface that has one of the IPs
+                      in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                      one expected IP must be specified.  Only external interfaces (such
+                      as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                      to protect traffic through a specific local workload interface.
+                      \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                      initially just pre-DNAT policy.  Please check Calico documentation
+                      for the latest position."
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance.
+                    type: string
+                  ports:
+                    description: Ports contains the endpoint's named ports, which may
+                      be referenced in security policy rules.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  profiles:
+                    description: A list of identifiers of security Profile objects that
+                      apply to this endpoint. Each profile is applied in the order that
+                      they appear in this list.  Profile rules are applied after the selector-based
+                      security policy.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamblocks.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMBlock
+        listKind: IPAMBlockList
+        plural: ipamblocks
+        singular: ipamblock
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMBlockSpec contains the specification for an IPAMBlock
+                  resource.
+                properties:
+                  affinity:
+                    type: string
+                  allocations:
+                    items:
+                      nullable: true
+                      type: integer
+                    type: array
+                  attributes:
+                    items:
+                      properties:
+                        handle_id:
+                          type: string
+                        secondary:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    type: array
+                  cidr:
+                    type: string
+                  deleted:
+                    type: boolean
+                  strictAffinity:
+                    type: boolean
+                  unallocated:
+                    items:
+                      type: integer
+                    type: array
+                required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamconfigs.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMConfig
+        listKind: IPAMConfigList
+        plural: ipamconfigs
+        singular: ipamconfig
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMConfigSpec contains the specification for an IPAMConfig
+                  resource.
+                properties:
+                  autoAllocateBlocks:
+                    type: boolean
+                  maxBlocksPerHost:
+                    description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                      that can be affine to each host.
+                    type: integer
+                  strictAffinity:
+                    type: boolean
+                required:
+                - autoAllocateBlocks
+                - strictAffinity
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamhandles.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMHandle
+        listKind: IPAMHandleList
+        plural: ipamhandles
+        singular: ipamhandle
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMHandleSpec contains the specification for an IPAMHandle
+                  resource.
+                properties:
+                  block:
+                    additionalProperties:
+                      type: integer
+                    type: object
+                  deleted:
+                    type: boolean
+                  handleID:
+                    type: string
+                required:
+                - block
+                - handleID
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ippools.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPPool
+        listKind: IPPoolList
+        plural: ippools
+        singular: ippool
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPPoolSpec contains the specification for an IPPool resource.
+                properties:
+                  blockSize:
+                    description: The block size to use for IP address assignments from
+                      this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                    type: integer
+                  cidr:
+                    description: The pool CIDR.
+                    type: string
+                  disabled:
+                    description: When disabled is true, Calico IPAM will not assign addresses
+                      from this pool.
+                    type: boolean
+                  ipip:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    properties:
+                      enabled:
+                        description: When enabled is true, ipip tunneling will be used
+                          to deliver packets to destinations within this pool.
+                        type: boolean
+                      mode:
+                        description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                          mode of "always" will also use IPIP tunneling for routing to
+                          destination IP addresses within this pool.  A mode of "cross-subnet"
+                          will only use IPIP tunneling when the destination node is on
+                          a different subnet to the originating node.  The default value
+                          (if not specified) is "always".
+                        type: string
+                    type: object
+                  ipipMode:
+                    description: Contains configuration for IPIP tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                      is disabled).
+                    type: string
+                  nat-outgoing:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    type: boolean
+                  natOutgoing:
+                    description: When nat-outgoing is true, packets sent from Calico networked
+                      containers in this pool to destinations outside of this pool will
+                      be masqueraded.
+                    type: boolean
+                  nodeSelector:
+                    description: Allows IPPool to allocate for a specific node by label
+                      selector.
+                    type: string
+                  vxlanMode:
+                    description: Contains configuration for VXLAN tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                      tunneling is disabled).
+                    type: string
+                required:
+                - cidr
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubecontrollersconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: KubeControllersConfiguration
+        listKind: KubeControllersConfigurationList
+        plural: kubecontrollersconfigurations
+        singular: kubecontrollersconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeControllersConfigurationSpec contains the values of the
+                  Kubernetes controllers configuration.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host endpoints.
+                              Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation of
+                                  host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the controller
+                              to determine if an IP address has been leaked. Set to 0
+                              to disable IP garbage collection. [Default: 15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+              status:
+                description: KubeControllersConfigurationStatus represents the status
+                  of the configuration. It's useful for admins to be able to see the actual
+                  config that was applied, which can be modified by environment variables
+                  on the kube-controllers process.
+                properties:
+                  environmentVars:
+                    additionalProperties:
+                      type: string
+                    description: EnvironmentVars contains the environment variables on
+                      the kube-controllers that influenced the RunningConfig.
+                    type: object
+                  runningConfig:
+                    description: RunningConfig contains the effective config that is running
+                      in the kube-controllers pod, after merging the API resource with
+                      any environment variables.
+                    properties:
+                      controllers:
+                        description: Controllers enables and configures individual Kubernetes
+                          controllers
+                        properties:
+                          namespace:
+                            description: Namespace enables and configures the namespace
+                              controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          node:
+                            description: Node enables and configures the node controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              hostEndpoint:
+                                description: HostEndpoint controls syncing nodes to host
+                                  endpoints. Disabled by default, set to nil to disable.
+                                properties:
+                                  autoCreate:
+                                    description: 'AutoCreate enables automatic creation
+                                      of host endpoints for every node. [Default: Disabled]'
+                                    type: string
+                                type: object
+                              leakGracePeriod:
+                                description: 'LeakGracePeriod is the period used by the
+                                  controller to determine if an IP address has been leaked.
+                                  Set to 0 to disable IP garbage collection. [Default:
+                                  15m]'
+                                type: string
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                              syncLabels:
+                                description: 'SyncLabels controls whether to copy Kubernetes
+                                  node labels to Calico nodes. [Default: Enabled]'
+                                type: string
+                            type: object
+                          policy:
+                            description: Policy enables and configures the policy controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          serviceAccount:
+                            description: ServiceAccount enables and configures the service
+                              account controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          workloadEndpoint:
+                            description: WorkloadEndpoint enables and configures the workload
+                              endpoint controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                        type: object
+                      etcdV3CompactionPeriod:
+                        description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                          compaction requests. Set to 0 to disable. [Default: 10m]'
+                        type: string
+                      healthChecks:
+                        description: 'HealthChecks enables or disables support for health
+                          checks [Default: Enabled]'
+                        type: string
+                      logSeverityScreen:
+                        description: 'LogSeverityScreen is the log severity above which
+                          logs are sent to the stdout. [Default: Info]'
+                        type: string
+                      prometheusMetricsPort:
+                        description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                          metrics server should bind to. Set to 0 to disable. [Default:
+                          9094]'
+                        type: integer
+                    required:
+                    - controllers
+                    type: object
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkPolicy
+        listKind: NetworkPolicyList
+        plural: networkpolicies
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress are present in the policy.  The default
+                      is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                      the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                      ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                      PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                      \n When the policy is read back again, Types will always be one
+                      of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkSet
+        listKind: NetworkSetList
+        plural: networksets
+        singular: networkset
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: NetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-kube-controllers
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      verbs:
+      - list
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - hostendpoints
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - clusterinformations
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - kubecontrollersconfigurations
+      verbs:
+      - get
+      - create
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-node
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - namespaces
+      verbs:
+      - get
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - patch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - bgpconfigurations
+      - bgppeers
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ipamconfigs
+      verbs:
+      - get
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      verbs:
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - daemonsets
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-kube-controllers
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      calico_backend: vxlan
+      cni_network_config: |-
+        {
+          "name": "k8s-pod-network",
+          "cniVersion": "0.3.1",
+          "plugins": [
+            {
+              "type": "calico",
+              "log_level": "info",
+              "log_file_path": "/var/log/calico/cni/cni.log",
+              "datastore_type": "kubernetes",
+              "nodename": "__KUBERNETES_NODE_NAME__",
+              "mtu": __CNI_MTU__,
+              "ipam": {
+                  "type": "calico-ipam"
+              },
+              "policy": {
+                  "type": "k8s"
+              },
+              "kubernetes": {
+                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              }
+            },
+            {
+              "type": "portmap",
+              "snat": true,
+              "capabilities": {"portMappings": true}
+            },
+            {
+              "type": "bandwidth",
+              "capabilities": {"bandwidth": true}
+            }
+          ]
+        }
+      typha_service_name: none
+      veth_mtu: "1350"
+    kind: ConfigMap
+    metadata:
+      name: calico-config
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-kube-controllers
+          name: calico-kube-controllers
+          namespace: kube-system
+        spec:
+          containers:
+          - env:
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            image: docker.io/calico/kube-controllers:v3.20.3
+            livenessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -l
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-kube-controllers
+            readinessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -r
+              periodSeconds: 10
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: calico-kube-controllers
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: calico-node
+      name: calico-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+        spec:
+          containers:
+          - env:
+            - name: FELIX_FEATUREDETECTOVERRIDE
+              value: ChecksumOffloadBroken=true
+            - name: CALICO_IPV4POOL_VXLAN
+              value: Always
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            - name: CLUSTER_TYPE
+              value: k8s,bgp
+            - name: IP
+              value: autodetect
+            - name: CALICO_IPV4POOL_IPIP
+              value: Never
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_WIREGUARDMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_AWSSRCDSTCHECK
+              value: Disable
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: ACCEPT
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/node:v3.20.3
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -shutdown
+            livenessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-live
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-node
+            readinessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-ready
+              periodSeconds: 10
+              timeoutSeconds: 10
+            resources:
+              requests:
+                cpu: 250m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /var/run/nodeagent
+              name: policysync
+            - mountPath: /sys/fs/
+              mountPropagation: Bidirectional
+              name: sysfs
+            - mountPath: /var/log/calico/cni
+              name: cni-log-dir
+              readOnly: true
+          hostNetwork: true
+          initContainers:
+          - command:
+            - /opt/cni/bin/calico-ipam
+            - -upgrade
+            env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: upgrade-ipam
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          - command:
+            - /opt/cni/bin/install
+            env:
+            - name: CNI_CONF_NAME
+              value: 10-calico.conflist
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  key: cni_network_config
+                  name: calico-config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: SLEEP
+              value: "false"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: install-cni
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+            name: flexvol-driver
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/driver
+              name: flexvol-driver-host
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: calico-node
+          terminationGracePeriodSeconds: 0
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /lib/modules
+            name: lib-modules
+          - hostPath:
+              path: /var/run/calico
+            name: var-run-calico
+          - hostPath:
+              path: /var/lib/calico
+            name: var-lib-calico
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+          - hostPath:
+              path: /sys/fs/
+              type: DirectoryOrCreate
+            name: sysfs
+          - hostPath:
+              path: /opt/cni/bin
+            name: cni-bin-dir
+          - hostPath:
+              path: /etc/cni/net.d
+            name: cni-net-dir
+          - hostPath:
+              path: /var/log/calico/cni
+            name: cni-log-dir
+          - hostPath:
+              path: /var/lib/cni/networks
+            name: host-local-net-dir
+          - hostPath:
+              path: /var/run/nodeagent
+              type: DirectoryOrCreate
+            name: policysync
+          - hostPath:
+              path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+              type: DirectoryOrCreate
+            name: flexvol-driver-host
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
   windows-cni: "# strictAffinity required for windows\napiVersion: crd.projectcalico.org/v1\nkind:
     IPAMConfig\nmetadata:\n  name: default\nspec:\n  autoAllocateBlocks: true\n  strictAffinity:
     true\n---\nkind: ConfigMap\napiVersion: v1\nmetadata:\n  name: calico-static-rules\n

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -3963,7 +3963,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.20.3
+            image: docker.io/calico/kube-controllers:v3.20.4
             livenessProbe:
               exec:
                 command:
@@ -4073,7 +4073,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.20.3
+            image: docker.io/calico/node:v3.20.4
             lifecycle:
               preStop:
                 exec:
@@ -4145,7 +4145,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: upgrade-ipam
             securityContext:
               privileged: true
@@ -4179,7 +4179,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: install-cni
             securityContext:
               privileged: true
@@ -4188,7 +4188,7 @@ data:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.4
             name: flexvol-driver
             securityContext:
               privileged: true

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -270,2440 +270,3985 @@ spec:
 ---
 apiVersion: v1
 data:
-  resources: "---\n# Source: calico/templates/calico-config.yaml\n# This ConfigMap
-    is used to configure a self-hosted Calico installation.\nkind: ConfigMap\napiVersion:
-    v1\nmetadata:\n  name: calico-config\n  namespace: kube-system\ndata:\n  # Typha
-    is disabled.\n  typha_service_name: \"none\"\n  # Configure the backend to use.\n
-    \ calico_backend: \"vxlan\"\n  # On Azure, the underlying network has an MTU of
-    1400, even though the network interface will have an MTU of 1500.\n  # We set
-    this value to 1350 for “physical network MTU size minus 50” since we use VXLAN,
-    which uses a 50-byte header.\n  # If enabling Wireguard, this value should be
-    changed to 1340 (Wireguard uses a 60-byte header).\n  # https://docs.projectcalico.org/networking/mtu#determine-mtu-size\n
-    \ veth_mtu: \"1350\"\n  \n  # The CNI network configuration to install on each
-    node. The special\n  # values in this config will be automatically populated.\n
-    \ cni_network_config: |-\n    {\n      \"name\": \"k8s-pod-network\",\n      \"cniVersion\":
-    \"0.3.1\",\n      \"plugins\": [\n        {\n          \"type\": \"calico\",\n
-    \         \"log_level\": \"info\",\n          \"log_file_path\": \"/var/log/calico/cni/cni.log\",\n
-    \         \"datastore_type\": \"kubernetes\",\n          \"nodename\": \"__KUBERNETES_NODE_NAME__\",\n
-    \         \"mtu\": __CNI_MTU__,\n          \"ipam\": {\n              \"type\":
-    \"calico-ipam\"\n          },\n          \"policy\": {\n              \"type\":
-    \"k8s\"\n          },\n          \"kubernetes\": {\n              \"kubeconfig\":
-    \"__KUBECONFIG_FILEPATH__\"\n          }\n        },\n        {\n          \"type\":
-    \"portmap\",\n          \"snat\": true,\n          \"capabilities\": {\"portMappings\":
-    true}\n        },\n        {\n          \"type\": \"bandwidth\",\n          \"capabilities\":
-    {\"bandwidth\": true}\n        }\n      ]\n    }\n\n---\n# Source: calico/templates/kdd-crds.yaml\n\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: bgpconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPConfiguration\n    listKind: BGPConfigurationList\n    plural:
-    bgpconfigurations\n    singular: bgpconfiguration\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    BGPConfiguration contains the configuration for any BGP routing.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPConfigurationSpec contains the
-    values of the BGP configuration.\n              properties:\n                asNumber:\n
-    \                 description: 'ASNumber is the default AS number used by a node.
-    [Default:\n                  64512]'\n                  format: int32\n                  type:
-    integer\n                communities:\n                  description: Communities
-    is a list of BGP community values and their\n                    arbitrary names
-    for tagging routes.\n                  items:\n                    description:
-    Community contains standard or large community value\n                      and
-    its name.\n                    properties:\n                      name:\n                        description:
-    Name given to community value.\n                        type: string\n                      value:\n
-    \                       description: Value must be of format `aa:nn` or `aa:nn:mm`.\n
-    \                         For standard community use `aa:nn` format, where `aa`
-    and\n                          `nn` are 16 bit number. For large community use
-    `aa:nn:mm`\n                          format, where `aa`, `nn` and `mm` are 32
-    bit number. Where,\n                          `aa` is an AS Number, `nn` and `mm`
-    are per-AS identifier.\n                        pattern: ^(\\d+):(\\d+)$|^(\\d+):(\\d+):(\\d+)$\n
-    \                       type: string\n                    type: object\n                  type:
-    array\n                listenPort:\n                  description: ListenPort
-    is the port where BGP protocol should listen.\n                    Defaults to
-    179\n                  maximum: 65535\n                  minimum: 1\n                  type:
-    integer\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: INFO]'\n                  type: string\n                nodeToNodeMeshEnabled:\n
-    \                 description: 'NodeToNodeMeshEnabled sets whether full node to
-    node\n                  BGP mesh is enabled. [Default: true]'\n                  type:
-    boolean\n                prefixAdvertisements:\n                  description:
-    PrefixAdvertisements contains per-prefix advertisement\n                    configuration.\n
-    \                 items:\n                    description: PrefixAdvertisement
-    configures advertisement properties\n                      for the specified CIDR.\n
-    \                   properties:\n                      cidr:\n                        description:
-    CIDR for which properties should be advertised.\n                        type:
-    string\n                      communities:\n                        description:
-    Communities can be list of either community names\n                          already
-    defined in `Specs.Communities` or community value\n                          of
-    format `aa:nn` or `aa:nn:mm`. For standard community use\n                          `aa:nn`
-    format, where `aa` and `nn` are 16 bit number. For\n                          large
-    community use `aa:nn:mm` format, where `aa`, `nn` and\n                          `mm`
-    are 32 bit number. Where,`aa` is an AS Number, `nn` and\n                          `mm`
-    are per-AS identifier.\n                        items:\n                          type:
-    string\n                        type: array\n                    type: object\n
-    \                 type: array\n                serviceClusterIPs:\n                  description:
-    ServiceClusterIPs are the CIDR blocks from which service\n                    cluster
-    IPs are allocated. If specified, Calico will advertise these\n                    blocks,
-    as well as any cluster IPs within them.\n                  items:\n                    description:
-    ServiceClusterIPBlock represents a single allowed ClusterIP\n                      CIDR
-    block.\n                    properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n                serviceExternalIPs:\n
-    \                 description: ServiceExternalIPs are the CIDR blocks for Kubernetes\n
-    \                   Service External IPs. Kubernetes Service ExternalIPs will
-    only be\n                    advertised if they are within one of these blocks.\n
-    \                 items:\n                    description: ServiceExternalIPBlock
-    represents a single allowed\n                      External IP CIDR block.\n                    properties:\n
-    \                     cidr:\n                        type: string\n                    type:
-    object\n                  type: array\n                serviceLoadBalancerIPs:\n
-    \                 description: ServiceLoadBalancerIPs are the CIDR blocks for
-    Kubernetes\n                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress\n
-    \                   IPs will only be advertised if they are within one of these
-    blocks.\n                  items:\n                    description: ServiceLoadBalancerIPBlock
-    represents a single allowed\n                      LoadBalancer IP CIDR block.\n
-    \                   properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: bgppeers.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPPeer\n    listKind: BGPPeerList\n    plural: bgppeers\n
-    \   singular: bgppeer\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPPeerSpec contains the specification
-    for a BGPPeer resource.\n              properties:\n                asNumber:\n
-    \                 description: The AS Number of the peer.\n                  format:
-    int32\n                  type: integer\n                keepOriginalNextHop:\n
-    \                 description: Option to keep the original nexthop field when
-    routes\n                    are sent to a BGP Peer. Setting \"true\" configures
-    the selected BGP\n                    Peers node to use the \"next hop keep;\"
-    instead of \"next hop self;\"(default)\n                    in the specific branch
-    of the Node on \"bird.cfg\".\n                  type: boolean\n                maxRestartTime:\n
-    \                 description: Time to allow for software restart.  When specified,
-    this\n                    is configured as the graceful restart timeout.  When
-    not specified,\n                    the BIRD default of 120s is used.\n                  type:
-    string\n                node:\n                  description: The node name identifying
-    the Calico node instance that\n                    is targeted by this peer. If
-    this is not set, and no nodeSelector\n                    is specified, then this
-    BGP peer selects all nodes in the cluster.\n                  type: string\n                nodeSelector:\n
-    \                 description: Selector for the nodes that should have this peering.
-    \ When\n                    this is set, the Node field must be empty.\n                  type:
-    string\n                password:\n                  description: Optional BGP
-    password for the peerings generated by this\n                    BGPPeer resource.\n
-    \                 properties:\n                    secretKeyRef:\n                      description:
-    Selects a key of a secret in the node pod's namespace.\n                      properties:\n
-    \                       key:\n                          description: The key of
-    the secret to select from.  Must be\n                            a valid secret
-    key.\n                          type: string\n                        name:\n
-    \                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n
-    \                         TODO: Add other useful fields. apiVersion, kind, uid?'\n
-    \                         type: string\n                        optional:\n                          description:
-    Specify whether the Secret or its key must be\n                            defined\n
-    \                         type: boolean\n                      required:\n                        -
-    key\n                      type: object\n                  type: object\n                peerIP:\n
-    \                 description: The IP address of the peer followed by an optional
-    port\n                    number to peer with. If port number is given, format
-    should be `[<IPv6>]:port`\n                    or `<IPv4>:<port>` for IPv4. If
-    optional port number is not set,\n                    and this peer IP and ASNumber
-    belongs to a calico/node with ListenPort\n                    set in BGPConfiguration,
-    then we use that port to peer.\n                  type: string\n                peerSelector:\n
-    \                 description: Selector for the remote nodes to peer with.  When
-    this\n                    is set, the PeerIP and ASNumber fields must be empty.
-    \ For each\n                    peering between the local node and selected remote
-    nodes, we configure\n                    an IPv4 peering if both ends have NodeBGPSpec.IPv4Address
-    specified,\n                    and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address
-    specified.  The\n                    remote AS number comes from the remote node’s
-    NodeBGPSpec.ASNumber,\n                    or the global default if that is not
-    set.\n                  type: string\n                sourceAddress:\n                  description:
-    Specifies whether and how to configure a source address\n                    for
-    the peerings generated by this BGPPeer resource.  Default value\n                    \"UseNodeIP\"
-    means to configure the node IP as the source address.  \"None\"\n                    means
-    not to configure a source address.\n                  type: string\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: blockaffinities.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BlockAffinity\n    listKind: BlockAffinityList\n    plural:
-    blockaffinities\n    singular: blockaffinity\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BlockAffinitySpec contains the specification
-    for a BlockAffinity\n                resource.\n              properties:\n                cidr:\n
-    \                 type: string\n                deleted:\n                  description:
-    Deleted indicates that this block affinity is being deleted.\n                    This
-    field is a string for compatibility with older releases that\n                    mistakenly
-    treat this field as a string.\n                  type: string\n                node:\n
-    \                 type: string\n                state:\n                  type:
-    string\n              required:\n                - cidr\n                - deleted\n
-    \               - node\n                - state\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: clusterinformations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: ClusterInformation\n    listKind: ClusterInformationList\n
-    \   plural: clusterinformations\n    singular: clusterinformation\n  scope: Cluster\n
-    \ versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    ClusterInformation contains the cluster specific information.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: ClusterInformationSpec contains
-    the values of describing\n                the cluster.\n              properties:\n
-    \               calicoVersion:\n                  description: CalicoVersion is
-    the version of Calico that the cluster\n                    is running\n                  type:
-    string\n                clusterGUID:\n                  description: ClusterGUID
-    is the GUID of the cluster\n                  type: string\n                clusterType:\n
-    \                 description: ClusterType describes the type of the cluster\n
-    \                 type: string\n                datastoreReady:\n                  description:
-    DatastoreReady is used during significant datastore migrations\n                    to
-    signal to components such as Felix that it should wait before\n                    accessing
-    the datastore.\n                  type: boolean\n                variant:\n                  description:
-    Variant declares which variant of Calico should be active.\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: felixconfigurations.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: FelixConfiguration\n    listKind:
-    FelixConfigurationList\n    plural: felixconfigurations\n    singular: felixconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         description: Felix Configuration contains the configuration for Felix.\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: FelixConfigurationSpec contains
-    the values of the Felix configuration.\n              properties:\n                allowIPIPPacketsFromWorkloads:\n
-    \                 description: 'AllowIPIPPacketsFromWorkloads controls whether
-    Felix\n                  will add a rule to drop IPIP encapsulated traffic from
-    workloads\n                  [Default: false]'\n                  type: boolean\n
-    \               allowVXLANPacketsFromWorkloads:\n                  description:
-    'AllowVXLANPacketsFromWorkloads controls whether Felix\n                  will
-    add a rule to drop VXLAN encapsulated traffic from workloads\n                  [Default:
-    false]'\n                  type: boolean\n                awsSrcDstCheck:\n                  description:
-    'Set source-destination-check on AWS EC2 instances. Accepted\n                  value
-    must be one of \"DoNothing\", \"Enabled\" or \"Disabled\". [Default:\n                  DoNothing]'\n
-    \                 enum:\n                    - DoNothing\n                    -
-    Enable\n                    - Disable\n                  type: string\n                bpfConnectTimeLoadBalancingEnabled:\n
-    \                 description: 'BPFConnectTimeLoadBalancingEnabled when in BPF
-    mode,\n                  controls whether Felix installs the connection-time load
-    balancer.  The\n                  connect-time load balancer is required for the
-    host to be able to\n                  reach Kubernetes services and it improves
-    the performance of pod-to-service\n                  connections.  The only reason
-    to disable it is for debugging purposes.  [Default:\n                  true]'\n
-    \                 type: boolean\n                bpfDataIfacePattern:\n                  description:
-    'BPFDataIfacePattern is a regular expression that controls\n                  which
-    interfaces Felix should attach BPF programs to in order to\n                  catch
-    traffic to/from the network.  This needs to match the interfaces\n                  that
-    Calico workload traffic flows over as well as any interfaces\n                  that
-    handle incoming traffic to nodeports and services from outside\n                  the
-    cluster.  It should not match the workload interfaces (usually\n                  named
-    cali...). [Default: ^(en.*|eth.*|tunl0$)]'\n                  type: string\n                bpfDisableUnprivileged:\n
-    \                 description: 'BPFDisableUnprivileged, if enabled, Felix sets
-    the kernel.unprivileged_bpf_disabled\n                  sysctl to disable unprivileged
-    use of BPF.  This ensures that unprivileged\n                  users cannot access
-    Calico''s BPF maps and cannot insert their own\n                  BPF programs
-    to interfere with Calico''s. [Default: true]'\n                  type: boolean\n
-    \               bpfEnabled:\n                  description: 'BPFEnabled, if enabled
-    Felix will use the BPF dataplane.\n                  [Default: false]'\n                  type:
-    boolean\n                bpfExtToServiceConnmark:\n                  description:
-    'BPFExtToServiceConnmark in BPF mode, control a 32bit\n                    mark
-    that is set on connections from an external client to a local\n                    service.
-    This mark allows us to control how packets of that connection\n                    are
-    routed within the host and how is routing intepreted by RPF\n                    check.
-    [Default: 0]'\n                  type: integer\n                bpfExternalServiceMode:\n
-    \                 description: 'BPFExternalServiceMode in BPF mode, controls how
-    connections\n                  from outside the cluster to services (node ports
-    and cluster IPs)\n                  are forwarded to remote workloads.  If set
-    to \"Tunnel\" then both\n                  request and response traffic is tunneled
-    to the remote node.  If\n                  set to \"DSR\", the request traffic
-    is tunneled but the response traffic\n                  is sent directly from
-    the remote node.  In \"DSR\" mode, the remote\n                  node appears
-    to use the IP of the ingress node; this requires a\n                  permissive
-    L2 network.  [Default: Tunnel]'\n                  type: string\n                bpfKubeProxyEndpointSlicesEnabled:\n
-    \                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode,
-    controls\n                    whether Felix's embedded kube-proxy accepts EndpointSlices
-    or not.\n                  type: boolean\n                bpfKubeProxyIptablesCleanupEnabled:\n
-    \                 description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled
-    in BPF\n                  mode, Felix will proactively clean up the upstream Kubernetes
-    kube-proxy''s\n                  iptables chains.  Should only be enabled if kube-proxy
-    is not running.  [Default:\n                  true]'\n                  type:
-    boolean\n                bpfKubeProxyMinSyncPeriod:\n                  description:
-    'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the\n                  minimum
-    time between updates to the dataplane for Felix''s embedded\n                  kube-proxy.
-    \ Lower values give reduced set-up latency.  Higher values\n                  reduce
-    Felix CPU usage by batching up more work.  [Default: 1s]'\n                  type:
-    string\n                bpfLogLevel:\n                  description: 'BPFLogLevel
-    controls the log level of the BPF programs\n                  when in BPF dataplane
-    mode.  One of \"Off\", \"Info\", or \"Debug\".  The\n                  logs are
-    emitted to the BPF trace pipe, accessible with the command\n                  `tc
-    exec bpf debug`. [Default: Off].'\n                  type: string\n                chainInsertMode:\n
-    \                 description: 'ChainInsertMode controls whether Felix hooks the
-    kernel’s\n                  top-level iptables chains by inserting a rule at the
-    top of the\n                  chain or by appending a rule at the bottom. insert
-    is the safe default\n                  since it prevents Calico’s rules from being
-    bypassed. If you switch\n                  to append mode, be sure that the other
-    rules in the chains signal\n                  acceptance by falling through to
-    the Calico rules, otherwise the\n                  Calico policy will be bypassed.
-    [Default: insert]'\n                  type: string\n                dataplaneDriver:\n
-    \                 type: string\n                debugDisableLogDropping:\n                  type:
-    boolean\n                debugMemoryProfilePath:\n                  type: string\n
-    \               debugSimulateCalcGraphHangAfter:\n                  type: string\n
-    \               debugSimulateDataplaneHangAfter:\n                  type: string\n
-    \               defaultEndpointToHostAction:\n                  description: 'DefaultEndpointToHostAction
-    controls what happens to\n                  traffic that goes from a workload
-    endpoint to the host itself (after\n                  the traffic hits the endpoint
-    egress policy). By default Calico\n                  blocks traffic from workload
-    endpoints to the host itself with an\n                  iptables “DROP” action.
-    If you want to allow some or all traffic\n                  from endpoint to host,
-    set this parameter to RETURN or ACCEPT. Use\n                  RETURN if you have
-    your own rules in the iptables “INPUT” chain;\n                  Calico will insert
-    its rules at the top of that chain, then “RETURN”\n                  packets to
-    the “INPUT” chain once it has completed processing workload\n                  endpoint
-    egress policy. Use ACCEPT to unconditionally accept packets\n                  from
-    workloads after processing workload endpoint egress policy.\n                  [Default:
-    Drop]'\n                  type: string\n                deviceRouteProtocol:\n
-    \                 description: This defines the route protocol added to programmed
-    device\n                    routes, by default this will be RTPROT_BOOT when left
-    blank.\n                  type: integer\n                deviceRouteSourceAddress:\n
-    \                 description: This is the source address to use on programmed
-    device\n                    routes. By default the source address is left blank,
-    leaving the\n                    kernel to choose the source address used.\n                  type:
-    string\n                disableConntrackInvalidCheck:\n                  type:
-    boolean\n                endpointReportingDelay:\n                  type: string\n
-    \               endpointReportingEnabled:\n                  type: boolean\n                externalNodesList:\n
-    \                 description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes\n
-    \                   which may source tunnel traffic and have the tunneled traffic
-    be\n                    accepted at calico nodes.\n                  items:\n
-    \                   type: string\n                  type: array\n                failsafeInboundHostPorts:\n
-    \                 description: 'FailsafeInboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow incoming traffic to
-    host endpoints\n                    on irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    inbound host ports, use the value\n                    none. The default value
-    allows ssh access and DHCP. [Default: tcp:22,\n                    udp:68, tcp:179,
-    tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'\n                  items:\n
-    \                   description: ProtoPort is combination of protocol, port, and
-    CIDR.\n                      Protocol and port must be specified.\n                    properties:\n
-    \                     net:\n                        type: string\n                      port:\n
-    \                       type: integer\n                      protocol:\n                        type:
-    string\n                    required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                failsafeOutboundHostPorts:\n
-    \                 description: 'FailsafeOutboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow outgoing traffic from
-    host endpoints\n                    to irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    outbound host ports, use the value\n                    none. The default value
-    opens etcd''s standard ports to ensure that\n                    Felix does not
-    get cut off from etcd as well as allowing DHCP and\n                    DNS. [Default:
-    tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,\n                    tcp:6667,
-    udp:53, udp:67]'\n                  items:\n                    description: ProtoPort
-    is combination of protocol, port, and CIDR.\n                      Protocol and
-    port must be specified.\n                    properties:\n                      net:\n
-    \                       type: string\n                      port:\n                        type:
-    integer\n                      protocol:\n                        type: string\n
-    \                   required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                featureDetectOverride:\n
-    \                 description: FeatureDetectOverride is used to override the feature\n
-    \                   detection. Values are specified in a comma separated list
-    with no\n                    spaces, example; \"SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=\".\n
-    \                   \"true\" or \"false\" will force the feature, empty or omitted
-    values\n                    are auto-detected.\n                  type: string\n
-    \               genericXDPEnabled:\n                  description: 'GenericXDPEnabled
-    enables Generic XDP so network cards\n                  that don''t support XDP
-    offload or driver modes can use XDP. This\n                  is not recommended
-    since it doesn''t provide better performance\n                  than iptables.
-    [Default: false]'\n                  type: boolean\n                healthEnabled:\n
-    \                 type: boolean\n                healthHost:\n                  type:
-    string\n                healthPort:\n                  type: integer\n                interfaceExclude:\n
-    \                 description: 'InterfaceExclude is a comma-separated list of
-    interfaces\n                  that Felix should exclude when monitoring for host
-    endpoints. The\n                  default value ensures that Felix ignores Kubernetes''
-    IPVS dummy\n                  interface, which is used internally by kube-proxy.
-    If you want to\n                  exclude multiple interface names using a single
-    value, the list\n                  supports regular expressions. For regular expressions
-    you must wrap\n                  the value with ''/''. For example having values
-    ''/^kube/,veth1''\n                  will exclude all interfaces that begin with
-    ''kube'' and also the\n                  interface ''veth1''. [Default: kube-ipvs0]'\n
-    \                 type: string\n                interfacePrefix:\n                  description:
-    'InterfacePrefix is the interface name prefix that identifies\n                  workload
-    endpoints and so distinguishes them from host endpoint\n                  interfaces.
-    Note: in environments other than bare metal, the orchestrators\n                  configure
-    this appropriately. For example our Kubernetes and Docker\n                  integrations
-    set the ‘cali’ value, and our OpenStack integration\n                  sets the
-    ‘tap’ value. [Default: cali]'\n                  type: string\n                interfaceRefreshInterval:\n
-    \                 description: InterfaceRefreshInterval is the period at which
-    Felix\n                    rescans local interfaces to verify their state. The
-    rescan can be\n                    disabled by setting the interval to 0.\n                  type:
-    string\n                ipipEnabled:\n                  type: boolean\n                ipipMTU:\n
-    \                 description: 'IPIPMTU is the MTU to set on the tunnel device.
-    See\n                  Configuring MTU [Default: 1440]'\n                  type:
-    integer\n                ipsetsRefreshInterval:\n                  description:
-    'IpsetsRefreshInterval is the period at which Felix re-checks\n                  all
-    iptables state to ensure that no other process has accidentally\n                  broken
-    Calico’s rules. Set to 0 to disable iptables refresh. [Default:\n                  90s]'\n
-    \                 type: string\n                iptablesBackend:\n                  description:
-    IptablesBackend specifies which backend of iptables will\n                    be
-    used. The default is legacy.\n                  type: string\n                iptablesFilterAllowAction:\n
-    \                 type: string\n                iptablesLockFilePath:\n                  description:
-    'IptablesLockFilePath is the location of the iptables\n                  lock
-    file. You may need to change this if the lock file is not in\n                  its
-    standard location (for example if you have mapped it into Felix’s\n                  container
-    at a different path). [Default: /run/xtables.lock]'\n                  type: string\n
-    \               iptablesLockProbeInterval:\n                  description: 'IptablesLockProbeInterval
-    is the time that Felix will\n                  wait between attempts to acquire
-    the iptables lock if it is not\n                  available. Lower values make
-    Felix more responsive when the lock\n                  is contended, but use more
-    CPU. [Default: 50ms]'\n                  type: string\n                iptablesLockTimeout:\n
-    \                 description: 'IptablesLockTimeout is the time that Felix will
-    wait\n                  for the iptables lock, or 0, to disable. To use this feature,
-    Felix\n                  must share the iptables lock file with all other processes
-    that\n                  also take the lock. When running Felix inside a container,
-    this\n                  requires the /run directory of the host to be mounted
-    into the calico/node\n                  or calico/felix container. [Default: 0s
-    disabled]'\n                  type: string\n                iptablesMangleAllowAction:\n
-    \                 type: string\n                iptablesMarkMask:\n                  description:
-    'IptablesMarkMask is the mask that Felix selects its\n                  IPTables
-    Mark bits from. Should be a 32 bit hexadecimal number with\n                  at
-    least 8 bits set, none of which clash with any other mark bits\n                  in
-    use on the system. [Default: 0xff000000]'\n                  format: int32\n                  type:
-    integer\n                iptablesNATOutgoingInterfaceFilter:\n                  type:
-    string\n                iptablesPostWriteCheckInterval:\n                  description:
-    'IptablesPostWriteCheckInterval is the period after Felix\n                  has
-    done a write to the dataplane that it schedules an extra read\n                  back
-    in order to check the write was not clobbered by another process.\n                  This
-    should only occur if another application on the system doesn’t\n                  respect
-    the iptables lock. [Default: 1s]'\n                  type: string\n                iptablesRefreshInterval:\n
-    \                 description: 'IptablesRefreshInterval is the period at which
-    Felix\n                    re-checks the IP sets in the dataplane to ensure that
-    no other process\n                    has accidentally broken Calico''s rules.
-    Set to 0 to disable IP\n                    sets refresh. Note: the default for
-    this value is lower than the\n                    other refresh intervals as a
-    workaround for a Linux kernel bug that\n                    was fixed in kernel
-    version 4.11. If you are using v4.11 or greater\n                    you may want
-    to set this to, a higher value to reduce Felix CPU\n                    usage.
-    [Default: 10s]'\n                  type: string\n                ipv6Support:\n
-    \                 type: boolean\n                kubeNodePortRanges:\n                  description:
-    'KubeNodePortRanges holds list of port ranges used for\n                  service
-    node ports. Only used if felix detects kube-proxy running\n                  in
-    ipvs mode. Felix uses these ranges to separate host and workload\n                  traffic.
-    [Default: 30000:32767].'\n                  items:\n                    anyOf:\n
-    \                     - type: integer\n                      - type: string\n
-    \                   pattern: ^.*\n                    x-kubernetes-int-or-string:
-    true\n                  type: array\n                logFilePath:\n                  description:
-    'LogFilePath is the full path to the Felix log. Set to\n                  none
-    to disable file logging. [Default: /var/log/calico/felix.log]'\n                  type:
-    string\n                logPrefix:\n                  description: 'LogPrefix
-    is the log prefix that Felix uses when rendering\n                  LOG rules.
-    [Default: calico-packet]'\n                  type: string\n                logSeverityFile:\n
-    \                 description: 'LogSeverityFile is the log severity above which
-    logs\n                  are sent to the log file. [Default: Info]'\n                  type:
-    string\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: Info]'\n                  type: string\n                logSeveritySys:\n
-    \                 description: 'LogSeveritySys is the log severity above which
-    logs\n                  are sent to the syslog. Set to None for no logging to
-    syslog. [Default:\n                  Info]'\n                  type: string\n
-    \               maxIpsetSize:\n                  type: integer\n                metadataAddr:\n
-    \                 description: 'MetadataAddr is the IP address or domain name
-    of the\n                  server that can answer VM queries for cloud-init metadata.
-    In OpenStack,\n                  this corresponds to the machine running nova-api
-    (or in Ubuntu,\n                  nova-api-metadata). A value of none (case insensitive)
-    means that\n                  Felix should not set up any NAT rule for the metadata
-    path. [Default:\n                  127.0.0.1]'\n                  type: string\n
-    \               metadataPort:\n                  description: 'MetadataPort is
-    the port of the metadata server. This,\n                  combined with global.MetadataAddr
-    (if not ‘None’), is used to set\n                  up a NAT rule, from 169.254.169.254:80
-    to MetadataAddr:MetadataPort.\n                  In most cases this should not
-    need to be changed [Default: 8775].'\n                  type: integer\n                mtuIfacePattern:\n
-    \                 description: MTUIfacePattern is a regular expression that controls\n
-    \                   which interfaces Felix should scan in order to calculate the
-    host's\n                    MTU. This should not match workload interfaces (usually
-    named cali...).\n                  type: string\n                natOutgoingAddress:\n
-    \                 description: NATOutgoingAddress specifies an address to use
-    when performing\n                    source NAT for traffic in a natOutgoing pool
-    that is leaving the\n                    network. By default the address used
-    is an address on the interface\n                    the traffic is leaving on
-    (ie it uses the iptables MASQUERADE target)\n                  type: string\n
-    \               natPortRange:\n                  anyOf:\n                    -
-    type: integer\n                    - type: string\n                  description:
-    NATPortRange specifies the range of ports that is used\n                    for
-    port mapping when doing outgoing NAT. When unset the default\n                    behavior
-    of the network stack is used.\n                  pattern: ^.*\n                  x-kubernetes-int-or-string:
-    true\n                netlinkTimeout:\n                  type: string\n                openstackRegion:\n
-    \                 description: 'OpenstackRegion is the name of the region that
-    a particular\n                  Felix belongs to. In a multi-region Calico/OpenStack
-    deployment,\n                  this must be configured somehow for each Felix
-    (here in the datamodel,\n                  or in felix.cfg or the environment
-    on each compute node), and must\n                  match the [calico] openstack_region
-    value configured in neutron.conf\n                  on each node. [Default: Empty]'\n
-    \                 type: string\n                policySyncPathPrefix:\n                  description:
-    'PolicySyncPathPrefix is used to by Felix to communicate\n                  policy
-    changes to external services, like Application layer policy.\n                  [Default:
-    Empty]'\n                  type: string\n                prometheusGoMetricsEnabled:\n
-    \                 description: 'PrometheusGoMetricsEnabled disables Go runtime
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                prometheusMetricsEnabled:\n                  description:
-    'PrometheusMetricsEnabled enables the Prometheus metrics\n                  server
-    in Felix if set to true. [Default: false]'\n                  type: boolean\n
-    \               prometheusMetricsHost:\n                  description: 'PrometheusMetricsHost
-    is the host that the Prometheus\n                  metrics server should bind
-    to. [Default: empty]'\n                  type: string\n                prometheusMetricsPort:\n
-    \                 description: 'PrometheusMetricsPort is the TCP port that the
-    Prometheus\n                  metrics server should bind to. [Default: 9091]'\n
-    \                 type: integer\n                prometheusProcessMetricsEnabled:\n
-    \                 description: 'PrometheusProcessMetricsEnabled disables process
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                removeExternalRoutes:\n                  description:
-    Whether or not to remove device routes that have not\n                    been
-    programmed by Felix. Disabling this will allow external applications\n                    to
-    also add device routes. This is enabled by default which means\n                    we
-    will remove externally added routes.\n                  type: boolean\n                reportingInterval:\n
-    \                 description: 'ReportingInterval is the interval at which Felix
-    reports\n                  its status into the datastore or 0 to disable. Must
-    be non-zero\n                  in OpenStack deployments. [Default: 30s]'\n                  type:
-    string\n                reportingTTL:\n                  description: 'ReportingTTL
-    is the time-to-live setting for process-wide\n                  status reports.
-    [Default: 90s]'\n                  type: string\n                routeRefreshInterval:\n
-    \                 description: 'RouterefreshInterval is the period at which Felix
-    re-checks\n                  the routes in the dataplane to ensure that no other
-    process has\n                  accidentally broken Calico’s rules. Set to 0 to
-    disable route refresh.\n                  [Default: 90s]'\n                  type:
-    string\n                routeSource:\n                  description: 'RouteSource
-    configures where Felix gets its routing\n                  information. - WorkloadIPs:
-    use workload endpoints to construct\n                  routes. - CalicoIPAM: the
-    default - use IPAM data to construct routes.'\n                  type: string\n
-    \               routeTableRange:\n                  description: Calico programs
-    additional Linux route tables for various\n                    purposes.  RouteTableRange
-    specifies the indices of the route tables\n                    that Calico should
-    use.\n                  properties:\n                    max:\n                      type:
-    integer\n                    min:\n                      type: integer\n                  required:\n
-    \                   - max\n                    - min\n                  type:
-    object\n                serviceLoopPrevention:\n                  description:
-    'When service IP advertisement is enabled, prevent routing\n                    loops
-    to service IPs that are not in use, by dropping or rejecting\n                    packets
-    that do not get DNAT''d by kube-proxy. Unless set to \"Disabled\",\n                    in
-    which case such routing loops continue to be allowed. [Default:\n                    Drop]'\n
-    \                 type: string\n                sidecarAccelerationEnabled:\n
-    \                 description: 'SidecarAccelerationEnabled enables experimental
-    sidecar\n                  acceleration [Default: false]'\n                  type:
-    boolean\n                usageReportingEnabled:\n                  description:
-    'UsageReportingEnabled reports anonymous Calico version\n                  number
-    and cluster size to projectcalico.org. Logs warnings returned\n                  by
-    the usage server. For example, if a significant security vulnerability\n                  has
-    been discovered in the version of Calico being used. [Default:\n                  true]'\n
-    \                 type: boolean\n                usageReportingInitialDelay:\n
-    \                 description: 'UsageReportingInitialDelay controls the minimum
-    delay\n                  before Felix makes a report. [Default: 300s]'\n                  type:
-    string\n                usageReportingInterval:\n                  description:
-    'UsageReportingInterval controls the interval at which\n                  Felix
-    makes reports. [Default: 86400s]'\n                  type: string\n                useInternalDataplaneDriver:\n
-    \                 type: boolean\n                vxlanEnabled:\n                  type:
-    boolean\n                vxlanMTU:\n                  description: 'VXLANMTU is
-    the MTU to set on the tunnel device. See\n                  Configuring MTU [Default:
-    1440]'\n                  type: integer\n                vxlanPort:\n                  type:
-    integer\n                vxlanVNI:\n                  type: integer\n                wireguardEnabled:\n
-    \                 description: 'WireguardEnabled controls whether Wireguard is
-    enabled.\n                  [Default: false]'\n                  type: boolean\n
-    \               wireguardInterfaceName:\n                  description: 'WireguardInterfaceName
-    specifies the name to use for\n                  the Wireguard interface. [Default:
-    wg.calico]'\n                  type: string\n                wireguardListeningPort:\n
-    \                 description: 'WireguardListeningPort controls the listening
-    port used\n                  by Wireguard. [Default: 51820]'\n                  type:
-    integer\n                wireguardMTU:\n                  description: 'WireguardMTU
-    controls the MTU on the Wireguard interface.\n                  See Configuring
-    MTU [Default: 1420]'\n                  type: integer\n                wireguardRoutingRulePriority:\n
-    \                 description: 'WireguardRoutingRulePriority controls the priority
-    value\n                  to use for the Wireguard routing rule. [Default: 99]'\n
-    \                 type: integer\n                xdpEnabled:\n                  description:
-    'XDPEnabled enables XDP acceleration for suitable untracked\n                  incoming
-    deny rules. [Default: true]'\n                  type: boolean\n                xdpRefreshInterval:\n
-    \                 description: 'XDPRefreshInterval is the period at which Felix
-    re-checks\n                  all XDP state to ensure that no other process has
-    accidentally broken\n                  Calico''s BPF maps or attached programs.
-    Set to 0 to disable XDP\n                  refresh. [Default: 90s]'\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: globalnetworkpolicies.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: GlobalNetworkPolicy\n    listKind:
-    GlobalNetworkPolicyList\n    plural: globalnetworkpolicies\n    singular: globalnetworkpolicy\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                applyOnForward:\n
-    \                 description: ApplyOnForward indicates to apply the rules in
-    this policy\n                    on forward traffic.\n                  type:
-    boolean\n                doNotTrack:\n                  description: DoNotTrack
-    indicates whether packets matched by the rules\n                    in this policy
-    should go through the data plane's connection tracking,\n                    such
-    as Linux conntrack.  If True, the rules in this policy are\n                    applied
-    before any data plane connection tracking, and packets allowed\n                    by
-    this policy are marked as not to be tracked.\n                  type: boolean\n
-    \               egress:\n                  description: The ordered set of egress
-    rules.  Each rule contains\n                    a set of packet match criteria
-    and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                namespaceSelector:\n                  description: NamespaceSelector
-    is an optional field for an expression\n                    used to select a pod
-    based on namespaces.\n                  type: string\n                order:\n
-    \                 description: Order is an optional field that specifies the order
-    in\n                    which the policy is applied. Policies with higher \"order\"
-    are applied\n                    after those with lower order.  If the order is
-    omitted, it may be\n                    considered to be \"infinite\" - i.e. the
-    policy will be applied last.  Policies\n                    with identical order
-    will be applied in alphanumerical order based\n                    on the Policy
-    \"Name\".\n                  type: number\n                preDNAT:\n                  description:
-    PreDNAT indicates to apply the rules in this policy before\n                    any
-    DNAT.\n                  type: boolean\n                selector:\n                  description:
-    \"The selector is an expression used to pick pick out\n                  the endpoints
-    that the policy should be applied to. \\n Selector\n                  expressions
-    follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n                  \\
-    ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel != \\\"string_literal\\\"\n
-    \                 \\  ->  not equal; also matches if label is not present \\tlabel
-    in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\", ... }  ->  true if the
-    value of label X is\n                  one of \\\"a\\\", \\\"b\\\", \\\"c\\\"
-    \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ... }  ->
-    \ true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress rules are present
-    in the policy.  The\n                  default is: \\n - [ PolicyTypeIngress ],
-    if there are no Egress rules\n                  (including the case where there
-    are   also no Ingress rules) \\n\n                  - [ PolicyTypeEgress ], if
-    there are Egress rules but no Ingress\n                  rules \\n - [ PolicyTypeIngress,
-    PolicyTypeEgress ], if there are\n                  both Ingress and Egress rules.
-    \\n When the policy is read back again,\n                  Types will always be
-    one of these values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: globalnetworksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: GlobalNetworkSet\n    listKind: GlobalNetworkSetList\n    plural:
-    globalnetworksets\n    singular: globalnetworkset\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs\n            that
-    share labels to allow rules to refer to them via selectors.  The labels\n            of
-    GlobalNetworkSet are not namespaced.\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: GlobalNetworkSetSpec contains the
-    specification for a NetworkSet\n                resource.\n              properties:\n
-    \               nets:\n                  description: The list of IP networks
-    that belong to this set.\n                  items:\n                    type:
-    string\n                  type: array\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: hostendpoints.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: HostEndpoint\n    listKind: HostEndpointList\n    plural:
-    hostendpoints\n    singular: hostendpoint\n  scope: Cluster\n  versions:\n    -
-    name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: HostEndpointSpec contains the specification
-    for a HostEndpoint\n                resource.\n              properties:\n                expectedIPs:\n
-    \                 description: \"The expected IP addresses (IPv4 and IPv6) of
-    the endpoint.\n                  If \\\"InterfaceName\\\" is not present, Calico
-    will look for an interface\n                  matching any of the IPs in the list
-    and apply policy to that. Note:\n                  \\tWhen using the selector
-    match criteria in an ingress or egress\n                  security Policy \\tor
-    Profile, Calico converts the selector into\n                  a set of IP addresses.
-    For host \\tendpoints, the ExpectedIPs field\n                  is used for that
-    purpose. (If only the interface \\tname is specified,\n                  Calico
-    does not learn the IPs of the interface for use in match\n                  \\tcriteria.)\"\n
-    \                 items:\n                    type: string\n                  type:
-    array\n                interfaceName:\n                  description: \"Either
-    \\\"*\\\", or the name of a specific Linux interface\n                  to apply
-    policy to; or empty.  \\\"*\\\" indicates that this HostEndpoint\n                  governs
-    all traffic to, from or through the default network namespace\n                  of
-    the host named by the \\\"Node\\\" field; entering and leaving that\n                  namespace
-    via any interface, including those from/to non-host-networked\n                  local
-    workloads. \\n If InterfaceName is not \\\"*\\\", this HostEndpoint\n                  only
-    governs traffic that enters or leaves the host through the\n                  specific
-    interface named by InterfaceName, or - when InterfaceName\n                  is
-    empty - through the specific interface that has one of the IPs\n                  in
-    ExpectedIPs. Therefore, when InterfaceName is empty, at least\n                  one
-    expected IP must be specified.  Only external interfaces (such\n                  as
-    “eth0”) are supported here; it isn't possible for a HostEndpoint\n                  to
-    protect traffic through a specific local workload interface.\n                  \\n
-    Note: Only some kinds of policy are implemented for \\\"*\\\" HostEndpoints;\n
-    \                 initially just pre-DNAT policy.  Please check Calico documentation\n
-    \                 for the latest position.\"\n                  type: string\n
-    \               node:\n                  description: The node name identifying
-    the Calico node instance.\n                  type: string\n                ports:\n
-    \                 description: Ports contains the endpoint's named ports, which
-    may\n                    be referenced in security policy rules.\n                  items:\n
-    \                   properties:\n                      name:\n                        type:
-    string\n                      port:\n                        type: integer\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                    required:\n                      - name\n                      -
-    port\n                      - protocol\n                    type: object\n                  type:
-    array\n                profiles:\n                  description: A list of identifiers
-    of security Profile objects that\n                    apply to this endpoint.
-    Each profile is applied in the order that\n                    they appear in
-    this list.  Profile rules are applied after the selector-based\n                    security
-    policy.\n                  items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: ipamblocks.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMBlock\n    listKind: IPAMBlockList\n
-    \   plural: ipamblocks\n    singular: ipamblock\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMBlockSpec contains the specification
-    for an IPAMBlock\n                resource.\n              properties:\n                affinity:\n
-    \                 type: string\n                allocations:\n                  items:\n
-    \                   type: integer\n                    # TODO: This nullable is
-    manually added in. We should update controller-gen\n                    # to handle
-    []*int properly itself.\n                    nullable: true\n                  type:
-    array\n                attributes:\n                  items:\n                    properties:\n
-    \                     handle_id:\n                        type: string\n                      secondary:\n
-    \                       additionalProperties:\n                          type:
-    string\n                        type: object\n                    type: object\n
-    \                 type: array\n                cidr:\n                  type:
-    string\n                deleted:\n                  type: boolean\n                strictAffinity:\n
-    \                 type: boolean\n                unallocated:\n                  items:\n
-    \                   type: integer\n                  type: array\n              required:\n
-    \               - allocations\n                - attributes\n                -
-    cidr\n                - strictAffinity\n                - unallocated\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMConfig\n    listKind: IPAMConfigList\n    plural: ipamconfigs\n
-    \   singular: ipamconfig\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMConfigSpec contains the specification
-    for an IPAMConfig\n                resource.\n              properties:\n                autoAllocateBlocks:\n
-    \                 type: boolean\n                maxBlocksPerHost:\n                  description:
-    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                    that
-    can be affine to each host.\n                  type: integer\n                strictAffinity:\n
-    \                 type: boolean\n              required:\n                - autoAllocateBlocks\n
-    \               - strictAffinity\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ipamhandles.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMHandle\n    listKind: IPAMHandleList\n    plural: ipamhandles\n
-    \   singular: ipamhandle\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMHandleSpec contains the specification
-    for an IPAMHandle\n                resource.\n              properties:\n                block:\n
-    \                 additionalProperties:\n                    type: integer\n                  type:
-    object\n                deleted:\n                  type: boolean\n                handleID:\n
-    \                 type: string\n              required:\n                - block\n
-    \               - handleID\n              type: object\n          type: object\n
-    \     served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ippools.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPPool\n    listKind: IPPoolList\n    plural: ippools\n    singular:
-    ippool\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPPoolSpec contains the specification
-    for an IPPool resource.\n              properties:\n                blockSize:\n
-    \                 description: The block size to use for IP address assignments
-    from\n                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.\n
-    \                 type: integer\n                cidr:\n                  description:
-    The pool CIDR.\n                  type: string\n                disabled:\n                  description:
-    When disabled is true, Calico IPAM will not assign addresses\n                    from
-    this pool.\n                  type: boolean\n                ipip:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  properties:\n                    enabled:\n                      description:
-    When enabled is true, ipip tunneling will be used\n                        to
-    deliver packets to destinations within this pool.\n                      type:
-    boolean\n                    mode:\n                      description: The IPIP
-    mode.  This can be one of \"always\" or \"cross-subnet\".  A\n                        mode
-    of \"always\" will also use IPIP tunneling for routing to\n                        destination
-    IP addresses within this pool.  A mode of \"cross-subnet\"\n                        will
-    only use IPIP tunneling when the destination node is on\n                        a
-    different subnet to the originating node.  The default value\n                        (if
-    not specified) is \"always\".\n                      type: string\n                  type:
-    object\n                ipipMode:\n                  description: Contains configuration
-    for IPIP tunneling for this pool.\n                    If not specified, then
-    this is defaulted to \"Never\" (i.e. IPIP tunneling\n                    is disabled).\n
-    \                 type: string\n                nat-outgoing:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  type: boolean\n                natOutgoing:\n                  description:
-    When nat-outgoing is true, packets sent from Calico networked\n                    containers
-    in this pool to destinations outside of this pool will\n                    be
-    masqueraded.\n                  type: boolean\n                nodeSelector:\n
-    \                 description: Allows IPPool to allocate for a specific node by
-    label\n                    selector.\n                  type: string\n                vxlanMode:\n
-    \                 description: Contains configuration for VXLAN tunneling for
-    this pool.\n                    If not specified, then this is defaulted to \"Never\"
-    (i.e. VXLAN\n                    tunneling is disabled).\n                  type:
-    string\n              required:\n                - cidr\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: kubecontrollersconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: KubeControllersConfiguration\n    listKind: KubeControllersConfigurationList\n
-    \   plural: kubecontrollersconfigurations\n    singular: kubecontrollersconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: KubeControllersConfigurationSpec
-    contains the values of the\n                Kubernetes controllers configuration.\n
-    \             properties:\n                controllers:\n                  description:
-    Controllers enables and configures individual Kubernetes\n                    controllers\n
-    \                 properties:\n                    namespace:\n                      description:
-    Namespace enables and configures the namespace controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   node:\n                      description: Node enables and
-    configures the node controller.\n                        Enabled by default, set
-    to nil to disable.\n                      properties:\n                        hostEndpoint:\n
-    \                         description: HostEndpoint controls syncing nodes to
-    host endpoints.\n                            Disabled by default, set to nil to
-    disable.\n                          properties:\n                            autoCreate:\n
-    \                             description: 'AutoCreate enables automatic creation
-    of\n                              host endpoints for every node. [Default: Disabled]'\n
-    \                             type: string\n                          type: object\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                       syncLabels:\n                          description: 'SyncLabels
-    controls whether to copy Kubernetes\n                          node labels to
-    Calico nodes. [Default: Enabled]'\n                          type: string\n                      type:
-    object\n                    policy:\n                      description: Policy
-    enables and configures the policy controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   serviceAccount:\n                      description: ServiceAccount
-    enables and configures the service\n                        account controller.
-    Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                    workloadEndpoint:\n                      description:
-    WorkloadEndpoint enables and configures the workload\n                        endpoint
-    controller. Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                  type: object\n                etcdV3CompactionPeriod:\n
-    \                 description: 'EtcdV3CompactionPeriod is the period between etcdv3\n
-    \                 compaction requests. Set to 0 to disable. [Default: 10m]'\n
-    \                 type: string\n                healthChecks:\n                  description:
-    'HealthChecks enables or disables support for health\n                  checks
-    [Default: Enabled]'\n                  type: string\n                logSeverityScreen:\n
-    \                 description: 'LogSeverityScreen is the log severity above which
-    logs\n                  are sent to the stdout. [Default: Info]'\n                  type:
-    string\n                prometheusMetricsPort:\n                  description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                    metrics
-    server should bind to. Set to 0 to disable. [Default: 9094]'\n                  type:
-    integer\n              required:\n                - controllers\n              type:
-    object\n            status:\n              description: KubeControllersConfigurationStatus
-    represents the status\n                of the configuration. It's useful for admins
-    to be able to see the actual\n                config that was applied, which can
-    be modified by environment variables\n                on the kube-controllers
-    process.\n              properties:\n                environmentVars:\n                  additionalProperties:\n
-    \                   type: string\n                  description: EnvironmentVars
-    contains the environment variables on\n                    the kube-controllers
-    that influenced the RunningConfig.\n                  type: object\n                runningConfig:\n
-    \                 description: RunningConfig contains the effective config that
-    is running\n                    in the kube-controllers pod, after merging the
-    API resource with\n                    any environment variables.\n                  properties:\n
-    \                   controllers:\n                      description: Controllers
-    enables and configures individual Kubernetes\n                        controllers\n
-    \                     properties:\n                        namespace:\n                          description:
-    Namespace enables and configures the namespace\n                            controller.
-    Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        node:\n
-    \                         description: Node enables and configures the node controller.\n
-    \                           Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           hostEndpoint:\n                              description:
-    HostEndpoint controls syncing nodes to host\n                                endpoints.
-    Disabled by default, set to nil to disable.\n                              properties:\n
-    \                               autoCreate:\n                                  description:
-    'AutoCreate enables automatic creation\n                                  of host
-    endpoints for every node. [Default: Disabled]'\n                                  type:
-    string\n                              type: object\n                            leakGracePeriod:\n
-    \                             description: 'LeakGracePeriod is the period used
-    by the\n                                controller to determine if an IP address
-    has been leaked.\n                                Set to 0 to disable IP garbage
-    collection. [Default:\n                                15m]'\n                              type:
-    string\n                            reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                            syncLabels:\n                              description:
-    'SyncLabels controls whether to copy Kubernetes\n                              node
-    labels to Calico nodes. [Default: Enabled]'\n                              type:
-    string\n                          type: object\n                        policy:\n
-    \                         description: Policy enables and configures the policy
-    controller.\n                            Enabled by default, set to nil to disable.\n
-    \                         properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        serviceAccount:\n
-    \                         description: ServiceAccount enables and configures the
-    service\n                            account controller. Enabled by default, set
-    to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        workloadEndpoint:\n
-    \                         description: WorkloadEndpoint enables and configures
-    the workload\n                            endpoint controller. Enabled by default,
-    set to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                      type: object\n
-    \                   etcdV3CompactionPeriod:\n                      description:
-    'EtcdV3CompactionPeriod is the period between etcdv3\n                      compaction
-    requests. Set to 0 to disable. [Default: 10m]'\n                      type: string\n
-    \                   healthChecks:\n                      description: 'HealthChecks
-    enables or disables support for health\n                      checks [Default:
-    Enabled]'\n                      type: string\n                    logSeverityScreen:\n
-    \                     description: 'LogSeverityScreen is the log severity above
-    which\n                      logs are sent to the stdout. [Default: Info]'\n                      type:
-    string\n                    prometheusMetricsPort:\n                      description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                        metrics
-    server should bind to. Set to 0 to disable. [Default:\n                        9094]'\n
-    \                     type: integer\n                  required:\n                    -
-    controllers\n                  type: object\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: networkpolicies.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkPolicy\n    listKind: NetworkPolicyList\n    plural:
-    networkpolicies\n    singular: networkpolicy\n  scope: Namespaced\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                egress:\n                  description:
-    The ordered set of egress rules.  Each rule contains\n                    a set
-    of packet match criteria and a corresponding action to apply.\n                  items:\n
-    \                   description: \"A Rule encapsulates a set of match criteria
-    and an\n                    action.  Both selector-based security Policy and security
-    Profiles\n                    reference rules - separated out as a list of rules
-    for both ingress\n                    and egress packet matching. \\n Each positive
-    match criteria has\n                    a negated version, prefixed with ”Not”.
-    All the match criteria\n                    within a rule must be satisfied for
-    a packet to match. A single\n                    rule can contain the positive
-    and negative version of a match\n                    and both must be satisfied
-    for the rule to match.\"\n                    properties:\n                      action:\n
-    \                       type: string\n                      destination:\n                        description:
-    Destination contains the match criteria that apply\n                          to
-    destination entity.\n                        properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                order:\n                  description: Order is an optional
-    field that specifies the order in\n                    which the policy is applied.
-    Policies with higher \"order\" are applied\n                    after those with
-    lower order.  If the order is omitted, it may be\n                    considered
-    to be \"infinite\" - i.e. the policy will be applied last.  Policies\n                    with
-    identical order will be applied in alphanumerical order based\n                    on
-    the Policy \"Name\".\n                  type: number\n                selector:\n
-    \                 description: \"The selector is an expression used to pick pick
-    out\n                  the endpoints that the policy should be applied to. \\n
-    Selector\n                  expressions follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n
-    \                 \\ ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel
-    != \\\"string_literal\\\"\n                  \\  ->  not equal; also matches if
-    label is not present \\tlabel in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\",
-    ... }  ->  true if the value of label X is\n                  one of \\\"a\\\",
-    \\\"b\\\", \\\"c\\\" \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ...
-    }  ->  true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress are present in the
-    policy.  The default\n                  is: \\n - [ PolicyTypeIngress ], if there
-    are no Egress rules (including\n                  the case where there are   also
-    no Ingress rules) \\n - [ PolicyTypeEgress\n                  ], if there are
-    Egress rules but no Ingress rules \\n - [ PolicyTypeIngress,\n                  PolicyTypeEgress
-    ], if there are both Ingress and Egress rules.\n                  \\n When the
-    policy is read back again, Types will always be one\n                  of these
-    values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: networksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkSet\n    listKind: NetworkSetList\n    plural: networksets\n
-    \   singular: networkset\n  scope: Namespaced\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          description: NetworkSet is the Namespaced-equivalent
-    of the GlobalNetworkSet.\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: NetworkSetSpec contains the specification
-    for a NetworkSet\n                resource.\n              properties:\n                nets:\n
-    \                 description: The list of IP networks that belong to this set.\n
-    \                 items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n---\n# Source: calico/templates/calico-kube-controllers-rbac.yaml\n\n#
-    Include a clusterrole for the kube-controllers component,\n# and bind it to the
-    calico-kube-controllers serviceaccount.\nkind: ClusterRole\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nrules:\n  # Nodes are watched to monitor for
-    deletions.\n  - apiGroups: [\"\"]\n    resources:\n      - nodes\n    verbs:\n
-    \     - watch\n      - list\n      - get\n  # Pods are watched to check for existence
-    as part of IPAM controller.\n  - apiGroups: [\"\"]\n    resources:\n      - pods\n
-    \   verbs:\n      - get\n      - list\n      - watch\n  # IPAM resources are manipulated
-    when nodes are deleted.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - ippools\n    verbs:\n      - list\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - blockaffinities\n      - ipamblocks\n      - ipamhandles\n
-    \   verbs:\n      - get\n      - list\n      - create\n      - update\n      -
-    delete\n      - watch\n  # kube-controllers manages hostendpoints.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - hostendpoints\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  #
-    Needs access to update clusterinformations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - clusterinformations\n    verbs:\n      - get\n      -
-    create\n      - update\n  # KubeControllersConfiguration is where it gets its
-    config\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - kubecontrollersconfigurations\n
-    \   verbs:\n      # read its own config\n      - get\n      # create a default
-    if none exists\n      - create\n      # update status\n      - update\n      #
-    watch for changes\n      - watch\n---\nkind: ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-kube-controllers\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-kube-controllers\n    namespace: kube-system\n---\n\n---\n# Source:
-    calico/templates/calico-node-rbac.yaml\n# Include a clusterrole for the calico-node
-    DaemonSet,\n# and bind it to the calico-node serviceaccount.\nkind: ClusterRole\napiVersion:
-    rbac.authorization.k8s.io/v1\nmetadata:\n  name: calico-node\nrules:\n  # The
-    CNI plugin needs to get pods, nodes, and namespaces.\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - pods\n      - nodes\n      - namespaces\n    verbs:\n
-    \     - get\n  # EndpointSlices are used for Service-based network policy rule\n
-    \ # enforcement.\n  - apiGroups: [\"discovery.k8s.io\"]\n    resources:\n      -
-    endpointslices\n    verbs:\n      - watch\n      - list\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - endpoints\n      - services\n    verbs:\n      # Used
-    to discover service IPs for advertisement.\n      - watch\n      - list\n      #
-    Used to discover Typhas.\n      - get\n  # Pod CIDR auto-detection on kubeadm
-    needs access to config maps.\n  - apiGroups: [\"\"]\n    resources:\n      - configmaps\n
-    \   verbs:\n      - get\n  - apiGroups: [\"\"]\n    resources:\n      - nodes/status\n
-    \   verbs:\n      # Needed for clearing NodeNetworkUnavailable flag.\n      -
-    patch\n      # Calico stores some configuration information in node annotations.\n
-    \     - update\n  # Watch for changes to Kubernetes NetworkPolicies.\n  - apiGroups:
-    [\"networking.k8s.io\"]\n    resources:\n      - networkpolicies\n    verbs:\n
-    \     - watch\n      - list\n  # Used by Calico for policy information.\n  - apiGroups:
-    [\"\"]\n    resources:\n      - pods\n      - namespaces\n      - serviceaccounts\n
-    \   verbs:\n      - list\n      - watch\n  # The CNI plugin patches pods/status.\n
-    \ - apiGroups: [\"\"]\n    resources:\n      - pods/status\n    verbs:\n      -
-    patch\n  # Calico monitors various CRDs for config.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - globalfelixconfigs\n      - felixconfigurations\n      -
-    bgppeers\n      - globalbgpconfigs\n      - bgpconfigurations\n      - ippools\n
-    \     - ipamblocks\n      - globalnetworkpolicies\n      - globalnetworksets\n
-    \     - networkpolicies\n      - networksets\n      - clusterinformations\n      -
-    hostendpoints\n      - blockaffinities\n    verbs:\n      - get\n      - list\n
-    \     - watch\n  # Calico must create and update some CRDs on startup.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - ippools\n      - felixconfigurations\n
-    \     - clusterinformations\n    verbs:\n      - create\n      - update\n  # Calico
-    stores some configuration information on the node.\n  - apiGroups: [\"\"]\n    resources:\n
-    \     - nodes\n    verbs:\n      - get\n      - list\n      - watch\n  # These
-    permissions are only required for upgrade from v2.6, and can\n  # be removed after
-    upgrade or on fresh installations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - bgpconfigurations\n      - bgppeers\n    verbs:\n      -
-    create\n      - update\n  # These permissions are required for Calico CNI to perform
-    IPAM allocations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n      - ipamblocks\n      - ipamhandles\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  -
-    apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - ipamconfigs\n
-    \   verbs:\n      - get\n  # Block affinities must also be watchable by confd
-    for route aggregation.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n    verbs:\n      - watch\n  # The Calico IPAM migration
-    needs to get daemonsets. These permissions can be\n  # removed if not upgrading
-    from an installation using host-local IPAM.\n  - apiGroups: [\"apps\"]\n    resources:\n
-    \     - daemonsets\n    verbs:\n      - get\n\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:
-    ClusterRoleBinding\nmetadata:\n  name: calico-node\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-node\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-node\n    namespace: kube-system\n\n---\n# Source: calico/templates/calico-node.yaml\n#
-    This manifest installs the calico-node container, as well\n# as the CNI plugins
-    and network config on\n# each master and worker node in a Kubernetes cluster.\nkind:
-    DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: calico-node\n  namespace: kube-system\n
-    \ labels:\n    k8s-app: calico-node\nspec:\n  selector:\n    matchLabels:\n      k8s-app:
-    calico-node\n  updateStrategy:\n    type: RollingUpdate\n    rollingUpdate:\n
-    \     maxUnavailable: 1\n  template:\n    metadata:\n      labels:\n        k8s-app:
-    calico-node\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n
-    \     hostNetwork: true\n      tolerations:\n        # Make sure calico-node gets
-    scheduled on all nodes.\n        - effect: NoSchedule\n          operator: Exists\n
-    \       # Mark the pod as a critical add-on for rescheduling.\n        - key:
-    CriticalAddonsOnly\n          operator: Exists\n        - effect: NoExecute\n
-    \         operator: Exists\n      serviceAccountName: calico-node\n      # Minimize
-    downtime during a rolling upgrade or deletion; tell Kubernetes to do a \"force\n
-    \     # deletion\": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.\n
-    \     terminationGracePeriodSeconds: 0\n      priorityClassName: system-node-critical\n
-    \     initContainers:\n        # This container performs upgrade from host-local
-    IPAM to calico-ipam.\n        # It can be deleted if this is a fresh installation,
-    or if you have already\n        # upgraded to use calico-ipam.\n        - name:
-    upgrade-ipam\n          image: calico/cni:v3.20.0\n          command: [\"/opt/cni/bin/calico-ipam\",
-    \"-upgrade\"]\n          envFrom:\n            - configMapRef:\n                #
-    Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for
-    eBPF mode.\n                name: kubernetes-services-endpoint\n                optional:
-    true\n          env:\n            - name: KUBERNETES_NODE_NAME\n              valueFrom:\n
-    \               fieldRef:\n                  fieldPath: spec.nodeName\n            -
-    name: CALICO_NETWORKING_BACKEND\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: calico_backend\n
-    \         volumeMounts:\n            - mountPath: /var/lib/cni/networks\n              name:
-    host-local-net-dir\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n          securityContext:\n            privileged: true\n        #
-    This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: calico/cni:v3.20.0\n
-    \         command: [\"/opt/cni/bin/install\"]\n          envFrom:\n            -
-    configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
-    to be overridden for eBPF mode.\n                name: kubernetes-services-endpoint\n
-    \               optional: true\n          env:\n            # Name of the CNI
-    config file to create.\n            - name: CNI_CONF_NAME\n              value:
-    \"10-calico.conflist\"\n            # The CNI network config to install on each
-    node.\n            - name: CNI_NETWORK_CONFIG\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: cni_network_config\n
-    \           # Set the hostname based on the k8s node name.\n            - name:
-    KUBERNETES_NODE_NAME\n              valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # CNI MTU Config variable\n            - name: CNI_MTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Prevents the container
-    from sleeping forever.\n            - name: SLEEP\n              value: \"false\"\n
-    \         volumeMounts:\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n            - mountPath: /host/etc/cni/net.d\n              name:
-    cni-net-dir\n          securityContext:\n            privileged: true\n        #
-    Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes\n
-    \       # to communicate with Felix over the Policy Sync API.\n        - name:
-    flexvol-driver\n          image: calico/pod2daemon-flexvol:v3.20.0\n          volumeMounts:\n
-    \           - name: flexvol-driver-host\n              mountPath: /host/driver\n
-    \         securityContext:\n            privileged: true\n      containers:\n
-    \       # Runs calico-node container on each Kubernetes node. This\n        #
-    container programs network policy and routes on each\n        # host.\n        -
-    name: calico-node\n          image: calico/node:v3.20.0\n          envFrom:\n
-    \           - configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and
-    KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.\n                name:
-    kubernetes-services-endpoint\n                optional: true\n          env:\n
-    \           # Use Kubernetes API as the backing datastore.\n            - name:
-    DATASTORE_TYPE\n              value: \"kubernetes\"\n            # Wait for the
-    datastore.\n            - name: WAIT_FOR_DATASTORE\n              value: \"true\"\n
-    \           # Set based on the k8s node name.\n            - name: NODENAME\n
-    \             valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # Choose the backend to use.\n            - name: CALICO_NETWORKING_BACKEND\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: calico_backend\n            # Cluster type
-    to identify the deployment type\n            - name: CLUSTER_TYPE\n              value:
-    \"k8s,bgp\"\n            # Auto-detect the BGP IP address.\n            - name:
-    IP\n              value: \"autodetect\"\n            # Enable VXLAN\n            -
-    name: CALICO_IPV4POOL_VXLAN\n              value: \"Always\"\n            # Set
-    MTU for tunnel device used if ipip is enabled\n            - name: FELIX_IPINIPMTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Set MTU for the
-    VXLAN tunnel device.\n            - name: FELIX_VXLANMTU\n              valueFrom:\n
-    \               configMapKeyRef:\n                  name: calico-config\n                  key:
-    veth_mtu\n            # Set MTU for the Wireguard tunnel device.\n            -
-    name: FELIX_WIREGUARDMTU\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: veth_mtu\n            #
-    The default IPv4 pool to create on startup if none exists. Pod IPs will be\n            #
-    chosen from this range. Changing this value after installation will have\n            #
-    no effect. This should fall within `--cluster-cidr`.\n            # - name: CALICO_IPV4POOL_CIDR\n
-    \           #   value: \"192.168.0.0/16\"\n            # Disable file logging
-    so `kubectl logs` works.\n            - name: CALICO_DISABLE_FILE_LOGGING\n              value:
-    \"true\"\n            # Set Felix endpoint to host default action to ACCEPT.\n
-    \           - name: FELIX_DEFAULTENDPOINTTOHOSTACTION\n              value: \"ACCEPT\"\n
-    \           # Disable IPv6 on Kubernetes.\n            - name: FELIX_IPV6SUPPORT\n
-    \             value: \"false\"\n            - name: FELIX_FEATUREDETECTOVERRIDE\n
-    \             value: \"ChecksumOffloadBroken=true\"\n            - name: FELIX_HEALTHENABLED\n
-    \             value: \"true\"\n          securityContext:\n            privileged:
-    true\n          resources:\n            requests:\n              cpu: 250m\n          livenessProbe:\n
-    \           exec:\n              command:\n                - /bin/calico-node\n
-    \               - -felix-live\n            periodSeconds: 10\n            initialDelaySeconds:
-    10\n            failureThreshold: 6\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /bin/calico-node\n                -
-    -felix-ready\n            periodSeconds: 10\n          volumeMounts:\n            -
-    mountPath: /host/etc/cni/net.d\n              name: cni-net-dir\n              readOnly:
-    false\n            - mountPath: /lib/modules\n              name: lib-modules\n
-    \             readOnly: true\n            - mountPath: /run/xtables.lock\n              name:
-    xtables-lock\n              readOnly: false\n            - mountPath: /var/run/calico\n
-    \             name: var-run-calico\n              readOnly: false\n            -
-    mountPath: /var/lib/calico\n              name: var-lib-calico\n              readOnly:
-    false\n            - name: policysync\n              mountPath: /var/run/nodeagent\n
-    \           # For eBPF mode, we need to be able to mount the BPF filesystem at
-    /sys/fs/bpf so we mount in the\n            # parent directory.\n            -
-    name: sysfs\n              mountPath: /sys/fs/\n              # Bidirectional
-    means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to
-    the host.\n              # If the host is known to mount that filesystem already
-    then Bidirectional can be omitted.\n              mountPropagation: Bidirectional\n
-    \           - name: cni-log-dir\n              mountPath: /var/log/calico/cni\n
-    \             readOnly: true\n      volumes:\n        # Used by calico-node.\n
-    \       - name: lib-modules\n          hostPath:\n            path: /lib/modules\n
-    \       - name: var-run-calico\n          hostPath:\n            path: /var/run/calico\n
-    \       - name: var-lib-calico\n          hostPath:\n            path: /var/lib/calico\n
-    \       - name: xtables-lock\n          hostPath:\n            path: /run/xtables.lock\n
-    \           type: FileOrCreate\n        - name: sysfs\n          hostPath:\n            path:
-    /sys/fs/\n            type: DirectoryOrCreate\n        # Used to install CNI.\n
-    \       - name: cni-bin-dir\n          hostPath:\n            path: /opt/cni/bin\n
-    \       - name: cni-net-dir\n          hostPath:\n            path: /etc/cni/net.d\n
-    \       # Used to access CNI logs.\n        - name: cni-log-dir\n          hostPath:\n
-    \           path: /var/log/calico/cni\n        # Mount in the directory for host-local
-    IPAM allocations. This is\n        # used when upgrading from host-local to calico-ipam,
-    and can be removed\n        # if not using the upgrade-ipam init container.\n
-    \       - name: host-local-net-dir\n          hostPath:\n            path: /var/lib/cni/networks\n
-    \       # Used to create per-pod Unix Domain Sockets\n        - name: policysync\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /var/run/nodeagent\n
-    \       # Used to install Flex Volume Driver\n        - name: flexvol-driver-host\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds\n---\n\napiVersion:
-    v1\nkind: ServiceAccount\nmetadata:\n  name: calico-node\n  namespace: kube-system\n\n---\n#
-    Source: calico/templates/calico-kube-controllers.yaml\n# See https://github.com/projectcalico/kube-controllers\napiVersion:
-    apps/v1\nkind: Deployment\nmetadata:\n  name: calico-kube-controllers\n  namespace:
-    kube-system\n  labels:\n    k8s-app: calico-kube-controllers\nspec:\n  # The controllers
-    can only have a single active instance.\n  replicas: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n  strategy:\n    type: Recreate\n  template:\n
-    \   metadata:\n      name: calico-kube-controllers\n      namespace: kube-system\n
-    \     labels:\n        k8s-app: calico-kube-controllers\n    spec:\n      nodeSelector:\n
-    \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
-    a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
-    Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
-    \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
-    \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
-    \         env:\n            # Choose which controllers to run.\n            -
-    name: ENABLED_CONTROLLERS\n              value: node\n            - name: DATASTORE_TYPE\n
-    \             value: kubernetes\n          livenessProbe:\n            exec:\n
-    \             command:\n              - /usr/bin/check-status\n              -
-    -l\n            periodSeconds: 10\n            initialDelaySeconds: 10\n            failureThreshold:
-    6\n            timeoutSeconds: 10\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /usr/bin/check-status\n                -
-    -r\n            periodSeconds: 10\n\n---\n\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n\n---\n\n# This manifest
-    creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler
-    to evict\n\napiVersion: policy/v1beta1\nkind: PodDisruptionBudget\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n  labels:\n    k8s-app:
-    calico-kube-controllers\nspec:\n  maxUnavailable: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n---\n# Source: calico/templates/calico-etcd-secrets.yaml\n\n---\n#
-    Source: calico/templates/calico-typha.yaml\n\n---\n# Source: calico/templates/configure-canal.yaml\n"
+  resources: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgpconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPConfiguration
+        listKind: BGPConfigurationList
+        plural: bgpconfigurations
+        singular: bgpconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: BGPConfiguration contains the configuration for any BGP routing.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPConfigurationSpec contains the values of the BGP configuration.
+                properties:
+                  asNumber:
+                    description: 'ASNumber is the default AS number used by a node. [Default:
+                      64512]'
+                    format: int32
+                    type: integer
+                  communities:
+                    description: Communities is a list of BGP community values and their
+                      arbitrary names for tagging routes.
+                    items:
+                      description: Community contains standard or large community value
+                        and its name.
+                      properties:
+                        name:
+                          description: Name given to community value.
+                          type: string
+                        value:
+                          description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                            For standard community use `aa:nn` format, where `aa` and
+                            `nn` are 16 bit number. For large community use `aa:nn:mm`
+                            format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                            `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                          pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                          type: string
+                      type: object
+                    type: array
+                  listenPort:
+                    description: ListenPort is the port where BGP protocol should listen.
+                      Defaults to 179
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: INFO]'
+                    type: string
+                  nodeToNodeMeshEnabled:
+                    description: 'NodeToNodeMeshEnabled sets whether full node to node
+                      BGP mesh is enabled. [Default: true]'
+                    type: boolean
+                  prefixAdvertisements:
+                    description: PrefixAdvertisements contains per-prefix advertisement
+                      configuration.
+                    items:
+                      description: PrefixAdvertisement configures advertisement properties
+                        for the specified CIDR.
+                      properties:
+                        cidr:
+                          description: CIDR for which properties should be advertised.
+                          type: string
+                        communities:
+                          description: Communities can be list of either community names
+                            already defined in `Specs.Communities` or community value
+                            of format `aa:nn` or `aa:nn:mm`. For standard community use
+                            `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                            large community use `aa:nn:mm` format, where `aa`, `nn` and
+                            `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                            `mm` are per-AS identifier.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  serviceClusterIPs:
+                    description: ServiceClusterIPs are the CIDR blocks from which service
+                      cluster IPs are allocated. If specified, Calico will advertise these
+                      blocks, as well as any cluster IPs within them.
+                    items:
+                      description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                        CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceExternalIPs:
+                    description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                      Service External IPs. Kubernetes Service ExternalIPs will only be
+                      advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceExternalIPBlock represents a single allowed
+                        External IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceLoadBalancerIPs:
+                    description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                      Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                      IPs will only be advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceLoadBalancerIPBlock represents a single allowed
+                        LoadBalancer IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgppeers.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPPeer
+        listKind: BGPPeerList
+        plural: bgppeers
+        singular: bgppeer
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPPeerSpec contains the specification for a BGPPeer resource.
+                properties:
+                  asNumber:
+                    description: The AS Number of the peer.
+                    format: int32
+                    type: integer
+                  keepOriginalNextHop:
+                    description: Option to keep the original nexthop field when routes
+                      are sent to a BGP Peer. Setting "true" configures the selected BGP
+                      Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                      in the specific branch of the Node on "bird.cfg".
+                    type: boolean
+                  maxRestartTime:
+                    description: Time to allow for software restart.  When specified,
+                      this is configured as the graceful restart timeout.  When not specified,
+                      the BIRD default of 120s is used.
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance that
+                      is targeted by this peer. If this is not set, and no nodeSelector
+                      is specified, then this BGP peer selects all nodes in the cluster.
+                    type: string
+                  nodeSelector:
+                    description: Selector for the nodes that should have this peering.  When
+                      this is set, the Node field must be empty.
+                    type: string
+                  password:
+                    description: Optional BGP password for the peerings generated by this
+                      BGPPeer resource.
+                    properties:
+                      secretKeyRef:
+                        description: Selects a key of a secret in the node pod's namespace.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be
+                              a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be
+                              defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  peerIP:
+                    description: The IP address of the peer followed by an optional port
+                      number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                      or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                      and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                      set in BGPConfiguration, then we use that port to peer.
+                    type: string
+                  peerSelector:
+                    description: Selector for the remote nodes to peer with.  When this
+                      is set, the PeerIP and ASNumber fields must be empty.  For each
+                      peering between the local node and selected remote nodes, we configure
+                      an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                      and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                      remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                      or the global default if that is not set.
+                    type: string
+                  sourceAddress:
+                    description: Specifies whether and how to configure a source address
+                      for the peerings generated by this BGPPeer resource.  Default value
+                      "UseNodeIP" means to configure the node IP as the source address.  "None"
+                      means not to configure a source address.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: blockaffinities.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BlockAffinity
+        listKind: BlockAffinityList
+        plural: blockaffinities
+        singular: blockaffinity
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BlockAffinitySpec contains the specification for a BlockAffinity
+                  resource.
+                properties:
+                  cidr:
+                    type: string
+                  deleted:
+                    description: Deleted indicates that this block affinity is being deleted.
+                      This field is a string for compatibility with older releases that
+                      mistakenly treat this field as a string.
+                    type: string
+                  node:
+                    type: string
+                  state:
+                    type: string
+                required:
+                - cidr
+                - deleted
+                - node
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: clusterinformations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: ClusterInformation
+        listKind: ClusterInformationList
+        plural: clusterinformations
+        singular: clusterinformation
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterInformation contains the cluster specific information.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterInformationSpec contains the values of describing
+                  the cluster.
+                properties:
+                  calicoVersion:
+                    description: CalicoVersion is the version of Calico that the cluster
+                      is running
+                    type: string
+                  clusterGUID:
+                    description: ClusterGUID is the GUID of the cluster
+                    type: string
+                  clusterType:
+                    description: ClusterType describes the type of the cluster
+                    type: string
+                  datastoreReady:
+                    description: DatastoreReady is used during significant datastore migrations
+                      to signal to components such as Felix that it should wait before
+                      accessing the datastore.
+                    type: boolean
+                  variant:
+                    description: Variant declares which variant of Calico should be active.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: felixconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: FelixConfiguration
+        listKind: FelixConfigurationList
+        plural: felixconfigurations
+        singular: felixconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: Felix Configuration contains the configuration for Felix.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: FelixConfigurationSpec contains the values of the Felix configuration.
+                properties:
+                  allowIPIPPacketsFromWorkloads:
+                    description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop IPIP encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  allowVXLANPacketsFromWorkloads:
+                    description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop VXLAN encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  awsSrcDstCheck:
+                    description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                      value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                      DoNothing]'
+                    enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                    type: string
+                  bpfConnectTimeLoadBalancingEnabled:
+                    description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                      controls whether Felix installs the connection-time load balancer.  The
+                      connect-time load balancer is required for the host to be able to
+                      reach Kubernetes services and it improves the performance of pod-to-service
+                      connections.  The only reason to disable it is for debugging purposes.  [Default:
+                      true]'
+                    type: boolean
+                  bpfDataIfacePattern:
+                    description: BPFDataIfacePattern is a regular expression that controls
+                      which interfaces Felix should attach BPF programs to in order to
+                      catch traffic to/from the network.  This needs to match the interfaces
+                      that Calico workload traffic flows over as well as any interfaces
+                      that handle incoming traffic to nodeports and services from outside
+                      the cluster.  It should not match the workload interfaces (usually
+                      named cali...).
+                    type: string
+                  bpfDisableUnprivileged:
+                    description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                      sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                      users cannot access Calico''s BPF maps and cannot insert their own
+                      BPF programs to interfere with Calico''s. [Default: true]'
+                    type: boolean
+                  bpfEnabled:
+                    description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                      [Default: false]'
+                    type: boolean
+                  bpfExtToServiceConnmark:
+                    description: 'BPFExtToServiceConnmark in BPF mode, controls a 32bit
+                      mark that is set on connections from an external client to a local
+                      service. This mark allows us to control how packets of that connection
+                      are routed within the host and how is routing intepreted by RPF
+                      check. [Default: 0]'
+                    type: integer
+                  bpfExternalServiceMode:
+                    description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                      from outside the cluster to services (node ports and cluster IPs)
+                      are forwarded to remote workloads.  If set to "Tunnel" then both
+                      request and response traffic is tunneled to the remote node.  If
+                      set to "DSR", the request traffic is tunneled but the response traffic
+                      is sent directly from the remote node.  In "DSR" mode, the remote
+                      node appears to use the IP of the ingress node; this requires a
+                      permissive L2 network.  [Default: Tunnel]'
+                    type: string
+                  bpfKubeProxyEndpointSlicesEnabled:
+                    description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                      whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                    type: boolean
+                  bpfKubeProxyIptablesCleanupEnabled:
+                    description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                      mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                      iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                      true]'
+                    type: boolean
+                  bpfKubeProxyMinSyncPeriod:
+                    description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                      minimum time between updates to the dataplane for Felix''s embedded
+                      kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                      reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                    type: string
+                  bpfLogLevel:
+                    description: 'BPFLogLevel controls the log level of the BPF programs
+                      when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                      logs are emitted to the BPF trace pipe, accessible with the command
+                      `tc exec bpf debug`. [Default: Off].'
+                    type: string
+                  chainInsertMode:
+                    description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                      top-level iptables chains by inserting a rule at the top of the
+                      chain or by appending a rule at the bottom. insert is the safe default
+                      since it prevents Calico''s rules from being bypassed. If you switch
+                      to append mode, be sure that the other rules in the chains signal
+                      acceptance by falling through to the Calico rules, otherwise the
+                      Calico policy will be bypassed. [Default: insert]'
+                    type: string
+                  dataplaneDriver:
+                    type: string
+                  debugDisableLogDropping:
+                    type: boolean
+                  debugMemoryProfilePath:
+                    type: string
+                  debugSimulateCalcGraphHangAfter:
+                    type: string
+                  debugSimulateDataplaneHangAfter:
+                    type: string
+                  defaultEndpointToHostAction:
+                    description: 'DefaultEndpointToHostAction controls what happens to
+                      traffic that goes from a workload endpoint to the host itself (after
+                      the traffic hits the endpoint egress policy). By default Calico
+                      blocks traffic from workload endpoints to the host itself with an
+                      iptables "DROP" action. If you want to allow some or all traffic
+                      from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                      RETURN if you have your own rules in the iptables "INPUT" chain;
+                      Calico will insert its rules at the top of that chain, then "RETURN"
+                      packets to the "INPUT" chain once it has completed processing workload
+                      endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                      from workloads after processing workload endpoint egress policy.
+                      [Default: Drop]'
+                    type: string
+                  deviceRouteProtocol:
+                    description: This defines the route protocol added to programmed device
+                      routes, by default this will be RTPROT_BOOT when left blank.
+                    type: integer
+                  deviceRouteSourceAddress:
+                    description: This is the source address to use on programmed device
+                      routes. By default the source address is left blank, leaving the
+                      kernel to choose the source address used.
+                    type: string
+                  disableConntrackInvalidCheck:
+                    type: boolean
+                  endpointReportingDelay:
+                    type: string
+                  endpointReportingEnabled:
+                    type: boolean
+                  externalNodesList:
+                    description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                      which may source tunnel traffic and have the tunneled traffic be
+                      accepted at calico nodes.
+                    items:
+                      type: string
+                    type: array
+                  failsafeInboundHostPorts:
+                    description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow incoming traffic to host endpoints
+                      on irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all inbound host ports, use the value
+                      none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                      udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  failsafeOutboundHostPorts:
+                    description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow outgoing traffic from host endpoints
+                      to irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all outbound host ports, use the value
+                      none. The default value opens etcd''s standard ports to ensure that
+                      Felix does not get cut off from etcd as well as allowing DHCP and
+                      DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                      tcp:6667, udp:53, udp:67]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  featureDetectOverride:
+                    description: FeatureDetectOverride is used to override the feature
+                      detection. Values are specified in a comma separated list with no
+                      spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                      "true" or "false" will force the feature, empty or omitted values
+                      are auto-detected.
+                    type: string
+                  genericXDPEnabled:
+                    description: 'GenericXDPEnabled enables Generic XDP so network cards
+                      that don''t support XDP offload or driver modes can use XDP. This
+                      is not recommended since it doesn''t provide better performance
+                      than iptables. [Default: false]'
+                    type: boolean
+                  healthEnabled:
+                    type: boolean
+                  healthHost:
+                    type: string
+                  healthPort:
+                    type: integer
+                  interfaceExclude:
+                    description: 'InterfaceExclude is a comma-separated list of interfaces
+                      that Felix should exclude when monitoring for host endpoints. The
+                      default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                      interface, which is used internally by kube-proxy. If you want to
+                      exclude multiple interface names using a single value, the list
+                      supports regular expressions. For regular expressions you must wrap
+                      the value with ''/''. For example having values ''/^kube/,veth1''
+                      will exclude all interfaces that begin with ''kube'' and also the
+                      interface ''veth1''. [Default: kube-ipvs0]'
+                    type: string
+                  interfacePrefix:
+                    description: 'InterfacePrefix is the interface name prefix that identifies
+                      workload endpoints and so distinguishes them from host endpoint
+                      interfaces. Note: in environments other than bare metal, the orchestrators
+                      configure this appropriately. For example our Kubernetes and Docker
+                      integrations set the ''cali'' value, and our OpenStack integration
+                      sets the ''tap'' value. [Default: cali]'
+                    type: string
+                  interfaceRefreshInterval:
+                    description: InterfaceRefreshInterval is the period at which Felix
+                      rescans local interfaces to verify their state. The rescan can be
+                      disabled by setting the interval to 0.
+                    type: string
+                  ipipEnabled:
+                    type: boolean
+                  ipipMTU:
+                    description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  ipsetsRefreshInterval:
+                    description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                      all iptables state to ensure that no other process has accidentally
+                      broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                      90s]'
+                    type: string
+                  iptablesBackend:
+                    description: IptablesBackend specifies which backend of iptables will
+                      be used. The default is legacy.
+                    type: string
+                  iptablesFilterAllowAction:
+                    type: string
+                  iptablesLockFilePath:
+                    description: 'IptablesLockFilePath is the location of the iptables
+                      lock file. You may need to change this if the lock file is not in
+                      its standard location (for example if you have mapped it into Felix''s
+                      container at a different path). [Default: /run/xtables.lock]'
+                    type: string
+                  iptablesLockProbeInterval:
+                    description: 'IptablesLockProbeInterval is the time that Felix will
+                      wait between attempts to acquire the iptables lock if it is not
+                      available. Lower values make Felix more responsive when the lock
+                      is contended, but use more CPU. [Default: 50ms]'
+                    type: string
+                  iptablesLockTimeout:
+                    description: 'IptablesLockTimeout is the time that Felix will wait
+                      for the iptables lock, or 0, to disable. To use this feature, Felix
+                      must share the iptables lock file with all other processes that
+                      also take the lock. When running Felix inside a container, this
+                      requires the /run directory of the host to be mounted into the calico/node
+                      or calico/felix container. [Default: 0s disabled]'
+                    type: string
+                  iptablesMangleAllowAction:
+                    type: string
+                  iptablesMarkMask:
+                    description: 'IptablesMarkMask is the mask that Felix selects its
+                      IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                      at least 8 bits set, none of which clash with any other mark bits
+                      in use on the system. [Default: 0xff000000]'
+                    format: int32
+                    type: integer
+                  iptablesNATOutgoingInterfaceFilter:
+                    type: string
+                  iptablesPostWriteCheckInterval:
+                    description: 'IptablesPostWriteCheckInterval is the period after Felix
+                      has done a write to the dataplane that it schedules an extra read
+                      back in order to check the write was not clobbered by another process.
+                      This should only occur if another application on the system doesn''t
+                      respect the iptables lock. [Default: 1s]'
+                    type: string
+                  iptablesRefreshInterval:
+                    description: 'IptablesRefreshInterval is the period at which Felix
+                      re-checks the IP sets in the dataplane to ensure that no other process
+                      has accidentally broken Calico''s rules. Set to 0 to disable IP
+                      sets refresh. Note: the default for this value is lower than the
+                      other refresh intervals as a workaround for a Linux kernel bug that
+                      was fixed in kernel version 4.11. If you are using v4.11 or greater
+                      you may want to set this to, a higher value to reduce Felix CPU
+                      usage. [Default: 10s]'
+                    type: string
+                  ipv6Support:
+                    type: boolean
+                  kubeNodePortRanges:
+                    description: 'KubeNodePortRanges holds list of port ranges used for
+                      service node ports. Only used if felix detects kube-proxy running
+                      in ipvs mode. Felix uses these ranges to separate host and workload
+                      traffic. [Default: 30000:32767].'
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  logFilePath:
+                    description: 'LogFilePath is the full path to the Felix log. Set to
+                      none to disable file logging. [Default: /var/log/calico/felix.log]'
+                    type: string
+                  logPrefix:
+                    description: 'LogPrefix is the log prefix that Felix uses when rendering
+                      LOG rules. [Default: calico-packet]'
+                    type: string
+                  logSeverityFile:
+                    description: 'LogSeverityFile is the log severity above which logs
+                      are sent to the log file. [Default: Info]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  logSeveritySys:
+                    description: 'LogSeveritySys is the log severity above which logs
+                      are sent to the syslog. Set to None for no logging to syslog. [Default:
+                      Info]'
+                    type: string
+                  maxIpsetSize:
+                    type: integer
+                  metadataAddr:
+                    description: 'MetadataAddr is the IP address or domain name of the
+                      server that can answer VM queries for cloud-init metadata. In OpenStack,
+                      this corresponds to the machine running nova-api (or in Ubuntu,
+                      nova-api-metadata). A value of none (case insensitive) means that
+                      Felix should not set up any NAT rule for the metadata path. [Default:
+                      127.0.0.1]'
+                    type: string
+                  metadataPort:
+                    description: 'MetadataPort is the port of the metadata server. This,
+                      combined with global.MetadataAddr (if not ''None''), is used to
+                      set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                      In most cases this should not need to be changed [Default: 8775].'
+                    type: integer
+                  mtuIfacePattern:
+                    description: MTUIfacePattern is a regular expression that controls
+                      which interfaces Felix should scan in order to calculate the host's
+                      MTU. This should not match workload interfaces (usually named cali...).
+                    type: string
+                  natOutgoingAddress:
+                    description: NATOutgoingAddress specifies an address to use when performing
+                      source NAT for traffic in a natOutgoing pool that is leaving the
+                      network. By default the address used is an address on the interface
+                      the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                    type: string
+                  natPortRange:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NATPortRange specifies the range of ports that is used
+                      for port mapping when doing outgoing NAT. When unset the default
+                      behavior of the network stack is used.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  netlinkTimeout:
+                    type: string
+                  openstackRegion:
+                    description: 'OpenstackRegion is the name of the region that a particular
+                      Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                      this must be configured somehow for each Felix (here in the datamodel,
+                      or in felix.cfg or the environment on each compute node), and must
+                      match the [calico] openstack_region value configured in neutron.conf
+                      on each node. [Default: Empty]'
+                    type: string
+                  policySyncPathPrefix:
+                    description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                      policy changes to external services, like Application layer policy.
+                      [Default: Empty]'
+                    type: string
+                  prometheusGoMetricsEnabled:
+                    description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusMetricsEnabled:
+                    description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                      server in Felix if set to true. [Default: false]'
+                    type: boolean
+                  prometheusMetricsHost:
+                    description: 'PrometheusMetricsHost is the host that the Prometheus
+                      metrics server should bind to. [Default: empty]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. [Default: 9091]'
+                    type: integer
+                  prometheusProcessMetricsEnabled:
+                    description: 'PrometheusProcessMetricsEnabled disables process metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusWireGuardMetricsEnabled:
+                    description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                      metrics collection, which the Prometheus client does by default,
+                      when set to false. This reduces the number of metrics reported,
+                      reducing Prometheus load. [Default: true]'
+                    type: boolean
+                  removeExternalRoutes:
+                    description: Whether or not to remove device routes that have not
+                      been programmed by Felix. Disabling this will allow external applications
+                      to also add device routes. This is enabled by default which means
+                      we will remove externally added routes.
+                    type: boolean
+                  reportingInterval:
+                    description: 'ReportingInterval is the interval at which Felix reports
+                      its status into the datastore or 0 to disable. Must be non-zero
+                      in OpenStack deployments. [Default: 30s]'
+                    type: string
+                  reportingTTL:
+                    description: 'ReportingTTL is the time-to-live setting for process-wide
+                      status reports. [Default: 90s]'
+                    type: string
+                  routeRefreshInterval:
+                    description: 'RouteRefreshInterval is the period at which Felix re-checks
+                      the routes in the dataplane to ensure that no other process has
+                      accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                      [Default: 90s]'
+                    type: string
+                  routeSource:
+                    description: 'RouteSource configures where Felix gets its routing
+                      information. - WorkloadIPs: use workload endpoints to construct
+                      routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                    type: string
+                  routeTableRange:
+                    description: Calico programs additional Linux route tables for various
+                      purposes.  RouteTableRange specifies the indices of the route tables
+                      that Calico should use.
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                    - max
+                    - min
+                    type: object
+                  serviceLoopPrevention:
+                    description: 'When service IP advertisement is enabled, prevent routing
+                      loops to service IPs that are not in use, by dropping or rejecting
+                      packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                      in which case such routing loops continue to be allowed. [Default:
+                      Drop]'
+                    type: string
+                  sidecarAccelerationEnabled:
+                    description: 'SidecarAccelerationEnabled enables experimental sidecar
+                      acceleration [Default: false]'
+                    type: boolean
+                  usageReportingEnabled:
+                    description: 'UsageReportingEnabled reports anonymous Calico version
+                      number and cluster size to projectcalico.org. Logs warnings returned
+                      by the usage server. For example, if a significant security vulnerability
+                      has been discovered in the version of Calico being used. [Default:
+                      true]'
+                    type: boolean
+                  usageReportingInitialDelay:
+                    description: 'UsageReportingInitialDelay controls the minimum delay
+                      before Felix makes a report. [Default: 300s]'
+                    type: string
+                  usageReportingInterval:
+                    description: 'UsageReportingInterval controls the interval at which
+                      Felix makes reports. [Default: 86400s]'
+                    type: string
+                  useInternalDataplaneDriver:
+                    type: boolean
+                  vxlanEnabled:
+                    type: boolean
+                  vxlanMTU:
+                    description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  vxlanPort:
+                    type: integer
+                  vxlanVNI:
+                    type: integer
+                  wireguardEnabled:
+                    description: 'WireguardEnabled controls whether Wireguard is enabled.
+                      [Default: false]'
+                    type: boolean
+                  wireguardHostEncryptionEnabled:
+                    description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                      host-to-host encryption is enabled. [Default: false]'
+                    type: boolean
+                  wireguardInterfaceName:
+                    description: 'WireguardInterfaceName specifies the name to use for
+                      the Wireguard interface. [Default: wg.calico]'
+                    type: string
+                  wireguardListeningPort:
+                    description: 'WireguardListeningPort controls the listening port used
+                      by Wireguard. [Default: 51820]'
+                    type: integer
+                  wireguardMTU:
+                    description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                      See Configuring MTU [Default: 1420]'
+                    type: integer
+                  wireguardRoutingRulePriority:
+                    description: 'WireguardRoutingRulePriority controls the priority value
+                      to use for the Wireguard routing rule. [Default: 99]'
+                    type: integer
+                  xdpEnabled:
+                    description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                      incoming deny rules. [Default: true]'
+                    type: boolean
+                  xdpRefreshInterval:
+                    description: 'XDPRefreshInterval is the period at which Felix re-checks
+                      all XDP state to ensure that no other process has accidentally broken
+                      Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                      refresh. [Default: 90s]'
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkPolicy
+        listKind: GlobalNetworkPolicyList
+        plural: globalnetworkpolicies
+        singular: globalnetworkpolicy
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  applyOnForward:
+                    description: ApplyOnForward indicates to apply the rules in this policy
+                      on forward traffic.
+                    type: boolean
+                  doNotTrack:
+                    description: DoNotTrack indicates whether packets matched by the rules
+                      in this policy should go through the data plane's connection tracking,
+                      such as Linux conntrack.  If True, the rules in this policy are
+                      applied before any data plane connection tracking, and packets allowed
+                      by this policy are marked as not to be tracked.
+                    type: boolean
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    description: NamespaceSelector is an optional field for an expression
+                      used to select a pod based on namespaces.
+                    type: string
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  preDNAT:
+                    description: PreDNAT indicates to apply the rules in this policy before
+                      any DNAT.
+                    type: boolean
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress rules are present in the policy.  The
+                      default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                      (including the case where there are   also no Ingress rules) \n
+                      - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                      rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                      both Ingress and Egress rules. \n When the policy is read back again,
+                      Types will always be one of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkSet
+        listKind: GlobalNetworkSetList
+        plural: globalnetworksets
+        singular: globalnetworkset
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+              that share labels to allow rules to refer to them via selectors.  The labels
+              of GlobalNetworkSet are not namespaced.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: hostendpoints.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: HostEndpoint
+        listKind: HostEndpointList
+        plural: hostendpoints
+        singular: hostendpoint
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: HostEndpointSpec contains the specification for a HostEndpoint
+                  resource.
+                properties:
+                  expectedIPs:
+                    description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                      If \"InterfaceName\" is not present, Calico will look for an interface
+                      matching any of the IPs in the list and apply policy to that. Note:
+                      \tWhen using the selector match criteria in an ingress or egress
+                      security Policy \tor Profile, Calico converts the selector into
+                      a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                      is used for that purpose. (If only the interface \tname is specified,
+                      Calico does not learn the IPs of the interface for use in match
+                      \tcriteria.)"
+                    items:
+                      type: string
+                    type: array
+                  interfaceName:
+                    description: "Either \"*\", or the name of a specific Linux interface
+                      to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                      governs all traffic to, from or through the default network namespace
+                      of the host named by the \"Node\" field; entering and leaving that
+                      namespace via any interface, including those from/to non-host-networked
+                      local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                      only governs traffic that enters or leaves the host through the
+                      specific interface named by InterfaceName, or - when InterfaceName
+                      is empty - through the specific interface that has one of the IPs
+                      in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                      one expected IP must be specified.  Only external interfaces (such
+                      as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                      to protect traffic through a specific local workload interface.
+                      \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                      initially just pre-DNAT policy.  Please check Calico documentation
+                      for the latest position."
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance.
+                    type: string
+                  ports:
+                    description: Ports contains the endpoint's named ports, which may
+                      be referenced in security policy rules.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  profiles:
+                    description: A list of identifiers of security Profile objects that
+                      apply to this endpoint. Each profile is applied in the order that
+                      they appear in this list.  Profile rules are applied after the selector-based
+                      security policy.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamblocks.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMBlock
+        listKind: IPAMBlockList
+        plural: ipamblocks
+        singular: ipamblock
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMBlockSpec contains the specification for an IPAMBlock
+                  resource.
+                properties:
+                  affinity:
+                    type: string
+                  allocations:
+                    items:
+                      nullable: true
+                      type: integer
+                    type: array
+                  attributes:
+                    items:
+                      properties:
+                        handle_id:
+                          type: string
+                        secondary:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    type: array
+                  cidr:
+                    type: string
+                  deleted:
+                    type: boolean
+                  strictAffinity:
+                    type: boolean
+                  unallocated:
+                    items:
+                      type: integer
+                    type: array
+                required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamconfigs.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMConfig
+        listKind: IPAMConfigList
+        plural: ipamconfigs
+        singular: ipamconfig
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMConfigSpec contains the specification for an IPAMConfig
+                  resource.
+                properties:
+                  autoAllocateBlocks:
+                    type: boolean
+                  maxBlocksPerHost:
+                    description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                      that can be affine to each host.
+                    type: integer
+                  strictAffinity:
+                    type: boolean
+                required:
+                - autoAllocateBlocks
+                - strictAffinity
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamhandles.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMHandle
+        listKind: IPAMHandleList
+        plural: ipamhandles
+        singular: ipamhandle
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMHandleSpec contains the specification for an IPAMHandle
+                  resource.
+                properties:
+                  block:
+                    additionalProperties:
+                      type: integer
+                    type: object
+                  deleted:
+                    type: boolean
+                  handleID:
+                    type: string
+                required:
+                - block
+                - handleID
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ippools.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPPool
+        listKind: IPPoolList
+        plural: ippools
+        singular: ippool
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPPoolSpec contains the specification for an IPPool resource.
+                properties:
+                  blockSize:
+                    description: The block size to use for IP address assignments from
+                      this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                    type: integer
+                  cidr:
+                    description: The pool CIDR.
+                    type: string
+                  disabled:
+                    description: When disabled is true, Calico IPAM will not assign addresses
+                      from this pool.
+                    type: boolean
+                  ipip:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    properties:
+                      enabled:
+                        description: When enabled is true, ipip tunneling will be used
+                          to deliver packets to destinations within this pool.
+                        type: boolean
+                      mode:
+                        description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                          mode of "always" will also use IPIP tunneling for routing to
+                          destination IP addresses within this pool.  A mode of "cross-subnet"
+                          will only use IPIP tunneling when the destination node is on
+                          a different subnet to the originating node.  The default value
+                          (if not specified) is "always".
+                        type: string
+                    type: object
+                  ipipMode:
+                    description: Contains configuration for IPIP tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                      is disabled).
+                    type: string
+                  nat-outgoing:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    type: boolean
+                  natOutgoing:
+                    description: When nat-outgoing is true, packets sent from Calico networked
+                      containers in this pool to destinations outside of this pool will
+                      be masqueraded.
+                    type: boolean
+                  nodeSelector:
+                    description: Allows IPPool to allocate for a specific node by label
+                      selector.
+                    type: string
+                  vxlanMode:
+                    description: Contains configuration for VXLAN tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                      tunneling is disabled).
+                    type: string
+                required:
+                - cidr
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubecontrollersconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: KubeControllersConfiguration
+        listKind: KubeControllersConfigurationList
+        plural: kubecontrollersconfigurations
+        singular: kubecontrollersconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeControllersConfigurationSpec contains the values of the
+                  Kubernetes controllers configuration.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host endpoints.
+                              Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation of
+                                  host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the controller
+                              to determine if an IP address has been leaked. Set to 0
+                              to disable IP garbage collection. [Default: 15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+              status:
+                description: KubeControllersConfigurationStatus represents the status
+                  of the configuration. It's useful for admins to be able to see the actual
+                  config that was applied, which can be modified by environment variables
+                  on the kube-controllers process.
+                properties:
+                  environmentVars:
+                    additionalProperties:
+                      type: string
+                    description: EnvironmentVars contains the environment variables on
+                      the kube-controllers that influenced the RunningConfig.
+                    type: object
+                  runningConfig:
+                    description: RunningConfig contains the effective config that is running
+                      in the kube-controllers pod, after merging the API resource with
+                      any environment variables.
+                    properties:
+                      controllers:
+                        description: Controllers enables and configures individual Kubernetes
+                          controllers
+                        properties:
+                          namespace:
+                            description: Namespace enables and configures the namespace
+                              controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          node:
+                            description: Node enables and configures the node controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              hostEndpoint:
+                                description: HostEndpoint controls syncing nodes to host
+                                  endpoints. Disabled by default, set to nil to disable.
+                                properties:
+                                  autoCreate:
+                                    description: 'AutoCreate enables automatic creation
+                                      of host endpoints for every node. [Default: Disabled]'
+                                    type: string
+                                type: object
+                              leakGracePeriod:
+                                description: 'LeakGracePeriod is the period used by the
+                                  controller to determine if an IP address has been leaked.
+                                  Set to 0 to disable IP garbage collection. [Default:
+                                  15m]'
+                                type: string
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                              syncLabels:
+                                description: 'SyncLabels controls whether to copy Kubernetes
+                                  node labels to Calico nodes. [Default: Enabled]'
+                                type: string
+                            type: object
+                          policy:
+                            description: Policy enables and configures the policy controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          serviceAccount:
+                            description: ServiceAccount enables and configures the service
+                              account controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          workloadEndpoint:
+                            description: WorkloadEndpoint enables and configures the workload
+                              endpoint controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                        type: object
+                      etcdV3CompactionPeriod:
+                        description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                          compaction requests. Set to 0 to disable. [Default: 10m]'
+                        type: string
+                      healthChecks:
+                        description: 'HealthChecks enables or disables support for health
+                          checks [Default: Enabled]'
+                        type: string
+                      logSeverityScreen:
+                        description: 'LogSeverityScreen is the log severity above which
+                          logs are sent to the stdout. [Default: Info]'
+                        type: string
+                      prometheusMetricsPort:
+                        description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                          metrics server should bind to. Set to 0 to disable. [Default:
+                          9094]'
+                        type: integer
+                    required:
+                    - controllers
+                    type: object
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkPolicy
+        listKind: NetworkPolicyList
+        plural: networkpolicies
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress are present in the policy.  The default
+                      is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                      the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                      ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                      PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                      \n When the policy is read back again, Types will always be one
+                      of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkSet
+        listKind: NetworkSetList
+        plural: networksets
+        singular: networkset
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: NetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-kube-controllers
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      verbs:
+      - list
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - hostendpoints
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - clusterinformations
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - kubecontrollersconfigurations
+      verbs:
+      - get
+      - create
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-node
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - namespaces
+      verbs:
+      - get
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - patch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - bgpconfigurations
+      - bgppeers
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ipamconfigs
+      verbs:
+      - get
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      verbs:
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - daemonsets
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-kube-controllers
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      calico_backend: vxlan
+      cni_network_config: |-
+        {
+          "name": "k8s-pod-network",
+          "cniVersion": "0.3.1",
+          "plugins": [
+            {
+              "type": "calico",
+              "log_level": "info",
+              "log_file_path": "/var/log/calico/cni/cni.log",
+              "datastore_type": "kubernetes",
+              "nodename": "__KUBERNETES_NODE_NAME__",
+              "mtu": __CNI_MTU__,
+              "ipam": {
+                  "type": "calico-ipam"
+              },
+              "policy": {
+                  "type": "k8s"
+              },
+              "kubernetes": {
+                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              }
+            },
+            {
+              "type": "portmap",
+              "snat": true,
+              "capabilities": {"portMappings": true}
+            },
+            {
+              "type": "bandwidth",
+              "capabilities": {"bandwidth": true}
+            }
+          ]
+        }
+      typha_service_name: none
+      veth_mtu: "1350"
+    kind: ConfigMap
+    metadata:
+      name: calico-config
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-kube-controllers
+          name: calico-kube-controllers
+          namespace: kube-system
+        spec:
+          containers:
+          - env:
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            image: docker.io/calico/kube-controllers:v3.20.3
+            livenessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -l
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-kube-controllers
+            readinessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -r
+              periodSeconds: 10
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: calico-kube-controllers
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: calico-node
+      name: calico-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+        spec:
+          containers:
+          - env:
+            - name: FELIX_FEATUREDETECTOVERRIDE
+              value: ChecksumOffloadBroken=true
+            - name: CALICO_IPV4POOL_VXLAN
+              value: Always
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            - name: CLUSTER_TYPE
+              value: k8s,bgp
+            - name: IP
+              value: autodetect
+            - name: CALICO_IPV4POOL_IPIP
+              value: Never
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_WIREGUARDMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_AWSSRCDSTCHECK
+              value: Disable
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: ACCEPT
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/node:v3.20.3
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -shutdown
+            livenessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-live
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-node
+            readinessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-ready
+              periodSeconds: 10
+              timeoutSeconds: 10
+            resources:
+              requests:
+                cpu: 250m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /var/run/nodeagent
+              name: policysync
+            - mountPath: /sys/fs/
+              mountPropagation: Bidirectional
+              name: sysfs
+            - mountPath: /var/log/calico/cni
+              name: cni-log-dir
+              readOnly: true
+          hostNetwork: true
+          initContainers:
+          - command:
+            - /opt/cni/bin/calico-ipam
+            - -upgrade
+            env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: upgrade-ipam
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          - command:
+            - /opt/cni/bin/install
+            env:
+            - name: CNI_CONF_NAME
+              value: 10-calico.conflist
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  key: cni_network_config
+                  name: calico-config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: SLEEP
+              value: "false"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: install-cni
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+            name: flexvol-driver
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/driver
+              name: flexvol-driver-host
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: calico-node
+          terminationGracePeriodSeconds: 0
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /lib/modules
+            name: lib-modules
+          - hostPath:
+              path: /var/run/calico
+            name: var-run-calico
+          - hostPath:
+              path: /var/lib/calico
+            name: var-lib-calico
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+          - hostPath:
+              path: /sys/fs/
+              type: DirectoryOrCreate
+            name: sysfs
+          - hostPath:
+              path: /opt/cni/bin
+            name: cni-bin-dir
+          - hostPath:
+              path: /etc/cni/net.d
+            name: cni-net-dir
+          - hostPath:
+              path: /var/log/calico/cni
+            name: cni-log-dir
+          - hostPath:
+              path: /var/lib/cni/networks
+            name: host-local-net-dir
+          - hostPath:
+              path: /var/run/nodeagent
+              type: DirectoryOrCreate
+            name: policysync
+          - hostPath:
+              path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+              type: DirectoryOrCreate
+            name: flexvol-driver-host
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
@@ -584,2440 +584,3985 @@ spec:
 ---
 apiVersion: v1
 data:
-  resources: "---\n# Source: calico/templates/calico-config.yaml\n# This ConfigMap
-    is used to configure a self-hosted Calico installation.\nkind: ConfigMap\napiVersion:
-    v1\nmetadata:\n  name: calico-config\n  namespace: kube-system\ndata:\n  # Typha
-    is disabled.\n  typha_service_name: \"none\"\n  # Configure the backend to use.\n
-    \ calico_backend: \"vxlan\"\n  # On Azure, the underlying network has an MTU of
-    1400, even though the network interface will have an MTU of 1500.\n  # We set
-    this value to 1350 for “physical network MTU size minus 50” since we use VXLAN,
-    which uses a 50-byte header.\n  # If enabling Wireguard, this value should be
-    changed to 1340 (Wireguard uses a 60-byte header).\n  # https://docs.projectcalico.org/networking/mtu#determine-mtu-size\n
-    \ veth_mtu: \"1350\"\n  \n  # The CNI network configuration to install on each
-    node. The special\n  # values in this config will be automatically populated.\n
-    \ cni_network_config: |-\n    {\n      \"name\": \"k8s-pod-network\",\n      \"cniVersion\":
-    \"0.3.1\",\n      \"plugins\": [\n        {\n          \"type\": \"calico\",\n
-    \         \"log_level\": \"info\",\n          \"log_file_path\": \"/var/log/calico/cni/cni.log\",\n
-    \         \"datastore_type\": \"kubernetes\",\n          \"nodename\": \"__KUBERNETES_NODE_NAME__\",\n
-    \         \"mtu\": __CNI_MTU__,\n          \"ipam\": {\n              \"type\":
-    \"calico-ipam\"\n          },\n          \"policy\": {\n              \"type\":
-    \"k8s\"\n          },\n          \"kubernetes\": {\n              \"kubeconfig\":
-    \"__KUBECONFIG_FILEPATH__\"\n          }\n        },\n        {\n          \"type\":
-    \"portmap\",\n          \"snat\": true,\n          \"capabilities\": {\"portMappings\":
-    true}\n        },\n        {\n          \"type\": \"bandwidth\",\n          \"capabilities\":
-    {\"bandwidth\": true}\n        }\n      ]\n    }\n\n---\n# Source: calico/templates/kdd-crds.yaml\n\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: bgpconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPConfiguration\n    listKind: BGPConfigurationList\n    plural:
-    bgpconfigurations\n    singular: bgpconfiguration\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    BGPConfiguration contains the configuration for any BGP routing.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPConfigurationSpec contains the
-    values of the BGP configuration.\n              properties:\n                asNumber:\n
-    \                 description: 'ASNumber is the default AS number used by a node.
-    [Default:\n                  64512]'\n                  format: int32\n                  type:
-    integer\n                communities:\n                  description: Communities
-    is a list of BGP community values and their\n                    arbitrary names
-    for tagging routes.\n                  items:\n                    description:
-    Community contains standard or large community value\n                      and
-    its name.\n                    properties:\n                      name:\n                        description:
-    Name given to community value.\n                        type: string\n                      value:\n
-    \                       description: Value must be of format `aa:nn` or `aa:nn:mm`.\n
-    \                         For standard community use `aa:nn` format, where `aa`
-    and\n                          `nn` are 16 bit number. For large community use
-    `aa:nn:mm`\n                          format, where `aa`, `nn` and `mm` are 32
-    bit number. Where,\n                          `aa` is an AS Number, `nn` and `mm`
-    are per-AS identifier.\n                        pattern: ^(\\d+):(\\d+)$|^(\\d+):(\\d+):(\\d+)$\n
-    \                       type: string\n                    type: object\n                  type:
-    array\n                listenPort:\n                  description: ListenPort
-    is the port where BGP protocol should listen.\n                    Defaults to
-    179\n                  maximum: 65535\n                  minimum: 1\n                  type:
-    integer\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: INFO]'\n                  type: string\n                nodeToNodeMeshEnabled:\n
-    \                 description: 'NodeToNodeMeshEnabled sets whether full node to
-    node\n                  BGP mesh is enabled. [Default: true]'\n                  type:
-    boolean\n                prefixAdvertisements:\n                  description:
-    PrefixAdvertisements contains per-prefix advertisement\n                    configuration.\n
-    \                 items:\n                    description: PrefixAdvertisement
-    configures advertisement properties\n                      for the specified CIDR.\n
-    \                   properties:\n                      cidr:\n                        description:
-    CIDR for which properties should be advertised.\n                        type:
-    string\n                      communities:\n                        description:
-    Communities can be list of either community names\n                          already
-    defined in `Specs.Communities` or community value\n                          of
-    format `aa:nn` or `aa:nn:mm`. For standard community use\n                          `aa:nn`
-    format, where `aa` and `nn` are 16 bit number. For\n                          large
-    community use `aa:nn:mm` format, where `aa`, `nn` and\n                          `mm`
-    are 32 bit number. Where,`aa` is an AS Number, `nn` and\n                          `mm`
-    are per-AS identifier.\n                        items:\n                          type:
-    string\n                        type: array\n                    type: object\n
-    \                 type: array\n                serviceClusterIPs:\n                  description:
-    ServiceClusterIPs are the CIDR blocks from which service\n                    cluster
-    IPs are allocated. If specified, Calico will advertise these\n                    blocks,
-    as well as any cluster IPs within them.\n                  items:\n                    description:
-    ServiceClusterIPBlock represents a single allowed ClusterIP\n                      CIDR
-    block.\n                    properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n                serviceExternalIPs:\n
-    \                 description: ServiceExternalIPs are the CIDR blocks for Kubernetes\n
-    \                   Service External IPs. Kubernetes Service ExternalIPs will
-    only be\n                    advertised if they are within one of these blocks.\n
-    \                 items:\n                    description: ServiceExternalIPBlock
-    represents a single allowed\n                      External IP CIDR block.\n                    properties:\n
-    \                     cidr:\n                        type: string\n                    type:
-    object\n                  type: array\n                serviceLoadBalancerIPs:\n
-    \                 description: ServiceLoadBalancerIPs are the CIDR blocks for
-    Kubernetes\n                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress\n
-    \                   IPs will only be advertised if they are within one of these
-    blocks.\n                  items:\n                    description: ServiceLoadBalancerIPBlock
-    represents a single allowed\n                      LoadBalancer IP CIDR block.\n
-    \                   properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: bgppeers.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPPeer\n    listKind: BGPPeerList\n    plural: bgppeers\n
-    \   singular: bgppeer\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPPeerSpec contains the specification
-    for a BGPPeer resource.\n              properties:\n                asNumber:\n
-    \                 description: The AS Number of the peer.\n                  format:
-    int32\n                  type: integer\n                keepOriginalNextHop:\n
-    \                 description: Option to keep the original nexthop field when
-    routes\n                    are sent to a BGP Peer. Setting \"true\" configures
-    the selected BGP\n                    Peers node to use the \"next hop keep;\"
-    instead of \"next hop self;\"(default)\n                    in the specific branch
-    of the Node on \"bird.cfg\".\n                  type: boolean\n                maxRestartTime:\n
-    \                 description: Time to allow for software restart.  When specified,
-    this\n                    is configured as the graceful restart timeout.  When
-    not specified,\n                    the BIRD default of 120s is used.\n                  type:
-    string\n                node:\n                  description: The node name identifying
-    the Calico node instance that\n                    is targeted by this peer. If
-    this is not set, and no nodeSelector\n                    is specified, then this
-    BGP peer selects all nodes in the cluster.\n                  type: string\n                nodeSelector:\n
-    \                 description: Selector for the nodes that should have this peering.
-    \ When\n                    this is set, the Node field must be empty.\n                  type:
-    string\n                password:\n                  description: Optional BGP
-    password for the peerings generated by this\n                    BGPPeer resource.\n
-    \                 properties:\n                    secretKeyRef:\n                      description:
-    Selects a key of a secret in the node pod's namespace.\n                      properties:\n
-    \                       key:\n                          description: The key of
-    the secret to select from.  Must be\n                            a valid secret
-    key.\n                          type: string\n                        name:\n
-    \                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n
-    \                         TODO: Add other useful fields. apiVersion, kind, uid?'\n
-    \                         type: string\n                        optional:\n                          description:
-    Specify whether the Secret or its key must be\n                            defined\n
-    \                         type: boolean\n                      required:\n                        -
-    key\n                      type: object\n                  type: object\n                peerIP:\n
-    \                 description: The IP address of the peer followed by an optional
-    port\n                    number to peer with. If port number is given, format
-    should be `[<IPv6>]:port`\n                    or `<IPv4>:<port>` for IPv4. If
-    optional port number is not set,\n                    and this peer IP and ASNumber
-    belongs to a calico/node with ListenPort\n                    set in BGPConfiguration,
-    then we use that port to peer.\n                  type: string\n                peerSelector:\n
-    \                 description: Selector for the remote nodes to peer with.  When
-    this\n                    is set, the PeerIP and ASNumber fields must be empty.
-    \ For each\n                    peering between the local node and selected remote
-    nodes, we configure\n                    an IPv4 peering if both ends have NodeBGPSpec.IPv4Address
-    specified,\n                    and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address
-    specified.  The\n                    remote AS number comes from the remote node’s
-    NodeBGPSpec.ASNumber,\n                    or the global default if that is not
-    set.\n                  type: string\n                sourceAddress:\n                  description:
-    Specifies whether and how to configure a source address\n                    for
-    the peerings generated by this BGPPeer resource.  Default value\n                    \"UseNodeIP\"
-    means to configure the node IP as the source address.  \"None\"\n                    means
-    not to configure a source address.\n                  type: string\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: blockaffinities.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BlockAffinity\n    listKind: BlockAffinityList\n    plural:
-    blockaffinities\n    singular: blockaffinity\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BlockAffinitySpec contains the specification
-    for a BlockAffinity\n                resource.\n              properties:\n                cidr:\n
-    \                 type: string\n                deleted:\n                  description:
-    Deleted indicates that this block affinity is being deleted.\n                    This
-    field is a string for compatibility with older releases that\n                    mistakenly
-    treat this field as a string.\n                  type: string\n                node:\n
-    \                 type: string\n                state:\n                  type:
-    string\n              required:\n                - cidr\n                - deleted\n
-    \               - node\n                - state\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: clusterinformations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: ClusterInformation\n    listKind: ClusterInformationList\n
-    \   plural: clusterinformations\n    singular: clusterinformation\n  scope: Cluster\n
-    \ versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    ClusterInformation contains the cluster specific information.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: ClusterInformationSpec contains
-    the values of describing\n                the cluster.\n              properties:\n
-    \               calicoVersion:\n                  description: CalicoVersion is
-    the version of Calico that the cluster\n                    is running\n                  type:
-    string\n                clusterGUID:\n                  description: ClusterGUID
-    is the GUID of the cluster\n                  type: string\n                clusterType:\n
-    \                 description: ClusterType describes the type of the cluster\n
-    \                 type: string\n                datastoreReady:\n                  description:
-    DatastoreReady is used during significant datastore migrations\n                    to
-    signal to components such as Felix that it should wait before\n                    accessing
-    the datastore.\n                  type: boolean\n                variant:\n                  description:
-    Variant declares which variant of Calico should be active.\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: felixconfigurations.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: FelixConfiguration\n    listKind:
-    FelixConfigurationList\n    plural: felixconfigurations\n    singular: felixconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         description: Felix Configuration contains the configuration for Felix.\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: FelixConfigurationSpec contains
-    the values of the Felix configuration.\n              properties:\n                allowIPIPPacketsFromWorkloads:\n
-    \                 description: 'AllowIPIPPacketsFromWorkloads controls whether
-    Felix\n                  will add a rule to drop IPIP encapsulated traffic from
-    workloads\n                  [Default: false]'\n                  type: boolean\n
-    \               allowVXLANPacketsFromWorkloads:\n                  description:
-    'AllowVXLANPacketsFromWorkloads controls whether Felix\n                  will
-    add a rule to drop VXLAN encapsulated traffic from workloads\n                  [Default:
-    false]'\n                  type: boolean\n                awsSrcDstCheck:\n                  description:
-    'Set source-destination-check on AWS EC2 instances. Accepted\n                  value
-    must be one of \"DoNothing\", \"Enabled\" or \"Disabled\". [Default:\n                  DoNothing]'\n
-    \                 enum:\n                    - DoNothing\n                    -
-    Enable\n                    - Disable\n                  type: string\n                bpfConnectTimeLoadBalancingEnabled:\n
-    \                 description: 'BPFConnectTimeLoadBalancingEnabled when in BPF
-    mode,\n                  controls whether Felix installs the connection-time load
-    balancer.  The\n                  connect-time load balancer is required for the
-    host to be able to\n                  reach Kubernetes services and it improves
-    the performance of pod-to-service\n                  connections.  The only reason
-    to disable it is for debugging purposes.  [Default:\n                  true]'\n
-    \                 type: boolean\n                bpfDataIfacePattern:\n                  description:
-    'BPFDataIfacePattern is a regular expression that controls\n                  which
-    interfaces Felix should attach BPF programs to in order to\n                  catch
-    traffic to/from the network.  This needs to match the interfaces\n                  that
-    Calico workload traffic flows over as well as any interfaces\n                  that
-    handle incoming traffic to nodeports and services from outside\n                  the
-    cluster.  It should not match the workload interfaces (usually\n                  named
-    cali...). [Default: ^(en.*|eth.*|tunl0$)]'\n                  type: string\n                bpfDisableUnprivileged:\n
-    \                 description: 'BPFDisableUnprivileged, if enabled, Felix sets
-    the kernel.unprivileged_bpf_disabled\n                  sysctl to disable unprivileged
-    use of BPF.  This ensures that unprivileged\n                  users cannot access
-    Calico''s BPF maps and cannot insert their own\n                  BPF programs
-    to interfere with Calico''s. [Default: true]'\n                  type: boolean\n
-    \               bpfEnabled:\n                  description: 'BPFEnabled, if enabled
-    Felix will use the BPF dataplane.\n                  [Default: false]'\n                  type:
-    boolean\n                bpfExtToServiceConnmark:\n                  description:
-    'BPFExtToServiceConnmark in BPF mode, control a 32bit\n                    mark
-    that is set on connections from an external client to a local\n                    service.
-    This mark allows us to control how packets of that connection\n                    are
-    routed within the host and how is routing intepreted by RPF\n                    check.
-    [Default: 0]'\n                  type: integer\n                bpfExternalServiceMode:\n
-    \                 description: 'BPFExternalServiceMode in BPF mode, controls how
-    connections\n                  from outside the cluster to services (node ports
-    and cluster IPs)\n                  are forwarded to remote workloads.  If set
-    to \"Tunnel\" then both\n                  request and response traffic is tunneled
-    to the remote node.  If\n                  set to \"DSR\", the request traffic
-    is tunneled but the response traffic\n                  is sent directly from
-    the remote node.  In \"DSR\" mode, the remote\n                  node appears
-    to use the IP of the ingress node; this requires a\n                  permissive
-    L2 network.  [Default: Tunnel]'\n                  type: string\n                bpfKubeProxyEndpointSlicesEnabled:\n
-    \                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode,
-    controls\n                    whether Felix's embedded kube-proxy accepts EndpointSlices
-    or not.\n                  type: boolean\n                bpfKubeProxyIptablesCleanupEnabled:\n
-    \                 description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled
-    in BPF\n                  mode, Felix will proactively clean up the upstream Kubernetes
-    kube-proxy''s\n                  iptables chains.  Should only be enabled if kube-proxy
-    is not running.  [Default:\n                  true]'\n                  type:
-    boolean\n                bpfKubeProxyMinSyncPeriod:\n                  description:
-    'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the\n                  minimum
-    time between updates to the dataplane for Felix''s embedded\n                  kube-proxy.
-    \ Lower values give reduced set-up latency.  Higher values\n                  reduce
-    Felix CPU usage by batching up more work.  [Default: 1s]'\n                  type:
-    string\n                bpfLogLevel:\n                  description: 'BPFLogLevel
-    controls the log level of the BPF programs\n                  when in BPF dataplane
-    mode.  One of \"Off\", \"Info\", or \"Debug\".  The\n                  logs are
-    emitted to the BPF trace pipe, accessible with the command\n                  `tc
-    exec bpf debug`. [Default: Off].'\n                  type: string\n                chainInsertMode:\n
-    \                 description: 'ChainInsertMode controls whether Felix hooks the
-    kernel’s\n                  top-level iptables chains by inserting a rule at the
-    top of the\n                  chain or by appending a rule at the bottom. insert
-    is the safe default\n                  since it prevents Calico’s rules from being
-    bypassed. If you switch\n                  to append mode, be sure that the other
-    rules in the chains signal\n                  acceptance by falling through to
-    the Calico rules, otherwise the\n                  Calico policy will be bypassed.
-    [Default: insert]'\n                  type: string\n                dataplaneDriver:\n
-    \                 type: string\n                debugDisableLogDropping:\n                  type:
-    boolean\n                debugMemoryProfilePath:\n                  type: string\n
-    \               debugSimulateCalcGraphHangAfter:\n                  type: string\n
-    \               debugSimulateDataplaneHangAfter:\n                  type: string\n
-    \               defaultEndpointToHostAction:\n                  description: 'DefaultEndpointToHostAction
-    controls what happens to\n                  traffic that goes from a workload
-    endpoint to the host itself (after\n                  the traffic hits the endpoint
-    egress policy). By default Calico\n                  blocks traffic from workload
-    endpoints to the host itself with an\n                  iptables “DROP” action.
-    If you want to allow some or all traffic\n                  from endpoint to host,
-    set this parameter to RETURN or ACCEPT. Use\n                  RETURN if you have
-    your own rules in the iptables “INPUT” chain;\n                  Calico will insert
-    its rules at the top of that chain, then “RETURN”\n                  packets to
-    the “INPUT” chain once it has completed processing workload\n                  endpoint
-    egress policy. Use ACCEPT to unconditionally accept packets\n                  from
-    workloads after processing workload endpoint egress policy.\n                  [Default:
-    Drop]'\n                  type: string\n                deviceRouteProtocol:\n
-    \                 description: This defines the route protocol added to programmed
-    device\n                    routes, by default this will be RTPROT_BOOT when left
-    blank.\n                  type: integer\n                deviceRouteSourceAddress:\n
-    \                 description: This is the source address to use on programmed
-    device\n                    routes. By default the source address is left blank,
-    leaving the\n                    kernel to choose the source address used.\n                  type:
-    string\n                disableConntrackInvalidCheck:\n                  type:
-    boolean\n                endpointReportingDelay:\n                  type: string\n
-    \               endpointReportingEnabled:\n                  type: boolean\n                externalNodesList:\n
-    \                 description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes\n
-    \                   which may source tunnel traffic and have the tunneled traffic
-    be\n                    accepted at calico nodes.\n                  items:\n
-    \                   type: string\n                  type: array\n                failsafeInboundHostPorts:\n
-    \                 description: 'FailsafeInboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow incoming traffic to
-    host endpoints\n                    on irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    inbound host ports, use the value\n                    none. The default value
-    allows ssh access and DHCP. [Default: tcp:22,\n                    udp:68, tcp:179,
-    tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'\n                  items:\n
-    \                   description: ProtoPort is combination of protocol, port, and
-    CIDR.\n                      Protocol and port must be specified.\n                    properties:\n
-    \                     net:\n                        type: string\n                      port:\n
-    \                       type: integer\n                      protocol:\n                        type:
-    string\n                    required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                failsafeOutboundHostPorts:\n
-    \                 description: 'FailsafeOutboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow outgoing traffic from
-    host endpoints\n                    to irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    outbound host ports, use the value\n                    none. The default value
-    opens etcd''s standard ports to ensure that\n                    Felix does not
-    get cut off from etcd as well as allowing DHCP and\n                    DNS. [Default:
-    tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,\n                    tcp:6667,
-    udp:53, udp:67]'\n                  items:\n                    description: ProtoPort
-    is combination of protocol, port, and CIDR.\n                      Protocol and
-    port must be specified.\n                    properties:\n                      net:\n
-    \                       type: string\n                      port:\n                        type:
-    integer\n                      protocol:\n                        type: string\n
-    \                   required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                featureDetectOverride:\n
-    \                 description: FeatureDetectOverride is used to override the feature\n
-    \                   detection. Values are specified in a comma separated list
-    with no\n                    spaces, example; \"SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=\".\n
-    \                   \"true\" or \"false\" will force the feature, empty or omitted
-    values\n                    are auto-detected.\n                  type: string\n
-    \               genericXDPEnabled:\n                  description: 'GenericXDPEnabled
-    enables Generic XDP so network cards\n                  that don''t support XDP
-    offload or driver modes can use XDP. This\n                  is not recommended
-    since it doesn''t provide better performance\n                  than iptables.
-    [Default: false]'\n                  type: boolean\n                healthEnabled:\n
-    \                 type: boolean\n                healthHost:\n                  type:
-    string\n                healthPort:\n                  type: integer\n                interfaceExclude:\n
-    \                 description: 'InterfaceExclude is a comma-separated list of
-    interfaces\n                  that Felix should exclude when monitoring for host
-    endpoints. The\n                  default value ensures that Felix ignores Kubernetes''
-    IPVS dummy\n                  interface, which is used internally by kube-proxy.
-    If you want to\n                  exclude multiple interface names using a single
-    value, the list\n                  supports regular expressions. For regular expressions
-    you must wrap\n                  the value with ''/''. For example having values
-    ''/^kube/,veth1''\n                  will exclude all interfaces that begin with
-    ''kube'' and also the\n                  interface ''veth1''. [Default: kube-ipvs0]'\n
-    \                 type: string\n                interfacePrefix:\n                  description:
-    'InterfacePrefix is the interface name prefix that identifies\n                  workload
-    endpoints and so distinguishes them from host endpoint\n                  interfaces.
-    Note: in environments other than bare metal, the orchestrators\n                  configure
-    this appropriately. For example our Kubernetes and Docker\n                  integrations
-    set the ‘cali’ value, and our OpenStack integration\n                  sets the
-    ‘tap’ value. [Default: cali]'\n                  type: string\n                interfaceRefreshInterval:\n
-    \                 description: InterfaceRefreshInterval is the period at which
-    Felix\n                    rescans local interfaces to verify their state. The
-    rescan can be\n                    disabled by setting the interval to 0.\n                  type:
-    string\n                ipipEnabled:\n                  type: boolean\n                ipipMTU:\n
-    \                 description: 'IPIPMTU is the MTU to set on the tunnel device.
-    See\n                  Configuring MTU [Default: 1440]'\n                  type:
-    integer\n                ipsetsRefreshInterval:\n                  description:
-    'IpsetsRefreshInterval is the period at which Felix re-checks\n                  all
-    iptables state to ensure that no other process has accidentally\n                  broken
-    Calico’s rules. Set to 0 to disable iptables refresh. [Default:\n                  90s]'\n
-    \                 type: string\n                iptablesBackend:\n                  description:
-    IptablesBackend specifies which backend of iptables will\n                    be
-    used. The default is legacy.\n                  type: string\n                iptablesFilterAllowAction:\n
-    \                 type: string\n                iptablesLockFilePath:\n                  description:
-    'IptablesLockFilePath is the location of the iptables\n                  lock
-    file. You may need to change this if the lock file is not in\n                  its
-    standard location (for example if you have mapped it into Felix’s\n                  container
-    at a different path). [Default: /run/xtables.lock]'\n                  type: string\n
-    \               iptablesLockProbeInterval:\n                  description: 'IptablesLockProbeInterval
-    is the time that Felix will\n                  wait between attempts to acquire
-    the iptables lock if it is not\n                  available. Lower values make
-    Felix more responsive when the lock\n                  is contended, but use more
-    CPU. [Default: 50ms]'\n                  type: string\n                iptablesLockTimeout:\n
-    \                 description: 'IptablesLockTimeout is the time that Felix will
-    wait\n                  for the iptables lock, or 0, to disable. To use this feature,
-    Felix\n                  must share the iptables lock file with all other processes
-    that\n                  also take the lock. When running Felix inside a container,
-    this\n                  requires the /run directory of the host to be mounted
-    into the calico/node\n                  or calico/felix container. [Default: 0s
-    disabled]'\n                  type: string\n                iptablesMangleAllowAction:\n
-    \                 type: string\n                iptablesMarkMask:\n                  description:
-    'IptablesMarkMask is the mask that Felix selects its\n                  IPTables
-    Mark bits from. Should be a 32 bit hexadecimal number with\n                  at
-    least 8 bits set, none of which clash with any other mark bits\n                  in
-    use on the system. [Default: 0xff000000]'\n                  format: int32\n                  type:
-    integer\n                iptablesNATOutgoingInterfaceFilter:\n                  type:
-    string\n                iptablesPostWriteCheckInterval:\n                  description:
-    'IptablesPostWriteCheckInterval is the period after Felix\n                  has
-    done a write to the dataplane that it schedules an extra read\n                  back
-    in order to check the write was not clobbered by another process.\n                  This
-    should only occur if another application on the system doesn’t\n                  respect
-    the iptables lock. [Default: 1s]'\n                  type: string\n                iptablesRefreshInterval:\n
-    \                 description: 'IptablesRefreshInterval is the period at which
-    Felix\n                    re-checks the IP sets in the dataplane to ensure that
-    no other process\n                    has accidentally broken Calico''s rules.
-    Set to 0 to disable IP\n                    sets refresh. Note: the default for
-    this value is lower than the\n                    other refresh intervals as a
-    workaround for a Linux kernel bug that\n                    was fixed in kernel
-    version 4.11. If you are using v4.11 or greater\n                    you may want
-    to set this to, a higher value to reduce Felix CPU\n                    usage.
-    [Default: 10s]'\n                  type: string\n                ipv6Support:\n
-    \                 type: boolean\n                kubeNodePortRanges:\n                  description:
-    'KubeNodePortRanges holds list of port ranges used for\n                  service
-    node ports. Only used if felix detects kube-proxy running\n                  in
-    ipvs mode. Felix uses these ranges to separate host and workload\n                  traffic.
-    [Default: 30000:32767].'\n                  items:\n                    anyOf:\n
-    \                     - type: integer\n                      - type: string\n
-    \                   pattern: ^.*\n                    x-kubernetes-int-or-string:
-    true\n                  type: array\n                logFilePath:\n                  description:
-    'LogFilePath is the full path to the Felix log. Set to\n                  none
-    to disable file logging. [Default: /var/log/calico/felix.log]'\n                  type:
-    string\n                logPrefix:\n                  description: 'LogPrefix
-    is the log prefix that Felix uses when rendering\n                  LOG rules.
-    [Default: calico-packet]'\n                  type: string\n                logSeverityFile:\n
-    \                 description: 'LogSeverityFile is the log severity above which
-    logs\n                  are sent to the log file. [Default: Info]'\n                  type:
-    string\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: Info]'\n                  type: string\n                logSeveritySys:\n
-    \                 description: 'LogSeveritySys is the log severity above which
-    logs\n                  are sent to the syslog. Set to None for no logging to
-    syslog. [Default:\n                  Info]'\n                  type: string\n
-    \               maxIpsetSize:\n                  type: integer\n                metadataAddr:\n
-    \                 description: 'MetadataAddr is the IP address or domain name
-    of the\n                  server that can answer VM queries for cloud-init metadata.
-    In OpenStack,\n                  this corresponds to the machine running nova-api
-    (or in Ubuntu,\n                  nova-api-metadata). A value of none (case insensitive)
-    means that\n                  Felix should not set up any NAT rule for the metadata
-    path. [Default:\n                  127.0.0.1]'\n                  type: string\n
-    \               metadataPort:\n                  description: 'MetadataPort is
-    the port of the metadata server. This,\n                  combined with global.MetadataAddr
-    (if not ‘None’), is used to set\n                  up a NAT rule, from 169.254.169.254:80
-    to MetadataAddr:MetadataPort.\n                  In most cases this should not
-    need to be changed [Default: 8775].'\n                  type: integer\n                mtuIfacePattern:\n
-    \                 description: MTUIfacePattern is a regular expression that controls\n
-    \                   which interfaces Felix should scan in order to calculate the
-    host's\n                    MTU. This should not match workload interfaces (usually
-    named cali...).\n                  type: string\n                natOutgoingAddress:\n
-    \                 description: NATOutgoingAddress specifies an address to use
-    when performing\n                    source NAT for traffic in a natOutgoing pool
-    that is leaving the\n                    network. By default the address used
-    is an address on the interface\n                    the traffic is leaving on
-    (ie it uses the iptables MASQUERADE target)\n                  type: string\n
-    \               natPortRange:\n                  anyOf:\n                    -
-    type: integer\n                    - type: string\n                  description:
-    NATPortRange specifies the range of ports that is used\n                    for
-    port mapping when doing outgoing NAT. When unset the default\n                    behavior
-    of the network stack is used.\n                  pattern: ^.*\n                  x-kubernetes-int-or-string:
-    true\n                netlinkTimeout:\n                  type: string\n                openstackRegion:\n
-    \                 description: 'OpenstackRegion is the name of the region that
-    a particular\n                  Felix belongs to. In a multi-region Calico/OpenStack
-    deployment,\n                  this must be configured somehow for each Felix
-    (here in the datamodel,\n                  or in felix.cfg or the environment
-    on each compute node), and must\n                  match the [calico] openstack_region
-    value configured in neutron.conf\n                  on each node. [Default: Empty]'\n
-    \                 type: string\n                policySyncPathPrefix:\n                  description:
-    'PolicySyncPathPrefix is used to by Felix to communicate\n                  policy
-    changes to external services, like Application layer policy.\n                  [Default:
-    Empty]'\n                  type: string\n                prometheusGoMetricsEnabled:\n
-    \                 description: 'PrometheusGoMetricsEnabled disables Go runtime
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                prometheusMetricsEnabled:\n                  description:
-    'PrometheusMetricsEnabled enables the Prometheus metrics\n                  server
-    in Felix if set to true. [Default: false]'\n                  type: boolean\n
-    \               prometheusMetricsHost:\n                  description: 'PrometheusMetricsHost
-    is the host that the Prometheus\n                  metrics server should bind
-    to. [Default: empty]'\n                  type: string\n                prometheusMetricsPort:\n
-    \                 description: 'PrometheusMetricsPort is the TCP port that the
-    Prometheus\n                  metrics server should bind to. [Default: 9091]'\n
-    \                 type: integer\n                prometheusProcessMetricsEnabled:\n
-    \                 description: 'PrometheusProcessMetricsEnabled disables process
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                removeExternalRoutes:\n                  description:
-    Whether or not to remove device routes that have not\n                    been
-    programmed by Felix. Disabling this will allow external applications\n                    to
-    also add device routes. This is enabled by default which means\n                    we
-    will remove externally added routes.\n                  type: boolean\n                reportingInterval:\n
-    \                 description: 'ReportingInterval is the interval at which Felix
-    reports\n                  its status into the datastore or 0 to disable. Must
-    be non-zero\n                  in OpenStack deployments. [Default: 30s]'\n                  type:
-    string\n                reportingTTL:\n                  description: 'ReportingTTL
-    is the time-to-live setting for process-wide\n                  status reports.
-    [Default: 90s]'\n                  type: string\n                routeRefreshInterval:\n
-    \                 description: 'RouterefreshInterval is the period at which Felix
-    re-checks\n                  the routes in the dataplane to ensure that no other
-    process has\n                  accidentally broken Calico’s rules. Set to 0 to
-    disable route refresh.\n                  [Default: 90s]'\n                  type:
-    string\n                routeSource:\n                  description: 'RouteSource
-    configures where Felix gets its routing\n                  information. - WorkloadIPs:
-    use workload endpoints to construct\n                  routes. - CalicoIPAM: the
-    default - use IPAM data to construct routes.'\n                  type: string\n
-    \               routeTableRange:\n                  description: Calico programs
-    additional Linux route tables for various\n                    purposes.  RouteTableRange
-    specifies the indices of the route tables\n                    that Calico should
-    use.\n                  properties:\n                    max:\n                      type:
-    integer\n                    min:\n                      type: integer\n                  required:\n
-    \                   - max\n                    - min\n                  type:
-    object\n                serviceLoopPrevention:\n                  description:
-    'When service IP advertisement is enabled, prevent routing\n                    loops
-    to service IPs that are not in use, by dropping or rejecting\n                    packets
-    that do not get DNAT''d by kube-proxy. Unless set to \"Disabled\",\n                    in
-    which case such routing loops continue to be allowed. [Default:\n                    Drop]'\n
-    \                 type: string\n                sidecarAccelerationEnabled:\n
-    \                 description: 'SidecarAccelerationEnabled enables experimental
-    sidecar\n                  acceleration [Default: false]'\n                  type:
-    boolean\n                usageReportingEnabled:\n                  description:
-    'UsageReportingEnabled reports anonymous Calico version\n                  number
-    and cluster size to projectcalico.org. Logs warnings returned\n                  by
-    the usage server. For example, if a significant security vulnerability\n                  has
-    been discovered in the version of Calico being used. [Default:\n                  true]'\n
-    \                 type: boolean\n                usageReportingInitialDelay:\n
-    \                 description: 'UsageReportingInitialDelay controls the minimum
-    delay\n                  before Felix makes a report. [Default: 300s]'\n                  type:
-    string\n                usageReportingInterval:\n                  description:
-    'UsageReportingInterval controls the interval at which\n                  Felix
-    makes reports. [Default: 86400s]'\n                  type: string\n                useInternalDataplaneDriver:\n
-    \                 type: boolean\n                vxlanEnabled:\n                  type:
-    boolean\n                vxlanMTU:\n                  description: 'VXLANMTU is
-    the MTU to set on the tunnel device. See\n                  Configuring MTU [Default:
-    1440]'\n                  type: integer\n                vxlanPort:\n                  type:
-    integer\n                vxlanVNI:\n                  type: integer\n                wireguardEnabled:\n
-    \                 description: 'WireguardEnabled controls whether Wireguard is
-    enabled.\n                  [Default: false]'\n                  type: boolean\n
-    \               wireguardInterfaceName:\n                  description: 'WireguardInterfaceName
-    specifies the name to use for\n                  the Wireguard interface. [Default:
-    wg.calico]'\n                  type: string\n                wireguardListeningPort:\n
-    \                 description: 'WireguardListeningPort controls the listening
-    port used\n                  by Wireguard. [Default: 51820]'\n                  type:
-    integer\n                wireguardMTU:\n                  description: 'WireguardMTU
-    controls the MTU on the Wireguard interface.\n                  See Configuring
-    MTU [Default: 1420]'\n                  type: integer\n                wireguardRoutingRulePriority:\n
-    \                 description: 'WireguardRoutingRulePriority controls the priority
-    value\n                  to use for the Wireguard routing rule. [Default: 99]'\n
-    \                 type: integer\n                xdpEnabled:\n                  description:
-    'XDPEnabled enables XDP acceleration for suitable untracked\n                  incoming
-    deny rules. [Default: true]'\n                  type: boolean\n                xdpRefreshInterval:\n
-    \                 description: 'XDPRefreshInterval is the period at which Felix
-    re-checks\n                  all XDP state to ensure that no other process has
-    accidentally broken\n                  Calico''s BPF maps or attached programs.
-    Set to 0 to disable XDP\n                  refresh. [Default: 90s]'\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: globalnetworkpolicies.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: GlobalNetworkPolicy\n    listKind:
-    GlobalNetworkPolicyList\n    plural: globalnetworkpolicies\n    singular: globalnetworkpolicy\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                applyOnForward:\n
-    \                 description: ApplyOnForward indicates to apply the rules in
-    this policy\n                    on forward traffic.\n                  type:
-    boolean\n                doNotTrack:\n                  description: DoNotTrack
-    indicates whether packets matched by the rules\n                    in this policy
-    should go through the data plane's connection tracking,\n                    such
-    as Linux conntrack.  If True, the rules in this policy are\n                    applied
-    before any data plane connection tracking, and packets allowed\n                    by
-    this policy are marked as not to be tracked.\n                  type: boolean\n
-    \               egress:\n                  description: The ordered set of egress
-    rules.  Each rule contains\n                    a set of packet match criteria
-    and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                namespaceSelector:\n                  description: NamespaceSelector
-    is an optional field for an expression\n                    used to select a pod
-    based on namespaces.\n                  type: string\n                order:\n
-    \                 description: Order is an optional field that specifies the order
-    in\n                    which the policy is applied. Policies with higher \"order\"
-    are applied\n                    after those with lower order.  If the order is
-    omitted, it may be\n                    considered to be \"infinite\" - i.e. the
-    policy will be applied last.  Policies\n                    with identical order
-    will be applied in alphanumerical order based\n                    on the Policy
-    \"Name\".\n                  type: number\n                preDNAT:\n                  description:
-    PreDNAT indicates to apply the rules in this policy before\n                    any
-    DNAT.\n                  type: boolean\n                selector:\n                  description:
-    \"The selector is an expression used to pick pick out\n                  the endpoints
-    that the policy should be applied to. \\n Selector\n                  expressions
-    follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n                  \\
-    ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel != \\\"string_literal\\\"\n
-    \                 \\  ->  not equal; also matches if label is not present \\tlabel
-    in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\", ... }  ->  true if the
-    value of label X is\n                  one of \\\"a\\\", \\\"b\\\", \\\"c\\\"
-    \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ... }  ->
-    \ true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress rules are present
-    in the policy.  The\n                  default is: \\n - [ PolicyTypeIngress ],
-    if there are no Egress rules\n                  (including the case where there
-    are   also no Ingress rules) \\n\n                  - [ PolicyTypeEgress ], if
-    there are Egress rules but no Ingress\n                  rules \\n - [ PolicyTypeIngress,
-    PolicyTypeEgress ], if there are\n                  both Ingress and Egress rules.
-    \\n When the policy is read back again,\n                  Types will always be
-    one of these values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: globalnetworksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: GlobalNetworkSet\n    listKind: GlobalNetworkSetList\n    plural:
-    globalnetworksets\n    singular: globalnetworkset\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs\n            that
-    share labels to allow rules to refer to them via selectors.  The labels\n            of
-    GlobalNetworkSet are not namespaced.\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: GlobalNetworkSetSpec contains the
-    specification for a NetworkSet\n                resource.\n              properties:\n
-    \               nets:\n                  description: The list of IP networks
-    that belong to this set.\n                  items:\n                    type:
-    string\n                  type: array\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: hostendpoints.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: HostEndpoint\n    listKind: HostEndpointList\n    plural:
-    hostendpoints\n    singular: hostendpoint\n  scope: Cluster\n  versions:\n    -
-    name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: HostEndpointSpec contains the specification
-    for a HostEndpoint\n                resource.\n              properties:\n                expectedIPs:\n
-    \                 description: \"The expected IP addresses (IPv4 and IPv6) of
-    the endpoint.\n                  If \\\"InterfaceName\\\" is not present, Calico
-    will look for an interface\n                  matching any of the IPs in the list
-    and apply policy to that. Note:\n                  \\tWhen using the selector
-    match criteria in an ingress or egress\n                  security Policy \\tor
-    Profile, Calico converts the selector into\n                  a set of IP addresses.
-    For host \\tendpoints, the ExpectedIPs field\n                  is used for that
-    purpose. (If only the interface \\tname is specified,\n                  Calico
-    does not learn the IPs of the interface for use in match\n                  \\tcriteria.)\"\n
-    \                 items:\n                    type: string\n                  type:
-    array\n                interfaceName:\n                  description: \"Either
-    \\\"*\\\", or the name of a specific Linux interface\n                  to apply
-    policy to; or empty.  \\\"*\\\" indicates that this HostEndpoint\n                  governs
-    all traffic to, from or through the default network namespace\n                  of
-    the host named by the \\\"Node\\\" field; entering and leaving that\n                  namespace
-    via any interface, including those from/to non-host-networked\n                  local
-    workloads. \\n If InterfaceName is not \\\"*\\\", this HostEndpoint\n                  only
-    governs traffic that enters or leaves the host through the\n                  specific
-    interface named by InterfaceName, or - when InterfaceName\n                  is
-    empty - through the specific interface that has one of the IPs\n                  in
-    ExpectedIPs. Therefore, when InterfaceName is empty, at least\n                  one
-    expected IP must be specified.  Only external interfaces (such\n                  as
-    “eth0”) are supported here; it isn't possible for a HostEndpoint\n                  to
-    protect traffic through a specific local workload interface.\n                  \\n
-    Note: Only some kinds of policy are implemented for \\\"*\\\" HostEndpoints;\n
-    \                 initially just pre-DNAT policy.  Please check Calico documentation\n
-    \                 for the latest position.\"\n                  type: string\n
-    \               node:\n                  description: The node name identifying
-    the Calico node instance.\n                  type: string\n                ports:\n
-    \                 description: Ports contains the endpoint's named ports, which
-    may\n                    be referenced in security policy rules.\n                  items:\n
-    \                   properties:\n                      name:\n                        type:
-    string\n                      port:\n                        type: integer\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                    required:\n                      - name\n                      -
-    port\n                      - protocol\n                    type: object\n                  type:
-    array\n                profiles:\n                  description: A list of identifiers
-    of security Profile objects that\n                    apply to this endpoint.
-    Each profile is applied in the order that\n                    they appear in
-    this list.  Profile rules are applied after the selector-based\n                    security
-    policy.\n                  items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: ipamblocks.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMBlock\n    listKind: IPAMBlockList\n
-    \   plural: ipamblocks\n    singular: ipamblock\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMBlockSpec contains the specification
-    for an IPAMBlock\n                resource.\n              properties:\n                affinity:\n
-    \                 type: string\n                allocations:\n                  items:\n
-    \                   type: integer\n                    # TODO: This nullable is
-    manually added in. We should update controller-gen\n                    # to handle
-    []*int properly itself.\n                    nullable: true\n                  type:
-    array\n                attributes:\n                  items:\n                    properties:\n
-    \                     handle_id:\n                        type: string\n                      secondary:\n
-    \                       additionalProperties:\n                          type:
-    string\n                        type: object\n                    type: object\n
-    \                 type: array\n                cidr:\n                  type:
-    string\n                deleted:\n                  type: boolean\n                strictAffinity:\n
-    \                 type: boolean\n                unallocated:\n                  items:\n
-    \                   type: integer\n                  type: array\n              required:\n
-    \               - allocations\n                - attributes\n                -
-    cidr\n                - strictAffinity\n                - unallocated\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMConfig\n    listKind: IPAMConfigList\n    plural: ipamconfigs\n
-    \   singular: ipamconfig\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMConfigSpec contains the specification
-    for an IPAMConfig\n                resource.\n              properties:\n                autoAllocateBlocks:\n
-    \                 type: boolean\n                maxBlocksPerHost:\n                  description:
-    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                    that
-    can be affine to each host.\n                  type: integer\n                strictAffinity:\n
-    \                 type: boolean\n              required:\n                - autoAllocateBlocks\n
-    \               - strictAffinity\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ipamhandles.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMHandle\n    listKind: IPAMHandleList\n    plural: ipamhandles\n
-    \   singular: ipamhandle\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMHandleSpec contains the specification
-    for an IPAMHandle\n                resource.\n              properties:\n                block:\n
-    \                 additionalProperties:\n                    type: integer\n                  type:
-    object\n                deleted:\n                  type: boolean\n                handleID:\n
-    \                 type: string\n              required:\n                - block\n
-    \               - handleID\n              type: object\n          type: object\n
-    \     served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ippools.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPPool\n    listKind: IPPoolList\n    plural: ippools\n    singular:
-    ippool\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPPoolSpec contains the specification
-    for an IPPool resource.\n              properties:\n                blockSize:\n
-    \                 description: The block size to use for IP address assignments
-    from\n                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.\n
-    \                 type: integer\n                cidr:\n                  description:
-    The pool CIDR.\n                  type: string\n                disabled:\n                  description:
-    When disabled is true, Calico IPAM will not assign addresses\n                    from
-    this pool.\n                  type: boolean\n                ipip:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  properties:\n                    enabled:\n                      description:
-    When enabled is true, ipip tunneling will be used\n                        to
-    deliver packets to destinations within this pool.\n                      type:
-    boolean\n                    mode:\n                      description: The IPIP
-    mode.  This can be one of \"always\" or \"cross-subnet\".  A\n                        mode
-    of \"always\" will also use IPIP tunneling for routing to\n                        destination
-    IP addresses within this pool.  A mode of \"cross-subnet\"\n                        will
-    only use IPIP tunneling when the destination node is on\n                        a
-    different subnet to the originating node.  The default value\n                        (if
-    not specified) is \"always\".\n                      type: string\n                  type:
-    object\n                ipipMode:\n                  description: Contains configuration
-    for IPIP tunneling for this pool.\n                    If not specified, then
-    this is defaulted to \"Never\" (i.e. IPIP tunneling\n                    is disabled).\n
-    \                 type: string\n                nat-outgoing:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  type: boolean\n                natOutgoing:\n                  description:
-    When nat-outgoing is true, packets sent from Calico networked\n                    containers
-    in this pool to destinations outside of this pool will\n                    be
-    masqueraded.\n                  type: boolean\n                nodeSelector:\n
-    \                 description: Allows IPPool to allocate for a specific node by
-    label\n                    selector.\n                  type: string\n                vxlanMode:\n
-    \                 description: Contains configuration for VXLAN tunneling for
-    this pool.\n                    If not specified, then this is defaulted to \"Never\"
-    (i.e. VXLAN\n                    tunneling is disabled).\n                  type:
-    string\n              required:\n                - cidr\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: kubecontrollersconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: KubeControllersConfiguration\n    listKind: KubeControllersConfigurationList\n
-    \   plural: kubecontrollersconfigurations\n    singular: kubecontrollersconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: KubeControllersConfigurationSpec
-    contains the values of the\n                Kubernetes controllers configuration.\n
-    \             properties:\n                controllers:\n                  description:
-    Controllers enables and configures individual Kubernetes\n                    controllers\n
-    \                 properties:\n                    namespace:\n                      description:
-    Namespace enables and configures the namespace controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   node:\n                      description: Node enables and
-    configures the node controller.\n                        Enabled by default, set
-    to nil to disable.\n                      properties:\n                        hostEndpoint:\n
-    \                         description: HostEndpoint controls syncing nodes to
-    host endpoints.\n                            Disabled by default, set to nil to
-    disable.\n                          properties:\n                            autoCreate:\n
-    \                             description: 'AutoCreate enables automatic creation
-    of\n                              host endpoints for every node. [Default: Disabled]'\n
-    \                             type: string\n                          type: object\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                       syncLabels:\n                          description: 'SyncLabels
-    controls whether to copy Kubernetes\n                          node labels to
-    Calico nodes. [Default: Enabled]'\n                          type: string\n                      type:
-    object\n                    policy:\n                      description: Policy
-    enables and configures the policy controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   serviceAccount:\n                      description: ServiceAccount
-    enables and configures the service\n                        account controller.
-    Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                    workloadEndpoint:\n                      description:
-    WorkloadEndpoint enables and configures the workload\n                        endpoint
-    controller. Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                  type: object\n                etcdV3CompactionPeriod:\n
-    \                 description: 'EtcdV3CompactionPeriod is the period between etcdv3\n
-    \                 compaction requests. Set to 0 to disable. [Default: 10m]'\n
-    \                 type: string\n                healthChecks:\n                  description:
-    'HealthChecks enables or disables support for health\n                  checks
-    [Default: Enabled]'\n                  type: string\n                logSeverityScreen:\n
-    \                 description: 'LogSeverityScreen is the log severity above which
-    logs\n                  are sent to the stdout. [Default: Info]'\n                  type:
-    string\n                prometheusMetricsPort:\n                  description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                    metrics
-    server should bind to. Set to 0 to disable. [Default: 9094]'\n                  type:
-    integer\n              required:\n                - controllers\n              type:
-    object\n            status:\n              description: KubeControllersConfigurationStatus
-    represents the status\n                of the configuration. It's useful for admins
-    to be able to see the actual\n                config that was applied, which can
-    be modified by environment variables\n                on the kube-controllers
-    process.\n              properties:\n                environmentVars:\n                  additionalProperties:\n
-    \                   type: string\n                  description: EnvironmentVars
-    contains the environment variables on\n                    the kube-controllers
-    that influenced the RunningConfig.\n                  type: object\n                runningConfig:\n
-    \                 description: RunningConfig contains the effective config that
-    is running\n                    in the kube-controllers pod, after merging the
-    API resource with\n                    any environment variables.\n                  properties:\n
-    \                   controllers:\n                      description: Controllers
-    enables and configures individual Kubernetes\n                        controllers\n
-    \                     properties:\n                        namespace:\n                          description:
-    Namespace enables and configures the namespace\n                            controller.
-    Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        node:\n
-    \                         description: Node enables and configures the node controller.\n
-    \                           Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           hostEndpoint:\n                              description:
-    HostEndpoint controls syncing nodes to host\n                                endpoints.
-    Disabled by default, set to nil to disable.\n                              properties:\n
-    \                               autoCreate:\n                                  description:
-    'AutoCreate enables automatic creation\n                                  of host
-    endpoints for every node. [Default: Disabled]'\n                                  type:
-    string\n                              type: object\n                            leakGracePeriod:\n
-    \                             description: 'LeakGracePeriod is the period used
-    by the\n                                controller to determine if an IP address
-    has been leaked.\n                                Set to 0 to disable IP garbage
-    collection. [Default:\n                                15m]'\n                              type:
-    string\n                            reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                            syncLabels:\n                              description:
-    'SyncLabels controls whether to copy Kubernetes\n                              node
-    labels to Calico nodes. [Default: Enabled]'\n                              type:
-    string\n                          type: object\n                        policy:\n
-    \                         description: Policy enables and configures the policy
-    controller.\n                            Enabled by default, set to nil to disable.\n
-    \                         properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        serviceAccount:\n
-    \                         description: ServiceAccount enables and configures the
-    service\n                            account controller. Enabled by default, set
-    to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        workloadEndpoint:\n
-    \                         description: WorkloadEndpoint enables and configures
-    the workload\n                            endpoint controller. Enabled by default,
-    set to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                      type: object\n
-    \                   etcdV3CompactionPeriod:\n                      description:
-    'EtcdV3CompactionPeriod is the period between etcdv3\n                      compaction
-    requests. Set to 0 to disable. [Default: 10m]'\n                      type: string\n
-    \                   healthChecks:\n                      description: 'HealthChecks
-    enables or disables support for health\n                      checks [Default:
-    Enabled]'\n                      type: string\n                    logSeverityScreen:\n
-    \                     description: 'LogSeverityScreen is the log severity above
-    which\n                      logs are sent to the stdout. [Default: Info]'\n                      type:
-    string\n                    prometheusMetricsPort:\n                      description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                        metrics
-    server should bind to. Set to 0 to disable. [Default:\n                        9094]'\n
-    \                     type: integer\n                  required:\n                    -
-    controllers\n                  type: object\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: networkpolicies.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkPolicy\n    listKind: NetworkPolicyList\n    plural:
-    networkpolicies\n    singular: networkpolicy\n  scope: Namespaced\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                egress:\n                  description:
-    The ordered set of egress rules.  Each rule contains\n                    a set
-    of packet match criteria and a corresponding action to apply.\n                  items:\n
-    \                   description: \"A Rule encapsulates a set of match criteria
-    and an\n                    action.  Both selector-based security Policy and security
-    Profiles\n                    reference rules - separated out as a list of rules
-    for both ingress\n                    and egress packet matching. \\n Each positive
-    match criteria has\n                    a negated version, prefixed with ”Not”.
-    All the match criteria\n                    within a rule must be satisfied for
-    a packet to match. A single\n                    rule can contain the positive
-    and negative version of a match\n                    and both must be satisfied
-    for the rule to match.\"\n                    properties:\n                      action:\n
-    \                       type: string\n                      destination:\n                        description:
-    Destination contains the match criteria that apply\n                          to
-    destination entity.\n                        properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                order:\n                  description: Order is an optional
-    field that specifies the order in\n                    which the policy is applied.
-    Policies with higher \"order\" are applied\n                    after those with
-    lower order.  If the order is omitted, it may be\n                    considered
-    to be \"infinite\" - i.e. the policy will be applied last.  Policies\n                    with
-    identical order will be applied in alphanumerical order based\n                    on
-    the Policy \"Name\".\n                  type: number\n                selector:\n
-    \                 description: \"The selector is an expression used to pick pick
-    out\n                  the endpoints that the policy should be applied to. \\n
-    Selector\n                  expressions follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n
-    \                 \\ ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel
-    != \\\"string_literal\\\"\n                  \\  ->  not equal; also matches if
-    label is not present \\tlabel in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\",
-    ... }  ->  true if the value of label X is\n                  one of \\\"a\\\",
-    \\\"b\\\", \\\"c\\\" \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ...
-    }  ->  true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress are present in the
-    policy.  The default\n                  is: \\n - [ PolicyTypeIngress ], if there
-    are no Egress rules (including\n                  the case where there are   also
-    no Ingress rules) \\n - [ PolicyTypeEgress\n                  ], if there are
-    Egress rules but no Ingress rules \\n - [ PolicyTypeIngress,\n                  PolicyTypeEgress
-    ], if there are both Ingress and Egress rules.\n                  \\n When the
-    policy is read back again, Types will always be one\n                  of these
-    values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: networksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkSet\n    listKind: NetworkSetList\n    plural: networksets\n
-    \   singular: networkset\n  scope: Namespaced\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          description: NetworkSet is the Namespaced-equivalent
-    of the GlobalNetworkSet.\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: NetworkSetSpec contains the specification
-    for a NetworkSet\n                resource.\n              properties:\n                nets:\n
-    \                 description: The list of IP networks that belong to this set.\n
-    \                 items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n---\n# Source: calico/templates/calico-kube-controllers-rbac.yaml\n\n#
-    Include a clusterrole for the kube-controllers component,\n# and bind it to the
-    calico-kube-controllers serviceaccount.\nkind: ClusterRole\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nrules:\n  # Nodes are watched to monitor for
-    deletions.\n  - apiGroups: [\"\"]\n    resources:\n      - nodes\n    verbs:\n
-    \     - watch\n      - list\n      - get\n  # Pods are watched to check for existence
-    as part of IPAM controller.\n  - apiGroups: [\"\"]\n    resources:\n      - pods\n
-    \   verbs:\n      - get\n      - list\n      - watch\n  # IPAM resources are manipulated
-    when nodes are deleted.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - ippools\n    verbs:\n      - list\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - blockaffinities\n      - ipamblocks\n      - ipamhandles\n
-    \   verbs:\n      - get\n      - list\n      - create\n      - update\n      -
-    delete\n      - watch\n  # kube-controllers manages hostendpoints.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - hostendpoints\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  #
-    Needs access to update clusterinformations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - clusterinformations\n    verbs:\n      - get\n      -
-    create\n      - update\n  # KubeControllersConfiguration is where it gets its
-    config\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - kubecontrollersconfigurations\n
-    \   verbs:\n      # read its own config\n      - get\n      # create a default
-    if none exists\n      - create\n      # update status\n      - update\n      #
-    watch for changes\n      - watch\n---\nkind: ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-kube-controllers\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-kube-controllers\n    namespace: kube-system\n---\n\n---\n# Source:
-    calico/templates/calico-node-rbac.yaml\n# Include a clusterrole for the calico-node
-    DaemonSet,\n# and bind it to the calico-node serviceaccount.\nkind: ClusterRole\napiVersion:
-    rbac.authorization.k8s.io/v1\nmetadata:\n  name: calico-node\nrules:\n  # The
-    CNI plugin needs to get pods, nodes, and namespaces.\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - pods\n      - nodes\n      - namespaces\n    verbs:\n
-    \     - get\n  # EndpointSlices are used for Service-based network policy rule\n
-    \ # enforcement.\n  - apiGroups: [\"discovery.k8s.io\"]\n    resources:\n      -
-    endpointslices\n    verbs:\n      - watch\n      - list\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - endpoints\n      - services\n    verbs:\n      # Used
-    to discover service IPs for advertisement.\n      - watch\n      - list\n      #
-    Used to discover Typhas.\n      - get\n  # Pod CIDR auto-detection on kubeadm
-    needs access to config maps.\n  - apiGroups: [\"\"]\n    resources:\n      - configmaps\n
-    \   verbs:\n      - get\n  - apiGroups: [\"\"]\n    resources:\n      - nodes/status\n
-    \   verbs:\n      # Needed for clearing NodeNetworkUnavailable flag.\n      -
-    patch\n      # Calico stores some configuration information in node annotations.\n
-    \     - update\n  # Watch for changes to Kubernetes NetworkPolicies.\n  - apiGroups:
-    [\"networking.k8s.io\"]\n    resources:\n      - networkpolicies\n    verbs:\n
-    \     - watch\n      - list\n  # Used by Calico for policy information.\n  - apiGroups:
-    [\"\"]\n    resources:\n      - pods\n      - namespaces\n      - serviceaccounts\n
-    \   verbs:\n      - list\n      - watch\n  # The CNI plugin patches pods/status.\n
-    \ - apiGroups: [\"\"]\n    resources:\n      - pods/status\n    verbs:\n      -
-    patch\n  # Calico monitors various CRDs for config.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - globalfelixconfigs\n      - felixconfigurations\n      -
-    bgppeers\n      - globalbgpconfigs\n      - bgpconfigurations\n      - ippools\n
-    \     - ipamblocks\n      - globalnetworkpolicies\n      - globalnetworksets\n
-    \     - networkpolicies\n      - networksets\n      - clusterinformations\n      -
-    hostendpoints\n      - blockaffinities\n    verbs:\n      - get\n      - list\n
-    \     - watch\n  # Calico must create and update some CRDs on startup.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - ippools\n      - felixconfigurations\n
-    \     - clusterinformations\n    verbs:\n      - create\n      - update\n  # Calico
-    stores some configuration information on the node.\n  - apiGroups: [\"\"]\n    resources:\n
-    \     - nodes\n    verbs:\n      - get\n      - list\n      - watch\n  # These
-    permissions are only required for upgrade from v2.6, and can\n  # be removed after
-    upgrade or on fresh installations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - bgpconfigurations\n      - bgppeers\n    verbs:\n      -
-    create\n      - update\n  # These permissions are required for Calico CNI to perform
-    IPAM allocations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n      - ipamblocks\n      - ipamhandles\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  -
-    apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - ipamconfigs\n
-    \   verbs:\n      - get\n  # Block affinities must also be watchable by confd
-    for route aggregation.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n    verbs:\n      - watch\n  # The Calico IPAM migration
-    needs to get daemonsets. These permissions can be\n  # removed if not upgrading
-    from an installation using host-local IPAM.\n  - apiGroups: [\"apps\"]\n    resources:\n
-    \     - daemonsets\n    verbs:\n      - get\n\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:
-    ClusterRoleBinding\nmetadata:\n  name: calico-node\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-node\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-node\n    namespace: kube-system\n\n---\n# Source: calico/templates/calico-node.yaml\n#
-    This manifest installs the calico-node container, as well\n# as the CNI plugins
-    and network config on\n# each master and worker node in a Kubernetes cluster.\nkind:
-    DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: calico-node\n  namespace: kube-system\n
-    \ labels:\n    k8s-app: calico-node\nspec:\n  selector:\n    matchLabels:\n      k8s-app:
-    calico-node\n  updateStrategy:\n    type: RollingUpdate\n    rollingUpdate:\n
-    \     maxUnavailable: 1\n  template:\n    metadata:\n      labels:\n        k8s-app:
-    calico-node\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n
-    \     hostNetwork: true\n      tolerations:\n        # Make sure calico-node gets
-    scheduled on all nodes.\n        - effect: NoSchedule\n          operator: Exists\n
-    \       # Mark the pod as a critical add-on for rescheduling.\n        - key:
-    CriticalAddonsOnly\n          operator: Exists\n        - effect: NoExecute\n
-    \         operator: Exists\n      serviceAccountName: calico-node\n      # Minimize
-    downtime during a rolling upgrade or deletion; tell Kubernetes to do a \"force\n
-    \     # deletion\": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.\n
-    \     terminationGracePeriodSeconds: 0\n      priorityClassName: system-node-critical\n
-    \     initContainers:\n        # This container performs upgrade from host-local
-    IPAM to calico-ipam.\n        # It can be deleted if this is a fresh installation,
-    or if you have already\n        # upgraded to use calico-ipam.\n        - name:
-    upgrade-ipam\n          image: calico/cni:v3.20.0\n          command: [\"/opt/cni/bin/calico-ipam\",
-    \"-upgrade\"]\n          envFrom:\n            - configMapRef:\n                #
-    Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for
-    eBPF mode.\n                name: kubernetes-services-endpoint\n                optional:
-    true\n          env:\n            - name: KUBERNETES_NODE_NAME\n              valueFrom:\n
-    \               fieldRef:\n                  fieldPath: spec.nodeName\n            -
-    name: CALICO_NETWORKING_BACKEND\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: calico_backend\n
-    \         volumeMounts:\n            - mountPath: /var/lib/cni/networks\n              name:
-    host-local-net-dir\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n          securityContext:\n            privileged: true\n        #
-    This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: calico/cni:v3.20.0\n
-    \         command: [\"/opt/cni/bin/install\"]\n          envFrom:\n            -
-    configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
-    to be overridden for eBPF mode.\n                name: kubernetes-services-endpoint\n
-    \               optional: true\n          env:\n            # Name of the CNI
-    config file to create.\n            - name: CNI_CONF_NAME\n              value:
-    \"10-calico.conflist\"\n            # The CNI network config to install on each
-    node.\n            - name: CNI_NETWORK_CONFIG\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: cni_network_config\n
-    \           # Set the hostname based on the k8s node name.\n            - name:
-    KUBERNETES_NODE_NAME\n              valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # CNI MTU Config variable\n            - name: CNI_MTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Prevents the container
-    from sleeping forever.\n            - name: SLEEP\n              value: \"false\"\n
-    \         volumeMounts:\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n            - mountPath: /host/etc/cni/net.d\n              name:
-    cni-net-dir\n          securityContext:\n            privileged: true\n        #
-    Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes\n
-    \       # to communicate with Felix over the Policy Sync API.\n        - name:
-    flexvol-driver\n          image: calico/pod2daemon-flexvol:v3.20.0\n          volumeMounts:\n
-    \           - name: flexvol-driver-host\n              mountPath: /host/driver\n
-    \         securityContext:\n            privileged: true\n      containers:\n
-    \       # Runs calico-node container on each Kubernetes node. This\n        #
-    container programs network policy and routes on each\n        # host.\n        -
-    name: calico-node\n          image: calico/node:v3.20.0\n          envFrom:\n
-    \           - configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and
-    KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.\n                name:
-    kubernetes-services-endpoint\n                optional: true\n          env:\n
-    \           # Use Kubernetes API as the backing datastore.\n            - name:
-    DATASTORE_TYPE\n              value: \"kubernetes\"\n            # Wait for the
-    datastore.\n            - name: WAIT_FOR_DATASTORE\n              value: \"true\"\n
-    \           # Set based on the k8s node name.\n            - name: NODENAME\n
-    \             valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # Choose the backend to use.\n            - name: CALICO_NETWORKING_BACKEND\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: calico_backend\n            # Cluster type
-    to identify the deployment type\n            - name: CLUSTER_TYPE\n              value:
-    \"k8s,bgp\"\n            # Auto-detect the BGP IP address.\n            - name:
-    IP\n              value: \"autodetect\"\n            # Enable VXLAN\n            -
-    name: CALICO_IPV4POOL_VXLAN\n              value: \"Always\"\n            # Set
-    MTU for tunnel device used if ipip is enabled\n            - name: FELIX_IPINIPMTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Set MTU for the
-    VXLAN tunnel device.\n            - name: FELIX_VXLANMTU\n              valueFrom:\n
-    \               configMapKeyRef:\n                  name: calico-config\n                  key:
-    veth_mtu\n            # Set MTU for the Wireguard tunnel device.\n            -
-    name: FELIX_WIREGUARDMTU\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: veth_mtu\n            #
-    The default IPv4 pool to create on startup if none exists. Pod IPs will be\n            #
-    chosen from this range. Changing this value after installation will have\n            #
-    no effect. This should fall within `--cluster-cidr`.\n            # - name: CALICO_IPV4POOL_CIDR\n
-    \           #   value: \"192.168.0.0/16\"\n            # Disable file logging
-    so `kubectl logs` works.\n            - name: CALICO_DISABLE_FILE_LOGGING\n              value:
-    \"true\"\n            # Set Felix endpoint to host default action to ACCEPT.\n
-    \           - name: FELIX_DEFAULTENDPOINTTOHOSTACTION\n              value: \"ACCEPT\"\n
-    \           # Disable IPv6 on Kubernetes.\n            - name: FELIX_IPV6SUPPORT\n
-    \             value: \"false\"\n            - name: FELIX_FEATUREDETECTOVERRIDE\n
-    \             value: \"ChecksumOffloadBroken=true\"\n            - name: FELIX_HEALTHENABLED\n
-    \             value: \"true\"\n          securityContext:\n            privileged:
-    true\n          resources:\n            requests:\n              cpu: 250m\n          livenessProbe:\n
-    \           exec:\n              command:\n                - /bin/calico-node\n
-    \               - -felix-live\n            periodSeconds: 10\n            initialDelaySeconds:
-    10\n            failureThreshold: 6\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /bin/calico-node\n                -
-    -felix-ready\n            periodSeconds: 10\n          volumeMounts:\n            -
-    mountPath: /host/etc/cni/net.d\n              name: cni-net-dir\n              readOnly:
-    false\n            - mountPath: /lib/modules\n              name: lib-modules\n
-    \             readOnly: true\n            - mountPath: /run/xtables.lock\n              name:
-    xtables-lock\n              readOnly: false\n            - mountPath: /var/run/calico\n
-    \             name: var-run-calico\n              readOnly: false\n            -
-    mountPath: /var/lib/calico\n              name: var-lib-calico\n              readOnly:
-    false\n            - name: policysync\n              mountPath: /var/run/nodeagent\n
-    \           # For eBPF mode, we need to be able to mount the BPF filesystem at
-    /sys/fs/bpf so we mount in the\n            # parent directory.\n            -
-    name: sysfs\n              mountPath: /sys/fs/\n              # Bidirectional
-    means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to
-    the host.\n              # If the host is known to mount that filesystem already
-    then Bidirectional can be omitted.\n              mountPropagation: Bidirectional\n
-    \           - name: cni-log-dir\n              mountPath: /var/log/calico/cni\n
-    \             readOnly: true\n      volumes:\n        # Used by calico-node.\n
-    \       - name: lib-modules\n          hostPath:\n            path: /lib/modules\n
-    \       - name: var-run-calico\n          hostPath:\n            path: /var/run/calico\n
-    \       - name: var-lib-calico\n          hostPath:\n            path: /var/lib/calico\n
-    \       - name: xtables-lock\n          hostPath:\n            path: /run/xtables.lock\n
-    \           type: FileOrCreate\n        - name: sysfs\n          hostPath:\n            path:
-    /sys/fs/\n            type: DirectoryOrCreate\n        # Used to install CNI.\n
-    \       - name: cni-bin-dir\n          hostPath:\n            path: /opt/cni/bin\n
-    \       - name: cni-net-dir\n          hostPath:\n            path: /etc/cni/net.d\n
-    \       # Used to access CNI logs.\n        - name: cni-log-dir\n          hostPath:\n
-    \           path: /var/log/calico/cni\n        # Mount in the directory for host-local
-    IPAM allocations. This is\n        # used when upgrading from host-local to calico-ipam,
-    and can be removed\n        # if not using the upgrade-ipam init container.\n
-    \       - name: host-local-net-dir\n          hostPath:\n            path: /var/lib/cni/networks\n
-    \       # Used to create per-pod Unix Domain Sockets\n        - name: policysync\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /var/run/nodeagent\n
-    \       # Used to install Flex Volume Driver\n        - name: flexvol-driver-host\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds\n---\n\napiVersion:
-    v1\nkind: ServiceAccount\nmetadata:\n  name: calico-node\n  namespace: kube-system\n\n---\n#
-    Source: calico/templates/calico-kube-controllers.yaml\n# See https://github.com/projectcalico/kube-controllers\napiVersion:
-    apps/v1\nkind: Deployment\nmetadata:\n  name: calico-kube-controllers\n  namespace:
-    kube-system\n  labels:\n    k8s-app: calico-kube-controllers\nspec:\n  # The controllers
-    can only have a single active instance.\n  replicas: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n  strategy:\n    type: Recreate\n  template:\n
-    \   metadata:\n      name: calico-kube-controllers\n      namespace: kube-system\n
-    \     labels:\n        k8s-app: calico-kube-controllers\n    spec:\n      nodeSelector:\n
-    \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
-    a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
-    Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
-    \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
-    \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
-    \         env:\n            # Choose which controllers to run.\n            -
-    name: ENABLED_CONTROLLERS\n              value: node\n            - name: DATASTORE_TYPE\n
-    \             value: kubernetes\n          livenessProbe:\n            exec:\n
-    \             command:\n              - /usr/bin/check-status\n              -
-    -l\n            periodSeconds: 10\n            initialDelaySeconds: 10\n            failureThreshold:
-    6\n            timeoutSeconds: 10\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /usr/bin/check-status\n                -
-    -r\n            periodSeconds: 10\n\n---\n\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n\n---\n\n# This manifest
-    creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler
-    to evict\n\napiVersion: policy/v1beta1\nkind: PodDisruptionBudget\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n  labels:\n    k8s-app:
-    calico-kube-controllers\nspec:\n  maxUnavailable: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n---\n# Source: calico/templates/calico-etcd-secrets.yaml\n\n---\n#
-    Source: calico/templates/calico-typha.yaml\n\n---\n# Source: calico/templates/configure-canal.yaml\n"
+  resources: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgpconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPConfiguration
+        listKind: BGPConfigurationList
+        plural: bgpconfigurations
+        singular: bgpconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: BGPConfiguration contains the configuration for any BGP routing.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPConfigurationSpec contains the values of the BGP configuration.
+                properties:
+                  asNumber:
+                    description: 'ASNumber is the default AS number used by a node. [Default:
+                      64512]'
+                    format: int32
+                    type: integer
+                  communities:
+                    description: Communities is a list of BGP community values and their
+                      arbitrary names for tagging routes.
+                    items:
+                      description: Community contains standard or large community value
+                        and its name.
+                      properties:
+                        name:
+                          description: Name given to community value.
+                          type: string
+                        value:
+                          description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                            For standard community use `aa:nn` format, where `aa` and
+                            `nn` are 16 bit number. For large community use `aa:nn:mm`
+                            format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                            `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                          pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                          type: string
+                      type: object
+                    type: array
+                  listenPort:
+                    description: ListenPort is the port where BGP protocol should listen.
+                      Defaults to 179
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: INFO]'
+                    type: string
+                  nodeToNodeMeshEnabled:
+                    description: 'NodeToNodeMeshEnabled sets whether full node to node
+                      BGP mesh is enabled. [Default: true]'
+                    type: boolean
+                  prefixAdvertisements:
+                    description: PrefixAdvertisements contains per-prefix advertisement
+                      configuration.
+                    items:
+                      description: PrefixAdvertisement configures advertisement properties
+                        for the specified CIDR.
+                      properties:
+                        cidr:
+                          description: CIDR for which properties should be advertised.
+                          type: string
+                        communities:
+                          description: Communities can be list of either community names
+                            already defined in `Specs.Communities` or community value
+                            of format `aa:nn` or `aa:nn:mm`. For standard community use
+                            `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                            large community use `aa:nn:mm` format, where `aa`, `nn` and
+                            `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                            `mm` are per-AS identifier.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  serviceClusterIPs:
+                    description: ServiceClusterIPs are the CIDR blocks from which service
+                      cluster IPs are allocated. If specified, Calico will advertise these
+                      blocks, as well as any cluster IPs within them.
+                    items:
+                      description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                        CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceExternalIPs:
+                    description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                      Service External IPs. Kubernetes Service ExternalIPs will only be
+                      advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceExternalIPBlock represents a single allowed
+                        External IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceLoadBalancerIPs:
+                    description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                      Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                      IPs will only be advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceLoadBalancerIPBlock represents a single allowed
+                        LoadBalancer IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgppeers.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPPeer
+        listKind: BGPPeerList
+        plural: bgppeers
+        singular: bgppeer
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPPeerSpec contains the specification for a BGPPeer resource.
+                properties:
+                  asNumber:
+                    description: The AS Number of the peer.
+                    format: int32
+                    type: integer
+                  keepOriginalNextHop:
+                    description: Option to keep the original nexthop field when routes
+                      are sent to a BGP Peer. Setting "true" configures the selected BGP
+                      Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                      in the specific branch of the Node on "bird.cfg".
+                    type: boolean
+                  maxRestartTime:
+                    description: Time to allow for software restart.  When specified,
+                      this is configured as the graceful restart timeout.  When not specified,
+                      the BIRD default of 120s is used.
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance that
+                      is targeted by this peer. If this is not set, and no nodeSelector
+                      is specified, then this BGP peer selects all nodes in the cluster.
+                    type: string
+                  nodeSelector:
+                    description: Selector for the nodes that should have this peering.  When
+                      this is set, the Node field must be empty.
+                    type: string
+                  password:
+                    description: Optional BGP password for the peerings generated by this
+                      BGPPeer resource.
+                    properties:
+                      secretKeyRef:
+                        description: Selects a key of a secret in the node pod's namespace.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be
+                              a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be
+                              defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  peerIP:
+                    description: The IP address of the peer followed by an optional port
+                      number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                      or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                      and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                      set in BGPConfiguration, then we use that port to peer.
+                    type: string
+                  peerSelector:
+                    description: Selector for the remote nodes to peer with.  When this
+                      is set, the PeerIP and ASNumber fields must be empty.  For each
+                      peering between the local node and selected remote nodes, we configure
+                      an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                      and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                      remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                      or the global default if that is not set.
+                    type: string
+                  sourceAddress:
+                    description: Specifies whether and how to configure a source address
+                      for the peerings generated by this BGPPeer resource.  Default value
+                      "UseNodeIP" means to configure the node IP as the source address.  "None"
+                      means not to configure a source address.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: blockaffinities.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BlockAffinity
+        listKind: BlockAffinityList
+        plural: blockaffinities
+        singular: blockaffinity
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BlockAffinitySpec contains the specification for a BlockAffinity
+                  resource.
+                properties:
+                  cidr:
+                    type: string
+                  deleted:
+                    description: Deleted indicates that this block affinity is being deleted.
+                      This field is a string for compatibility with older releases that
+                      mistakenly treat this field as a string.
+                    type: string
+                  node:
+                    type: string
+                  state:
+                    type: string
+                required:
+                - cidr
+                - deleted
+                - node
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: clusterinformations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: ClusterInformation
+        listKind: ClusterInformationList
+        plural: clusterinformations
+        singular: clusterinformation
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterInformation contains the cluster specific information.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterInformationSpec contains the values of describing
+                  the cluster.
+                properties:
+                  calicoVersion:
+                    description: CalicoVersion is the version of Calico that the cluster
+                      is running
+                    type: string
+                  clusterGUID:
+                    description: ClusterGUID is the GUID of the cluster
+                    type: string
+                  clusterType:
+                    description: ClusterType describes the type of the cluster
+                    type: string
+                  datastoreReady:
+                    description: DatastoreReady is used during significant datastore migrations
+                      to signal to components such as Felix that it should wait before
+                      accessing the datastore.
+                    type: boolean
+                  variant:
+                    description: Variant declares which variant of Calico should be active.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: felixconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: FelixConfiguration
+        listKind: FelixConfigurationList
+        plural: felixconfigurations
+        singular: felixconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: Felix Configuration contains the configuration for Felix.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: FelixConfigurationSpec contains the values of the Felix configuration.
+                properties:
+                  allowIPIPPacketsFromWorkloads:
+                    description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop IPIP encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  allowVXLANPacketsFromWorkloads:
+                    description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop VXLAN encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  awsSrcDstCheck:
+                    description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                      value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                      DoNothing]'
+                    enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                    type: string
+                  bpfConnectTimeLoadBalancingEnabled:
+                    description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                      controls whether Felix installs the connection-time load balancer.  The
+                      connect-time load balancer is required for the host to be able to
+                      reach Kubernetes services and it improves the performance of pod-to-service
+                      connections.  The only reason to disable it is for debugging purposes.  [Default:
+                      true]'
+                    type: boolean
+                  bpfDataIfacePattern:
+                    description: BPFDataIfacePattern is a regular expression that controls
+                      which interfaces Felix should attach BPF programs to in order to
+                      catch traffic to/from the network.  This needs to match the interfaces
+                      that Calico workload traffic flows over as well as any interfaces
+                      that handle incoming traffic to nodeports and services from outside
+                      the cluster.  It should not match the workload interfaces (usually
+                      named cali...).
+                    type: string
+                  bpfDisableUnprivileged:
+                    description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                      sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                      users cannot access Calico''s BPF maps and cannot insert their own
+                      BPF programs to interfere with Calico''s. [Default: true]'
+                    type: boolean
+                  bpfEnabled:
+                    description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                      [Default: false]'
+                    type: boolean
+                  bpfExtToServiceConnmark:
+                    description: 'BPFExtToServiceConnmark in BPF mode, controls a 32bit
+                      mark that is set on connections from an external client to a local
+                      service. This mark allows us to control how packets of that connection
+                      are routed within the host and how is routing intepreted by RPF
+                      check. [Default: 0]'
+                    type: integer
+                  bpfExternalServiceMode:
+                    description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                      from outside the cluster to services (node ports and cluster IPs)
+                      are forwarded to remote workloads.  If set to "Tunnel" then both
+                      request and response traffic is tunneled to the remote node.  If
+                      set to "DSR", the request traffic is tunneled but the response traffic
+                      is sent directly from the remote node.  In "DSR" mode, the remote
+                      node appears to use the IP of the ingress node; this requires a
+                      permissive L2 network.  [Default: Tunnel]'
+                    type: string
+                  bpfKubeProxyEndpointSlicesEnabled:
+                    description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                      whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                    type: boolean
+                  bpfKubeProxyIptablesCleanupEnabled:
+                    description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                      mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                      iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                      true]'
+                    type: boolean
+                  bpfKubeProxyMinSyncPeriod:
+                    description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                      minimum time between updates to the dataplane for Felix''s embedded
+                      kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                      reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                    type: string
+                  bpfLogLevel:
+                    description: 'BPFLogLevel controls the log level of the BPF programs
+                      when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                      logs are emitted to the BPF trace pipe, accessible with the command
+                      `tc exec bpf debug`. [Default: Off].'
+                    type: string
+                  chainInsertMode:
+                    description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                      top-level iptables chains by inserting a rule at the top of the
+                      chain or by appending a rule at the bottom. insert is the safe default
+                      since it prevents Calico''s rules from being bypassed. If you switch
+                      to append mode, be sure that the other rules in the chains signal
+                      acceptance by falling through to the Calico rules, otherwise the
+                      Calico policy will be bypassed. [Default: insert]'
+                    type: string
+                  dataplaneDriver:
+                    type: string
+                  debugDisableLogDropping:
+                    type: boolean
+                  debugMemoryProfilePath:
+                    type: string
+                  debugSimulateCalcGraphHangAfter:
+                    type: string
+                  debugSimulateDataplaneHangAfter:
+                    type: string
+                  defaultEndpointToHostAction:
+                    description: 'DefaultEndpointToHostAction controls what happens to
+                      traffic that goes from a workload endpoint to the host itself (after
+                      the traffic hits the endpoint egress policy). By default Calico
+                      blocks traffic from workload endpoints to the host itself with an
+                      iptables "DROP" action. If you want to allow some or all traffic
+                      from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                      RETURN if you have your own rules in the iptables "INPUT" chain;
+                      Calico will insert its rules at the top of that chain, then "RETURN"
+                      packets to the "INPUT" chain once it has completed processing workload
+                      endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                      from workloads after processing workload endpoint egress policy.
+                      [Default: Drop]'
+                    type: string
+                  deviceRouteProtocol:
+                    description: This defines the route protocol added to programmed device
+                      routes, by default this will be RTPROT_BOOT when left blank.
+                    type: integer
+                  deviceRouteSourceAddress:
+                    description: This is the source address to use on programmed device
+                      routes. By default the source address is left blank, leaving the
+                      kernel to choose the source address used.
+                    type: string
+                  disableConntrackInvalidCheck:
+                    type: boolean
+                  endpointReportingDelay:
+                    type: string
+                  endpointReportingEnabled:
+                    type: boolean
+                  externalNodesList:
+                    description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                      which may source tunnel traffic and have the tunneled traffic be
+                      accepted at calico nodes.
+                    items:
+                      type: string
+                    type: array
+                  failsafeInboundHostPorts:
+                    description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow incoming traffic to host endpoints
+                      on irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all inbound host ports, use the value
+                      none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                      udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  failsafeOutboundHostPorts:
+                    description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow outgoing traffic from host endpoints
+                      to irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all outbound host ports, use the value
+                      none. The default value opens etcd''s standard ports to ensure that
+                      Felix does not get cut off from etcd as well as allowing DHCP and
+                      DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                      tcp:6667, udp:53, udp:67]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  featureDetectOverride:
+                    description: FeatureDetectOverride is used to override the feature
+                      detection. Values are specified in a comma separated list with no
+                      spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                      "true" or "false" will force the feature, empty or omitted values
+                      are auto-detected.
+                    type: string
+                  genericXDPEnabled:
+                    description: 'GenericXDPEnabled enables Generic XDP so network cards
+                      that don''t support XDP offload or driver modes can use XDP. This
+                      is not recommended since it doesn''t provide better performance
+                      than iptables. [Default: false]'
+                    type: boolean
+                  healthEnabled:
+                    type: boolean
+                  healthHost:
+                    type: string
+                  healthPort:
+                    type: integer
+                  interfaceExclude:
+                    description: 'InterfaceExclude is a comma-separated list of interfaces
+                      that Felix should exclude when monitoring for host endpoints. The
+                      default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                      interface, which is used internally by kube-proxy. If you want to
+                      exclude multiple interface names using a single value, the list
+                      supports regular expressions. For regular expressions you must wrap
+                      the value with ''/''. For example having values ''/^kube/,veth1''
+                      will exclude all interfaces that begin with ''kube'' and also the
+                      interface ''veth1''. [Default: kube-ipvs0]'
+                    type: string
+                  interfacePrefix:
+                    description: 'InterfacePrefix is the interface name prefix that identifies
+                      workload endpoints and so distinguishes them from host endpoint
+                      interfaces. Note: in environments other than bare metal, the orchestrators
+                      configure this appropriately. For example our Kubernetes and Docker
+                      integrations set the ''cali'' value, and our OpenStack integration
+                      sets the ''tap'' value. [Default: cali]'
+                    type: string
+                  interfaceRefreshInterval:
+                    description: InterfaceRefreshInterval is the period at which Felix
+                      rescans local interfaces to verify their state. The rescan can be
+                      disabled by setting the interval to 0.
+                    type: string
+                  ipipEnabled:
+                    type: boolean
+                  ipipMTU:
+                    description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  ipsetsRefreshInterval:
+                    description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                      all iptables state to ensure that no other process has accidentally
+                      broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                      90s]'
+                    type: string
+                  iptablesBackend:
+                    description: IptablesBackend specifies which backend of iptables will
+                      be used. The default is legacy.
+                    type: string
+                  iptablesFilterAllowAction:
+                    type: string
+                  iptablesLockFilePath:
+                    description: 'IptablesLockFilePath is the location of the iptables
+                      lock file. You may need to change this if the lock file is not in
+                      its standard location (for example if you have mapped it into Felix''s
+                      container at a different path). [Default: /run/xtables.lock]'
+                    type: string
+                  iptablesLockProbeInterval:
+                    description: 'IptablesLockProbeInterval is the time that Felix will
+                      wait between attempts to acquire the iptables lock if it is not
+                      available. Lower values make Felix more responsive when the lock
+                      is contended, but use more CPU. [Default: 50ms]'
+                    type: string
+                  iptablesLockTimeout:
+                    description: 'IptablesLockTimeout is the time that Felix will wait
+                      for the iptables lock, or 0, to disable. To use this feature, Felix
+                      must share the iptables lock file with all other processes that
+                      also take the lock. When running Felix inside a container, this
+                      requires the /run directory of the host to be mounted into the calico/node
+                      or calico/felix container. [Default: 0s disabled]'
+                    type: string
+                  iptablesMangleAllowAction:
+                    type: string
+                  iptablesMarkMask:
+                    description: 'IptablesMarkMask is the mask that Felix selects its
+                      IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                      at least 8 bits set, none of which clash with any other mark bits
+                      in use on the system. [Default: 0xff000000]'
+                    format: int32
+                    type: integer
+                  iptablesNATOutgoingInterfaceFilter:
+                    type: string
+                  iptablesPostWriteCheckInterval:
+                    description: 'IptablesPostWriteCheckInterval is the period after Felix
+                      has done a write to the dataplane that it schedules an extra read
+                      back in order to check the write was not clobbered by another process.
+                      This should only occur if another application on the system doesn''t
+                      respect the iptables lock. [Default: 1s]'
+                    type: string
+                  iptablesRefreshInterval:
+                    description: 'IptablesRefreshInterval is the period at which Felix
+                      re-checks the IP sets in the dataplane to ensure that no other process
+                      has accidentally broken Calico''s rules. Set to 0 to disable IP
+                      sets refresh. Note: the default for this value is lower than the
+                      other refresh intervals as a workaround for a Linux kernel bug that
+                      was fixed in kernel version 4.11. If you are using v4.11 or greater
+                      you may want to set this to, a higher value to reduce Felix CPU
+                      usage. [Default: 10s]'
+                    type: string
+                  ipv6Support:
+                    type: boolean
+                  kubeNodePortRanges:
+                    description: 'KubeNodePortRanges holds list of port ranges used for
+                      service node ports. Only used if felix detects kube-proxy running
+                      in ipvs mode. Felix uses these ranges to separate host and workload
+                      traffic. [Default: 30000:32767].'
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  logFilePath:
+                    description: 'LogFilePath is the full path to the Felix log. Set to
+                      none to disable file logging. [Default: /var/log/calico/felix.log]'
+                    type: string
+                  logPrefix:
+                    description: 'LogPrefix is the log prefix that Felix uses when rendering
+                      LOG rules. [Default: calico-packet]'
+                    type: string
+                  logSeverityFile:
+                    description: 'LogSeverityFile is the log severity above which logs
+                      are sent to the log file. [Default: Info]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  logSeveritySys:
+                    description: 'LogSeveritySys is the log severity above which logs
+                      are sent to the syslog. Set to None for no logging to syslog. [Default:
+                      Info]'
+                    type: string
+                  maxIpsetSize:
+                    type: integer
+                  metadataAddr:
+                    description: 'MetadataAddr is the IP address or domain name of the
+                      server that can answer VM queries for cloud-init metadata. In OpenStack,
+                      this corresponds to the machine running nova-api (or in Ubuntu,
+                      nova-api-metadata). A value of none (case insensitive) means that
+                      Felix should not set up any NAT rule for the metadata path. [Default:
+                      127.0.0.1]'
+                    type: string
+                  metadataPort:
+                    description: 'MetadataPort is the port of the metadata server. This,
+                      combined with global.MetadataAddr (if not ''None''), is used to
+                      set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                      In most cases this should not need to be changed [Default: 8775].'
+                    type: integer
+                  mtuIfacePattern:
+                    description: MTUIfacePattern is a regular expression that controls
+                      which interfaces Felix should scan in order to calculate the host's
+                      MTU. This should not match workload interfaces (usually named cali...).
+                    type: string
+                  natOutgoingAddress:
+                    description: NATOutgoingAddress specifies an address to use when performing
+                      source NAT for traffic in a natOutgoing pool that is leaving the
+                      network. By default the address used is an address on the interface
+                      the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                    type: string
+                  natPortRange:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NATPortRange specifies the range of ports that is used
+                      for port mapping when doing outgoing NAT. When unset the default
+                      behavior of the network stack is used.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  netlinkTimeout:
+                    type: string
+                  openstackRegion:
+                    description: 'OpenstackRegion is the name of the region that a particular
+                      Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                      this must be configured somehow for each Felix (here in the datamodel,
+                      or in felix.cfg or the environment on each compute node), and must
+                      match the [calico] openstack_region value configured in neutron.conf
+                      on each node. [Default: Empty]'
+                    type: string
+                  policySyncPathPrefix:
+                    description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                      policy changes to external services, like Application layer policy.
+                      [Default: Empty]'
+                    type: string
+                  prometheusGoMetricsEnabled:
+                    description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusMetricsEnabled:
+                    description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                      server in Felix if set to true. [Default: false]'
+                    type: boolean
+                  prometheusMetricsHost:
+                    description: 'PrometheusMetricsHost is the host that the Prometheus
+                      metrics server should bind to. [Default: empty]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. [Default: 9091]'
+                    type: integer
+                  prometheusProcessMetricsEnabled:
+                    description: 'PrometheusProcessMetricsEnabled disables process metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusWireGuardMetricsEnabled:
+                    description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                      metrics collection, which the Prometheus client does by default,
+                      when set to false. This reduces the number of metrics reported,
+                      reducing Prometheus load. [Default: true]'
+                    type: boolean
+                  removeExternalRoutes:
+                    description: Whether or not to remove device routes that have not
+                      been programmed by Felix. Disabling this will allow external applications
+                      to also add device routes. This is enabled by default which means
+                      we will remove externally added routes.
+                    type: boolean
+                  reportingInterval:
+                    description: 'ReportingInterval is the interval at which Felix reports
+                      its status into the datastore or 0 to disable. Must be non-zero
+                      in OpenStack deployments. [Default: 30s]'
+                    type: string
+                  reportingTTL:
+                    description: 'ReportingTTL is the time-to-live setting for process-wide
+                      status reports. [Default: 90s]'
+                    type: string
+                  routeRefreshInterval:
+                    description: 'RouteRefreshInterval is the period at which Felix re-checks
+                      the routes in the dataplane to ensure that no other process has
+                      accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                      [Default: 90s]'
+                    type: string
+                  routeSource:
+                    description: 'RouteSource configures where Felix gets its routing
+                      information. - WorkloadIPs: use workload endpoints to construct
+                      routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                    type: string
+                  routeTableRange:
+                    description: Calico programs additional Linux route tables for various
+                      purposes.  RouteTableRange specifies the indices of the route tables
+                      that Calico should use.
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                    - max
+                    - min
+                    type: object
+                  serviceLoopPrevention:
+                    description: 'When service IP advertisement is enabled, prevent routing
+                      loops to service IPs that are not in use, by dropping or rejecting
+                      packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                      in which case such routing loops continue to be allowed. [Default:
+                      Drop]'
+                    type: string
+                  sidecarAccelerationEnabled:
+                    description: 'SidecarAccelerationEnabled enables experimental sidecar
+                      acceleration [Default: false]'
+                    type: boolean
+                  usageReportingEnabled:
+                    description: 'UsageReportingEnabled reports anonymous Calico version
+                      number and cluster size to projectcalico.org. Logs warnings returned
+                      by the usage server. For example, if a significant security vulnerability
+                      has been discovered in the version of Calico being used. [Default:
+                      true]'
+                    type: boolean
+                  usageReportingInitialDelay:
+                    description: 'UsageReportingInitialDelay controls the minimum delay
+                      before Felix makes a report. [Default: 300s]'
+                    type: string
+                  usageReportingInterval:
+                    description: 'UsageReportingInterval controls the interval at which
+                      Felix makes reports. [Default: 86400s]'
+                    type: string
+                  useInternalDataplaneDriver:
+                    type: boolean
+                  vxlanEnabled:
+                    type: boolean
+                  vxlanMTU:
+                    description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  vxlanPort:
+                    type: integer
+                  vxlanVNI:
+                    type: integer
+                  wireguardEnabled:
+                    description: 'WireguardEnabled controls whether Wireguard is enabled.
+                      [Default: false]'
+                    type: boolean
+                  wireguardHostEncryptionEnabled:
+                    description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                      host-to-host encryption is enabled. [Default: false]'
+                    type: boolean
+                  wireguardInterfaceName:
+                    description: 'WireguardInterfaceName specifies the name to use for
+                      the Wireguard interface. [Default: wg.calico]'
+                    type: string
+                  wireguardListeningPort:
+                    description: 'WireguardListeningPort controls the listening port used
+                      by Wireguard. [Default: 51820]'
+                    type: integer
+                  wireguardMTU:
+                    description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                      See Configuring MTU [Default: 1420]'
+                    type: integer
+                  wireguardRoutingRulePriority:
+                    description: 'WireguardRoutingRulePriority controls the priority value
+                      to use for the Wireguard routing rule. [Default: 99]'
+                    type: integer
+                  xdpEnabled:
+                    description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                      incoming deny rules. [Default: true]'
+                    type: boolean
+                  xdpRefreshInterval:
+                    description: 'XDPRefreshInterval is the period at which Felix re-checks
+                      all XDP state to ensure that no other process has accidentally broken
+                      Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                      refresh. [Default: 90s]'
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkPolicy
+        listKind: GlobalNetworkPolicyList
+        plural: globalnetworkpolicies
+        singular: globalnetworkpolicy
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  applyOnForward:
+                    description: ApplyOnForward indicates to apply the rules in this policy
+                      on forward traffic.
+                    type: boolean
+                  doNotTrack:
+                    description: DoNotTrack indicates whether packets matched by the rules
+                      in this policy should go through the data plane's connection tracking,
+                      such as Linux conntrack.  If True, the rules in this policy are
+                      applied before any data plane connection tracking, and packets allowed
+                      by this policy are marked as not to be tracked.
+                    type: boolean
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    description: NamespaceSelector is an optional field for an expression
+                      used to select a pod based on namespaces.
+                    type: string
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  preDNAT:
+                    description: PreDNAT indicates to apply the rules in this policy before
+                      any DNAT.
+                    type: boolean
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress rules are present in the policy.  The
+                      default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                      (including the case where there are   also no Ingress rules) \n
+                      - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                      rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                      both Ingress and Egress rules. \n When the policy is read back again,
+                      Types will always be one of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkSet
+        listKind: GlobalNetworkSetList
+        plural: globalnetworksets
+        singular: globalnetworkset
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+              that share labels to allow rules to refer to them via selectors.  The labels
+              of GlobalNetworkSet are not namespaced.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: hostendpoints.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: HostEndpoint
+        listKind: HostEndpointList
+        plural: hostendpoints
+        singular: hostendpoint
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: HostEndpointSpec contains the specification for a HostEndpoint
+                  resource.
+                properties:
+                  expectedIPs:
+                    description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                      If \"InterfaceName\" is not present, Calico will look for an interface
+                      matching any of the IPs in the list and apply policy to that. Note:
+                      \tWhen using the selector match criteria in an ingress or egress
+                      security Policy \tor Profile, Calico converts the selector into
+                      a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                      is used for that purpose. (If only the interface \tname is specified,
+                      Calico does not learn the IPs of the interface for use in match
+                      \tcriteria.)"
+                    items:
+                      type: string
+                    type: array
+                  interfaceName:
+                    description: "Either \"*\", or the name of a specific Linux interface
+                      to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                      governs all traffic to, from or through the default network namespace
+                      of the host named by the \"Node\" field; entering and leaving that
+                      namespace via any interface, including those from/to non-host-networked
+                      local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                      only governs traffic that enters or leaves the host through the
+                      specific interface named by InterfaceName, or - when InterfaceName
+                      is empty - through the specific interface that has one of the IPs
+                      in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                      one expected IP must be specified.  Only external interfaces (such
+                      as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                      to protect traffic through a specific local workload interface.
+                      \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                      initially just pre-DNAT policy.  Please check Calico documentation
+                      for the latest position."
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance.
+                    type: string
+                  ports:
+                    description: Ports contains the endpoint's named ports, which may
+                      be referenced in security policy rules.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  profiles:
+                    description: A list of identifiers of security Profile objects that
+                      apply to this endpoint. Each profile is applied in the order that
+                      they appear in this list.  Profile rules are applied after the selector-based
+                      security policy.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamblocks.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMBlock
+        listKind: IPAMBlockList
+        plural: ipamblocks
+        singular: ipamblock
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMBlockSpec contains the specification for an IPAMBlock
+                  resource.
+                properties:
+                  affinity:
+                    type: string
+                  allocations:
+                    items:
+                      nullable: true
+                      type: integer
+                    type: array
+                  attributes:
+                    items:
+                      properties:
+                        handle_id:
+                          type: string
+                        secondary:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    type: array
+                  cidr:
+                    type: string
+                  deleted:
+                    type: boolean
+                  strictAffinity:
+                    type: boolean
+                  unallocated:
+                    items:
+                      type: integer
+                    type: array
+                required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamconfigs.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMConfig
+        listKind: IPAMConfigList
+        plural: ipamconfigs
+        singular: ipamconfig
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMConfigSpec contains the specification for an IPAMConfig
+                  resource.
+                properties:
+                  autoAllocateBlocks:
+                    type: boolean
+                  maxBlocksPerHost:
+                    description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                      that can be affine to each host.
+                    type: integer
+                  strictAffinity:
+                    type: boolean
+                required:
+                - autoAllocateBlocks
+                - strictAffinity
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamhandles.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMHandle
+        listKind: IPAMHandleList
+        plural: ipamhandles
+        singular: ipamhandle
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMHandleSpec contains the specification for an IPAMHandle
+                  resource.
+                properties:
+                  block:
+                    additionalProperties:
+                      type: integer
+                    type: object
+                  deleted:
+                    type: boolean
+                  handleID:
+                    type: string
+                required:
+                - block
+                - handleID
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ippools.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPPool
+        listKind: IPPoolList
+        plural: ippools
+        singular: ippool
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPPoolSpec contains the specification for an IPPool resource.
+                properties:
+                  blockSize:
+                    description: The block size to use for IP address assignments from
+                      this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                    type: integer
+                  cidr:
+                    description: The pool CIDR.
+                    type: string
+                  disabled:
+                    description: When disabled is true, Calico IPAM will not assign addresses
+                      from this pool.
+                    type: boolean
+                  ipip:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    properties:
+                      enabled:
+                        description: When enabled is true, ipip tunneling will be used
+                          to deliver packets to destinations within this pool.
+                        type: boolean
+                      mode:
+                        description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                          mode of "always" will also use IPIP tunneling for routing to
+                          destination IP addresses within this pool.  A mode of "cross-subnet"
+                          will only use IPIP tunneling when the destination node is on
+                          a different subnet to the originating node.  The default value
+                          (if not specified) is "always".
+                        type: string
+                    type: object
+                  ipipMode:
+                    description: Contains configuration for IPIP tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                      is disabled).
+                    type: string
+                  nat-outgoing:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    type: boolean
+                  natOutgoing:
+                    description: When nat-outgoing is true, packets sent from Calico networked
+                      containers in this pool to destinations outside of this pool will
+                      be masqueraded.
+                    type: boolean
+                  nodeSelector:
+                    description: Allows IPPool to allocate for a specific node by label
+                      selector.
+                    type: string
+                  vxlanMode:
+                    description: Contains configuration for VXLAN tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                      tunneling is disabled).
+                    type: string
+                required:
+                - cidr
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubecontrollersconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: KubeControllersConfiguration
+        listKind: KubeControllersConfigurationList
+        plural: kubecontrollersconfigurations
+        singular: kubecontrollersconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeControllersConfigurationSpec contains the values of the
+                  Kubernetes controllers configuration.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host endpoints.
+                              Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation of
+                                  host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the controller
+                              to determine if an IP address has been leaked. Set to 0
+                              to disable IP garbage collection. [Default: 15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+              status:
+                description: KubeControllersConfigurationStatus represents the status
+                  of the configuration. It's useful for admins to be able to see the actual
+                  config that was applied, which can be modified by environment variables
+                  on the kube-controllers process.
+                properties:
+                  environmentVars:
+                    additionalProperties:
+                      type: string
+                    description: EnvironmentVars contains the environment variables on
+                      the kube-controllers that influenced the RunningConfig.
+                    type: object
+                  runningConfig:
+                    description: RunningConfig contains the effective config that is running
+                      in the kube-controllers pod, after merging the API resource with
+                      any environment variables.
+                    properties:
+                      controllers:
+                        description: Controllers enables and configures individual Kubernetes
+                          controllers
+                        properties:
+                          namespace:
+                            description: Namespace enables and configures the namespace
+                              controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          node:
+                            description: Node enables and configures the node controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              hostEndpoint:
+                                description: HostEndpoint controls syncing nodes to host
+                                  endpoints. Disabled by default, set to nil to disable.
+                                properties:
+                                  autoCreate:
+                                    description: 'AutoCreate enables automatic creation
+                                      of host endpoints for every node. [Default: Disabled]'
+                                    type: string
+                                type: object
+                              leakGracePeriod:
+                                description: 'LeakGracePeriod is the period used by the
+                                  controller to determine if an IP address has been leaked.
+                                  Set to 0 to disable IP garbage collection. [Default:
+                                  15m]'
+                                type: string
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                              syncLabels:
+                                description: 'SyncLabels controls whether to copy Kubernetes
+                                  node labels to Calico nodes. [Default: Enabled]'
+                                type: string
+                            type: object
+                          policy:
+                            description: Policy enables and configures the policy controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          serviceAccount:
+                            description: ServiceAccount enables and configures the service
+                              account controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          workloadEndpoint:
+                            description: WorkloadEndpoint enables and configures the workload
+                              endpoint controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                        type: object
+                      etcdV3CompactionPeriod:
+                        description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                          compaction requests. Set to 0 to disable. [Default: 10m]'
+                        type: string
+                      healthChecks:
+                        description: 'HealthChecks enables or disables support for health
+                          checks [Default: Enabled]'
+                        type: string
+                      logSeverityScreen:
+                        description: 'LogSeverityScreen is the log severity above which
+                          logs are sent to the stdout. [Default: Info]'
+                        type: string
+                      prometheusMetricsPort:
+                        description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                          metrics server should bind to. Set to 0 to disable. [Default:
+                          9094]'
+                        type: integer
+                    required:
+                    - controllers
+                    type: object
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkPolicy
+        listKind: NetworkPolicyList
+        plural: networkpolicies
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress are present in the policy.  The default
+                      is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                      the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                      ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                      PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                      \n When the policy is read back again, Types will always be one
+                      of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkSet
+        listKind: NetworkSetList
+        plural: networksets
+        singular: networkset
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: NetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-kube-controllers
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      verbs:
+      - list
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - hostendpoints
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - clusterinformations
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - kubecontrollersconfigurations
+      verbs:
+      - get
+      - create
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-node
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - namespaces
+      verbs:
+      - get
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - patch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - bgpconfigurations
+      - bgppeers
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ipamconfigs
+      verbs:
+      - get
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      verbs:
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - daemonsets
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-kube-controllers
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      calico_backend: vxlan
+      cni_network_config: |-
+        {
+          "name": "k8s-pod-network",
+          "cniVersion": "0.3.1",
+          "plugins": [
+            {
+              "type": "calico",
+              "log_level": "info",
+              "log_file_path": "/var/log/calico/cni/cni.log",
+              "datastore_type": "kubernetes",
+              "nodename": "__KUBERNETES_NODE_NAME__",
+              "mtu": __CNI_MTU__,
+              "ipam": {
+                  "type": "calico-ipam"
+              },
+              "policy": {
+                  "type": "k8s"
+              },
+              "kubernetes": {
+                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              }
+            },
+            {
+              "type": "portmap",
+              "snat": true,
+              "capabilities": {"portMappings": true}
+            },
+            {
+              "type": "bandwidth",
+              "capabilities": {"bandwidth": true}
+            }
+          ]
+        }
+      typha_service_name: none
+      veth_mtu: "1350"
+    kind: ConfigMap
+    metadata:
+      name: calico-config
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-kube-controllers
+          name: calico-kube-controllers
+          namespace: kube-system
+        spec:
+          containers:
+          - env:
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            image: docker.io/calico/kube-controllers:v3.20.3
+            livenessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -l
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-kube-controllers
+            readinessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -r
+              periodSeconds: 10
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: calico-kube-controllers
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: calico-node
+      name: calico-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+        spec:
+          containers:
+          - env:
+            - name: FELIX_FEATUREDETECTOVERRIDE
+              value: ChecksumOffloadBroken=true
+            - name: CALICO_IPV4POOL_VXLAN
+              value: Always
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            - name: CLUSTER_TYPE
+              value: k8s,bgp
+            - name: IP
+              value: autodetect
+            - name: CALICO_IPV4POOL_IPIP
+              value: Never
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_WIREGUARDMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_AWSSRCDSTCHECK
+              value: Disable
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: ACCEPT
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/node:v3.20.3
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -shutdown
+            livenessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-live
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-node
+            readinessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-ready
+              periodSeconds: 10
+              timeoutSeconds: 10
+            resources:
+              requests:
+                cpu: 250m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /var/run/nodeagent
+              name: policysync
+            - mountPath: /sys/fs/
+              mountPropagation: Bidirectional
+              name: sysfs
+            - mountPath: /var/log/calico/cni
+              name: cni-log-dir
+              readOnly: true
+          hostNetwork: true
+          initContainers:
+          - command:
+            - /opt/cni/bin/calico-ipam
+            - -upgrade
+            env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: upgrade-ipam
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          - command:
+            - /opt/cni/bin/install
+            env:
+            - name: CNI_CONF_NAME
+              value: 10-calico.conflist
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  key: cni_network_config
+                  name: calico-config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: SLEEP
+              value: "false"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: install-cni
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+            name: flexvol-driver
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/driver
+              name: flexvol-driver-host
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: calico-node
+          terminationGracePeriodSeconds: 0
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /lib/modules
+            name: lib-modules
+          - hostPath:
+              path: /var/run/calico
+            name: var-run-calico
+          - hostPath:
+              path: /var/lib/calico
+            name: var-lib-calico
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+          - hostPath:
+              path: /sys/fs/
+              type: DirectoryOrCreate
+            name: sysfs
+          - hostPath:
+              path: /opt/cni/bin
+            name: cni-bin-dir
+          - hostPath:
+              path: /etc/cni/net.d
+            name: cni-net-dir
+          - hostPath:
+              path: /var/log/calico/cni
+            name: cni-log-dir
+          - hostPath:
+              path: /var/lib/cni/networks
+            name: host-local-net-dir
+          - hostPath:
+              path: /var/run/nodeagent
+              type: DirectoryOrCreate
+            name: policysync
+          - hostPath:
+              path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+              type: DirectoryOrCreate
+            name: flexvol-driver-host
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
@@ -4277,7 +4277,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.20.3
+            image: docker.io/calico/kube-controllers:v3.20.4
             livenessProbe:
               exec:
                 command:
@@ -4387,7 +4387,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.20.3
+            image: docker.io/calico/node:v3.20.4
             lifecycle:
               preStop:
                 exec:
@@ -4459,7 +4459,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: upgrade-ipam
             securityContext:
               privileged: true
@@ -4493,7 +4493,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: install-cni
             securityContext:
               privileged: true
@@ -4502,7 +4502,7 @@ data:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.4
             name: flexvol-driver
             securityContext:
               privileged: true

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -301,22 +301,3600 @@ spec:
 apiVersion: v1
 data:
   resources: |
-    ---
-    # Source: calico/templates/calico-config.yaml
-    # This ConfigMap is used to configure a self-hosted Calico installation.
-    kind: ConfigMap
-    apiVersion: v1
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
     metadata:
-      name: calico-config
+      name: bgpconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPConfiguration
+        listKind: BGPConfigurationList
+        plural: bgpconfigurations
+        singular: bgpconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: BGPConfiguration contains the configuration for any BGP routing.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPConfigurationSpec contains the values of the BGP configuration.
+                properties:
+                  asNumber:
+                    description: 'ASNumber is the default AS number used by a node. [Default:
+                      64512]'
+                    format: int32
+                    type: integer
+                  communities:
+                    description: Communities is a list of BGP community values and their
+                      arbitrary names for tagging routes.
+                    items:
+                      description: Community contains standard or large community value
+                        and its name.
+                      properties:
+                        name:
+                          description: Name given to community value.
+                          type: string
+                        value:
+                          description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                            For standard community use `aa:nn` format, where `aa` and
+                            `nn` are 16 bit number. For large community use `aa:nn:mm`
+                            format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                            `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                          pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                          type: string
+                      type: object
+                    type: array
+                  listenPort:
+                    description: ListenPort is the port where BGP protocol should listen.
+                      Defaults to 179
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: INFO]'
+                    type: string
+                  nodeToNodeMeshEnabled:
+                    description: 'NodeToNodeMeshEnabled sets whether full node to node
+                      BGP mesh is enabled. [Default: true]'
+                    type: boolean
+                  prefixAdvertisements:
+                    description: PrefixAdvertisements contains per-prefix advertisement
+                      configuration.
+                    items:
+                      description: PrefixAdvertisement configures advertisement properties
+                        for the specified CIDR.
+                      properties:
+                        cidr:
+                          description: CIDR for which properties should be advertised.
+                          type: string
+                        communities:
+                          description: Communities can be list of either community names
+                            already defined in `Specs.Communities` or community value
+                            of format `aa:nn` or `aa:nn:mm`. For standard community use
+                            `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                            large community use `aa:nn:mm` format, where `aa`, `nn` and
+                            `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                            `mm` are per-AS identifier.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  serviceClusterIPs:
+                    description: ServiceClusterIPs are the CIDR blocks from which service
+                      cluster IPs are allocated. If specified, Calico will advertise these
+                      blocks, as well as any cluster IPs within them.
+                    items:
+                      description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                        CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceExternalIPs:
+                    description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                      Service External IPs. Kubernetes Service ExternalIPs will only be
+                      advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceExternalIPBlock represents a single allowed
+                        External IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceLoadBalancerIPs:
+                    description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                      Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                      IPs will only be advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceLoadBalancerIPBlock represents a single allowed
+                        LoadBalancer IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgppeers.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPPeer
+        listKind: BGPPeerList
+        plural: bgppeers
+        singular: bgppeer
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPPeerSpec contains the specification for a BGPPeer resource.
+                properties:
+                  asNumber:
+                    description: The AS Number of the peer.
+                    format: int32
+                    type: integer
+                  keepOriginalNextHop:
+                    description: Option to keep the original nexthop field when routes
+                      are sent to a BGP Peer. Setting "true" configures the selected BGP
+                      Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                      in the specific branch of the Node on "bird.cfg".
+                    type: boolean
+                  maxRestartTime:
+                    description: Time to allow for software restart.  When specified,
+                      this is configured as the graceful restart timeout.  When not specified,
+                      the BIRD default of 120s is used.
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance that
+                      is targeted by this peer. If this is not set, and no nodeSelector
+                      is specified, then this BGP peer selects all nodes in the cluster.
+                    type: string
+                  nodeSelector:
+                    description: Selector for the nodes that should have this peering.  When
+                      this is set, the Node field must be empty.
+                    type: string
+                  password:
+                    description: Optional BGP password for the peerings generated by this
+                      BGPPeer resource.
+                    properties:
+                      secretKeyRef:
+                        description: Selects a key of a secret in the node pod's namespace.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be
+                              a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be
+                              defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  peerIP:
+                    description: The IP address of the peer followed by an optional port
+                      number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                      or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                      and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                      set in BGPConfiguration, then we use that port to peer.
+                    type: string
+                  peerSelector:
+                    description: Selector for the remote nodes to peer with.  When this
+                      is set, the PeerIP and ASNumber fields must be empty.  For each
+                      peering between the local node and selected remote nodes, we configure
+                      an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                      and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                      remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                      or the global default if that is not set.
+                    type: string
+                  sourceAddress:
+                    description: Specifies whether and how to configure a source address
+                      for the peerings generated by this BGPPeer resource.  Default value
+                      "UseNodeIP" means to configure the node IP as the source address.  "None"
+                      means not to configure a source address.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: blockaffinities.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BlockAffinity
+        listKind: BlockAffinityList
+        plural: blockaffinities
+        singular: blockaffinity
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BlockAffinitySpec contains the specification for a BlockAffinity
+                  resource.
+                properties:
+                  cidr:
+                    type: string
+                  deleted:
+                    description: Deleted indicates that this block affinity is being deleted.
+                      This field is a string for compatibility with older releases that
+                      mistakenly treat this field as a string.
+                    type: string
+                  node:
+                    type: string
+                  state:
+                    type: string
+                required:
+                - cidr
+                - deleted
+                - node
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: clusterinformations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: ClusterInformation
+        listKind: ClusterInformationList
+        plural: clusterinformations
+        singular: clusterinformation
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterInformation contains the cluster specific information.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterInformationSpec contains the values of describing
+                  the cluster.
+                properties:
+                  calicoVersion:
+                    description: CalicoVersion is the version of Calico that the cluster
+                      is running
+                    type: string
+                  clusterGUID:
+                    description: ClusterGUID is the GUID of the cluster
+                    type: string
+                  clusterType:
+                    description: ClusterType describes the type of the cluster
+                    type: string
+                  datastoreReady:
+                    description: DatastoreReady is used during significant datastore migrations
+                      to signal to components such as Felix that it should wait before
+                      accessing the datastore.
+                    type: boolean
+                  variant:
+                    description: Variant declares which variant of Calico should be active.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: felixconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: FelixConfiguration
+        listKind: FelixConfigurationList
+        plural: felixconfigurations
+        singular: felixconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: Felix Configuration contains the configuration for Felix.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: FelixConfigurationSpec contains the values of the Felix configuration.
+                properties:
+                  allowIPIPPacketsFromWorkloads:
+                    description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop IPIP encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  allowVXLANPacketsFromWorkloads:
+                    description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop VXLAN encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  awsSrcDstCheck:
+                    description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                      value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                      DoNothing]'
+                    enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                    type: string
+                  bpfConnectTimeLoadBalancingEnabled:
+                    description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                      controls whether Felix installs the connection-time load balancer.  The
+                      connect-time load balancer is required for the host to be able to
+                      reach Kubernetes services and it improves the performance of pod-to-service
+                      connections.  The only reason to disable it is for debugging purposes.  [Default:
+                      true]'
+                    type: boolean
+                  bpfDataIfacePattern:
+                    description: BPFDataIfacePattern is a regular expression that controls
+                      which interfaces Felix should attach BPF programs to in order to
+                      catch traffic to/from the network.  This needs to match the interfaces
+                      that Calico workload traffic flows over as well as any interfaces
+                      that handle incoming traffic to nodeports and services from outside
+                      the cluster.  It should not match the workload interfaces (usually
+                      named cali...).
+                    type: string
+                  bpfDisableUnprivileged:
+                    description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                      sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                      users cannot access Calico''s BPF maps and cannot insert their own
+                      BPF programs to interfere with Calico''s. [Default: true]'
+                    type: boolean
+                  bpfEnabled:
+                    description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                      [Default: false]'
+                    type: boolean
+                  bpfExtToServiceConnmark:
+                    description: 'BPFExtToServiceConnmark in BPF mode, controls a 32bit
+                      mark that is set on connections from an external client to a local
+                      service. This mark allows us to control how packets of that connection
+                      are routed within the host and how is routing intepreted by RPF
+                      check. [Default: 0]'
+                    type: integer
+                  bpfExternalServiceMode:
+                    description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                      from outside the cluster to services (node ports and cluster IPs)
+                      are forwarded to remote workloads.  If set to "Tunnel" then both
+                      request and response traffic is tunneled to the remote node.  If
+                      set to "DSR", the request traffic is tunneled but the response traffic
+                      is sent directly from the remote node.  In "DSR" mode, the remote
+                      node appears to use the IP of the ingress node; this requires a
+                      permissive L2 network.  [Default: Tunnel]'
+                    type: string
+                  bpfKubeProxyEndpointSlicesEnabled:
+                    description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                      whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                    type: boolean
+                  bpfKubeProxyIptablesCleanupEnabled:
+                    description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                      mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                      iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                      true]'
+                    type: boolean
+                  bpfKubeProxyMinSyncPeriod:
+                    description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                      minimum time between updates to the dataplane for Felix''s embedded
+                      kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                      reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                    type: string
+                  bpfLogLevel:
+                    description: 'BPFLogLevel controls the log level of the BPF programs
+                      when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                      logs are emitted to the BPF trace pipe, accessible with the command
+                      `tc exec bpf debug`. [Default: Off].'
+                    type: string
+                  chainInsertMode:
+                    description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                      top-level iptables chains by inserting a rule at the top of the
+                      chain or by appending a rule at the bottom. insert is the safe default
+                      since it prevents Calico''s rules from being bypassed. If you switch
+                      to append mode, be sure that the other rules in the chains signal
+                      acceptance by falling through to the Calico rules, otherwise the
+                      Calico policy will be bypassed. [Default: insert]'
+                    type: string
+                  dataplaneDriver:
+                    type: string
+                  debugDisableLogDropping:
+                    type: boolean
+                  debugMemoryProfilePath:
+                    type: string
+                  debugSimulateCalcGraphHangAfter:
+                    type: string
+                  debugSimulateDataplaneHangAfter:
+                    type: string
+                  defaultEndpointToHostAction:
+                    description: 'DefaultEndpointToHostAction controls what happens to
+                      traffic that goes from a workload endpoint to the host itself (after
+                      the traffic hits the endpoint egress policy). By default Calico
+                      blocks traffic from workload endpoints to the host itself with an
+                      iptables "DROP" action. If you want to allow some or all traffic
+                      from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                      RETURN if you have your own rules in the iptables "INPUT" chain;
+                      Calico will insert its rules at the top of that chain, then "RETURN"
+                      packets to the "INPUT" chain once it has completed processing workload
+                      endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                      from workloads after processing workload endpoint egress policy.
+                      [Default: Drop]'
+                    type: string
+                  deviceRouteProtocol:
+                    description: This defines the route protocol added to programmed device
+                      routes, by default this will be RTPROT_BOOT when left blank.
+                    type: integer
+                  deviceRouteSourceAddress:
+                    description: This is the source address to use on programmed device
+                      routes. By default the source address is left blank, leaving the
+                      kernel to choose the source address used.
+                    type: string
+                  disableConntrackInvalidCheck:
+                    type: boolean
+                  endpointReportingDelay:
+                    type: string
+                  endpointReportingEnabled:
+                    type: boolean
+                  externalNodesList:
+                    description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                      which may source tunnel traffic and have the tunneled traffic be
+                      accepted at calico nodes.
+                    items:
+                      type: string
+                    type: array
+                  failsafeInboundHostPorts:
+                    description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow incoming traffic to host endpoints
+                      on irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all inbound host ports, use the value
+                      none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                      udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  failsafeOutboundHostPorts:
+                    description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow outgoing traffic from host endpoints
+                      to irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all outbound host ports, use the value
+                      none. The default value opens etcd''s standard ports to ensure that
+                      Felix does not get cut off from etcd as well as allowing DHCP and
+                      DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                      tcp:6667, udp:53, udp:67]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  featureDetectOverride:
+                    description: FeatureDetectOverride is used to override the feature
+                      detection. Values are specified in a comma separated list with no
+                      spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                      "true" or "false" will force the feature, empty or omitted values
+                      are auto-detected.
+                    type: string
+                  genericXDPEnabled:
+                    description: 'GenericXDPEnabled enables Generic XDP so network cards
+                      that don''t support XDP offload or driver modes can use XDP. This
+                      is not recommended since it doesn''t provide better performance
+                      than iptables. [Default: false]'
+                    type: boolean
+                  healthEnabled:
+                    type: boolean
+                  healthHost:
+                    type: string
+                  healthPort:
+                    type: integer
+                  interfaceExclude:
+                    description: 'InterfaceExclude is a comma-separated list of interfaces
+                      that Felix should exclude when monitoring for host endpoints. The
+                      default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                      interface, which is used internally by kube-proxy. If you want to
+                      exclude multiple interface names using a single value, the list
+                      supports regular expressions. For regular expressions you must wrap
+                      the value with ''/''. For example having values ''/^kube/,veth1''
+                      will exclude all interfaces that begin with ''kube'' and also the
+                      interface ''veth1''. [Default: kube-ipvs0]'
+                    type: string
+                  interfacePrefix:
+                    description: 'InterfacePrefix is the interface name prefix that identifies
+                      workload endpoints and so distinguishes them from host endpoint
+                      interfaces. Note: in environments other than bare metal, the orchestrators
+                      configure this appropriately. For example our Kubernetes and Docker
+                      integrations set the ''cali'' value, and our OpenStack integration
+                      sets the ''tap'' value. [Default: cali]'
+                    type: string
+                  interfaceRefreshInterval:
+                    description: InterfaceRefreshInterval is the period at which Felix
+                      rescans local interfaces to verify their state. The rescan can be
+                      disabled by setting the interval to 0.
+                    type: string
+                  ipipEnabled:
+                    type: boolean
+                  ipipMTU:
+                    description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  ipsetsRefreshInterval:
+                    description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                      all iptables state to ensure that no other process has accidentally
+                      broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                      90s]'
+                    type: string
+                  iptablesBackend:
+                    description: IptablesBackend specifies which backend of iptables will
+                      be used. The default is legacy.
+                    type: string
+                  iptablesFilterAllowAction:
+                    type: string
+                  iptablesLockFilePath:
+                    description: 'IptablesLockFilePath is the location of the iptables
+                      lock file. You may need to change this if the lock file is not in
+                      its standard location (for example if you have mapped it into Felix''s
+                      container at a different path). [Default: /run/xtables.lock]'
+                    type: string
+                  iptablesLockProbeInterval:
+                    description: 'IptablesLockProbeInterval is the time that Felix will
+                      wait between attempts to acquire the iptables lock if it is not
+                      available. Lower values make Felix more responsive when the lock
+                      is contended, but use more CPU. [Default: 50ms]'
+                    type: string
+                  iptablesLockTimeout:
+                    description: 'IptablesLockTimeout is the time that Felix will wait
+                      for the iptables lock, or 0, to disable. To use this feature, Felix
+                      must share the iptables lock file with all other processes that
+                      also take the lock. When running Felix inside a container, this
+                      requires the /run directory of the host to be mounted into the calico/node
+                      or calico/felix container. [Default: 0s disabled]'
+                    type: string
+                  iptablesMangleAllowAction:
+                    type: string
+                  iptablesMarkMask:
+                    description: 'IptablesMarkMask is the mask that Felix selects its
+                      IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                      at least 8 bits set, none of which clash with any other mark bits
+                      in use on the system. [Default: 0xff000000]'
+                    format: int32
+                    type: integer
+                  iptablesNATOutgoingInterfaceFilter:
+                    type: string
+                  iptablesPostWriteCheckInterval:
+                    description: 'IptablesPostWriteCheckInterval is the period after Felix
+                      has done a write to the dataplane that it schedules an extra read
+                      back in order to check the write was not clobbered by another process.
+                      This should only occur if another application on the system doesn''t
+                      respect the iptables lock. [Default: 1s]'
+                    type: string
+                  iptablesRefreshInterval:
+                    description: 'IptablesRefreshInterval is the period at which Felix
+                      re-checks the IP sets in the dataplane to ensure that no other process
+                      has accidentally broken Calico''s rules. Set to 0 to disable IP
+                      sets refresh. Note: the default for this value is lower than the
+                      other refresh intervals as a workaround for a Linux kernel bug that
+                      was fixed in kernel version 4.11. If you are using v4.11 or greater
+                      you may want to set this to, a higher value to reduce Felix CPU
+                      usage. [Default: 10s]'
+                    type: string
+                  ipv6Support:
+                    type: boolean
+                  kubeNodePortRanges:
+                    description: 'KubeNodePortRanges holds list of port ranges used for
+                      service node ports. Only used if felix detects kube-proxy running
+                      in ipvs mode. Felix uses these ranges to separate host and workload
+                      traffic. [Default: 30000:32767].'
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  logFilePath:
+                    description: 'LogFilePath is the full path to the Felix log. Set to
+                      none to disable file logging. [Default: /var/log/calico/felix.log]'
+                    type: string
+                  logPrefix:
+                    description: 'LogPrefix is the log prefix that Felix uses when rendering
+                      LOG rules. [Default: calico-packet]'
+                    type: string
+                  logSeverityFile:
+                    description: 'LogSeverityFile is the log severity above which logs
+                      are sent to the log file. [Default: Info]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  logSeveritySys:
+                    description: 'LogSeveritySys is the log severity above which logs
+                      are sent to the syslog. Set to None for no logging to syslog. [Default:
+                      Info]'
+                    type: string
+                  maxIpsetSize:
+                    type: integer
+                  metadataAddr:
+                    description: 'MetadataAddr is the IP address or domain name of the
+                      server that can answer VM queries for cloud-init metadata. In OpenStack,
+                      this corresponds to the machine running nova-api (or in Ubuntu,
+                      nova-api-metadata). A value of none (case insensitive) means that
+                      Felix should not set up any NAT rule for the metadata path. [Default:
+                      127.0.0.1]'
+                    type: string
+                  metadataPort:
+                    description: 'MetadataPort is the port of the metadata server. This,
+                      combined with global.MetadataAddr (if not ''None''), is used to
+                      set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                      In most cases this should not need to be changed [Default: 8775].'
+                    type: integer
+                  mtuIfacePattern:
+                    description: MTUIfacePattern is a regular expression that controls
+                      which interfaces Felix should scan in order to calculate the host's
+                      MTU. This should not match workload interfaces (usually named cali...).
+                    type: string
+                  natOutgoingAddress:
+                    description: NATOutgoingAddress specifies an address to use when performing
+                      source NAT for traffic in a natOutgoing pool that is leaving the
+                      network. By default the address used is an address on the interface
+                      the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                    type: string
+                  natPortRange:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NATPortRange specifies the range of ports that is used
+                      for port mapping when doing outgoing NAT. When unset the default
+                      behavior of the network stack is used.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  netlinkTimeout:
+                    type: string
+                  openstackRegion:
+                    description: 'OpenstackRegion is the name of the region that a particular
+                      Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                      this must be configured somehow for each Felix (here in the datamodel,
+                      or in felix.cfg or the environment on each compute node), and must
+                      match the [calico] openstack_region value configured in neutron.conf
+                      on each node. [Default: Empty]'
+                    type: string
+                  policySyncPathPrefix:
+                    description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                      policy changes to external services, like Application layer policy.
+                      [Default: Empty]'
+                    type: string
+                  prometheusGoMetricsEnabled:
+                    description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusMetricsEnabled:
+                    description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                      server in Felix if set to true. [Default: false]'
+                    type: boolean
+                  prometheusMetricsHost:
+                    description: 'PrometheusMetricsHost is the host that the Prometheus
+                      metrics server should bind to. [Default: empty]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. [Default: 9091]'
+                    type: integer
+                  prometheusProcessMetricsEnabled:
+                    description: 'PrometheusProcessMetricsEnabled disables process metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusWireGuardMetricsEnabled:
+                    description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                      metrics collection, which the Prometheus client does by default,
+                      when set to false. This reduces the number of metrics reported,
+                      reducing Prometheus load. [Default: true]'
+                    type: boolean
+                  removeExternalRoutes:
+                    description: Whether or not to remove device routes that have not
+                      been programmed by Felix. Disabling this will allow external applications
+                      to also add device routes. This is enabled by default which means
+                      we will remove externally added routes.
+                    type: boolean
+                  reportingInterval:
+                    description: 'ReportingInterval is the interval at which Felix reports
+                      its status into the datastore or 0 to disable. Must be non-zero
+                      in OpenStack deployments. [Default: 30s]'
+                    type: string
+                  reportingTTL:
+                    description: 'ReportingTTL is the time-to-live setting for process-wide
+                      status reports. [Default: 90s]'
+                    type: string
+                  routeRefreshInterval:
+                    description: 'RouteRefreshInterval is the period at which Felix re-checks
+                      the routes in the dataplane to ensure that no other process has
+                      accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                      [Default: 90s]'
+                    type: string
+                  routeSource:
+                    description: 'RouteSource configures where Felix gets its routing
+                      information. - WorkloadIPs: use workload endpoints to construct
+                      routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                    type: string
+                  routeTableRange:
+                    description: Calico programs additional Linux route tables for various
+                      purposes.  RouteTableRange specifies the indices of the route tables
+                      that Calico should use.
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                    - max
+                    - min
+                    type: object
+                  serviceLoopPrevention:
+                    description: 'When service IP advertisement is enabled, prevent routing
+                      loops to service IPs that are not in use, by dropping or rejecting
+                      packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                      in which case such routing loops continue to be allowed. [Default:
+                      Drop]'
+                    type: string
+                  sidecarAccelerationEnabled:
+                    description: 'SidecarAccelerationEnabled enables experimental sidecar
+                      acceleration [Default: false]'
+                    type: boolean
+                  usageReportingEnabled:
+                    description: 'UsageReportingEnabled reports anonymous Calico version
+                      number and cluster size to projectcalico.org. Logs warnings returned
+                      by the usage server. For example, if a significant security vulnerability
+                      has been discovered in the version of Calico being used. [Default:
+                      true]'
+                    type: boolean
+                  usageReportingInitialDelay:
+                    description: 'UsageReportingInitialDelay controls the minimum delay
+                      before Felix makes a report. [Default: 300s]'
+                    type: string
+                  usageReportingInterval:
+                    description: 'UsageReportingInterval controls the interval at which
+                      Felix makes reports. [Default: 86400s]'
+                    type: string
+                  useInternalDataplaneDriver:
+                    type: boolean
+                  vxlanEnabled:
+                    type: boolean
+                  vxlanMTU:
+                    description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  vxlanPort:
+                    type: integer
+                  vxlanVNI:
+                    type: integer
+                  wireguardEnabled:
+                    description: 'WireguardEnabled controls whether Wireguard is enabled.
+                      [Default: false]'
+                    type: boolean
+                  wireguardHostEncryptionEnabled:
+                    description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                      host-to-host encryption is enabled. [Default: false]'
+                    type: boolean
+                  wireguardInterfaceName:
+                    description: 'WireguardInterfaceName specifies the name to use for
+                      the Wireguard interface. [Default: wg.calico]'
+                    type: string
+                  wireguardListeningPort:
+                    description: 'WireguardListeningPort controls the listening port used
+                      by Wireguard. [Default: 51820]'
+                    type: integer
+                  wireguardMTU:
+                    description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                      See Configuring MTU [Default: 1420]'
+                    type: integer
+                  wireguardRoutingRulePriority:
+                    description: 'WireguardRoutingRulePriority controls the priority value
+                      to use for the Wireguard routing rule. [Default: 99]'
+                    type: integer
+                  xdpEnabled:
+                    description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                      incoming deny rules. [Default: true]'
+                    type: boolean
+                  xdpRefreshInterval:
+                    description: 'XDPRefreshInterval is the period at which Felix re-checks
+                      all XDP state to ensure that no other process has accidentally broken
+                      Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                      refresh. [Default: 90s]'
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkPolicy
+        listKind: GlobalNetworkPolicyList
+        plural: globalnetworkpolicies
+        singular: globalnetworkpolicy
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  applyOnForward:
+                    description: ApplyOnForward indicates to apply the rules in this policy
+                      on forward traffic.
+                    type: boolean
+                  doNotTrack:
+                    description: DoNotTrack indicates whether packets matched by the rules
+                      in this policy should go through the data plane's connection tracking,
+                      such as Linux conntrack.  If True, the rules in this policy are
+                      applied before any data plane connection tracking, and packets allowed
+                      by this policy are marked as not to be tracked.
+                    type: boolean
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    description: NamespaceSelector is an optional field for an expression
+                      used to select a pod based on namespaces.
+                    type: string
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  preDNAT:
+                    description: PreDNAT indicates to apply the rules in this policy before
+                      any DNAT.
+                    type: boolean
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress rules are present in the policy.  The
+                      default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                      (including the case where there are   also no Ingress rules) \n
+                      - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                      rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                      both Ingress and Egress rules. \n When the policy is read back again,
+                      Types will always be one of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkSet
+        listKind: GlobalNetworkSetList
+        plural: globalnetworksets
+        singular: globalnetworkset
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+              that share labels to allow rules to refer to them via selectors.  The labels
+              of GlobalNetworkSet are not namespaced.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: hostendpoints.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: HostEndpoint
+        listKind: HostEndpointList
+        plural: hostendpoints
+        singular: hostendpoint
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: HostEndpointSpec contains the specification for a HostEndpoint
+                  resource.
+                properties:
+                  expectedIPs:
+                    description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                      If \"InterfaceName\" is not present, Calico will look for an interface
+                      matching any of the IPs in the list and apply policy to that. Note:
+                      \tWhen using the selector match criteria in an ingress or egress
+                      security Policy \tor Profile, Calico converts the selector into
+                      a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                      is used for that purpose. (If only the interface \tname is specified,
+                      Calico does not learn the IPs of the interface for use in match
+                      \tcriteria.)"
+                    items:
+                      type: string
+                    type: array
+                  interfaceName:
+                    description: "Either \"*\", or the name of a specific Linux interface
+                      to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                      governs all traffic to, from or through the default network namespace
+                      of the host named by the \"Node\" field; entering and leaving that
+                      namespace via any interface, including those from/to non-host-networked
+                      local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                      only governs traffic that enters or leaves the host through the
+                      specific interface named by InterfaceName, or - when InterfaceName
+                      is empty - through the specific interface that has one of the IPs
+                      in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                      one expected IP must be specified.  Only external interfaces (such
+                      as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                      to protect traffic through a specific local workload interface.
+                      \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                      initially just pre-DNAT policy.  Please check Calico documentation
+                      for the latest position."
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance.
+                    type: string
+                  ports:
+                    description: Ports contains the endpoint's named ports, which may
+                      be referenced in security policy rules.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  profiles:
+                    description: A list of identifiers of security Profile objects that
+                      apply to this endpoint. Each profile is applied in the order that
+                      they appear in this list.  Profile rules are applied after the selector-based
+                      security policy.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamblocks.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMBlock
+        listKind: IPAMBlockList
+        plural: ipamblocks
+        singular: ipamblock
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMBlockSpec contains the specification for an IPAMBlock
+                  resource.
+                properties:
+                  affinity:
+                    type: string
+                  allocations:
+                    items:
+                      nullable: true
+                      type: integer
+                    type: array
+                  attributes:
+                    items:
+                      properties:
+                        handle_id:
+                          type: string
+                        secondary:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    type: array
+                  cidr:
+                    type: string
+                  deleted:
+                    type: boolean
+                  strictAffinity:
+                    type: boolean
+                  unallocated:
+                    items:
+                      type: integer
+                    type: array
+                required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamconfigs.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMConfig
+        listKind: IPAMConfigList
+        plural: ipamconfigs
+        singular: ipamconfig
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMConfigSpec contains the specification for an IPAMConfig
+                  resource.
+                properties:
+                  autoAllocateBlocks:
+                    type: boolean
+                  maxBlocksPerHost:
+                    description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                      that can be affine to each host.
+                    type: integer
+                  strictAffinity:
+                    type: boolean
+                required:
+                - autoAllocateBlocks
+                - strictAffinity
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamhandles.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMHandle
+        listKind: IPAMHandleList
+        plural: ipamhandles
+        singular: ipamhandle
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMHandleSpec contains the specification for an IPAMHandle
+                  resource.
+                properties:
+                  block:
+                    additionalProperties:
+                      type: integer
+                    type: object
+                  deleted:
+                    type: boolean
+                  handleID:
+                    type: string
+                required:
+                - block
+                - handleID
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ippools.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPPool
+        listKind: IPPoolList
+        plural: ippools
+        singular: ippool
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPPoolSpec contains the specification for an IPPool resource.
+                properties:
+                  blockSize:
+                    description: The block size to use for IP address assignments from
+                      this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                    type: integer
+                  cidr:
+                    description: The pool CIDR.
+                    type: string
+                  disabled:
+                    description: When disabled is true, Calico IPAM will not assign addresses
+                      from this pool.
+                    type: boolean
+                  ipip:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    properties:
+                      enabled:
+                        description: When enabled is true, ipip tunneling will be used
+                          to deliver packets to destinations within this pool.
+                        type: boolean
+                      mode:
+                        description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                          mode of "always" will also use IPIP tunneling for routing to
+                          destination IP addresses within this pool.  A mode of "cross-subnet"
+                          will only use IPIP tunneling when the destination node is on
+                          a different subnet to the originating node.  The default value
+                          (if not specified) is "always".
+                        type: string
+                    type: object
+                  ipipMode:
+                    description: Contains configuration for IPIP tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                      is disabled).
+                    type: string
+                  nat-outgoing:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    type: boolean
+                  natOutgoing:
+                    description: When nat-outgoing is true, packets sent from Calico networked
+                      containers in this pool to destinations outside of this pool will
+                      be masqueraded.
+                    type: boolean
+                  nodeSelector:
+                    description: Allows IPPool to allocate for a specific node by label
+                      selector.
+                    type: string
+                  vxlanMode:
+                    description: Contains configuration for VXLAN tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                      tunneling is disabled).
+                    type: string
+                required:
+                - cidr
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubecontrollersconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: KubeControllersConfiguration
+        listKind: KubeControllersConfigurationList
+        plural: kubecontrollersconfigurations
+        singular: kubecontrollersconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeControllersConfigurationSpec contains the values of the
+                  Kubernetes controllers configuration.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host endpoints.
+                              Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation of
+                                  host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the controller
+                              to determine if an IP address has been leaked. Set to 0
+                              to disable IP garbage collection. [Default: 15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+              status:
+                description: KubeControllersConfigurationStatus represents the status
+                  of the configuration. It's useful for admins to be able to see the actual
+                  config that was applied, which can be modified by environment variables
+                  on the kube-controllers process.
+                properties:
+                  environmentVars:
+                    additionalProperties:
+                      type: string
+                    description: EnvironmentVars contains the environment variables on
+                      the kube-controllers that influenced the RunningConfig.
+                    type: object
+                  runningConfig:
+                    description: RunningConfig contains the effective config that is running
+                      in the kube-controllers pod, after merging the API resource with
+                      any environment variables.
+                    properties:
+                      controllers:
+                        description: Controllers enables and configures individual Kubernetes
+                          controllers
+                        properties:
+                          namespace:
+                            description: Namespace enables and configures the namespace
+                              controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          node:
+                            description: Node enables and configures the node controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              hostEndpoint:
+                                description: HostEndpoint controls syncing nodes to host
+                                  endpoints. Disabled by default, set to nil to disable.
+                                properties:
+                                  autoCreate:
+                                    description: 'AutoCreate enables automatic creation
+                                      of host endpoints for every node. [Default: Disabled]'
+                                    type: string
+                                type: object
+                              leakGracePeriod:
+                                description: 'LeakGracePeriod is the period used by the
+                                  controller to determine if an IP address has been leaked.
+                                  Set to 0 to disable IP garbage collection. [Default:
+                                  15m]'
+                                type: string
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                              syncLabels:
+                                description: 'SyncLabels controls whether to copy Kubernetes
+                                  node labels to Calico nodes. [Default: Enabled]'
+                                type: string
+                            type: object
+                          policy:
+                            description: Policy enables and configures the policy controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          serviceAccount:
+                            description: ServiceAccount enables and configures the service
+                              account controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          workloadEndpoint:
+                            description: WorkloadEndpoint enables and configures the workload
+                              endpoint controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                        type: object
+                      etcdV3CompactionPeriod:
+                        description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                          compaction requests. Set to 0 to disable. [Default: 10m]'
+                        type: string
+                      healthChecks:
+                        description: 'HealthChecks enables or disables support for health
+                          checks [Default: Enabled]'
+                        type: string
+                      logSeverityScreen:
+                        description: 'LogSeverityScreen is the log severity above which
+                          logs are sent to the stdout. [Default: Info]'
+                        type: string
+                      prometheusMetricsPort:
+                        description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                          metrics server should bind to. Set to 0 to disable. [Default:
+                          9094]'
+                        type: integer
+                    required:
+                    - controllers
+                    type: object
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkPolicy
+        listKind: NetworkPolicyList
+        plural: networkpolicies
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress are present in the policy.  The default
+                      is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                      the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                      ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                      PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                      \n When the policy is read back again, Types will always be one
+                      of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkSet
+        listKind: NetworkSetList
+        plural: networksets
+        singular: networkset
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: NetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
       namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-kube-controllers
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      verbs:
+      - list
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - hostendpoints
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - clusterinformations
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - kubecontrollersconfigurations
+      verbs:
+      - get
+      - create
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-node
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - namespaces
+      verbs:
+      - get
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - patch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - bgpconfigurations
+      - bgppeers
+      verbs:
+      - create
+      - update
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-kube-controllers
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: v1
     data:
-      # Typha is disabled.
-      typha_service_name: "none"
-      # Configure the backend to use.
-      calico_backend: "none"
-
-      # The CNI network configuration to install on each node. The special
-      # values in this config will be automatically populated.
       cni_network_config: |-
         {
           "name": "k8s-pod-network",
@@ -351,3952 +3929,37 @@ data:
             }
           ]
         }
-
-    ---
-    # Source: calico/templates/kdd-crds.yaml
-
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
+      typha_service_name: calico-typha
+      veth_mtu: "1350"
+    kind: ConfigMap
     metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: bgpconfigurations.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: BGPConfiguration
-        listKind: BGPConfigurationList
-        plural: bgpconfigurations
-        singular: bgpconfiguration
-      scope: Cluster
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              description: BGPConfiguration contains the configuration for any BGP routing.
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: BGPConfigurationSpec contains the values of the BGP configuration.
-                  properties:
-                    asNumber:
-                      description: 'ASNumber is the default AS number used by a node. [Default:
-                      64512]'
-                      format: int32
-                      type: integer
-                    communities:
-                      description: Communities is a list of BGP community values and their
-                        arbitrary names for tagging routes.
-                      items:
-                        description: Community contains standard or large community value
-                          and its name.
-                        properties:
-                          name:
-                            description: Name given to community value.
-                            type: string
-                          value:
-                            description: Value must be of format `aa:nn` or `aa:nn:mm`.
-                              For standard community use `aa:nn` format, where `aa` and
-                              `nn` are 16 bit number. For large community use `aa:nn:mm`
-                              format, where `aa`, `nn` and `mm` are 32 bit number. Where,
-                              `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
-                            pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
-                            type: string
-                        type: object
-                      type: array
-                    listenPort:
-                      description: ListenPort is the port where BGP protocol should listen.
-                        Defaults to 179
-                      maximum: 65535
-                      minimum: 1
-                      type: integer
-                    logSeverityScreen:
-                      description: 'LogSeverityScreen is the log severity above which logs
-                      are sent to the stdout. [Default: INFO]'
-                      type: string
-                    nodeToNodeMeshEnabled:
-                      description: 'NodeToNodeMeshEnabled sets whether full node to node
-                      BGP mesh is enabled. [Default: true]'
-                      type: boolean
-                    prefixAdvertisements:
-                      description: PrefixAdvertisements contains per-prefix advertisement
-                        configuration.
-                      items:
-                        description: PrefixAdvertisement configures advertisement properties
-                          for the specified CIDR.
-                        properties:
-                          cidr:
-                            description: CIDR for which properties should be advertised.
-                            type: string
-                          communities:
-                            description: Communities can be list of either community names
-                              already defined in `Specs.Communities` or community value
-                              of format `aa:nn` or `aa:nn:mm`. For standard community use
-                              `aa:nn` format, where `aa` and `nn` are 16 bit number. For
-                              large community use `aa:nn:mm` format, where `aa`, `nn` and
-                              `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
-                              `mm` are per-AS identifier.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      type: array
-                    serviceClusterIPs:
-                      description: ServiceClusterIPs are the CIDR blocks from which service
-                        cluster IPs are allocated. If specified, Calico will advertise these
-                        blocks, as well as any cluster IPs within them.
-                      items:
-                        description: ServiceClusterIPBlock represents a single allowed ClusterIP
-                          CIDR block.
-                        properties:
-                          cidr:
-                            type: string
-                        type: object
-                      type: array
-                    serviceExternalIPs:
-                      description: ServiceExternalIPs are the CIDR blocks for Kubernetes
-                        Service External IPs. Kubernetes Service ExternalIPs will only be
-                        advertised if they are within one of these blocks.
-                      items:
-                        description: ServiceExternalIPBlock represents a single allowed
-                          External IP CIDR block.
-                        properties:
-                          cidr:
-                            type: string
-                        type: object
-                      type: array
-                    serviceLoadBalancerIPs:
-                      description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
-                        Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
-                        IPs will only be advertised if they are within one of these blocks.
-                      items:
-                        description: ServiceLoadBalancerIPBlock represents a single allowed
-                          LoadBalancer IP CIDR block.
-                        properties:
-                          cidr:
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: bgppeers.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: BGPPeer
-        listKind: BGPPeerList
-        plural: bgppeers
-        singular: bgppeer
-      scope: Cluster
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: BGPPeerSpec contains the specification for a BGPPeer resource.
-                  properties:
-                    asNumber:
-                      description: The AS Number of the peer.
-                      format: int32
-                      type: integer
-                    keepOriginalNextHop:
-                      description: Option to keep the original nexthop field when routes
-                        are sent to a BGP Peer. Setting "true" configures the selected BGP
-                        Peers node to use the "next hop keep;" instead of "next hop self;"(default)
-                        in the specific branch of the Node on "bird.cfg".
-                      type: boolean
-                    maxRestartTime:
-                      description: Time to allow for software restart.  When specified, this
-                        is configured as the graceful restart timeout.  When not specified,
-                        the BIRD default of 120s is used.
-                      type: string
-                    node:
-                      description: The node name identifying the Calico node instance that
-                        is targeted by this peer. If this is not set, and no nodeSelector
-                        is specified, then this BGP peer selects all nodes in the cluster.
-                      type: string
-                    nodeSelector:
-                      description: Selector for the nodes that should have this peering.  When
-                        this is set, the Node field must be empty.
-                      type: string
-                    password:
-                      description: Optional BGP password for the peerings generated by this
-                        BGPPeer resource.
-                      properties:
-                        secretKeyRef:
-                          description: Selects a key of a secret in the node pod's namespace.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must be
-                                a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must be
-                                defined
-                              type: boolean
-                          required:
-                            - key
-                          type: object
-                      type: object
-                    peerIP:
-                      description: The IP address of the peer followed by an optional port
-                        number to peer with. If port number is given, format should be `[<IPv6>]:port`
-                        or `<IPv4>:<port>` for IPv4. If optional port number is not set,
-                        and this peer IP and ASNumber belongs to a calico/node with ListenPort
-                        set in BGPConfiguration, then we use that port to peer.
-                      type: string
-                    peerSelector:
-                      description: Selector for the remote nodes to peer with.  When this
-                        is set, the PeerIP and ASNumber fields must be empty.  For each
-                        peering between the local node and selected remote nodes, we configure
-                        an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
-                        and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
-                        remote AS number comes from the remote node’s NodeBGPSpec.ASNumber,
-                        or the global default if that is not set.
-                      type: string
-                    sourceAddress:
-                      description: Specifies whether and how to configure a source address
-                        for the peerings generated by this BGPPeer resource.  Default value
-                        "UseNodeIP" means to configure the node IP as the source address.  "None"
-                        means not to configure a source address.
-                      type: string
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: blockaffinities.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: BlockAffinity
-        listKind: BlockAffinityList
-        plural: blockaffinities
-        singular: blockaffinity
-      scope: Cluster
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: BlockAffinitySpec contains the specification for a BlockAffinity
-                    resource.
-                  properties:
-                    cidr:
-                      type: string
-                    deleted:
-                      description: Deleted indicates that this block affinity is being deleted.
-                        This field is a string for compatibility with older releases that
-                        mistakenly treat this field as a string.
-                      type: string
-                    node:
-                      type: string
-                    state:
-                      type: string
-                  required:
-                    - cidr
-                    - deleted
-                    - node
-                    - state
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: clusterinformations.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: ClusterInformation
-        listKind: ClusterInformationList
-        plural: clusterinformations
-        singular: clusterinformation
-      scope: Cluster
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              description: ClusterInformation contains the cluster specific information.
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: ClusterInformationSpec contains the values of describing
-                    the cluster.
-                  properties:
-                    calicoVersion:
-                      description: CalicoVersion is the version of Calico that the cluster
-                        is running
-                      type: string
-                    clusterGUID:
-                      description: ClusterGUID is the GUID of the cluster
-                      type: string
-                    clusterType:
-                      description: ClusterType describes the type of the cluster
-                      type: string
-                    datastoreReady:
-                      description: DatastoreReady is used during significant datastore migrations
-                        to signal to components such as Felix that it should wait before
-                        accessing the datastore.
-                      type: boolean
-                    variant:
-                      description: Variant declares which variant of Calico should be active.
-                      type: string
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: felixconfigurations.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: FelixConfiguration
-        listKind: FelixConfigurationList
-        plural: felixconfigurations
-        singular: felixconfiguration
-      scope: Cluster
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              description: Felix Configuration contains the configuration for Felix.
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: FelixConfigurationSpec contains the values of the Felix configuration.
-                  properties:
-                    allowIPIPPacketsFromWorkloads:
-                      description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
-                      will add a rule to drop IPIP encapsulated traffic from workloads
-                      [Default: false]'
-                      type: boolean
-                    allowVXLANPacketsFromWorkloads:
-                      description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
-                      will add a rule to drop VXLAN encapsulated traffic from workloads
-                      [Default: false]'
-                      type: boolean
-                    awsSrcDstCheck:
-                      description: 'Set source-destination-check on AWS EC2 instances. Accepted
-                      value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
-                      DoNothing]'
-                      enum:
-                        - DoNothing
-                        - Enable
-                        - Disable
-                      type: string
-                    bpfConnectTimeLoadBalancingEnabled:
-                      description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
-                      controls whether Felix installs the connection-time load balancer.  The
-                      connect-time load balancer is required for the host to be able to
-                      reach Kubernetes services and it improves the performance of pod-to-service
-                      connections.  The only reason to disable it is for debugging purposes.  [Default:
-                      true]'
-                      type: boolean
-                    bpfDataIfacePattern:
-                      description: 'BPFDataIfacePattern is a regular expression that controls
-                      which interfaces Felix should attach BPF programs to in order to
-                      catch traffic to/from the network.  This needs to match the interfaces
-                      that Calico workload traffic flows over as well as any interfaces
-                      that handle incoming traffic to nodeports and services from outside
-                      the cluster.  It should not match the workload interfaces (usually
-                      named cali...). [Default: ^(en.*|eth.*|tunl0$)]'
-                      type: string
-                    bpfDisableUnprivileged:
-                      description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
-                      sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
-                      users cannot access Calico''s BPF maps and cannot insert their own
-                      BPF programs to interfere with Calico''s. [Default: true]'
-                      type: boolean
-                    bpfEnabled:
-                      description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
-                      [Default: false]'
-                      type: boolean
-                    bpfExtToServiceConnmark:
-                      description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit
-                        mark that is set on connections from an external client to a local
-                        service. This mark allows us to control how packets of that connection
-                        are routed within the host and how is routing intepreted by RPF
-                        check. [Default: 0]'
-                      type: integer
-                    bpfExternalServiceMode:
-                      description: 'BPFExternalServiceMode in BPF mode, controls how connections
-                      from outside the cluster to services (node ports and cluster IPs)
-                      are forwarded to remote workloads.  If set to "Tunnel" then both
-                      request and response traffic is tunneled to the remote node.  If
-                      set to "DSR", the request traffic is tunneled but the response traffic
-                      is sent directly from the remote node.  In "DSR" mode, the remote
-                      node appears to use the IP of the ingress node; this requires a
-                      permissive L2 network.  [Default: Tunnel]'
-                      type: string
-                    bpfKubeProxyEndpointSlicesEnabled:
-                      description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
-                        whether Felix's embedded kube-proxy accepts EndpointSlices or not.
-                      type: boolean
-                    bpfKubeProxyIptablesCleanupEnabled:
-                      description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
-                      mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
-                      iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
-                      true]'
-                      type: boolean
-                    bpfKubeProxyMinSyncPeriod:
-                      description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
-                      minimum time between updates to the dataplane for Felix''s embedded
-                      kube-proxy.  Lower values give reduced set-up latency.  Higher values
-                      reduce Felix CPU usage by batching up more work.  [Default: 1s]'
-                      type: string
-                    bpfLogLevel:
-                      description: 'BPFLogLevel controls the log level of the BPF programs
-                      when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
-                      logs are emitted to the BPF trace pipe, accessible with the command
-                      `tc exec bpf debug`. [Default: Off].'
-                      type: string
-                    chainInsertMode:
-                      description: 'ChainInsertMode controls whether Felix hooks the kernel’s
-                      top-level iptables chains by inserting a rule at the top of the
-                      chain or by appending a rule at the bottom. insert is the safe default
-                      since it prevents Calico’s rules from being bypassed. If you switch
-                      to append mode, be sure that the other rules in the chains signal
-                      acceptance by falling through to the Calico rules, otherwise the
-                      Calico policy will be bypassed. [Default: insert]'
-                      type: string
-                    dataplaneDriver:
-                      type: string
-                    debugDisableLogDropping:
-                      type: boolean
-                    debugMemoryProfilePath:
-                      type: string
-                    debugSimulateCalcGraphHangAfter:
-                      type: string
-                    debugSimulateDataplaneHangAfter:
-                      type: string
-                    defaultEndpointToHostAction:
-                      description: 'DefaultEndpointToHostAction controls what happens to
-                      traffic that goes from a workload endpoint to the host itself (after
-                      the traffic hits the endpoint egress policy). By default Calico
-                      blocks traffic from workload endpoints to the host itself with an
-                      iptables “DROP” action. If you want to allow some or all traffic
-                      from endpoint to host, set this parameter to RETURN or ACCEPT. Use
-                      RETURN if you have your own rules in the iptables “INPUT” chain;
-                      Calico will insert its rules at the top of that chain, then “RETURN”
-                      packets to the “INPUT” chain once it has completed processing workload
-                      endpoint egress policy. Use ACCEPT to unconditionally accept packets
-                      from workloads after processing workload endpoint egress policy.
-                      [Default: Drop]'
-                      type: string
-                    deviceRouteProtocol:
-                      description: This defines the route protocol added to programmed device
-                        routes, by default this will be RTPROT_BOOT when left blank.
-                      type: integer
-                    deviceRouteSourceAddress:
-                      description: This is the source address to use on programmed device
-                        routes. By default the source address is left blank, leaving the
-                        kernel to choose the source address used.
-                      type: string
-                    disableConntrackInvalidCheck:
-                      type: boolean
-                    endpointReportingDelay:
-                      type: string
-                    endpointReportingEnabled:
-                      type: boolean
-                    externalNodesList:
-                      description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
-                        which may source tunnel traffic and have the tunneled traffic be
-                        accepted at calico nodes.
-                      items:
-                        type: string
-                      type: array
-                    failsafeInboundHostPorts:
-                      description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
-                        and CIDRs that Felix will allow incoming traffic to host endpoints
-                        on irrespective of the security policy. This is useful to avoid
-                        accidentally cutting off a host with incorrect configuration. For
-                        back-compatibility, if the protocol is not specified, it defaults
-                        to "tcp". If a CIDR is not specified, it will allow traffic from
-                        all addresses. To disable all inbound host ports, use the value
-                        none. The default value allows ssh access and DHCP. [Default: tcp:22,
-                        udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
-                      items:
-                        description: ProtoPort is combination of protocol, port, and CIDR.
-                          Protocol and port must be specified.
-                        properties:
-                          net:
-                            type: string
-                          port:
-                            type: integer
-                          protocol:
-                            type: string
-                        required:
-                          - port
-                          - protocol
-                        type: object
-                      type: array
-                    failsafeOutboundHostPorts:
-                      description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
-                        and CIDRs that Felix will allow outgoing traffic from host endpoints
-                        to irrespective of the security policy. This is useful to avoid
-                        accidentally cutting off a host with incorrect configuration. For
-                        back-compatibility, if the protocol is not specified, it defaults
-                        to "tcp". If a CIDR is not specified, it will allow traffic from
-                        all addresses. To disable all outbound host ports, use the value
-                        none. The default value opens etcd''s standard ports to ensure that
-                        Felix does not get cut off from etcd as well as allowing DHCP and
-                        DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
-                        tcp:6667, udp:53, udp:67]'
-                      items:
-                        description: ProtoPort is combination of protocol, port, and CIDR.
-                          Protocol and port must be specified.
-                        properties:
-                          net:
-                            type: string
-                          port:
-                            type: integer
-                          protocol:
-                            type: string
-                        required:
-                          - port
-                          - protocol
-                        type: object
-                      type: array
-                    featureDetectOverride:
-                      description: FeatureDetectOverride is used to override the feature
-                        detection. Values are specified in a comma separated list with no
-                        spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
-                        "true" or "false" will force the feature, empty or omitted values
-                        are auto-detected.
-                      type: string
-                    genericXDPEnabled:
-                      description: 'GenericXDPEnabled enables Generic XDP so network cards
-                      that don''t support XDP offload or driver modes can use XDP. This
-                      is not recommended since it doesn''t provide better performance
-                      than iptables. [Default: false]'
-                      type: boolean
-                    healthEnabled:
-                      type: boolean
-                    healthHost:
-                      type: string
-                    healthPort:
-                      type: integer
-                    interfaceExclude:
-                      description: 'InterfaceExclude is a comma-separated list of interfaces
-                      that Felix should exclude when monitoring for host endpoints. The
-                      default value ensures that Felix ignores Kubernetes'' IPVS dummy
-                      interface, which is used internally by kube-proxy. If you want to
-                      exclude multiple interface names using a single value, the list
-                      supports regular expressions. For regular expressions you must wrap
-                      the value with ''/''. For example having values ''/^kube/,veth1''
-                      will exclude all interfaces that begin with ''kube'' and also the
-                      interface ''veth1''. [Default: kube-ipvs0]'
-                      type: string
-                    interfacePrefix:
-                      description: 'InterfacePrefix is the interface name prefix that identifies
-                      workload endpoints and so distinguishes them from host endpoint
-                      interfaces. Note: in environments other than bare metal, the orchestrators
-                      configure this appropriately. For example our Kubernetes and Docker
-                      integrations set the ‘cali’ value, and our OpenStack integration
-                      sets the ‘tap’ value. [Default: cali]'
-                      type: string
-                    interfaceRefreshInterval:
-                      description: InterfaceRefreshInterval is the period at which Felix
-                        rescans local interfaces to verify their state. The rescan can be
-                        disabled by setting the interval to 0.
-                      type: string
-                    ipipEnabled:
-                      type: boolean
-                    ipipMTU:
-                      description: 'IPIPMTU is the MTU to set on the tunnel device. See
-                      Configuring MTU [Default: 1440]'
-                      type: integer
-                    ipsetsRefreshInterval:
-                      description: 'IpsetsRefreshInterval is the period at which Felix re-checks
-                      all iptables state to ensure that no other process has accidentally
-                      broken Calico’s rules. Set to 0 to disable iptables refresh. [Default:
-                      90s]'
-                      type: string
-                    iptablesBackend:
-                      description: IptablesBackend specifies which backend of iptables will
-                        be used. The default is legacy.
-                      type: string
-                    iptablesFilterAllowAction:
-                      type: string
-                    iptablesLockFilePath:
-                      description: 'IptablesLockFilePath is the location of the iptables
-                      lock file. You may need to change this if the lock file is not in
-                      its standard location (for example if you have mapped it into Felix’s
-                      container at a different path). [Default: /run/xtables.lock]'
-                      type: string
-                    iptablesLockProbeInterval:
-                      description: 'IptablesLockProbeInterval is the time that Felix will
-                      wait between attempts to acquire the iptables lock if it is not
-                      available. Lower values make Felix more responsive when the lock
-                      is contended, but use more CPU. [Default: 50ms]'
-                      type: string
-                    iptablesLockTimeout:
-                      description: 'IptablesLockTimeout is the time that Felix will wait
-                      for the iptables lock, or 0, to disable. To use this feature, Felix
-                      must share the iptables lock file with all other processes that
-                      also take the lock. When running Felix inside a container, this
-                      requires the /run directory of the host to be mounted into the calico/node
-                      or calico/felix container. [Default: 0s disabled]'
-                      type: string
-                    iptablesMangleAllowAction:
-                      type: string
-                    iptablesMarkMask:
-                      description: 'IptablesMarkMask is the mask that Felix selects its
-                      IPTables Mark bits from. Should be a 32 bit hexadecimal number with
-                      at least 8 bits set, none of which clash with any other mark bits
-                      in use on the system. [Default: 0xff000000]'
-                      format: int32
-                      type: integer
-                    iptablesNATOutgoingInterfaceFilter:
-                      type: string
-                    iptablesPostWriteCheckInterval:
-                      description: 'IptablesPostWriteCheckInterval is the period after Felix
-                      has done a write to the dataplane that it schedules an extra read
-                      back in order to check the write was not clobbered by another process.
-                      This should only occur if another application on the system doesn’t
-                      respect the iptables lock. [Default: 1s]'
-                      type: string
-                    iptablesRefreshInterval:
-                      description: 'IptablesRefreshInterval is the period at which Felix
-                        re-checks the IP sets in the dataplane to ensure that no other process
-                        has accidentally broken Calico''s rules. Set to 0 to disable IP
-                        sets refresh. Note: the default for this value is lower than the
-                        other refresh intervals as a workaround for a Linux kernel bug that
-                        was fixed in kernel version 4.11. If you are using v4.11 or greater
-                        you may want to set this to, a higher value to reduce Felix CPU
-                        usage. [Default: 10s]'
-                      type: string
-                    ipv6Support:
-                      type: boolean
-                    kubeNodePortRanges:
-                      description: 'KubeNodePortRanges holds list of port ranges used for
-                      service node ports. Only used if felix detects kube-proxy running
-                      in ipvs mode. Felix uses these ranges to separate host and workload
-                      traffic. [Default: 30000:32767].'
-                      items:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^.*
-                        x-kubernetes-int-or-string: true
-                      type: array
-                    logFilePath:
-                      description: 'LogFilePath is the full path to the Felix log. Set to
-                      none to disable file logging. [Default: /var/log/calico/felix.log]'
-                      type: string
-                    logPrefix:
-                      description: 'LogPrefix is the log prefix that Felix uses when rendering
-                      LOG rules. [Default: calico-packet]'
-                      type: string
-                    logSeverityFile:
-                      description: 'LogSeverityFile is the log severity above which logs
-                      are sent to the log file. [Default: Info]'
-                      type: string
-                    logSeverityScreen:
-                      description: 'LogSeverityScreen is the log severity above which logs
-                      are sent to the stdout. [Default: Info]'
-                      type: string
-                    logSeveritySys:
-                      description: 'LogSeveritySys is the log severity above which logs
-                      are sent to the syslog. Set to None for no logging to syslog. [Default:
-                      Info]'
-                      type: string
-                    maxIpsetSize:
-                      type: integer
-                    metadataAddr:
-                      description: 'MetadataAddr is the IP address or domain name of the
-                      server that can answer VM queries for cloud-init metadata. In OpenStack,
-                      this corresponds to the machine running nova-api (or in Ubuntu,
-                      nova-api-metadata). A value of none (case insensitive) means that
-                      Felix should not set up any NAT rule for the metadata path. [Default:
-                      127.0.0.1]'
-                      type: string
-                    metadataPort:
-                      description: 'MetadataPort is the port of the metadata server. This,
-                      combined with global.MetadataAddr (if not ‘None’), is used to set
-                      up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
-                      In most cases this should not need to be changed [Default: 8775].'
-                      type: integer
-                    mtuIfacePattern:
-                      description: MTUIfacePattern is a regular expression that controls
-                        which interfaces Felix should scan in order to calculate the host's
-                        MTU. This should not match workload interfaces (usually named cali...).
-                      type: string
-                    natOutgoingAddress:
-                      description: NATOutgoingAddress specifies an address to use when performing
-                        source NAT for traffic in a natOutgoing pool that is leaving the
-                        network. By default the address used is an address on the interface
-                        the traffic is leaving on (ie it uses the iptables MASQUERADE target)
-                      type: string
-                    natPortRange:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: NATPortRange specifies the range of ports that is used
-                        for port mapping when doing outgoing NAT. When unset the default
-                        behavior of the network stack is used.
-                      pattern: ^.*
-                      x-kubernetes-int-or-string: true
-                    netlinkTimeout:
-                      type: string
-                    openstackRegion:
-                      description: 'OpenstackRegion is the name of the region that a particular
-                      Felix belongs to. In a multi-region Calico/OpenStack deployment,
-                      this must be configured somehow for each Felix (here in the datamodel,
-                      or in felix.cfg or the environment on each compute node), and must
-                      match the [calico] openstack_region value configured in neutron.conf
-                      on each node. [Default: Empty]'
-                      type: string
-                    policySyncPathPrefix:
-                      description: 'PolicySyncPathPrefix is used to by Felix to communicate
-                      policy changes to external services, like Application layer policy.
-                      [Default: Empty]'
-                      type: string
-                    prometheusGoMetricsEnabled:
-                      description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
-                      collection, which the Prometheus client does by default, when set
-                      to false. This reduces the number of metrics reported, reducing
-                      Prometheus load. [Default: true]'
-                      type: boolean
-                    prometheusMetricsEnabled:
-                      description: 'PrometheusMetricsEnabled enables the Prometheus metrics
-                      server in Felix if set to true. [Default: false]'
-                      type: boolean
-                    prometheusMetricsHost:
-                      description: 'PrometheusMetricsHost is the host that the Prometheus
-                      metrics server should bind to. [Default: empty]'
-                      type: string
-                    prometheusMetricsPort:
-                      description: 'PrometheusMetricsPort is the TCP port that the Prometheus
-                      metrics server should bind to. [Default: 9091]'
-                      type: integer
-                    prometheusProcessMetricsEnabled:
-                      description: 'PrometheusProcessMetricsEnabled disables process metrics
-                      collection, which the Prometheus client does by default, when set
-                      to false. This reduces the number of metrics reported, reducing
-                      Prometheus load. [Default: true]'
-                      type: boolean
-                    removeExternalRoutes:
-                      description: Whether or not to remove device routes that have not
-                        been programmed by Felix. Disabling this will allow external applications
-                        to also add device routes. This is enabled by default which means
-                        we will remove externally added routes.
-                      type: boolean
-                    reportingInterval:
-                      description: 'ReportingInterval is the interval at which Felix reports
-                      its status into the datastore or 0 to disable. Must be non-zero
-                      in OpenStack deployments. [Default: 30s]'
-                      type: string
-                    reportingTTL:
-                      description: 'ReportingTTL is the time-to-live setting for process-wide
-                      status reports. [Default: 90s]'
-                      type: string
-                    routeRefreshInterval:
-                      description: 'RouterefreshInterval is the period at which Felix re-checks
-                      the routes in the dataplane to ensure that no other process has
-                      accidentally broken Calico’s rules. Set to 0 to disable route refresh.
-                      [Default: 90s]'
-                      type: string
-                    routeSource:
-                      description: 'RouteSource configures where Felix gets its routing
-                      information. - WorkloadIPs: use workload endpoints to construct
-                      routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
-                      type: string
-                    routeTableRange:
-                      description: Calico programs additional Linux route tables for various
-                        purposes.  RouteTableRange specifies the indices of the route tables
-                        that Calico should use.
-                      properties:
-                        max:
-                          type: integer
-                        min:
-                          type: integer
-                      required:
-                        - max
-                        - min
-                      type: object
-                    serviceLoopPrevention:
-                      description: 'When service IP advertisement is enabled, prevent routing
-                        loops to service IPs that are not in use, by dropping or rejecting
-                        packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
-                        in which case such routing loops continue to be allowed. [Default:
-                        Drop]'
-                      type: string
-                    sidecarAccelerationEnabled:
-                      description: 'SidecarAccelerationEnabled enables experimental sidecar
-                      acceleration [Default: false]'
-                      type: boolean
-                    usageReportingEnabled:
-                      description: 'UsageReportingEnabled reports anonymous Calico version
-                      number and cluster size to projectcalico.org. Logs warnings returned
-                      by the usage server. For example, if a significant security vulnerability
-                      has been discovered in the version of Calico being used. [Default:
-                      true]'
-                      type: boolean
-                    usageReportingInitialDelay:
-                      description: 'UsageReportingInitialDelay controls the minimum delay
-                      before Felix makes a report. [Default: 300s]'
-                      type: string
-                    usageReportingInterval:
-                      description: 'UsageReportingInterval controls the interval at which
-                      Felix makes reports. [Default: 86400s]'
-                      type: string
-                    useInternalDataplaneDriver:
-                      type: boolean
-                    vxlanEnabled:
-                      type: boolean
-                    vxlanMTU:
-                      description: 'VXLANMTU is the MTU to set on the tunnel device. See
-                      Configuring MTU [Default: 1440]'
-                      type: integer
-                    vxlanPort:
-                      type: integer
-                    vxlanVNI:
-                      type: integer
-                    wireguardEnabled:
-                      description: 'WireguardEnabled controls whether Wireguard is enabled.
-                      [Default: false]'
-                      type: boolean
-                    wireguardInterfaceName:
-                      description: 'WireguardInterfaceName specifies the name to use for
-                      the Wireguard interface. [Default: wg.calico]'
-                      type: string
-                    wireguardListeningPort:
-                      description: 'WireguardListeningPort controls the listening port used
-                      by Wireguard. [Default: 51820]'
-                      type: integer
-                    wireguardMTU:
-                      description: 'WireguardMTU controls the MTU on the Wireguard interface.
-                      See Configuring MTU [Default: 1420]'
-                      type: integer
-                    wireguardRoutingRulePriority:
-                      description: 'WireguardRoutingRulePriority controls the priority value
-                      to use for the Wireguard routing rule. [Default: 99]'
-                      type: integer
-                    xdpEnabled:
-                      description: 'XDPEnabled enables XDP acceleration for suitable untracked
-                      incoming deny rules. [Default: true]'
-                      type: boolean
-                    xdpRefreshInterval:
-                      description: 'XDPRefreshInterval is the period at which Felix re-checks
-                      all XDP state to ensure that no other process has accidentally broken
-                      Calico''s BPF maps or attached programs. Set to 0 to disable XDP
-                      refresh. [Default: 90s]'
-                      type: string
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: globalnetworkpolicies.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: GlobalNetworkPolicy
-        listKind: GlobalNetworkPolicyList
-        plural: globalnetworkpolicies
-        singular: globalnetworkpolicy
-      scope: Cluster
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  properties:
-                    applyOnForward:
-                      description: ApplyOnForward indicates to apply the rules in this policy
-                        on forward traffic.
-                      type: boolean
-                    doNotTrack:
-                      description: DoNotTrack indicates whether packets matched by the rules
-                        in this policy should go through the data plane's connection tracking,
-                        such as Linux conntrack.  If True, the rules in this policy are
-                        applied before any data plane connection tracking, and packets allowed
-                        by this policy are marked as not to be tracked.
-                      type: boolean
-                    egress:
-                      description: The ordered set of egress rules.  Each rule contains
-                        a set of packet match criteria and a corresponding action to apply.
-                      items:
-                        description: "A Rule encapsulates a set of match criteria and an
-                        action.  Both selector-based security Policy and security Profiles
-                        reference rules - separated out as a list of rules for both ingress
-                        and egress packet matching. \n Each positive match criteria has
-                        a negated version, prefixed with ”Not”. All the match criteria
-                        within a rule must be satisfied for a packet to match. A single
-                        rule can contain the positive and negative version of a match
-                        and both must be satisfied for the rule to match."
-                        properties:
-                          action:
-                            type: string
-                          destination:
-                            description: Destination contains the match criteria that apply
-                              to destination entity.
-                            properties:
-                              namespaceSelector:
-                                description: "NamespaceSelector is an optional field that
-                                contains a selector expression. Only traffic that originates
-                                from (or terminates at) endpoints within the selected
-                                namespaces will be matched. When both NamespaceSelector
-                                and Selector are defined on the same rule, then only workload
-                                endpoints that are matched by both selectors will be selected
-                                by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                                implies that the Selector is limited to selecting only
-                                workload endpoints in the same namespace as the NetworkPolicy.
-                                \n For NetworkPolicy, `global()` NamespaceSelector implies
-                                that the Selector is limited to selecting only GlobalNetworkSet
-                                or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                                NamespaceSelector implies the Selector applies to workload
-                                endpoints across all namespaces."
-                                type: string
-                              nets:
-                                description: Nets is an optional field that restricts the
-                                  rule to only apply to traffic that originates from (or
-                                  terminates at) IP addresses in any of the given subnets.
-                                items:
-                                  type: string
-                                type: array
-                              notNets:
-                                description: NotNets is the negated version of the Nets
-                                  field.
-                                items:
-                                  type: string
-                                type: array
-                              notPorts:
-                                description: NotPorts is the negated version of the Ports
-                                  field. Since only some protocols have ports, if any ports
-                                  are specified it requires the Protocol match in the Rule
-                                  to be set to "TCP" or "UDP".
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              notSelector:
-                                description: NotSelector is the negated version of the Selector
-                                  field.  See Selector field for subtleties with negated
-                                  selectors.
-                                type: string
-                              ports:
-                                description: "Ports is an optional field that restricts
-                                the rule to only apply to traffic that has a source (destination)
-                                port that matches one of these ranges/values. This value
-                                is a list of integers or strings that represent ranges
-                                of ports. \n Since only some protocols have ports, if
-                                any ports are specified it requires the Protocol match
-                                in the Rule to be set to \"TCP\" or \"UDP\"."
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              selector:
-                                description: "Selector is an optional field that contains
-                                a selector expression (see Policy for sample syntax).
-                                \ Only traffic that originates from (terminates at) endpoints
-                                matching the selector will be matched. \n Note that: in
-                                addition to the negated version of the Selector (see NotSelector
-                                below), the selector expression syntax itself supports
-                                negation.  The two types of negation are subtly different.
-                                One negates the set of matched endpoints, the other negates
-                                the whole match: \n \tSelector = \"!has(my_label)\" matches
-                                packets that are from other Calico-controlled \tendpoints
-                                that do not have the label “my_label”. \n \tNotSelector
-                                = \"has(my_label)\" matches packets that are not from
-                                Calico-controlled \tendpoints that do have the label “my_label”.
-                                \n The effect is that the latter will accept packets from
-                                non-Calico sources whereas the former is limited to packets
-                                from Calico-controlled endpoints."
-                                type: string
-                              serviceAccounts:
-                                description: ServiceAccounts is an optional field that restricts
-                                  the rule to only apply to traffic that originates from
-                                  (or terminates at) a pod running as a matching service
-                                  account.
-                                properties:
-                                  names:
-                                    description: Names is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account whose name is in the list.
-                                    items:
-                                      type: string
-                                    type: array
-                                  selector:
-                                    description: Selector is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account that matches the given label selector. If
-                                      both Names and Selector are specified then they are
-                                      AND'ed.
-                                    type: string
-                                type: object
-                              services:
-                                description: "Services is an optional field that contains
-                                  options for matching Kubernetes Services. If specified,
-                                  only traffic that originates from or terminates at endpoints
-                                  within the selected service(s) will be matched, and only
-                                  to/from each endpoint's port. \n Services cannot be specified
-                                  on the same rule as Selector, NotSelector, NamespaceSelector,
-                                  Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                                  Only valid on egress rules."
-                                properties:
-                                  name:
-                                    description: Name specifies the name of a Kubernetes
-                                      Service to match.
-                                    type: string
-                                  namespace:
-                                    description: Namespace specifies the namespace of the
-                                      given Service. If left empty, the rule will match
-                                      within this policy's namespace.
-                                    type: string
-                                type: object
-                            type: object
-                          http:
-                            description: HTTP contains match criteria that apply to HTTP
-                              requests.
-                            properties:
-                              methods:
-                                description: Methods is an optional field that restricts
-                                  the rule to apply only to HTTP requests that use one of
-                                  the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                                  methods are OR'd together.
-                                items:
-                                  type: string
-                                type: array
-                              paths:
-                                description: 'Paths is an optional field that restricts
-                                the rule to apply to HTTP requests that use one of the
-                                listed HTTP Paths. Multiple paths are OR''d together.
-                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                                ONLY specify either a `exact` or a `prefix` match. The
-                                validator will check for it.'
-                                items:
-                                  description: 'HTTPPath specifies an HTTP path to match.
-                                  It may be either of the form: exact: <path>: which matches
-                                  the path exactly or prefix: <path-prefix>: which matches
-                                  the path prefix'
-                                  properties:
-                                    exact:
-                                      type: string
-                                    prefix:
-                                      type: string
-                                  type: object
-                                type: array
-                            type: object
-                          icmp:
-                            description: ICMP is an optional field that restricts the rule
-                              to apply to a specific type and code of ICMP traffic.  This
-                              should only be specified if the Protocol field is set to "ICMP"
-                              or "ICMPv6".
-                            properties:
-                              code:
-                                description: Match on a specific ICMP code.  If specified,
-                                  the Type value must also be specified. This is a technical
-                                  limitation imposed by the kernel’s iptables firewall,
-                                  which Calico uses to enforce the rule.
-                                type: integer
-                              type:
-                                description: Match on a specific ICMP type.  For example
-                                  a value of 8 refers to ICMP Echo Request (i.e. pings).
-                                type: integer
-                            type: object
-                          ipVersion:
-                            description: IPVersion is an optional field that restricts the
-                              rule to only match a specific IP version.
-                            type: integer
-                          metadata:
-                            description: Metadata contains additional information for this
-                              rule
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                description: Annotations is a set of key value pairs that
-                                  give extra information about the rule
-                                type: object
-                            type: object
-                          notICMP:
-                            description: NotICMP is the negated version of the ICMP field.
-                            properties:
-                              code:
-                                description: Match on a specific ICMP code.  If specified,
-                                  the Type value must also be specified. This is a technical
-                                  limitation imposed by the kernel’s iptables firewall,
-                                  which Calico uses to enforce the rule.
-                                type: integer
-                              type:
-                                description: Match on a specific ICMP type.  For example
-                                  a value of 8 refers to ICMP Echo Request (i.e. pings).
-                                type: integer
-                            type: object
-                          notProtocol:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            description: NotProtocol is the negated version of the Protocol
-                              field.
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          protocol:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            description: "Protocol is an optional field that restricts the
-                            rule to only apply to traffic of a specific IP protocol. Required
-                            if any of the EntityRules contain Ports (because ports only
-                            apply to certain protocols). \n Must be one of these string
-                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                            \"UDPLite\" or an integer in the range 1-255."
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          source:
-                            description: Source contains the match criteria that apply to
-                              source entity.
-                            properties:
-                              namespaceSelector:
-                                description: "NamespaceSelector is an optional field that
-                                contains a selector expression. Only traffic that originates
-                                from (or terminates at) endpoints within the selected
-                                namespaces will be matched. When both NamespaceSelector
-                                and Selector are defined on the same rule, then only workload
-                                endpoints that are matched by both selectors will be selected
-                                by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                                implies that the Selector is limited to selecting only
-                                workload endpoints in the same namespace as the NetworkPolicy.
-                                \n For NetworkPolicy, `global()` NamespaceSelector implies
-                                that the Selector is limited to selecting only GlobalNetworkSet
-                                or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                                NamespaceSelector implies the Selector applies to workload
-                                endpoints across all namespaces."
-                                type: string
-                              nets:
-                                description: Nets is an optional field that restricts the
-                                  rule to only apply to traffic that originates from (or
-                                  terminates at) IP addresses in any of the given subnets.
-                                items:
-                                  type: string
-                                type: array
-                              notNets:
-                                description: NotNets is the negated version of the Nets
-                                  field.
-                                items:
-                                  type: string
-                                type: array
-                              notPorts:
-                                description: NotPorts is the negated version of the Ports
-                                  field. Since only some protocols have ports, if any ports
-                                  are specified it requires the Protocol match in the Rule
-                                  to be set to "TCP" or "UDP".
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              notSelector:
-                                description: NotSelector is the negated version of the Selector
-                                  field.  See Selector field for subtleties with negated
-                                  selectors.
-                                type: string
-                              ports:
-                                description: "Ports is an optional field that restricts
-                                the rule to only apply to traffic that has a source (destination)
-                                port that matches one of these ranges/values. This value
-                                is a list of integers or strings that represent ranges
-                                of ports. \n Since only some protocols have ports, if
-                                any ports are specified it requires the Protocol match
-                                in the Rule to be set to \"TCP\" or \"UDP\"."
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              selector:
-                                description: "Selector is an optional field that contains
-                                a selector expression (see Policy for sample syntax).
-                                \ Only traffic that originates from (terminates at) endpoints
-                                matching the selector will be matched. \n Note that: in
-                                addition to the negated version of the Selector (see NotSelector
-                                below), the selector expression syntax itself supports
-                                negation.  The two types of negation are subtly different.
-                                One negates the set of matched endpoints, the other negates
-                                the whole match: \n \tSelector = \"!has(my_label)\" matches
-                                packets that are from other Calico-controlled \tendpoints
-                                that do not have the label “my_label”. \n \tNotSelector
-                                = \"has(my_label)\" matches packets that are not from
-                                Calico-controlled \tendpoints that do have the label “my_label”.
-                                \n The effect is that the latter will accept packets from
-                                non-Calico sources whereas the former is limited to packets
-                                from Calico-controlled endpoints."
-                                type: string
-                              serviceAccounts:
-                                description: ServiceAccounts is an optional field that restricts
-                                  the rule to only apply to traffic that originates from
-                                  (or terminates at) a pod running as a matching service
-                                  account.
-                                properties:
-                                  names:
-                                    description: Names is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account whose name is in the list.
-                                    items:
-                                      type: string
-                                    type: array
-                                  selector:
-                                    description: Selector is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account that matches the given label selector. If
-                                      both Names and Selector are specified then they are
-                                      AND'ed.
-                                    type: string
-                                type: object
-                              services:
-                                description: "Services is an optional field that contains
-                                  options for matching Kubernetes Services. If specified,
-                                  only traffic that originates from or terminates at endpoints
-                                  within the selected service(s) will be matched, and only
-                                  to/from each endpoint's port. \n Services cannot be specified
-                                  on the same rule as Selector, NotSelector, NamespaceSelector,
-                                  Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                                  Only valid on egress rules."
-                                properties:
-                                  name:
-                                    description: Name specifies the name of a Kubernetes
-                                      Service to match.
-                                    type: string
-                                  namespace:
-                                    description: Namespace specifies the namespace of the
-                                      given Service. If left empty, the rule will match
-                                      within this policy's namespace.
-                                    type: string
-                                type: object
-                            type: object
-                        required:
-                          - action
-                        type: object
-                      type: array
-                    ingress:
-                      description: The ordered set of ingress rules.  Each rule contains
-                        a set of packet match criteria and a corresponding action to apply.
-                      items:
-                        description: "A Rule encapsulates a set of match criteria and an
-                        action.  Both selector-based security Policy and security Profiles
-                        reference rules - separated out as a list of rules for both ingress
-                        and egress packet matching. \n Each positive match criteria has
-                        a negated version, prefixed with ”Not”. All the match criteria
-                        within a rule must be satisfied for a packet to match. A single
-                        rule can contain the positive and negative version of a match
-                        and both must be satisfied for the rule to match."
-                        properties:
-                          action:
-                            type: string
-                          destination:
-                            description: Destination contains the match criteria that apply
-                              to destination entity.
-                            properties:
-                              namespaceSelector:
-                                description: "NamespaceSelector is an optional field that
-                                contains a selector expression. Only traffic that originates
-                                from (or terminates at) endpoints within the selected
-                                namespaces will be matched. When both NamespaceSelector
-                                and Selector are defined on the same rule, then only workload
-                                endpoints that are matched by both selectors will be selected
-                                by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                                implies that the Selector is limited to selecting only
-                                workload endpoints in the same namespace as the NetworkPolicy.
-                                \n For NetworkPolicy, `global()` NamespaceSelector implies
-                                that the Selector is limited to selecting only GlobalNetworkSet
-                                or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                                NamespaceSelector implies the Selector applies to workload
-                                endpoints across all namespaces."
-                                type: string
-                              nets:
-                                description: Nets is an optional field that restricts the
-                                  rule to only apply to traffic that originates from (or
-                                  terminates at) IP addresses in any of the given subnets.
-                                items:
-                                  type: string
-                                type: array
-                              notNets:
-                                description: NotNets is the negated version of the Nets
-                                  field.
-                                items:
-                                  type: string
-                                type: array
-                              notPorts:
-                                description: NotPorts is the negated version of the Ports
-                                  field. Since only some protocols have ports, if any ports
-                                  are specified it requires the Protocol match in the Rule
-                                  to be set to "TCP" or "UDP".
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              notSelector:
-                                description: NotSelector is the negated version of the Selector
-                                  field.  See Selector field for subtleties with negated
-                                  selectors.
-                                type: string
-                              ports:
-                                description: "Ports is an optional field that restricts
-                                the rule to only apply to traffic that has a source (destination)
-                                port that matches one of these ranges/values. This value
-                                is a list of integers or strings that represent ranges
-                                of ports. \n Since only some protocols have ports, if
-                                any ports are specified it requires the Protocol match
-                                in the Rule to be set to \"TCP\" or \"UDP\"."
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              selector:
-                                description: "Selector is an optional field that contains
-                                a selector expression (see Policy for sample syntax).
-                                \ Only traffic that originates from (terminates at) endpoints
-                                matching the selector will be matched. \n Note that: in
-                                addition to the negated version of the Selector (see NotSelector
-                                below), the selector expression syntax itself supports
-                                negation.  The two types of negation are subtly different.
-                                One negates the set of matched endpoints, the other negates
-                                the whole match: \n \tSelector = \"!has(my_label)\" matches
-                                packets that are from other Calico-controlled \tendpoints
-                                that do not have the label “my_label”. \n \tNotSelector
-                                = \"has(my_label)\" matches packets that are not from
-                                Calico-controlled \tendpoints that do have the label “my_label”.
-                                \n The effect is that the latter will accept packets from
-                                non-Calico sources whereas the former is limited to packets
-                                from Calico-controlled endpoints."
-                                type: string
-                              serviceAccounts:
-                                description: ServiceAccounts is an optional field that restricts
-                                  the rule to only apply to traffic that originates from
-                                  (or terminates at) a pod running as a matching service
-                                  account.
-                                properties:
-                                  names:
-                                    description: Names is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account whose name is in the list.
-                                    items:
-                                      type: string
-                                    type: array
-                                  selector:
-                                    description: Selector is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account that matches the given label selector. If
-                                      both Names and Selector are specified then they are
-                                      AND'ed.
-                                    type: string
-                                type: object
-                              services:
-                                description: "Services is an optional field that contains
-                                  options for matching Kubernetes Services. If specified,
-                                  only traffic that originates from or terminates at endpoints
-                                  within the selected service(s) will be matched, and only
-                                  to/from each endpoint's port. \n Services cannot be specified
-                                  on the same rule as Selector, NotSelector, NamespaceSelector,
-                                  Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                                  Only valid on egress rules."
-                                properties:
-                                  name:
-                                    description: Name specifies the name of a Kubernetes
-                                      Service to match.
-                                    type: string
-                                  namespace:
-                                    description: Namespace specifies the namespace of the
-                                      given Service. If left empty, the rule will match
-                                      within this policy's namespace.
-                                    type: string
-                                type: object
-                            type: object
-                          http:
-                            description: HTTP contains match criteria that apply to HTTP
-                              requests.
-                            properties:
-                              methods:
-                                description: Methods is an optional field that restricts
-                                  the rule to apply only to HTTP requests that use one of
-                                  the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                                  methods are OR'd together.
-                                items:
-                                  type: string
-                                type: array
-                              paths:
-                                description: 'Paths is an optional field that restricts
-                                the rule to apply to HTTP requests that use one of the
-                                listed HTTP Paths. Multiple paths are OR''d together.
-                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                                ONLY specify either a `exact` or a `prefix` match. The
-                                validator will check for it.'
-                                items:
-                                  description: 'HTTPPath specifies an HTTP path to match.
-                                  It may be either of the form: exact: <path>: which matches
-                                  the path exactly or prefix: <path-prefix>: which matches
-                                  the path prefix'
-                                  properties:
-                                    exact:
-                                      type: string
-                                    prefix:
-                                      type: string
-                                  type: object
-                                type: array
-                            type: object
-                          icmp:
-                            description: ICMP is an optional field that restricts the rule
-                              to apply to a specific type and code of ICMP traffic.  This
-                              should only be specified if the Protocol field is set to "ICMP"
-                              or "ICMPv6".
-                            properties:
-                              code:
-                                description: Match on a specific ICMP code.  If specified,
-                                  the Type value must also be specified. This is a technical
-                                  limitation imposed by the kernel’s iptables firewall,
-                                  which Calico uses to enforce the rule.
-                                type: integer
-                              type:
-                                description: Match on a specific ICMP type.  For example
-                                  a value of 8 refers to ICMP Echo Request (i.e. pings).
-                                type: integer
-                            type: object
-                          ipVersion:
-                            description: IPVersion is an optional field that restricts the
-                              rule to only match a specific IP version.
-                            type: integer
-                          metadata:
-                            description: Metadata contains additional information for this
-                              rule
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                description: Annotations is a set of key value pairs that
-                                  give extra information about the rule
-                                type: object
-                            type: object
-                          notICMP:
-                            description: NotICMP is the negated version of the ICMP field.
-                            properties:
-                              code:
-                                description: Match on a specific ICMP code.  If specified,
-                                  the Type value must also be specified. This is a technical
-                                  limitation imposed by the kernel’s iptables firewall,
-                                  which Calico uses to enforce the rule.
-                                type: integer
-                              type:
-                                description: Match on a specific ICMP type.  For example
-                                  a value of 8 refers to ICMP Echo Request (i.e. pings).
-                                type: integer
-                            type: object
-                          notProtocol:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            description: NotProtocol is the negated version of the Protocol
-                              field.
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          protocol:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            description: "Protocol is an optional field that restricts the
-                            rule to only apply to traffic of a specific IP protocol. Required
-                            if any of the EntityRules contain Ports (because ports only
-                            apply to certain protocols). \n Must be one of these string
-                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                            \"UDPLite\" or an integer in the range 1-255."
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          source:
-                            description: Source contains the match criteria that apply to
-                              source entity.
-                            properties:
-                              namespaceSelector:
-                                description: "NamespaceSelector is an optional field that
-                                contains a selector expression. Only traffic that originates
-                                from (or terminates at) endpoints within the selected
-                                namespaces will be matched. When both NamespaceSelector
-                                and Selector are defined on the same rule, then only workload
-                                endpoints that are matched by both selectors will be selected
-                                by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                                implies that the Selector is limited to selecting only
-                                workload endpoints in the same namespace as the NetworkPolicy.
-                                \n For NetworkPolicy, `global()` NamespaceSelector implies
-                                that the Selector is limited to selecting only GlobalNetworkSet
-                                or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                                NamespaceSelector implies the Selector applies to workload
-                                endpoints across all namespaces."
-                                type: string
-                              nets:
-                                description: Nets is an optional field that restricts the
-                                  rule to only apply to traffic that originates from (or
-                                  terminates at) IP addresses in any of the given subnets.
-                                items:
-                                  type: string
-                                type: array
-                              notNets:
-                                description: NotNets is the negated version of the Nets
-                                  field.
-                                items:
-                                  type: string
-                                type: array
-                              notPorts:
-                                description: NotPorts is the negated version of the Ports
-                                  field. Since only some protocols have ports, if any ports
-                                  are specified it requires the Protocol match in the Rule
-                                  to be set to "TCP" or "UDP".
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              notSelector:
-                                description: NotSelector is the negated version of the Selector
-                                  field.  See Selector field for subtleties with negated
-                                  selectors.
-                                type: string
-                              ports:
-                                description: "Ports is an optional field that restricts
-                                the rule to only apply to traffic that has a source (destination)
-                                port that matches one of these ranges/values. This value
-                                is a list of integers or strings that represent ranges
-                                of ports. \n Since only some protocols have ports, if
-                                any ports are specified it requires the Protocol match
-                                in the Rule to be set to \"TCP\" or \"UDP\"."
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              selector:
-                                description: "Selector is an optional field that contains
-                                a selector expression (see Policy for sample syntax).
-                                \ Only traffic that originates from (terminates at) endpoints
-                                matching the selector will be matched. \n Note that: in
-                                addition to the negated version of the Selector (see NotSelector
-                                below), the selector expression syntax itself supports
-                                negation.  The two types of negation are subtly different.
-                                One negates the set of matched endpoints, the other negates
-                                the whole match: \n \tSelector = \"!has(my_label)\" matches
-                                packets that are from other Calico-controlled \tendpoints
-                                that do not have the label “my_label”. \n \tNotSelector
-                                = \"has(my_label)\" matches packets that are not from
-                                Calico-controlled \tendpoints that do have the label “my_label”.
-                                \n The effect is that the latter will accept packets from
-                                non-Calico sources whereas the former is limited to packets
-                                from Calico-controlled endpoints."
-                                type: string
-                              serviceAccounts:
-                                description: ServiceAccounts is an optional field that restricts
-                                  the rule to only apply to traffic that originates from
-                                  (or terminates at) a pod running as a matching service
-                                  account.
-                                properties:
-                                  names:
-                                    description: Names is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account whose name is in the list.
-                                    items:
-                                      type: string
-                                    type: array
-                                  selector:
-                                    description: Selector is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account that matches the given label selector. If
-                                      both Names and Selector are specified then they are
-                                      AND'ed.
-                                    type: string
-                                type: object
-                              services:
-                                description: "Services is an optional field that contains
-                                  options for matching Kubernetes Services. If specified,
-                                  only traffic that originates from or terminates at endpoints
-                                  within the selected service(s) will be matched, and only
-                                  to/from each endpoint's port. \n Services cannot be specified
-                                  on the same rule as Selector, NotSelector, NamespaceSelector,
-                                  Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                                  Only valid on egress rules."
-                                properties:
-                                  name:
-                                    description: Name specifies the name of a Kubernetes
-                                      Service to match.
-                                    type: string
-                                  namespace:
-                                    description: Namespace specifies the namespace of the
-                                      given Service. If left empty, the rule will match
-                                      within this policy's namespace.
-                                    type: string
-                                type: object
-                            type: object
-                        required:
-                          - action
-                        type: object
-                      type: array
-                    namespaceSelector:
-                      description: NamespaceSelector is an optional field for an expression
-                        used to select a pod based on namespaces.
-                      type: string
-                    order:
-                      description: Order is an optional field that specifies the order in
-                        which the policy is applied. Policies with higher "order" are applied
-                        after those with lower order.  If the order is omitted, it may be
-                        considered to be "infinite" - i.e. the policy will be applied last.  Policies
-                        with identical order will be applied in alphanumerical order based
-                        on the Policy "Name".
-                      type: number
-                    preDNAT:
-                      description: PreDNAT indicates to apply the rules in this policy before
-                        any DNAT.
-                      type: boolean
-                    selector:
-                      description: "The selector is an expression used to pick pick out
-                      the endpoints that the policy should be applied to. \n Selector
-                      expressions follow this syntax: \n \tlabel == \"string_literal\"
-                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
-                      \  ->  not equal; also matches if label is not present \tlabel in
-                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
-                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
-                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
-                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
-                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
-                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
-                      or the empty selector -> matches all endpoints. \n Label names are
-                      allowed to contain alphanumerics, -, _ and /. String literals are
-                      more permissive but they do not support escape characters. \n Examples
-                      (with made-up labels): \n \ttype == \"webserver\" && deployment
-                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
-                      \"dev\" \t! has(label_name)"
-                      type: string
-                    serviceAccountSelector:
-                      description: ServiceAccountSelector is an optional field for an expression
-                        used to select a pod based on service accounts.
-                      type: string
-                    types:
-                      description: "Types indicates whether this policy applies to ingress,
-                      or to egress, or to both.  When not explicitly specified (and so
-                      the value on creation is empty or nil), Calico defaults Types according
-                      to what Ingress and Egress rules are present in the policy.  The
-                      default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
-                      (including the case where there are   also no Ingress rules) \n
-                      - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
-                      rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
-                      both Ingress and Egress rules. \n When the policy is read back again,
-                      Types will always be one of these values, never empty or nil."
-                      items:
-                        description: PolicyType enumerates the possible values of the PolicySpec
-                          Types field.
-                        type: string
-                      type: array
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: globalnetworksets.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: GlobalNetworkSet
-        listKind: GlobalNetworkSetList
-        plural: globalnetworksets
-        singular: globalnetworkset
-      scope: Cluster
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
-                that share labels to allow rules to refer to them via selectors.  The labels
-                of GlobalNetworkSet are not namespaced.
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: GlobalNetworkSetSpec contains the specification for a NetworkSet
-                    resource.
-                  properties:
-                    nets:
-                      description: The list of IP networks that belong to this set.
-                      items:
-                        type: string
-                      type: array
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: hostendpoints.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: HostEndpoint
-        listKind: HostEndpointList
-        plural: hostendpoints
-        singular: hostendpoint
-      scope: Cluster
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: HostEndpointSpec contains the specification for a HostEndpoint
-                    resource.
-                  properties:
-                    expectedIPs:
-                      description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
-                      If \"InterfaceName\" is not present, Calico will look for an interface
-                      matching any of the IPs in the list and apply policy to that. Note:
-                      \tWhen using the selector match criteria in an ingress or egress
-                      security Policy \tor Profile, Calico converts the selector into
-                      a set of IP addresses. For host \tendpoints, the ExpectedIPs field
-                      is used for that purpose. (If only the interface \tname is specified,
-                      Calico does not learn the IPs of the interface for use in match
-                      \tcriteria.)"
-                      items:
-                        type: string
-                      type: array
-                    interfaceName:
-                      description: "Either \"*\", or the name of a specific Linux interface
-                      to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
-                      governs all traffic to, from or through the default network namespace
-                      of the host named by the \"Node\" field; entering and leaving that
-                      namespace via any interface, including those from/to non-host-networked
-                      local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
-                      only governs traffic that enters or leaves the host through the
-                      specific interface named by InterfaceName, or - when InterfaceName
-                      is empty - through the specific interface that has one of the IPs
-                      in ExpectedIPs. Therefore, when InterfaceName is empty, at least
-                      one expected IP must be specified.  Only external interfaces (such
-                      as “eth0”) are supported here; it isn't possible for a HostEndpoint
-                      to protect traffic through a specific local workload interface.
-                      \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
-                      initially just pre-DNAT policy.  Please check Calico documentation
-                      for the latest position."
-                      type: string
-                    node:
-                      description: The node name identifying the Calico node instance.
-                      type: string
-                    ports:
-                      description: Ports contains the endpoint's named ports, which may
-                        be referenced in security policy rules.
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          port:
-                            type: integer
-                          protocol:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                        required:
-                          - name
-                          - port
-                          - protocol
-                        type: object
-                      type: array
-                    profiles:
-                      description: A list of identifiers of security Profile objects that
-                        apply to this endpoint. Each profile is applied in the order that
-                        they appear in this list.  Profile rules are applied after the selector-based
-                        security policy.
-                      items:
-                        type: string
-                      type: array
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: ipamblocks.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: IPAMBlock
-        listKind: IPAMBlockList
-        plural: ipamblocks
-        singular: ipamblock
-      scope: Cluster
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: IPAMBlockSpec contains the specification for an IPAMBlock
-                    resource.
-                  properties:
-                    affinity:
-                      type: string
-                    allocations:
-                      items:
-                        type: integer
-                        # TODO: This nullable is manually added in. We should update controller-gen
-                        # to handle []*int properly itself.
-                        nullable: true
-                      type: array
-                    attributes:
-                      items:
-                        properties:
-                          handle_id:
-                            type: string
-                          secondary:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      type: array
-                    cidr:
-                      type: string
-                    deleted:
-                      type: boolean
-                    strictAffinity:
-                      type: boolean
-                    unallocated:
-                      items:
-                        type: integer
-                      type: array
-                  required:
-                    - allocations
-                    - attributes
-                    - cidr
-                    - strictAffinity
-                    - unallocated
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: ipamconfigs.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: IPAMConfig
-        listKind: IPAMConfigList
-        plural: ipamconfigs
-        singular: ipamconfig
-      scope: Cluster
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: IPAMConfigSpec contains the specification for an IPAMConfig
-                    resource.
-                  properties:
-                    autoAllocateBlocks:
-                      type: boolean
-                    maxBlocksPerHost:
-                      description: MaxBlocksPerHost, if non-zero, is the max number of blocks
-                        that can be affine to each host.
-                      type: integer
-                    strictAffinity:
-                      type: boolean
-                  required:
-                    - autoAllocateBlocks
-                    - strictAffinity
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: ipamhandles.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: IPAMHandle
-        listKind: IPAMHandleList
-        plural: ipamhandles
-        singular: ipamhandle
-      scope: Cluster
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: IPAMHandleSpec contains the specification for an IPAMHandle
-                    resource.
-                  properties:
-                    block:
-                      additionalProperties:
-                        type: integer
-                      type: object
-                    deleted:
-                      type: boolean
-                    handleID:
-                      type: string
-                  required:
-                    - block
-                    - handleID
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: ippools.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: IPPool
-        listKind: IPPoolList
-        plural: ippools
-        singular: ippool
-      scope: Cluster
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: IPPoolSpec contains the specification for an IPPool resource.
-                  properties:
-                    blockSize:
-                      description: The block size to use for IP address assignments from
-                        this pool. Defaults to 26 for IPv4 and 112 for IPv6.
-                      type: integer
-                    cidr:
-                      description: The pool CIDR.
-                      type: string
-                    disabled:
-                      description: When disabled is true, Calico IPAM will not assign addresses
-                        from this pool.
-                      type: boolean
-                    ipip:
-                      description: 'Deprecated: this field is only used for APIv1 backwards
-                      compatibility. Setting this field is not allowed, this field is
-                      for internal use only.'
-                      properties:
-                        enabled:
-                          description: When enabled is true, ipip tunneling will be used
-                            to deliver packets to destinations within this pool.
-                          type: boolean
-                        mode:
-                          description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
-                            mode of "always" will also use IPIP tunneling for routing to
-                            destination IP addresses within this pool.  A mode of "cross-subnet"
-                            will only use IPIP tunneling when the destination node is on
-                            a different subnet to the originating node.  The default value
-                            (if not specified) is "always".
-                          type: string
-                      type: object
-                    ipipMode:
-                      description: Contains configuration for IPIP tunneling for this pool.
-                        If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
-                        is disabled).
-                      type: string
-                    nat-outgoing:
-                      description: 'Deprecated: this field is only used for APIv1 backwards
-                      compatibility. Setting this field is not allowed, this field is
-                      for internal use only.'
-                      type: boolean
-                    natOutgoing:
-                      description: When nat-outgoing is true, packets sent from Calico networked
-                        containers in this pool to destinations outside of this pool will
-                        be masqueraded.
-                      type: boolean
-                    nodeSelector:
-                      description: Allows IPPool to allocate for a specific node by label
-                        selector.
-                      type: string
-                    vxlanMode:
-                      description: Contains configuration for VXLAN tunneling for this pool.
-                        If not specified, then this is defaulted to "Never" (i.e. VXLAN
-                        tunneling is disabled).
-                      type: string
-                  required:
-                    - cidr
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: kubecontrollersconfigurations.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: KubeControllersConfiguration
-        listKind: KubeControllersConfigurationList
-        plural: kubecontrollersconfigurations
-        singular: kubecontrollersconfiguration
-      scope: Cluster
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: KubeControllersConfigurationSpec contains the values of the
-                    Kubernetes controllers configuration.
-                  properties:
-                    controllers:
-                      description: Controllers enables and configures individual Kubernetes
-                        controllers
-                      properties:
-                        namespace:
-                          description: Namespace enables and configures the namespace controller.
-                            Enabled by default, set to nil to disable.
-                          properties:
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform reconciliation
-                              with the Calico datastore. [Default: 5m]'
-                              type: string
-                          type: object
-                        node:
-                          description: Node enables and configures the node controller.
-                            Enabled by default, set to nil to disable.
-                          properties:
-                            hostEndpoint:
-                              description: HostEndpoint controls syncing nodes to host endpoints.
-                                Disabled by default, set to nil to disable.
-                              properties:
-                                autoCreate:
-                                  description: 'AutoCreate enables automatic creation of
-                                  host endpoints for every node. [Default: Disabled]'
-                                  type: string
-                              type: object
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform reconciliation
-                              with the Calico datastore. [Default: 5m]'
-                              type: string
-                            syncLabels:
-                              description: 'SyncLabels controls whether to copy Kubernetes
-                              node labels to Calico nodes. [Default: Enabled]'
-                              type: string
-                          type: object
-                        policy:
-                          description: Policy enables and configures the policy controller.
-                            Enabled by default, set to nil to disable.
-                          properties:
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform reconciliation
-                              with the Calico datastore. [Default: 5m]'
-                              type: string
-                          type: object
-                        serviceAccount:
-                          description: ServiceAccount enables and configures the service
-                            account controller. Enabled by default, set to nil to disable.
-                          properties:
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform reconciliation
-                              with the Calico datastore. [Default: 5m]'
-                              type: string
-                          type: object
-                        workloadEndpoint:
-                          description: WorkloadEndpoint enables and configures the workload
-                            endpoint controller. Enabled by default, set to nil to disable.
-                          properties:
-                            reconcilerPeriod:
-                              description: 'ReconcilerPeriod is the period to perform reconciliation
-                              with the Calico datastore. [Default: 5m]'
-                              type: string
-                          type: object
-                      type: object
-                    etcdV3CompactionPeriod:
-                      description: 'EtcdV3CompactionPeriod is the period between etcdv3
-                      compaction requests. Set to 0 to disable. [Default: 10m]'
-                      type: string
-                    healthChecks:
-                      description: 'HealthChecks enables or disables support for health
-                      checks [Default: Enabled]'
-                      type: string
-                    logSeverityScreen:
-                      description: 'LogSeverityScreen is the log severity above which logs
-                      are sent to the stdout. [Default: Info]'
-                      type: string
-                    prometheusMetricsPort:
-                      description: 'PrometheusMetricsPort is the TCP port that the Prometheus
-                        metrics server should bind to. Set to 0 to disable. [Default: 9094]'
-                      type: integer
-                  required:
-                    - controllers
-                  type: object
-                status:
-                  description: KubeControllersConfigurationStatus represents the status
-                    of the configuration. It's useful for admins to be able to see the actual
-                    config that was applied, which can be modified by environment variables
-                    on the kube-controllers process.
-                  properties:
-                    environmentVars:
-                      additionalProperties:
-                        type: string
-                      description: EnvironmentVars contains the environment variables on
-                        the kube-controllers that influenced the RunningConfig.
-                      type: object
-                    runningConfig:
-                      description: RunningConfig contains the effective config that is running
-                        in the kube-controllers pod, after merging the API resource with
-                        any environment variables.
-                      properties:
-                        controllers:
-                          description: Controllers enables and configures individual Kubernetes
-                            controllers
-                          properties:
-                            namespace:
-                              description: Namespace enables and configures the namespace
-                                controller. Enabled by default, set to nil to disable.
-                              properties:
-                                reconcilerPeriod:
-                                  description: 'ReconcilerPeriod is the period to perform
-                                  reconciliation with the Calico datastore. [Default:
-                                  5m]'
-                                  type: string
-                              type: object
-                            node:
-                              description: Node enables and configures the node controller.
-                                Enabled by default, set to nil to disable.
-                              properties:
-                                hostEndpoint:
-                                  description: HostEndpoint controls syncing nodes to host
-                                    endpoints. Disabled by default, set to nil to disable.
-                                  properties:
-                                    autoCreate:
-                                      description: 'AutoCreate enables automatic creation
-                                      of host endpoints for every node. [Default: Disabled]'
-                                      type: string
-                                  type: object
-                                leakGracePeriod:
-                                  description: 'LeakGracePeriod is the period used by the
-                                    controller to determine if an IP address has been leaked.
-                                    Set to 0 to disable IP garbage collection. [Default:
-                                    15m]'
-                                  type: string
-                                reconcilerPeriod:
-                                  description: 'ReconcilerPeriod is the period to perform
-                                  reconciliation with the Calico datastore. [Default:
-                                  5m]'
-                                  type: string
-                                syncLabels:
-                                  description: 'SyncLabels controls whether to copy Kubernetes
-                                  node labels to Calico nodes. [Default: Enabled]'
-                                  type: string
-                              type: object
-                            policy:
-                              description: Policy enables and configures the policy controller.
-                                Enabled by default, set to nil to disable.
-                              properties:
-                                reconcilerPeriod:
-                                  description: 'ReconcilerPeriod is the period to perform
-                                  reconciliation with the Calico datastore. [Default:
-                                  5m]'
-                                  type: string
-                              type: object
-                            serviceAccount:
-                              description: ServiceAccount enables and configures the service
-                                account controller. Enabled by default, set to nil to disable.
-                              properties:
-                                reconcilerPeriod:
-                                  description: 'ReconcilerPeriod is the period to perform
-                                  reconciliation with the Calico datastore. [Default:
-                                  5m]'
-                                  type: string
-                              type: object
-                            workloadEndpoint:
-                              description: WorkloadEndpoint enables and configures the workload
-                                endpoint controller. Enabled by default, set to nil to disable.
-                              properties:
-                                reconcilerPeriod:
-                                  description: 'ReconcilerPeriod is the period to perform
-                                  reconciliation with the Calico datastore. [Default:
-                                  5m]'
-                                  type: string
-                              type: object
-                          type: object
-                        etcdV3CompactionPeriod:
-                          description: 'EtcdV3CompactionPeriod is the period between etcdv3
-                          compaction requests. Set to 0 to disable. [Default: 10m]'
-                          type: string
-                        healthChecks:
-                          description: 'HealthChecks enables or disables support for health
-                          checks [Default: Enabled]'
-                          type: string
-                        logSeverityScreen:
-                          description: 'LogSeverityScreen is the log severity above which
-                          logs are sent to the stdout. [Default: Info]'
-                          type: string
-                        prometheusMetricsPort:
-                          description: 'PrometheusMetricsPort is the TCP port that the Prometheus
-                            metrics server should bind to. Set to 0 to disable. [Default:
-                            9094]'
-                          type: integer
-                      required:
-                        - controllers
-                      type: object
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: networkpolicies.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: NetworkPolicy
-        listKind: NetworkPolicyList
-        plural: networkpolicies
-        singular: networkpolicy
-      scope: Namespaced
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  properties:
-                    egress:
-                      description: The ordered set of egress rules.  Each rule contains
-                        a set of packet match criteria and a corresponding action to apply.
-                      items:
-                        description: "A Rule encapsulates a set of match criteria and an
-                        action.  Both selector-based security Policy and security Profiles
-                        reference rules - separated out as a list of rules for both ingress
-                        and egress packet matching. \n Each positive match criteria has
-                        a negated version, prefixed with ”Not”. All the match criteria
-                        within a rule must be satisfied for a packet to match. A single
-                        rule can contain the positive and negative version of a match
-                        and both must be satisfied for the rule to match."
-                        properties:
-                          action:
-                            type: string
-                          destination:
-                            description: Destination contains the match criteria that apply
-                              to destination entity.
-                            properties:
-                              namespaceSelector:
-                                description: "NamespaceSelector is an optional field that
-                                contains a selector expression. Only traffic that originates
-                                from (or terminates at) endpoints within the selected
-                                namespaces will be matched. When both NamespaceSelector
-                                and Selector are defined on the same rule, then only workload
-                                endpoints that are matched by both selectors will be selected
-                                by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                                implies that the Selector is limited to selecting only
-                                workload endpoints in the same namespace as the NetworkPolicy.
-                                \n For NetworkPolicy, `global()` NamespaceSelector implies
-                                that the Selector is limited to selecting only GlobalNetworkSet
-                                or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                                NamespaceSelector implies the Selector applies to workload
-                                endpoints across all namespaces."
-                                type: string
-                              nets:
-                                description: Nets is an optional field that restricts the
-                                  rule to only apply to traffic that originates from (or
-                                  terminates at) IP addresses in any of the given subnets.
-                                items:
-                                  type: string
-                                type: array
-                              notNets:
-                                description: NotNets is the negated version of the Nets
-                                  field.
-                                items:
-                                  type: string
-                                type: array
-                              notPorts:
-                                description: NotPorts is the negated version of the Ports
-                                  field. Since only some protocols have ports, if any ports
-                                  are specified it requires the Protocol match in the Rule
-                                  to be set to "TCP" or "UDP".
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              notSelector:
-                                description: NotSelector is the negated version of the Selector
-                                  field.  See Selector field for subtleties with negated
-                                  selectors.
-                                type: string
-                              ports:
-                                description: "Ports is an optional field that restricts
-                                the rule to only apply to traffic that has a source (destination)
-                                port that matches one of these ranges/values. This value
-                                is a list of integers or strings that represent ranges
-                                of ports. \n Since only some protocols have ports, if
-                                any ports are specified it requires the Protocol match
-                                in the Rule to be set to \"TCP\" or \"UDP\"."
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              selector:
-                                description: "Selector is an optional field that contains
-                                a selector expression (see Policy for sample syntax).
-                                \ Only traffic that originates from (terminates at) endpoints
-                                matching the selector will be matched. \n Note that: in
-                                addition to the negated version of the Selector (see NotSelector
-                                below), the selector expression syntax itself supports
-                                negation.  The two types of negation are subtly different.
-                                One negates the set of matched endpoints, the other negates
-                                the whole match: \n \tSelector = \"!has(my_label)\" matches
-                                packets that are from other Calico-controlled \tendpoints
-                                that do not have the label “my_label”. \n \tNotSelector
-                                = \"has(my_label)\" matches packets that are not from
-                                Calico-controlled \tendpoints that do have the label “my_label”.
-                                \n The effect is that the latter will accept packets from
-                                non-Calico sources whereas the former is limited to packets
-                                from Calico-controlled endpoints."
-                                type: string
-                              serviceAccounts:
-                                description: ServiceAccounts is an optional field that restricts
-                                  the rule to only apply to traffic that originates from
-                                  (or terminates at) a pod running as a matching service
-                                  account.
-                                properties:
-                                  names:
-                                    description: Names is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account whose name is in the list.
-                                    items:
-                                      type: string
-                                    type: array
-                                  selector:
-                                    description: Selector is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account that matches the given label selector. If
-                                      both Names and Selector are specified then they are
-                                      AND'ed.
-                                    type: string
-                                type: object
-                              services:
-                                description: "Services is an optional field that contains
-                                  options for matching Kubernetes Services. If specified,
-                                  only traffic that originates from or terminates at endpoints
-                                  within the selected service(s) will be matched, and only
-                                  to/from each endpoint's port. \n Services cannot be specified
-                                  on the same rule as Selector, NotSelector, NamespaceSelector,
-                                  Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                                  Only valid on egress rules."
-                                properties:
-                                  name:
-                                    description: Name specifies the name of a Kubernetes
-                                      Service to match.
-                                    type: string
-                                  namespace:
-                                    description: Namespace specifies the namespace of the
-                                      given Service. If left empty, the rule will match
-                                      within this policy's namespace.
-                                    type: string
-                                type: object
-                            type: object
-                          http:
-                            description: HTTP contains match criteria that apply to HTTP
-                              requests.
-                            properties:
-                              methods:
-                                description: Methods is an optional field that restricts
-                                  the rule to apply only to HTTP requests that use one of
-                                  the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                                  methods are OR'd together.
-                                items:
-                                  type: string
-                                type: array
-                              paths:
-                                description: 'Paths is an optional field that restricts
-                                the rule to apply to HTTP requests that use one of the
-                                listed HTTP Paths. Multiple paths are OR''d together.
-                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                                ONLY specify either a `exact` or a `prefix` match. The
-                                validator will check for it.'
-                                items:
-                                  description: 'HTTPPath specifies an HTTP path to match.
-                                  It may be either of the form: exact: <path>: which matches
-                                  the path exactly or prefix: <path-prefix>: which matches
-                                  the path prefix'
-                                  properties:
-                                    exact:
-                                      type: string
-                                    prefix:
-                                      type: string
-                                  type: object
-                                type: array
-                            type: object
-                          icmp:
-                            description: ICMP is an optional field that restricts the rule
-                              to apply to a specific type and code of ICMP traffic.  This
-                              should only be specified if the Protocol field is set to "ICMP"
-                              or "ICMPv6".
-                            properties:
-                              code:
-                                description: Match on a specific ICMP code.  If specified,
-                                  the Type value must also be specified. This is a technical
-                                  limitation imposed by the kernel’s iptables firewall,
-                                  which Calico uses to enforce the rule.
-                                type: integer
-                              type:
-                                description: Match on a specific ICMP type.  For example
-                                  a value of 8 refers to ICMP Echo Request (i.e. pings).
-                                type: integer
-                            type: object
-                          ipVersion:
-                            description: IPVersion is an optional field that restricts the
-                              rule to only match a specific IP version.
-                            type: integer
-                          metadata:
-                            description: Metadata contains additional information for this
-                              rule
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                description: Annotations is a set of key value pairs that
-                                  give extra information about the rule
-                                type: object
-                            type: object
-                          notICMP:
-                            description: NotICMP is the negated version of the ICMP field.
-                            properties:
-                              code:
-                                description: Match on a specific ICMP code.  If specified,
-                                  the Type value must also be specified. This is a technical
-                                  limitation imposed by the kernel’s iptables firewall,
-                                  which Calico uses to enforce the rule.
-                                type: integer
-                              type:
-                                description: Match on a specific ICMP type.  For example
-                                  a value of 8 refers to ICMP Echo Request (i.e. pings).
-                                type: integer
-                            type: object
-                          notProtocol:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            description: NotProtocol is the negated version of the Protocol
-                              field.
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          protocol:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            description: "Protocol is an optional field that restricts the
-                            rule to only apply to traffic of a specific IP protocol. Required
-                            if any of the EntityRules contain Ports (because ports only
-                            apply to certain protocols). \n Must be one of these string
-                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                            \"UDPLite\" or an integer in the range 1-255."
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          source:
-                            description: Source contains the match criteria that apply to
-                              source entity.
-                            properties:
-                              namespaceSelector:
-                                description: "NamespaceSelector is an optional field that
-                                contains a selector expression. Only traffic that originates
-                                from (or terminates at) endpoints within the selected
-                                namespaces will be matched. When both NamespaceSelector
-                                and Selector are defined on the same rule, then only workload
-                                endpoints that are matched by both selectors will be selected
-                                by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                                implies that the Selector is limited to selecting only
-                                workload endpoints in the same namespace as the NetworkPolicy.
-                                \n For NetworkPolicy, `global()` NamespaceSelector implies
-                                that the Selector is limited to selecting only GlobalNetworkSet
-                                or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                                NamespaceSelector implies the Selector applies to workload
-                                endpoints across all namespaces."
-                                type: string
-                              nets:
-                                description: Nets is an optional field that restricts the
-                                  rule to only apply to traffic that originates from (or
-                                  terminates at) IP addresses in any of the given subnets.
-                                items:
-                                  type: string
-                                type: array
-                              notNets:
-                                description: NotNets is the negated version of the Nets
-                                  field.
-                                items:
-                                  type: string
-                                type: array
-                              notPorts:
-                                description: NotPorts is the negated version of the Ports
-                                  field. Since only some protocols have ports, if any ports
-                                  are specified it requires the Protocol match in the Rule
-                                  to be set to "TCP" or "UDP".
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              notSelector:
-                                description: NotSelector is the negated version of the Selector
-                                  field.  See Selector field for subtleties with negated
-                                  selectors.
-                                type: string
-                              ports:
-                                description: "Ports is an optional field that restricts
-                                the rule to only apply to traffic that has a source (destination)
-                                port that matches one of these ranges/values. This value
-                                is a list of integers or strings that represent ranges
-                                of ports. \n Since only some protocols have ports, if
-                                any ports are specified it requires the Protocol match
-                                in the Rule to be set to \"TCP\" or \"UDP\"."
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              selector:
-                                description: "Selector is an optional field that contains
-                                a selector expression (see Policy for sample syntax).
-                                \ Only traffic that originates from (terminates at) endpoints
-                                matching the selector will be matched. \n Note that: in
-                                addition to the negated version of the Selector (see NotSelector
-                                below), the selector expression syntax itself supports
-                                negation.  The two types of negation are subtly different.
-                                One negates the set of matched endpoints, the other negates
-                                the whole match: \n \tSelector = \"!has(my_label)\" matches
-                                packets that are from other Calico-controlled \tendpoints
-                                that do not have the label “my_label”. \n \tNotSelector
-                                = \"has(my_label)\" matches packets that are not from
-                                Calico-controlled \tendpoints that do have the label “my_label”.
-                                \n The effect is that the latter will accept packets from
-                                non-Calico sources whereas the former is limited to packets
-                                from Calico-controlled endpoints."
-                                type: string
-                              serviceAccounts:
-                                description: ServiceAccounts is an optional field that restricts
-                                  the rule to only apply to traffic that originates from
-                                  (or terminates at) a pod running as a matching service
-                                  account.
-                                properties:
-                                  names:
-                                    description: Names is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account whose name is in the list.
-                                    items:
-                                      type: string
-                                    type: array
-                                  selector:
-                                    description: Selector is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account that matches the given label selector. If
-                                      both Names and Selector are specified then they are
-                                      AND'ed.
-                                    type: string
-                                type: object
-                              services:
-                                description: "Services is an optional field that contains
-                                  options for matching Kubernetes Services. If specified,
-                                  only traffic that originates from or terminates at endpoints
-                                  within the selected service(s) will be matched, and only
-                                  to/from each endpoint's port. \n Services cannot be specified
-                                  on the same rule as Selector, NotSelector, NamespaceSelector,
-                                  Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                                  Only valid on egress rules."
-                                properties:
-                                  name:
-                                    description: Name specifies the name of a Kubernetes
-                                      Service to match.
-                                    type: string
-                                  namespace:
-                                    description: Namespace specifies the namespace of the
-                                      given Service. If left empty, the rule will match
-                                      within this policy's namespace.
-                                    type: string
-                                type: object
-                            type: object
-                        required:
-                          - action
-                        type: object
-                      type: array
-                    ingress:
-                      description: The ordered set of ingress rules.  Each rule contains
-                        a set of packet match criteria and a corresponding action to apply.
-                      items:
-                        description: "A Rule encapsulates a set of match criteria and an
-                        action.  Both selector-based security Policy and security Profiles
-                        reference rules - separated out as a list of rules for both ingress
-                        and egress packet matching. \n Each positive match criteria has
-                        a negated version, prefixed with ”Not”. All the match criteria
-                        within a rule must be satisfied for a packet to match. A single
-                        rule can contain the positive and negative version of a match
-                        and both must be satisfied for the rule to match."
-                        properties:
-                          action:
-                            type: string
-                          destination:
-                            description: Destination contains the match criteria that apply
-                              to destination entity.
-                            properties:
-                              namespaceSelector:
-                                description: "NamespaceSelector is an optional field that
-                                contains a selector expression. Only traffic that originates
-                                from (or terminates at) endpoints within the selected
-                                namespaces will be matched. When both NamespaceSelector
-                                and Selector are defined on the same rule, then only workload
-                                endpoints that are matched by both selectors will be selected
-                                by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                                implies that the Selector is limited to selecting only
-                                workload endpoints in the same namespace as the NetworkPolicy.
-                                \n For NetworkPolicy, `global()` NamespaceSelector implies
-                                that the Selector is limited to selecting only GlobalNetworkSet
-                                or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                                NamespaceSelector implies the Selector applies to workload
-                                endpoints across all namespaces."
-                                type: string
-                              nets:
-                                description: Nets is an optional field that restricts the
-                                  rule to only apply to traffic that originates from (or
-                                  terminates at) IP addresses in any of the given subnets.
-                                items:
-                                  type: string
-                                type: array
-                              notNets:
-                                description: NotNets is the negated version of the Nets
-                                  field.
-                                items:
-                                  type: string
-                                type: array
-                              notPorts:
-                                description: NotPorts is the negated version of the Ports
-                                  field. Since only some protocols have ports, if any ports
-                                  are specified it requires the Protocol match in the Rule
-                                  to be set to "TCP" or "UDP".
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              notSelector:
-                                description: NotSelector is the negated version of the Selector
-                                  field.  See Selector field for subtleties with negated
-                                  selectors.
-                                type: string
-                              ports:
-                                description: "Ports is an optional field that restricts
-                                the rule to only apply to traffic that has a source (destination)
-                                port that matches one of these ranges/values. This value
-                                is a list of integers or strings that represent ranges
-                                of ports. \n Since only some protocols have ports, if
-                                any ports are specified it requires the Protocol match
-                                in the Rule to be set to \"TCP\" or \"UDP\"."
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              selector:
-                                description: "Selector is an optional field that contains
-                                a selector expression (see Policy for sample syntax).
-                                \ Only traffic that originates from (terminates at) endpoints
-                                matching the selector will be matched. \n Note that: in
-                                addition to the negated version of the Selector (see NotSelector
-                                below), the selector expression syntax itself supports
-                                negation.  The two types of negation are subtly different.
-                                One negates the set of matched endpoints, the other negates
-                                the whole match: \n \tSelector = \"!has(my_label)\" matches
-                                packets that are from other Calico-controlled \tendpoints
-                                that do not have the label “my_label”. \n \tNotSelector
-                                = \"has(my_label)\" matches packets that are not from
-                                Calico-controlled \tendpoints that do have the label “my_label”.
-                                \n The effect is that the latter will accept packets from
-                                non-Calico sources whereas the former is limited to packets
-                                from Calico-controlled endpoints."
-                                type: string
-                              serviceAccounts:
-                                description: ServiceAccounts is an optional field that restricts
-                                  the rule to only apply to traffic that originates from
-                                  (or terminates at) a pod running as a matching service
-                                  account.
-                                properties:
-                                  names:
-                                    description: Names is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account whose name is in the list.
-                                    items:
-                                      type: string
-                                    type: array
-                                  selector:
-                                    description: Selector is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account that matches the given label selector. If
-                                      both Names and Selector are specified then they are
-                                      AND'ed.
-                                    type: string
-                                type: object
-                              services:
-                                description: "Services is an optional field that contains
-                                  options for matching Kubernetes Services. If specified,
-                                  only traffic that originates from or terminates at endpoints
-                                  within the selected service(s) will be matched, and only
-                                  to/from each endpoint's port. \n Services cannot be specified
-                                  on the same rule as Selector, NotSelector, NamespaceSelector,
-                                  Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                                  Only valid on egress rules."
-                                properties:
-                                  name:
-                                    description: Name specifies the name of a Kubernetes
-                                      Service to match.
-                                    type: string
-                                  namespace:
-                                    description: Namespace specifies the namespace of the
-                                      given Service. If left empty, the rule will match
-                                      within this policy's namespace.
-                                    type: string
-                                type: object
-                            type: object
-                          http:
-                            description: HTTP contains match criteria that apply to HTTP
-                              requests.
-                            properties:
-                              methods:
-                                description: Methods is an optional field that restricts
-                                  the rule to apply only to HTTP requests that use one of
-                                  the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                                  methods are OR'd together.
-                                items:
-                                  type: string
-                                type: array
-                              paths:
-                                description: 'Paths is an optional field that restricts
-                                the rule to apply to HTTP requests that use one of the
-                                listed HTTP Paths. Multiple paths are OR''d together.
-                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                                ONLY specify either a `exact` or a `prefix` match. The
-                                validator will check for it.'
-                                items:
-                                  description: 'HTTPPath specifies an HTTP path to match.
-                                  It may be either of the form: exact: <path>: which matches
-                                  the path exactly or prefix: <path-prefix>: which matches
-                                  the path prefix'
-                                  properties:
-                                    exact:
-                                      type: string
-                                    prefix:
-                                      type: string
-                                  type: object
-                                type: array
-                            type: object
-                          icmp:
-                            description: ICMP is an optional field that restricts the rule
-                              to apply to a specific type and code of ICMP traffic.  This
-                              should only be specified if the Protocol field is set to "ICMP"
-                              or "ICMPv6".
-                            properties:
-                              code:
-                                description: Match on a specific ICMP code.  If specified,
-                                  the Type value must also be specified. This is a technical
-                                  limitation imposed by the kernel’s iptables firewall,
-                                  which Calico uses to enforce the rule.
-                                type: integer
-                              type:
-                                description: Match on a specific ICMP type.  For example
-                                  a value of 8 refers to ICMP Echo Request (i.e. pings).
-                                type: integer
-                            type: object
-                          ipVersion:
-                            description: IPVersion is an optional field that restricts the
-                              rule to only match a specific IP version.
-                            type: integer
-                          metadata:
-                            description: Metadata contains additional information for this
-                              rule
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                description: Annotations is a set of key value pairs that
-                                  give extra information about the rule
-                                type: object
-                            type: object
-                          notICMP:
-                            description: NotICMP is the negated version of the ICMP field.
-                            properties:
-                              code:
-                                description: Match on a specific ICMP code.  If specified,
-                                  the Type value must also be specified. This is a technical
-                                  limitation imposed by the kernel’s iptables firewall,
-                                  which Calico uses to enforce the rule.
-                                type: integer
-                              type:
-                                description: Match on a specific ICMP type.  For example
-                                  a value of 8 refers to ICMP Echo Request (i.e. pings).
-                                type: integer
-                            type: object
-                          notProtocol:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            description: NotProtocol is the negated version of the Protocol
-                              field.
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          protocol:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            description: "Protocol is an optional field that restricts the
-                            rule to only apply to traffic of a specific IP protocol. Required
-                            if any of the EntityRules contain Ports (because ports only
-                            apply to certain protocols). \n Must be one of these string
-                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                            \"UDPLite\" or an integer in the range 1-255."
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          source:
-                            description: Source contains the match criteria that apply to
-                              source entity.
-                            properties:
-                              namespaceSelector:
-                                description: "NamespaceSelector is an optional field that
-                                contains a selector expression. Only traffic that originates
-                                from (or terminates at) endpoints within the selected
-                                namespaces will be matched. When both NamespaceSelector
-                                and Selector are defined on the same rule, then only workload
-                                endpoints that are matched by both selectors will be selected
-                                by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                                implies that the Selector is limited to selecting only
-                                workload endpoints in the same namespace as the NetworkPolicy.
-                                \n For NetworkPolicy, `global()` NamespaceSelector implies
-                                that the Selector is limited to selecting only GlobalNetworkSet
-                                or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                                NamespaceSelector implies the Selector applies to workload
-                                endpoints across all namespaces."
-                                type: string
-                              nets:
-                                description: Nets is an optional field that restricts the
-                                  rule to only apply to traffic that originates from (or
-                                  terminates at) IP addresses in any of the given subnets.
-                                items:
-                                  type: string
-                                type: array
-                              notNets:
-                                description: NotNets is the negated version of the Nets
-                                  field.
-                                items:
-                                  type: string
-                                type: array
-                              notPorts:
-                                description: NotPorts is the negated version of the Ports
-                                  field. Since only some protocols have ports, if any ports
-                                  are specified it requires the Protocol match in the Rule
-                                  to be set to "TCP" or "UDP".
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              notSelector:
-                                description: NotSelector is the negated version of the Selector
-                                  field.  See Selector field for subtleties with negated
-                                  selectors.
-                                type: string
-                              ports:
-                                description: "Ports is an optional field that restricts
-                                the rule to only apply to traffic that has a source (destination)
-                                port that matches one of these ranges/values. This value
-                                is a list of integers or strings that represent ranges
-                                of ports. \n Since only some protocols have ports, if
-                                any ports are specified it requires the Protocol match
-                                in the Rule to be set to \"TCP\" or \"UDP\"."
-                                items:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^.*
-                                  x-kubernetes-int-or-string: true
-                                type: array
-                              selector:
-                                description: "Selector is an optional field that contains
-                                a selector expression (see Policy for sample syntax).
-                                \ Only traffic that originates from (terminates at) endpoints
-                                matching the selector will be matched. \n Note that: in
-                                addition to the negated version of the Selector (see NotSelector
-                                below), the selector expression syntax itself supports
-                                negation.  The two types of negation are subtly different.
-                                One negates the set of matched endpoints, the other negates
-                                the whole match: \n \tSelector = \"!has(my_label)\" matches
-                                packets that are from other Calico-controlled \tendpoints
-                                that do not have the label “my_label”. \n \tNotSelector
-                                = \"has(my_label)\" matches packets that are not from
-                                Calico-controlled \tendpoints that do have the label “my_label”.
-                                \n The effect is that the latter will accept packets from
-                                non-Calico sources whereas the former is limited to packets
-                                from Calico-controlled endpoints."
-                                type: string
-                              serviceAccounts:
-                                description: ServiceAccounts is an optional field that restricts
-                                  the rule to only apply to traffic that originates from
-                                  (or terminates at) a pod running as a matching service
-                                  account.
-                                properties:
-                                  names:
-                                    description: Names is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account whose name is in the list.
-                                    items:
-                                      type: string
-                                    type: array
-                                  selector:
-                                    description: Selector is an optional field that restricts
-                                      the rule to only apply to traffic that originates
-                                      from (or terminates at) a pod running as a service
-                                      account that matches the given label selector. If
-                                      both Names and Selector are specified then they are
-                                      AND'ed.
-                                    type: string
-                                type: object
-                              services:
-                                description: "Services is an optional field that contains
-                                  options for matching Kubernetes Services. If specified,
-                                  only traffic that originates from or terminates at endpoints
-                                  within the selected service(s) will be matched, and only
-                                  to/from each endpoint's port. \n Services cannot be specified
-                                  on the same rule as Selector, NotSelector, NamespaceSelector,
-                                  Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                                  Only valid on egress rules."
-                                properties:
-                                  name:
-                                    description: Name specifies the name of a Kubernetes
-                                      Service to match.
-                                    type: string
-                                  namespace:
-                                    description: Namespace specifies the namespace of the
-                                      given Service. If left empty, the rule will match
-                                      within this policy's namespace.
-                                    type: string
-                                type: object
-                            type: object
-                        required:
-                          - action
-                        type: object
-                      type: array
-                    order:
-                      description: Order is an optional field that specifies the order in
-                        which the policy is applied. Policies with higher "order" are applied
-                        after those with lower order.  If the order is omitted, it may be
-                        considered to be "infinite" - i.e. the policy will be applied last.  Policies
-                        with identical order will be applied in alphanumerical order based
-                        on the Policy "Name".
-                      type: number
-                    selector:
-                      description: "The selector is an expression used to pick pick out
-                      the endpoints that the policy should be applied to. \n Selector
-                      expressions follow this syntax: \n \tlabel == \"string_literal\"
-                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
-                      \  ->  not equal; also matches if label is not present \tlabel in
-                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
-                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
-                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
-                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
-                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
-                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
-                      or the empty selector -> matches all endpoints. \n Label names are
-                      allowed to contain alphanumerics, -, _ and /. String literals are
-                      more permissive but they do not support escape characters. \n Examples
-                      (with made-up labels): \n \ttype == \"webserver\" && deployment
-                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
-                      \"dev\" \t! has(label_name)"
-                      type: string
-                    serviceAccountSelector:
-                      description: ServiceAccountSelector is an optional field for an expression
-                        used to select a pod based on service accounts.
-                      type: string
-                    types:
-                      description: "Types indicates whether this policy applies to ingress,
-                      or to egress, or to both.  When not explicitly specified (and so
-                      the value on creation is empty or nil), Calico defaults Types according
-                      to what Ingress and Egress are present in the policy.  The default
-                      is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
-                      the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
-                      ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
-                      PolicyTypeEgress ], if there are both Ingress and Egress rules.
-                      \n When the policy is read back again, Types will always be one
-                      of these values, never empty or nil."
-                      items:
-                        description: PolicyType enumerates the possible values of the PolicySpec
-                          Types field.
-                        type: string
-                      type: array
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-
-    ---
-    apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: (devel)
-      creationTimestamp: null
-      name: networksets.crd.projectcalico.org
-    spec:
-      group: crd.projectcalico.org
-      names:
-        kind: NetworkSet
-        listKind: NetworkSetList
-        plural: networksets
-        singular: networkset
-      scope: Namespaced
-      versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: NetworkSetSpec contains the specification for a NetworkSet
-                    resource.
-                  properties:
-                    nets:
-                      description: The list of IP networks that belong to this set.
-                      items:
-                        type: string
-                      type: array
-                  type: object
-              type: object
-          served: true
-          storage: true
-    status:
-      acceptedNames:
-        kind: ""
-        plural: ""
-      conditions: []
-      storedVersions: []
-
-    ---
-    ---
-    # Source: calico/templates/calico-kube-controllers-rbac.yaml
-
-    # Include a clusterrole for the kube-controllers component,
-    # and bind it to the calico-kube-controllers serviceaccount.
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: calico-kube-controllers
-    rules:
-      # Nodes are watched to monitor for deletions.
-      - apiGroups: [""]
-        resources:
-          - nodes
-        verbs:
-          - watch
-          - list
-          - get
-      # Pods are watched to check for existence as part of IPAM controller.
-      - apiGroups: [""]
-        resources:
-          - pods
-        verbs:
-          - get
-          - list
-          - watch
-      # IPAM resources are manipulated when nodes are deleted.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - ippools
-        verbs:
-          - list
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - blockaffinities
-          - ipamblocks
-          - ipamhandles
-        verbs:
-          - get
-          - list
-          - create
-          - update
-          - delete
-          - watch
-      # kube-controllers manages hostendpoints.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - hostendpoints
-        verbs:
-          - get
-          - list
-          - create
-          - update
-          - delete
-      # Needs access to update clusterinformations.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - clusterinformations
-        verbs:
-          - get
-          - create
-          - update
-      # KubeControllersConfiguration is where it gets its config
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - kubecontrollersconfigurations
-        verbs:
-          # read its own config
-          - get
-          # create a default if none exists
-          - create
-          # update status
-          - update
-          # watch for changes
-          - watch
-    ---
-    kind: ClusterRoleBinding
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: calico-kube-controllers
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: calico-kube-controllers
-    subjects:
-      - kind: ServiceAccount
-        name: calico-kube-controllers
-        namespace: kube-system
-    ---
-
-    ---
-    # Source: calico/templates/calico-node-rbac.yaml
-    # Include a clusterrole for the calico-node DaemonSet,
-    # and bind it to the calico-node serviceaccount.
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: calico-node
-    rules:
-      # The CNI plugin needs to get pods, nodes, and namespaces.
-      - apiGroups: [""]
-        resources:
-          - pods
-          - nodes
-          - namespaces
-        verbs:
-          - get
-      # EndpointSlices are used for Service-based network policy rule
-      # enforcement.
-      - apiGroups: ["discovery.k8s.io"]
-        resources:
-          - endpointslices
-        verbs:
-          - watch
-          - list
-      - apiGroups: [""]
-        resources:
-          - endpoints
-          - services
-        verbs:
-          # Used to discover service IPs for advertisement.
-          - watch
-          - list
-          # Used to discover Typhas.
-          - get
-      # Pod CIDR auto-detection on kubeadm needs access to config maps.
-      - apiGroups: [""]
-        resources:
-          - configmaps
-        verbs:
-          - get
-      - apiGroups: [""]
-        resources:
-          - nodes/status
-        verbs:
-          # Needed for clearing NodeNetworkUnavailable flag.
-          - patch
-          # Calico stores some configuration information in node annotations.
-          - update
-      # Watch for changes to Kubernetes NetworkPolicies.
-      - apiGroups: ["networking.k8s.io"]
-        resources:
-          - networkpolicies
-        verbs:
-          - watch
-          - list
-      # Used by Calico for policy information.
-      - apiGroups: [""]
-        resources:
-          - pods
-          - namespaces
-          - serviceaccounts
-        verbs:
-          - list
-          - watch
-      # The CNI plugin patches pods/status.
-      - apiGroups: [""]
-        resources:
-          - pods/status
-        verbs:
-          - patch
-      # Calico monitors various CRDs for config.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - globalfelixconfigs
-          - felixconfigurations
-          - bgppeers
-          - globalbgpconfigs
-          - bgpconfigurations
-          - ippools
-          - ipamblocks
-          - globalnetworkpolicies
-          - globalnetworksets
-          - networkpolicies
-          - networksets
-          - clusterinformations
-          - hostendpoints
-          - blockaffinities
-        verbs:
-          - get
-          - list
-          - watch
-      # Calico must create and update some CRDs on startup.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - ippools
-          - felixconfigurations
-          - clusterinformations
-        verbs:
-          - create
-          - update
-      # Calico stores some configuration information on the node.
-      - apiGroups: [""]
-        resources:
-          - nodes
-        verbs:
-          - get
-          - list
-          - watch
-      # These permissions are only required for upgrade from v2.6, and can
-      # be removed after upgrade or on fresh installations.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - bgpconfigurations
-          - bgppeers
-        verbs:
-          - create
-          - update
-      # These permissions are required for Calico CNI to perform IPAM allocations.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - blockaffinities
-          - ipamblocks
-          - ipamhandles
-        verbs:
-          - get
-          - list
-          - create
-          - update
-          - delete
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - ipamconfigs
-        verbs:
-          - get
-      # Block affinities must also be watchable by confd for route aggregation.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - blockaffinities
-        verbs:
-          - watch
-      # The Calico IPAM migration needs to get daemonsets. These permissions can be
-      # removed if not upgrading from an installation using host-local IPAM.
-      - apiGroups: ["apps"]
-        resources:
-          - daemonsets
-        verbs:
-          - get
-
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: calico-node
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: calico-node
-    subjects:
-      - kind: ServiceAccount
-        name: calico-node
-        namespace: kube-system
-
-    ---
-    # Source: calico/templates/calico-node.yaml
-    # This manifest installs the calico-node container, as well
-    # as the CNI plugins and network config on
-    # each master and worker node in a Kubernetes cluster.
-    kind: DaemonSet
-    apiVersion: apps/v1
-    metadata:
-      name: calico-node
+      name: calico-config
       namespace: kube-system
-      labels:
-        k8s-app: calico-node
-    spec:
-      selector:
-        matchLabels:
-          k8s-app: calico-node
-      updateStrategy:
-        type: RollingUpdate
-        rollingUpdate:
-          maxUnavailable: 1
-      template:
-        metadata:
-          labels:
-            k8s-app: calico-node
-        spec:
-          nodeSelector:
-            kubernetes.io/os: linux
-          hostNetwork: true
-          tolerations:
-            # Make sure calico-node gets scheduled on all nodes.
-            - effect: NoSchedule
-              operator: Exists
-            # Mark the pod as a critical add-on for rescheduling.
-            - key: CriticalAddonsOnly
-              operator: Exists
-            - effect: NoExecute
-              operator: Exists
-          serviceAccountName: calico-node
-          # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
-          # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
-          terminationGracePeriodSeconds: 0
-          priorityClassName: system-node-critical
-          initContainers:
-            # This container installs the CNI binaries
-            # and CNI network config file on each node.
-            - name: install-cni
-              image: calico/cni:v3.20.0
-              command: ["/opt/cni/bin/install"]
-              env:
-                # Name of the CNI config file to create.
-                - name: CNI_CONF_NAME
-                  value: "10-calico.conflist"
-                # The CNI network config to install on each node.
-                - name: CNI_NETWORK_CONFIG
-                  valueFrom:
-                    configMapKeyRef:
-                      name: calico-config
-                      key: cni_network_config
-                # Set the hostname based on the k8s node name.
-                - name: KUBERNETES_NODE_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: spec.nodeName
-                # Prevents the container from sleeping forever.
-                - name: SLEEP
-                  value: "false"
-              volumeMounts:
-                - mountPath: /host/opt/cni/bin
-                  name: cni-bin-dir
-                - mountPath: /host/etc/cni/net.d
-                  name: cni-net-dir
-              securityContext:
-                privileged: true
-            # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
-            # to communicate with Felix over the Policy Sync API.
-            - name: flexvol-driver
-              image: calico/pod2daemon-flexvol:v3.20.0
-              volumeMounts:
-                - name: flexvol-driver-host
-                  mountPath: /host/driver
-              securityContext:
-                privileged: true
-          containers:
-            # Runs calico-node container on each Kubernetes node. This
-            # container programs network policy and routes on each
-            # host.
-            - name: calico-node
-              image: calico/node:v3.20.0
-              env:
-                # Use Kubernetes API as the backing datastore.
-                - name: DATASTORE_TYPE
-                  value: "kubernetes"
-                # Wait for the datastore.
-                - name: WAIT_FOR_DATASTORE
-                  value: "true"
-                # Set based on the k8s node name.
-                - name: NODENAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: spec.nodeName
-                # Choose the backend to use.
-                - name: CALICO_NETWORKING_BACKEND
-                  valueFrom:
-                    configMapKeyRef:
-                      name: calico-config
-                      key: calico_backend
-                # Cluster type to identify the deployment type
-                - name: CLUSTER_TYPE
-                  value: "k8s"
-                # Enable or Disable VXLAN on the default IP pool.
-                - name: CALICO_IPV4POOL_VXLAN
-                  value: "Never"
-                # The default IPv4 pool to create on startup if none exists. Pod IPs will be
-                # chosen from this range. Changing this value after installation will have
-                # no effect. This should fall within `--cluster-cidr`.
-                # - name: CALICO_IPV4POOL_CIDR
-                #   value: "192.168.0.0/16"
-                # https://docs.projectcalico.org/reference/public-cloud/azure#azure-user-defined-routes
-                - name: CALICO_IPv6POOL_CIDR
-                  value: "2001:1234:5678:9a40::/58"
-                - name: IP6
-                  value: "autodetect"
-                # Disable file logging so `kubectl logs` works.
-                - name: CALICO_DISABLE_FILE_LOGGING
-                  value: "true"
-                # Set Felix endpoint to host default action to ACCEPT.
-                - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-                  value: "ACCEPT"
-                # Disable IPv6 on Kubernetes.
-                - name: FELIX_IPV6SUPPORT
-                  value: "true"
-                - name: FELIX_FEATUREDETECTOVERRIDE
-                  value: "ChecksumOffloadBroken=true"
-                - name: FELIX_HEALTHENABLED
-                  value: "true"
-              securityContext:
-                privileged: true
-              resources:
-                requests:
-                  cpu: 250m
-              livenessProbe:
-                exec:
-                  command:
-                    - /bin/calico-node
-                    - -felix-live
-                periodSeconds: 10
-                initialDelaySeconds: 10
-                failureThreshold: 6
-              readinessProbe:
-                exec:
-                  command:
-                    - /bin/calico-node
-                    - -felix-ready
-                periodSeconds: 10
-              volumeMounts:
-                - mountPath: /lib/modules
-                  name: lib-modules
-                  readOnly: true
-                - mountPath: /run/xtables.lock
-                  name: xtables-lock
-                  readOnly: false
-                - mountPath: /var/run/calico
-                  name: var-run-calico
-                  readOnly: false
-                - mountPath: /var/lib/calico
-                  name: var-lib-calico
-                  readOnly: false
-                - name: policysync
-                  mountPath: /var/run/nodeagent
-                # For eBPF mode, we need to be able to mount the BPF filesystem at /sys/fs/bpf so we mount in the
-                # parent directory.
-                - name: sysfs
-                  mountPath: /sys/fs/
-                  # Bidirectional means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to the host.
-                  # If the host is known to mount that filesystem already then Bidirectional can be omitted.
-                  mountPropagation: Bidirectional
-                - name: cni-log-dir
-                  mountPath: /var/log/calico/cni
-                  readOnly: true
-          volumes:
-            # Used by calico-node.
-            - name: lib-modules
-              hostPath:
-                path: /lib/modules
-            - name: var-run-calico
-              hostPath:
-                path: /var/run/calico
-            - name: var-lib-calico
-              hostPath:
-                path: /var/lib/calico
-            - name: xtables-lock
-              hostPath:
-                path: /run/xtables.lock
-                type: FileOrCreate
-            - name: sysfs
-              hostPath:
-                path: /sys/fs/
-                type: DirectoryOrCreate
-            # Used to install CNI.
-            - name: cni-bin-dir
-              hostPath:
-                path: /opt/cni/bin
-            - name: cni-net-dir
-              hostPath:
-                path: /etc/cni/net.d
-            # Used to access CNI logs.
-            - name: cni-log-dir
-              hostPath:
-                path: /var/log/calico/cni
-            # Mount in the directory for host-local IPAM allocations. This is
-            # used when upgrading from host-local to calico-ipam, and can be removed
-            # if not using the upgrade-ipam init container.
-            - name: host-local-net-dir
-              hostPath:
-                path: /var/lib/cni/networks
-            # Used to create per-pod Unix Domain Sockets
-            - name: policysync
-              hostPath:
-                type: DirectoryOrCreate
-                path: /var/run/nodeagent
-            # Used to install Flex Volume Driver
-            - name: flexvol-driver-host
-              hostPath:
-                type: DirectoryOrCreate
-                path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
     ---
-
     apiVersion: v1
-    kind: ServiceAccount
+    kind: Service
     metadata:
-      name: calico-node
+      labels:
+        k8s-app: calico-typha
+      name: calico-typha
       namespace: kube-system
-
+    spec:
+      ports:
+      - name: calico-typha
+        port: 5473
+        protocol: TCP
+        targetPort: calico-typha
+      selector:
+        k8s-app: calico-typha
     ---
-    # Source: calico/templates/calico-kube-controllers.yaml
-    # See https://github.com/projectcalico/kube-controllers
     apiVersion: apps/v1
     kind: Deployment
     metadata:
-      name: calico-kube-controllers
-      namespace: kube-system
       labels:
         k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
     spec:
-      # The controllers can only have a single active instance.
       replicas: 1
       selector:
         matchLabels:
@@ -4305,78 +3968,340 @@ data:
         type: Recreate
       template:
         metadata:
-          name: calico-kube-controllers
-          namespace: kube-system
           labels:
             k8s-app: calico-kube-controllers
+          name: calico-kube-controllers
+          namespace: kube-system
         spec:
+          containers:
+          - env:
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            image: docker.io/calico/kube-controllers:v3.20.3
+            livenessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -l
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-kube-controllers
+            readinessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -r
+              periodSeconds: 10
           nodeSelector:
             kubernetes.io/os: linux
-          tolerations:
-            # Mark the pod as a critical add-on for rescheduling.
-            - key: CriticalAddonsOnly
-              operator: Exists
-            - key: node-role.kubernetes.io/master
-              effect: NoSchedule
-          serviceAccountName: calico-kube-controllers
           priorityClassName: system-cluster-critical
-          containers:
-            - name: calico-kube-controllers
-              image: calico/kube-controllers:v3.20.0
-              env:
-                # Choose which controllers to run.
-                - name: ENABLED_CONTROLLERS
-                  value: node
-                - name: DATASTORE_TYPE
-                  value: kubernetes
-              livenessProbe:
-                exec:
-                  command:
-                  - /usr/bin/check-status
-                  - -l
-                periodSeconds: 10
-                initialDelaySeconds: 10
-                failureThreshold: 6
-                timeoutSeconds: 10
-              readinessProbe:
-                exec:
-                  command:
-                    - /usr/bin/check-status
-                    - -r
-                periodSeconds: 10
-
+          serviceAccountName: calico-kube-controllers
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
     ---
-
-    apiVersion: v1
-    kind: ServiceAccount
+    apiVersion: apps/v1
+    kind: Deployment
     metadata:
-      name: calico-kube-controllers
+      labels:
+        k8s-app: calico-typha
+      name: calico-typha
       namespace: kube-system
-
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          k8s-app: calico-typha
+      template:
+        metadata:
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+          labels:
+            k8s-app: calico-typha
+        spec:
+          containers:
+          - env:
+            - name: TYPHA_LOGSEVERITYSCREEN
+              value: info
+            - name: TYPHA_LOGFILEPATH
+              value: none
+            - name: TYPHA_LOGSEVERITYSYS
+              value: none
+            - name: TYPHA_CONNECTIONREBALANCINGMODE
+              value: kubernetes
+            - name: TYPHA_DATASTORETYPE
+              value: kubernetes
+            - name: TYPHA_HEALTHENABLED
+              value: "true"
+            - name: USE_POD_CIDR
+              value: "true"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/typha:v3.20.3
+            livenessProbe:
+              httpGet:
+                host: localhost
+                path: /liveness
+                port: 9098
+              initialDelaySeconds: 30
+              periodSeconds: 30
+              timeoutSeconds: 10
+            name: calico-typha
+            ports:
+            - containerPort: 5473
+              name: calico-typha
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                host: localhost
+                path: /readiness
+                port: 9098
+              periodSeconds: 10
+              timeoutSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              runAsNonRoot: true
+          hostNetwork: true
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          securityContext:
+            fsGroup: 65534
+          serviceAccountName: calico-node
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
     ---
-
-    # This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
-
     apiVersion: policy/v1beta1
     kind: PodDisruptionBudget
     metadata:
-      name: calico-kube-controllers
-      namespace: kube-system
       labels:
         k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
     spec:
       maxUnavailable: 1
       selector:
         matchLabels:
           k8s-app: calico-kube-controllers
     ---
-    # Source: calico/templates/calico-etcd-secrets.yaml
-
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        k8s-app: calico-typha
+      name: calico-typha
+      namespace: kube-system
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-typha
     ---
-    # Source: calico/templates/calico-typha.yaml
-
-    ---
-    # Source: calico/templates/configure-canal.yaml
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: calico-node
+      name: calico-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+        spec:
+          containers:
+          - env:
+            - name: CALICO_IPv6POOL_CIDR
+              value: 2001:1234:5678:9a40::/58
+            - name: IP6
+              value: autodetect
+            - name: FELIX_IPV6SUPPORT
+              value: "true"
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: USE_POD_CIDR
+              value: "true"
+            - name: FELIX_TYPHAK8SSERVICENAME
+              valueFrom:
+                configMapKeyRef:
+                  key: typha_service_name
+                  name: calico-config
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              value: none
+            - name: CLUSTER_TYPE
+              value: k8s
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: ACCEPT
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/node:v3.20.3
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -shutdown
+            livenessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-live
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-node
+            readinessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-ready
+              periodSeconds: 10
+              timeoutSeconds: 10
+            resources:
+              requests:
+                cpu: 250m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /var/run/nodeagent
+              name: policysync
+            - mountPath: /sys/fs/
+              mountPropagation: Bidirectional
+              name: sysfs
+            - mountPath: /var/log/calico/cni
+              name: cni-log-dir
+              readOnly: true
+          hostNetwork: true
+          initContainers:
+          - command:
+            - /opt/cni/bin/install
+            env:
+            - name: CNI_CONF_NAME
+              value: 10-calico.conflist
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  key: cni_network_config
+                  name: calico-config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: SLEEP
+              value: "false"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: install-cni
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+            name: flexvol-driver
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/driver
+              name: flexvol-driver-host
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: calico-node
+          terminationGracePeriodSeconds: 0
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /lib/modules
+            name: lib-modules
+          - hostPath:
+              path: /var/run/calico
+            name: var-run-calico
+          - hostPath:
+              path: /var/lib/calico
+            name: var-lib-calico
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+          - hostPath:
+              path: /sys/fs/
+              type: DirectoryOrCreate
+            name: sysfs
+          - hostPath:
+              path: /opt/cni/bin
+            name: cni-bin-dir
+          - hostPath:
+              path: /etc/cni/net.d
+            name: cni-net-dir
+          - hostPath:
+              path: /var/log/calico/cni
+            name: cni-log-dir
+          - hostPath:
+              path: /var/run/nodeagent
+              type: DirectoryOrCreate
+            name: policysync
+          - hostPath:
+              path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+              type: DirectoryOrCreate
+            name: flexvol-driver-host
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -3979,7 +3979,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.20.3
+            image: docker.io/calico/kube-controllers:v3.20.4
             livenessProbe:
               exec:
                 command:
@@ -4046,7 +4046,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/typha:v3.20.3
+            image: docker.io/calico/typha:v3.20.4
             livenessProbe:
               httpGet:
                 host: localhost
@@ -4160,7 +4160,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.20.3
+            image: docker.io/calico/node:v3.20.4
             lifecycle:
               preStop:
                 exec:
@@ -4235,7 +4235,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: install-cni
             securityContext:
               privileged: true
@@ -4244,7 +4244,7 @@ data:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.4
             name: flexvol-driver
             securityContext:
               privileged: true

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -4230,7 +4230,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.20.3
+            image: docker.io/calico/kube-controllers:v3.20.4
             livenessProbe:
               exec:
                 command:
@@ -4340,7 +4340,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.20.3
+            image: docker.io/calico/node:v3.20.4
             lifecycle:
               preStop:
                 exec:
@@ -4412,7 +4412,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: upgrade-ipam
             securityContext:
               privileged: true
@@ -4446,7 +4446,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: install-cni
             securityContext:
               privileged: true
@@ -4455,7 +4455,7 @@ data:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.4
             name: flexvol-driver
             securityContext:
               privileged: true
@@ -4563,7 +4563,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.20.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.20.4-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -4582,7 +4582,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.20.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.20.4-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -4593,7 +4593,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.20.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.20.4-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -537,2440 +537,3985 @@ data:
     \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
     kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
     \   type: RollingUpdate\n"
-  resources: "---\n# Source: calico/templates/calico-config.yaml\n# This ConfigMap
-    is used to configure a self-hosted Calico installation.\nkind: ConfigMap\napiVersion:
-    v1\nmetadata:\n  name: calico-config\n  namespace: kube-system\ndata:\n  # Typha
-    is disabled.\n  typha_service_name: \"none\"\n  # Configure the backend to use.\n
-    \ calico_backend: \"vxlan\"\n  # On Azure, the underlying network has an MTU of
-    1400, even though the network interface will have an MTU of 1500.\n  # We set
-    this value to 1350 for “physical network MTU size minus 50” since we use VXLAN,
-    which uses a 50-byte header.\n  # If enabling Wireguard, this value should be
-    changed to 1340 (Wireguard uses a 60-byte header).\n  # https://docs.projectcalico.org/networking/mtu#determine-mtu-size\n
-    \ veth_mtu: \"1350\"\n  \n  # The CNI network configuration to install on each
-    node. The special\n  # values in this config will be automatically populated.\n
-    \ cni_network_config: |-\n    {\n      \"name\": \"k8s-pod-network\",\n      \"cniVersion\":
-    \"0.3.1\",\n      \"plugins\": [\n        {\n          \"type\": \"calico\",\n
-    \         \"log_level\": \"info\",\n          \"log_file_path\": \"/var/log/calico/cni/cni.log\",\n
-    \         \"datastore_type\": \"kubernetes\",\n          \"nodename\": \"__KUBERNETES_NODE_NAME__\",\n
-    \         \"mtu\": __CNI_MTU__,\n          \"ipam\": {\n              \"type\":
-    \"calico-ipam\"\n          },\n          \"policy\": {\n              \"type\":
-    \"k8s\"\n          },\n          \"kubernetes\": {\n              \"kubeconfig\":
-    \"__KUBECONFIG_FILEPATH__\"\n          }\n        },\n        {\n          \"type\":
-    \"portmap\",\n          \"snat\": true,\n          \"capabilities\": {\"portMappings\":
-    true}\n        },\n        {\n          \"type\": \"bandwidth\",\n          \"capabilities\":
-    {\"bandwidth\": true}\n        }\n      ]\n    }\n\n---\n# Source: calico/templates/kdd-crds.yaml\n\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: bgpconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPConfiguration\n    listKind: BGPConfigurationList\n    plural:
-    bgpconfigurations\n    singular: bgpconfiguration\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    BGPConfiguration contains the configuration for any BGP routing.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPConfigurationSpec contains the
-    values of the BGP configuration.\n              properties:\n                asNumber:\n
-    \                 description: 'ASNumber is the default AS number used by a node.
-    [Default:\n                  64512]'\n                  format: int32\n                  type:
-    integer\n                communities:\n                  description: Communities
-    is a list of BGP community values and their\n                    arbitrary names
-    for tagging routes.\n                  items:\n                    description:
-    Community contains standard or large community value\n                      and
-    its name.\n                    properties:\n                      name:\n                        description:
-    Name given to community value.\n                        type: string\n                      value:\n
-    \                       description: Value must be of format `aa:nn` or `aa:nn:mm`.\n
-    \                         For standard community use `aa:nn` format, where `aa`
-    and\n                          `nn` are 16 bit number. For large community use
-    `aa:nn:mm`\n                          format, where `aa`, `nn` and `mm` are 32
-    bit number. Where,\n                          `aa` is an AS Number, `nn` and `mm`
-    are per-AS identifier.\n                        pattern: ^(\\d+):(\\d+)$|^(\\d+):(\\d+):(\\d+)$\n
-    \                       type: string\n                    type: object\n                  type:
-    array\n                listenPort:\n                  description: ListenPort
-    is the port where BGP protocol should listen.\n                    Defaults to
-    179\n                  maximum: 65535\n                  minimum: 1\n                  type:
-    integer\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: INFO]'\n                  type: string\n                nodeToNodeMeshEnabled:\n
-    \                 description: 'NodeToNodeMeshEnabled sets whether full node to
-    node\n                  BGP mesh is enabled. [Default: true]'\n                  type:
-    boolean\n                prefixAdvertisements:\n                  description:
-    PrefixAdvertisements contains per-prefix advertisement\n                    configuration.\n
-    \                 items:\n                    description: PrefixAdvertisement
-    configures advertisement properties\n                      for the specified CIDR.\n
-    \                   properties:\n                      cidr:\n                        description:
-    CIDR for which properties should be advertised.\n                        type:
-    string\n                      communities:\n                        description:
-    Communities can be list of either community names\n                          already
-    defined in `Specs.Communities` or community value\n                          of
-    format `aa:nn` or `aa:nn:mm`. For standard community use\n                          `aa:nn`
-    format, where `aa` and `nn` are 16 bit number. For\n                          large
-    community use `aa:nn:mm` format, where `aa`, `nn` and\n                          `mm`
-    are 32 bit number. Where,`aa` is an AS Number, `nn` and\n                          `mm`
-    are per-AS identifier.\n                        items:\n                          type:
-    string\n                        type: array\n                    type: object\n
-    \                 type: array\n                serviceClusterIPs:\n                  description:
-    ServiceClusterIPs are the CIDR blocks from which service\n                    cluster
-    IPs are allocated. If specified, Calico will advertise these\n                    blocks,
-    as well as any cluster IPs within them.\n                  items:\n                    description:
-    ServiceClusterIPBlock represents a single allowed ClusterIP\n                      CIDR
-    block.\n                    properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n                serviceExternalIPs:\n
-    \                 description: ServiceExternalIPs are the CIDR blocks for Kubernetes\n
-    \                   Service External IPs. Kubernetes Service ExternalIPs will
-    only be\n                    advertised if they are within one of these blocks.\n
-    \                 items:\n                    description: ServiceExternalIPBlock
-    represents a single allowed\n                      External IP CIDR block.\n                    properties:\n
-    \                     cidr:\n                        type: string\n                    type:
-    object\n                  type: array\n                serviceLoadBalancerIPs:\n
-    \                 description: ServiceLoadBalancerIPs are the CIDR blocks for
-    Kubernetes\n                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress\n
-    \                   IPs will only be advertised if they are within one of these
-    blocks.\n                  items:\n                    description: ServiceLoadBalancerIPBlock
-    represents a single allowed\n                      LoadBalancer IP CIDR block.\n
-    \                   properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: bgppeers.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPPeer\n    listKind: BGPPeerList\n    plural: bgppeers\n
-    \   singular: bgppeer\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPPeerSpec contains the specification
-    for a BGPPeer resource.\n              properties:\n                asNumber:\n
-    \                 description: The AS Number of the peer.\n                  format:
-    int32\n                  type: integer\n                keepOriginalNextHop:\n
-    \                 description: Option to keep the original nexthop field when
-    routes\n                    are sent to a BGP Peer. Setting \"true\" configures
-    the selected BGP\n                    Peers node to use the \"next hop keep;\"
-    instead of \"next hop self;\"(default)\n                    in the specific branch
-    of the Node on \"bird.cfg\".\n                  type: boolean\n                maxRestartTime:\n
-    \                 description: Time to allow for software restart.  When specified,
-    this\n                    is configured as the graceful restart timeout.  When
-    not specified,\n                    the BIRD default of 120s is used.\n                  type:
-    string\n                node:\n                  description: The node name identifying
-    the Calico node instance that\n                    is targeted by this peer. If
-    this is not set, and no nodeSelector\n                    is specified, then this
-    BGP peer selects all nodes in the cluster.\n                  type: string\n                nodeSelector:\n
-    \                 description: Selector for the nodes that should have this peering.
-    \ When\n                    this is set, the Node field must be empty.\n                  type:
-    string\n                password:\n                  description: Optional BGP
-    password for the peerings generated by this\n                    BGPPeer resource.\n
-    \                 properties:\n                    secretKeyRef:\n                      description:
-    Selects a key of a secret in the node pod's namespace.\n                      properties:\n
-    \                       key:\n                          description: The key of
-    the secret to select from.  Must be\n                            a valid secret
-    key.\n                          type: string\n                        name:\n
-    \                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n
-    \                         TODO: Add other useful fields. apiVersion, kind, uid?'\n
-    \                         type: string\n                        optional:\n                          description:
-    Specify whether the Secret or its key must be\n                            defined\n
-    \                         type: boolean\n                      required:\n                        -
-    key\n                      type: object\n                  type: object\n                peerIP:\n
-    \                 description: The IP address of the peer followed by an optional
-    port\n                    number to peer with. If port number is given, format
-    should be `[<IPv6>]:port`\n                    or `<IPv4>:<port>` for IPv4. If
-    optional port number is not set,\n                    and this peer IP and ASNumber
-    belongs to a calico/node with ListenPort\n                    set in BGPConfiguration,
-    then we use that port to peer.\n                  type: string\n                peerSelector:\n
-    \                 description: Selector for the remote nodes to peer with.  When
-    this\n                    is set, the PeerIP and ASNumber fields must be empty.
-    \ For each\n                    peering between the local node and selected remote
-    nodes, we configure\n                    an IPv4 peering if both ends have NodeBGPSpec.IPv4Address
-    specified,\n                    and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address
-    specified.  The\n                    remote AS number comes from the remote node’s
-    NodeBGPSpec.ASNumber,\n                    or the global default if that is not
-    set.\n                  type: string\n                sourceAddress:\n                  description:
-    Specifies whether and how to configure a source address\n                    for
-    the peerings generated by this BGPPeer resource.  Default value\n                    \"UseNodeIP\"
-    means to configure the node IP as the source address.  \"None\"\n                    means
-    not to configure a source address.\n                  type: string\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: blockaffinities.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BlockAffinity\n    listKind: BlockAffinityList\n    plural:
-    blockaffinities\n    singular: blockaffinity\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BlockAffinitySpec contains the specification
-    for a BlockAffinity\n                resource.\n              properties:\n                cidr:\n
-    \                 type: string\n                deleted:\n                  description:
-    Deleted indicates that this block affinity is being deleted.\n                    This
-    field is a string for compatibility with older releases that\n                    mistakenly
-    treat this field as a string.\n                  type: string\n                node:\n
-    \                 type: string\n                state:\n                  type:
-    string\n              required:\n                - cidr\n                - deleted\n
-    \               - node\n                - state\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: clusterinformations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: ClusterInformation\n    listKind: ClusterInformationList\n
-    \   plural: clusterinformations\n    singular: clusterinformation\n  scope: Cluster\n
-    \ versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    ClusterInformation contains the cluster specific information.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: ClusterInformationSpec contains
-    the values of describing\n                the cluster.\n              properties:\n
-    \               calicoVersion:\n                  description: CalicoVersion is
-    the version of Calico that the cluster\n                    is running\n                  type:
-    string\n                clusterGUID:\n                  description: ClusterGUID
-    is the GUID of the cluster\n                  type: string\n                clusterType:\n
-    \                 description: ClusterType describes the type of the cluster\n
-    \                 type: string\n                datastoreReady:\n                  description:
-    DatastoreReady is used during significant datastore migrations\n                    to
-    signal to components such as Felix that it should wait before\n                    accessing
-    the datastore.\n                  type: boolean\n                variant:\n                  description:
-    Variant declares which variant of Calico should be active.\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: felixconfigurations.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: FelixConfiguration\n    listKind:
-    FelixConfigurationList\n    plural: felixconfigurations\n    singular: felixconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         description: Felix Configuration contains the configuration for Felix.\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: FelixConfigurationSpec contains
-    the values of the Felix configuration.\n              properties:\n                allowIPIPPacketsFromWorkloads:\n
-    \                 description: 'AllowIPIPPacketsFromWorkloads controls whether
-    Felix\n                  will add a rule to drop IPIP encapsulated traffic from
-    workloads\n                  [Default: false]'\n                  type: boolean\n
-    \               allowVXLANPacketsFromWorkloads:\n                  description:
-    'AllowVXLANPacketsFromWorkloads controls whether Felix\n                  will
-    add a rule to drop VXLAN encapsulated traffic from workloads\n                  [Default:
-    false]'\n                  type: boolean\n                awsSrcDstCheck:\n                  description:
-    'Set source-destination-check on AWS EC2 instances. Accepted\n                  value
-    must be one of \"DoNothing\", \"Enabled\" or \"Disabled\". [Default:\n                  DoNothing]'\n
-    \                 enum:\n                    - DoNothing\n                    -
-    Enable\n                    - Disable\n                  type: string\n                bpfConnectTimeLoadBalancingEnabled:\n
-    \                 description: 'BPFConnectTimeLoadBalancingEnabled when in BPF
-    mode,\n                  controls whether Felix installs the connection-time load
-    balancer.  The\n                  connect-time load balancer is required for the
-    host to be able to\n                  reach Kubernetes services and it improves
-    the performance of pod-to-service\n                  connections.  The only reason
-    to disable it is for debugging purposes.  [Default:\n                  true]'\n
-    \                 type: boolean\n                bpfDataIfacePattern:\n                  description:
-    'BPFDataIfacePattern is a regular expression that controls\n                  which
-    interfaces Felix should attach BPF programs to in order to\n                  catch
-    traffic to/from the network.  This needs to match the interfaces\n                  that
-    Calico workload traffic flows over as well as any interfaces\n                  that
-    handle incoming traffic to nodeports and services from outside\n                  the
-    cluster.  It should not match the workload interfaces (usually\n                  named
-    cali...). [Default: ^(en.*|eth.*|tunl0$)]'\n                  type: string\n                bpfDisableUnprivileged:\n
-    \                 description: 'BPFDisableUnprivileged, if enabled, Felix sets
-    the kernel.unprivileged_bpf_disabled\n                  sysctl to disable unprivileged
-    use of BPF.  This ensures that unprivileged\n                  users cannot access
-    Calico''s BPF maps and cannot insert their own\n                  BPF programs
-    to interfere with Calico''s. [Default: true]'\n                  type: boolean\n
-    \               bpfEnabled:\n                  description: 'BPFEnabled, if enabled
-    Felix will use the BPF dataplane.\n                  [Default: false]'\n                  type:
-    boolean\n                bpfExtToServiceConnmark:\n                  description:
-    'BPFExtToServiceConnmark in BPF mode, control a 32bit\n                    mark
-    that is set on connections from an external client to a local\n                    service.
-    This mark allows us to control how packets of that connection\n                    are
-    routed within the host and how is routing intepreted by RPF\n                    check.
-    [Default: 0]'\n                  type: integer\n                bpfExternalServiceMode:\n
-    \                 description: 'BPFExternalServiceMode in BPF mode, controls how
-    connections\n                  from outside the cluster to services (node ports
-    and cluster IPs)\n                  are forwarded to remote workloads.  If set
-    to \"Tunnel\" then both\n                  request and response traffic is tunneled
-    to the remote node.  If\n                  set to \"DSR\", the request traffic
-    is tunneled but the response traffic\n                  is sent directly from
-    the remote node.  In \"DSR\" mode, the remote\n                  node appears
-    to use the IP of the ingress node; this requires a\n                  permissive
-    L2 network.  [Default: Tunnel]'\n                  type: string\n                bpfKubeProxyEndpointSlicesEnabled:\n
-    \                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode,
-    controls\n                    whether Felix's embedded kube-proxy accepts EndpointSlices
-    or not.\n                  type: boolean\n                bpfKubeProxyIptablesCleanupEnabled:\n
-    \                 description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled
-    in BPF\n                  mode, Felix will proactively clean up the upstream Kubernetes
-    kube-proxy''s\n                  iptables chains.  Should only be enabled if kube-proxy
-    is not running.  [Default:\n                  true]'\n                  type:
-    boolean\n                bpfKubeProxyMinSyncPeriod:\n                  description:
-    'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the\n                  minimum
-    time between updates to the dataplane for Felix''s embedded\n                  kube-proxy.
-    \ Lower values give reduced set-up latency.  Higher values\n                  reduce
-    Felix CPU usage by batching up more work.  [Default: 1s]'\n                  type:
-    string\n                bpfLogLevel:\n                  description: 'BPFLogLevel
-    controls the log level of the BPF programs\n                  when in BPF dataplane
-    mode.  One of \"Off\", \"Info\", or \"Debug\".  The\n                  logs are
-    emitted to the BPF trace pipe, accessible with the command\n                  `tc
-    exec bpf debug`. [Default: Off].'\n                  type: string\n                chainInsertMode:\n
-    \                 description: 'ChainInsertMode controls whether Felix hooks the
-    kernel’s\n                  top-level iptables chains by inserting a rule at the
-    top of the\n                  chain or by appending a rule at the bottom. insert
-    is the safe default\n                  since it prevents Calico’s rules from being
-    bypassed. If you switch\n                  to append mode, be sure that the other
-    rules in the chains signal\n                  acceptance by falling through to
-    the Calico rules, otherwise the\n                  Calico policy will be bypassed.
-    [Default: insert]'\n                  type: string\n                dataplaneDriver:\n
-    \                 type: string\n                debugDisableLogDropping:\n                  type:
-    boolean\n                debugMemoryProfilePath:\n                  type: string\n
-    \               debugSimulateCalcGraphHangAfter:\n                  type: string\n
-    \               debugSimulateDataplaneHangAfter:\n                  type: string\n
-    \               defaultEndpointToHostAction:\n                  description: 'DefaultEndpointToHostAction
-    controls what happens to\n                  traffic that goes from a workload
-    endpoint to the host itself (after\n                  the traffic hits the endpoint
-    egress policy). By default Calico\n                  blocks traffic from workload
-    endpoints to the host itself with an\n                  iptables “DROP” action.
-    If you want to allow some or all traffic\n                  from endpoint to host,
-    set this parameter to RETURN or ACCEPT. Use\n                  RETURN if you have
-    your own rules in the iptables “INPUT” chain;\n                  Calico will insert
-    its rules at the top of that chain, then “RETURN”\n                  packets to
-    the “INPUT” chain once it has completed processing workload\n                  endpoint
-    egress policy. Use ACCEPT to unconditionally accept packets\n                  from
-    workloads after processing workload endpoint egress policy.\n                  [Default:
-    Drop]'\n                  type: string\n                deviceRouteProtocol:\n
-    \                 description: This defines the route protocol added to programmed
-    device\n                    routes, by default this will be RTPROT_BOOT when left
-    blank.\n                  type: integer\n                deviceRouteSourceAddress:\n
-    \                 description: This is the source address to use on programmed
-    device\n                    routes. By default the source address is left blank,
-    leaving the\n                    kernel to choose the source address used.\n                  type:
-    string\n                disableConntrackInvalidCheck:\n                  type:
-    boolean\n                endpointReportingDelay:\n                  type: string\n
-    \               endpointReportingEnabled:\n                  type: boolean\n                externalNodesList:\n
-    \                 description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes\n
-    \                   which may source tunnel traffic and have the tunneled traffic
-    be\n                    accepted at calico nodes.\n                  items:\n
-    \                   type: string\n                  type: array\n                failsafeInboundHostPorts:\n
-    \                 description: 'FailsafeInboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow incoming traffic to
-    host endpoints\n                    on irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    inbound host ports, use the value\n                    none. The default value
-    allows ssh access and DHCP. [Default: tcp:22,\n                    udp:68, tcp:179,
-    tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'\n                  items:\n
-    \                   description: ProtoPort is combination of protocol, port, and
-    CIDR.\n                      Protocol and port must be specified.\n                    properties:\n
-    \                     net:\n                        type: string\n                      port:\n
-    \                       type: integer\n                      protocol:\n                        type:
-    string\n                    required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                failsafeOutboundHostPorts:\n
-    \                 description: 'FailsafeOutboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow outgoing traffic from
-    host endpoints\n                    to irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    outbound host ports, use the value\n                    none. The default value
-    opens etcd''s standard ports to ensure that\n                    Felix does not
-    get cut off from etcd as well as allowing DHCP and\n                    DNS. [Default:
-    tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,\n                    tcp:6667,
-    udp:53, udp:67]'\n                  items:\n                    description: ProtoPort
-    is combination of protocol, port, and CIDR.\n                      Protocol and
-    port must be specified.\n                    properties:\n                      net:\n
-    \                       type: string\n                      port:\n                        type:
-    integer\n                      protocol:\n                        type: string\n
-    \                   required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                featureDetectOverride:\n
-    \                 description: FeatureDetectOverride is used to override the feature\n
-    \                   detection. Values are specified in a comma separated list
-    with no\n                    spaces, example; \"SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=\".\n
-    \                   \"true\" or \"false\" will force the feature, empty or omitted
-    values\n                    are auto-detected.\n                  type: string\n
-    \               genericXDPEnabled:\n                  description: 'GenericXDPEnabled
-    enables Generic XDP so network cards\n                  that don''t support XDP
-    offload or driver modes can use XDP. This\n                  is not recommended
-    since it doesn''t provide better performance\n                  than iptables.
-    [Default: false]'\n                  type: boolean\n                healthEnabled:\n
-    \                 type: boolean\n                healthHost:\n                  type:
-    string\n                healthPort:\n                  type: integer\n                interfaceExclude:\n
-    \                 description: 'InterfaceExclude is a comma-separated list of
-    interfaces\n                  that Felix should exclude when monitoring for host
-    endpoints. The\n                  default value ensures that Felix ignores Kubernetes''
-    IPVS dummy\n                  interface, which is used internally by kube-proxy.
-    If you want to\n                  exclude multiple interface names using a single
-    value, the list\n                  supports regular expressions. For regular expressions
-    you must wrap\n                  the value with ''/''. For example having values
-    ''/^kube/,veth1''\n                  will exclude all interfaces that begin with
-    ''kube'' and also the\n                  interface ''veth1''. [Default: kube-ipvs0]'\n
-    \                 type: string\n                interfacePrefix:\n                  description:
-    'InterfacePrefix is the interface name prefix that identifies\n                  workload
-    endpoints and so distinguishes them from host endpoint\n                  interfaces.
-    Note: in environments other than bare metal, the orchestrators\n                  configure
-    this appropriately. For example our Kubernetes and Docker\n                  integrations
-    set the ‘cali’ value, and our OpenStack integration\n                  sets the
-    ‘tap’ value. [Default: cali]'\n                  type: string\n                interfaceRefreshInterval:\n
-    \                 description: InterfaceRefreshInterval is the period at which
-    Felix\n                    rescans local interfaces to verify their state. The
-    rescan can be\n                    disabled by setting the interval to 0.\n                  type:
-    string\n                ipipEnabled:\n                  type: boolean\n                ipipMTU:\n
-    \                 description: 'IPIPMTU is the MTU to set on the tunnel device.
-    See\n                  Configuring MTU [Default: 1440]'\n                  type:
-    integer\n                ipsetsRefreshInterval:\n                  description:
-    'IpsetsRefreshInterval is the period at which Felix re-checks\n                  all
-    iptables state to ensure that no other process has accidentally\n                  broken
-    Calico’s rules. Set to 0 to disable iptables refresh. [Default:\n                  90s]'\n
-    \                 type: string\n                iptablesBackend:\n                  description:
-    IptablesBackend specifies which backend of iptables will\n                    be
-    used. The default is legacy.\n                  type: string\n                iptablesFilterAllowAction:\n
-    \                 type: string\n                iptablesLockFilePath:\n                  description:
-    'IptablesLockFilePath is the location of the iptables\n                  lock
-    file. You may need to change this if the lock file is not in\n                  its
-    standard location (for example if you have mapped it into Felix’s\n                  container
-    at a different path). [Default: /run/xtables.lock]'\n                  type: string\n
-    \               iptablesLockProbeInterval:\n                  description: 'IptablesLockProbeInterval
-    is the time that Felix will\n                  wait between attempts to acquire
-    the iptables lock if it is not\n                  available. Lower values make
-    Felix more responsive when the lock\n                  is contended, but use more
-    CPU. [Default: 50ms]'\n                  type: string\n                iptablesLockTimeout:\n
-    \                 description: 'IptablesLockTimeout is the time that Felix will
-    wait\n                  for the iptables lock, or 0, to disable. To use this feature,
-    Felix\n                  must share the iptables lock file with all other processes
-    that\n                  also take the lock. When running Felix inside a container,
-    this\n                  requires the /run directory of the host to be mounted
-    into the calico/node\n                  or calico/felix container. [Default: 0s
-    disabled]'\n                  type: string\n                iptablesMangleAllowAction:\n
-    \                 type: string\n                iptablesMarkMask:\n                  description:
-    'IptablesMarkMask is the mask that Felix selects its\n                  IPTables
-    Mark bits from. Should be a 32 bit hexadecimal number with\n                  at
-    least 8 bits set, none of which clash with any other mark bits\n                  in
-    use on the system. [Default: 0xff000000]'\n                  format: int32\n                  type:
-    integer\n                iptablesNATOutgoingInterfaceFilter:\n                  type:
-    string\n                iptablesPostWriteCheckInterval:\n                  description:
-    'IptablesPostWriteCheckInterval is the period after Felix\n                  has
-    done a write to the dataplane that it schedules an extra read\n                  back
-    in order to check the write was not clobbered by another process.\n                  This
-    should only occur if another application on the system doesn’t\n                  respect
-    the iptables lock. [Default: 1s]'\n                  type: string\n                iptablesRefreshInterval:\n
-    \                 description: 'IptablesRefreshInterval is the period at which
-    Felix\n                    re-checks the IP sets in the dataplane to ensure that
-    no other process\n                    has accidentally broken Calico''s rules.
-    Set to 0 to disable IP\n                    sets refresh. Note: the default for
-    this value is lower than the\n                    other refresh intervals as a
-    workaround for a Linux kernel bug that\n                    was fixed in kernel
-    version 4.11. If you are using v4.11 or greater\n                    you may want
-    to set this to, a higher value to reduce Felix CPU\n                    usage.
-    [Default: 10s]'\n                  type: string\n                ipv6Support:\n
-    \                 type: boolean\n                kubeNodePortRanges:\n                  description:
-    'KubeNodePortRanges holds list of port ranges used for\n                  service
-    node ports. Only used if felix detects kube-proxy running\n                  in
-    ipvs mode. Felix uses these ranges to separate host and workload\n                  traffic.
-    [Default: 30000:32767].'\n                  items:\n                    anyOf:\n
-    \                     - type: integer\n                      - type: string\n
-    \                   pattern: ^.*\n                    x-kubernetes-int-or-string:
-    true\n                  type: array\n                logFilePath:\n                  description:
-    'LogFilePath is the full path to the Felix log. Set to\n                  none
-    to disable file logging. [Default: /var/log/calico/felix.log]'\n                  type:
-    string\n                logPrefix:\n                  description: 'LogPrefix
-    is the log prefix that Felix uses when rendering\n                  LOG rules.
-    [Default: calico-packet]'\n                  type: string\n                logSeverityFile:\n
-    \                 description: 'LogSeverityFile is the log severity above which
-    logs\n                  are sent to the log file. [Default: Info]'\n                  type:
-    string\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: Info]'\n                  type: string\n                logSeveritySys:\n
-    \                 description: 'LogSeveritySys is the log severity above which
-    logs\n                  are sent to the syslog. Set to None for no logging to
-    syslog. [Default:\n                  Info]'\n                  type: string\n
-    \               maxIpsetSize:\n                  type: integer\n                metadataAddr:\n
-    \                 description: 'MetadataAddr is the IP address or domain name
-    of the\n                  server that can answer VM queries for cloud-init metadata.
-    In OpenStack,\n                  this corresponds to the machine running nova-api
-    (or in Ubuntu,\n                  nova-api-metadata). A value of none (case insensitive)
-    means that\n                  Felix should not set up any NAT rule for the metadata
-    path. [Default:\n                  127.0.0.1]'\n                  type: string\n
-    \               metadataPort:\n                  description: 'MetadataPort is
-    the port of the metadata server. This,\n                  combined with global.MetadataAddr
-    (if not ‘None’), is used to set\n                  up a NAT rule, from 169.254.169.254:80
-    to MetadataAddr:MetadataPort.\n                  In most cases this should not
-    need to be changed [Default: 8775].'\n                  type: integer\n                mtuIfacePattern:\n
-    \                 description: MTUIfacePattern is a regular expression that controls\n
-    \                   which interfaces Felix should scan in order to calculate the
-    host's\n                    MTU. This should not match workload interfaces (usually
-    named cali...).\n                  type: string\n                natOutgoingAddress:\n
-    \                 description: NATOutgoingAddress specifies an address to use
-    when performing\n                    source NAT for traffic in a natOutgoing pool
-    that is leaving the\n                    network. By default the address used
-    is an address on the interface\n                    the traffic is leaving on
-    (ie it uses the iptables MASQUERADE target)\n                  type: string\n
-    \               natPortRange:\n                  anyOf:\n                    -
-    type: integer\n                    - type: string\n                  description:
-    NATPortRange specifies the range of ports that is used\n                    for
-    port mapping when doing outgoing NAT. When unset the default\n                    behavior
-    of the network stack is used.\n                  pattern: ^.*\n                  x-kubernetes-int-or-string:
-    true\n                netlinkTimeout:\n                  type: string\n                openstackRegion:\n
-    \                 description: 'OpenstackRegion is the name of the region that
-    a particular\n                  Felix belongs to. In a multi-region Calico/OpenStack
-    deployment,\n                  this must be configured somehow for each Felix
-    (here in the datamodel,\n                  or in felix.cfg or the environment
-    on each compute node), and must\n                  match the [calico] openstack_region
-    value configured in neutron.conf\n                  on each node. [Default: Empty]'\n
-    \                 type: string\n                policySyncPathPrefix:\n                  description:
-    'PolicySyncPathPrefix is used to by Felix to communicate\n                  policy
-    changes to external services, like Application layer policy.\n                  [Default:
-    Empty]'\n                  type: string\n                prometheusGoMetricsEnabled:\n
-    \                 description: 'PrometheusGoMetricsEnabled disables Go runtime
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                prometheusMetricsEnabled:\n                  description:
-    'PrometheusMetricsEnabled enables the Prometheus metrics\n                  server
-    in Felix if set to true. [Default: false]'\n                  type: boolean\n
-    \               prometheusMetricsHost:\n                  description: 'PrometheusMetricsHost
-    is the host that the Prometheus\n                  metrics server should bind
-    to. [Default: empty]'\n                  type: string\n                prometheusMetricsPort:\n
-    \                 description: 'PrometheusMetricsPort is the TCP port that the
-    Prometheus\n                  metrics server should bind to. [Default: 9091]'\n
-    \                 type: integer\n                prometheusProcessMetricsEnabled:\n
-    \                 description: 'PrometheusProcessMetricsEnabled disables process
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                removeExternalRoutes:\n                  description:
-    Whether or not to remove device routes that have not\n                    been
-    programmed by Felix. Disabling this will allow external applications\n                    to
-    also add device routes. This is enabled by default which means\n                    we
-    will remove externally added routes.\n                  type: boolean\n                reportingInterval:\n
-    \                 description: 'ReportingInterval is the interval at which Felix
-    reports\n                  its status into the datastore or 0 to disable. Must
-    be non-zero\n                  in OpenStack deployments. [Default: 30s]'\n                  type:
-    string\n                reportingTTL:\n                  description: 'ReportingTTL
-    is the time-to-live setting for process-wide\n                  status reports.
-    [Default: 90s]'\n                  type: string\n                routeRefreshInterval:\n
-    \                 description: 'RouterefreshInterval is the period at which Felix
-    re-checks\n                  the routes in the dataplane to ensure that no other
-    process has\n                  accidentally broken Calico’s rules. Set to 0 to
-    disable route refresh.\n                  [Default: 90s]'\n                  type:
-    string\n                routeSource:\n                  description: 'RouteSource
-    configures where Felix gets its routing\n                  information. - WorkloadIPs:
-    use workload endpoints to construct\n                  routes. - CalicoIPAM: the
-    default - use IPAM data to construct routes.'\n                  type: string\n
-    \               routeTableRange:\n                  description: Calico programs
-    additional Linux route tables for various\n                    purposes.  RouteTableRange
-    specifies the indices of the route tables\n                    that Calico should
-    use.\n                  properties:\n                    max:\n                      type:
-    integer\n                    min:\n                      type: integer\n                  required:\n
-    \                   - max\n                    - min\n                  type:
-    object\n                serviceLoopPrevention:\n                  description:
-    'When service IP advertisement is enabled, prevent routing\n                    loops
-    to service IPs that are not in use, by dropping or rejecting\n                    packets
-    that do not get DNAT''d by kube-proxy. Unless set to \"Disabled\",\n                    in
-    which case such routing loops continue to be allowed. [Default:\n                    Drop]'\n
-    \                 type: string\n                sidecarAccelerationEnabled:\n
-    \                 description: 'SidecarAccelerationEnabled enables experimental
-    sidecar\n                  acceleration [Default: false]'\n                  type:
-    boolean\n                usageReportingEnabled:\n                  description:
-    'UsageReportingEnabled reports anonymous Calico version\n                  number
-    and cluster size to projectcalico.org. Logs warnings returned\n                  by
-    the usage server. For example, if a significant security vulnerability\n                  has
-    been discovered in the version of Calico being used. [Default:\n                  true]'\n
-    \                 type: boolean\n                usageReportingInitialDelay:\n
-    \                 description: 'UsageReportingInitialDelay controls the minimum
-    delay\n                  before Felix makes a report. [Default: 300s]'\n                  type:
-    string\n                usageReportingInterval:\n                  description:
-    'UsageReportingInterval controls the interval at which\n                  Felix
-    makes reports. [Default: 86400s]'\n                  type: string\n                useInternalDataplaneDriver:\n
-    \                 type: boolean\n                vxlanEnabled:\n                  type:
-    boolean\n                vxlanMTU:\n                  description: 'VXLANMTU is
-    the MTU to set on the tunnel device. See\n                  Configuring MTU [Default:
-    1440]'\n                  type: integer\n                vxlanPort:\n                  type:
-    integer\n                vxlanVNI:\n                  type: integer\n                wireguardEnabled:\n
-    \                 description: 'WireguardEnabled controls whether Wireguard is
-    enabled.\n                  [Default: false]'\n                  type: boolean\n
-    \               wireguardInterfaceName:\n                  description: 'WireguardInterfaceName
-    specifies the name to use for\n                  the Wireguard interface. [Default:
-    wg.calico]'\n                  type: string\n                wireguardListeningPort:\n
-    \                 description: 'WireguardListeningPort controls the listening
-    port used\n                  by Wireguard. [Default: 51820]'\n                  type:
-    integer\n                wireguardMTU:\n                  description: 'WireguardMTU
-    controls the MTU on the Wireguard interface.\n                  See Configuring
-    MTU [Default: 1420]'\n                  type: integer\n                wireguardRoutingRulePriority:\n
-    \                 description: 'WireguardRoutingRulePriority controls the priority
-    value\n                  to use for the Wireguard routing rule. [Default: 99]'\n
-    \                 type: integer\n                xdpEnabled:\n                  description:
-    'XDPEnabled enables XDP acceleration for suitable untracked\n                  incoming
-    deny rules. [Default: true]'\n                  type: boolean\n                xdpRefreshInterval:\n
-    \                 description: 'XDPRefreshInterval is the period at which Felix
-    re-checks\n                  all XDP state to ensure that no other process has
-    accidentally broken\n                  Calico''s BPF maps or attached programs.
-    Set to 0 to disable XDP\n                  refresh. [Default: 90s]'\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: globalnetworkpolicies.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: GlobalNetworkPolicy\n    listKind:
-    GlobalNetworkPolicyList\n    plural: globalnetworkpolicies\n    singular: globalnetworkpolicy\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                applyOnForward:\n
-    \                 description: ApplyOnForward indicates to apply the rules in
-    this policy\n                    on forward traffic.\n                  type:
-    boolean\n                doNotTrack:\n                  description: DoNotTrack
-    indicates whether packets matched by the rules\n                    in this policy
-    should go through the data plane's connection tracking,\n                    such
-    as Linux conntrack.  If True, the rules in this policy are\n                    applied
-    before any data plane connection tracking, and packets allowed\n                    by
-    this policy are marked as not to be tracked.\n                  type: boolean\n
-    \               egress:\n                  description: The ordered set of egress
-    rules.  Each rule contains\n                    a set of packet match criteria
-    and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                namespaceSelector:\n                  description: NamespaceSelector
-    is an optional field for an expression\n                    used to select a pod
-    based on namespaces.\n                  type: string\n                order:\n
-    \                 description: Order is an optional field that specifies the order
-    in\n                    which the policy is applied. Policies with higher \"order\"
-    are applied\n                    after those with lower order.  If the order is
-    omitted, it may be\n                    considered to be \"infinite\" - i.e. the
-    policy will be applied last.  Policies\n                    with identical order
-    will be applied in alphanumerical order based\n                    on the Policy
-    \"Name\".\n                  type: number\n                preDNAT:\n                  description:
-    PreDNAT indicates to apply the rules in this policy before\n                    any
-    DNAT.\n                  type: boolean\n                selector:\n                  description:
-    \"The selector is an expression used to pick pick out\n                  the endpoints
-    that the policy should be applied to. \\n Selector\n                  expressions
-    follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n                  \\
-    ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel != \\\"string_literal\\\"\n
-    \                 \\  ->  not equal; also matches if label is not present \\tlabel
-    in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\", ... }  ->  true if the
-    value of label X is\n                  one of \\\"a\\\", \\\"b\\\", \\\"c\\\"
-    \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ... }  ->
-    \ true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress rules are present
-    in the policy.  The\n                  default is: \\n - [ PolicyTypeIngress ],
-    if there are no Egress rules\n                  (including the case where there
-    are   also no Ingress rules) \\n\n                  - [ PolicyTypeEgress ], if
-    there are Egress rules but no Ingress\n                  rules \\n - [ PolicyTypeIngress,
-    PolicyTypeEgress ], if there are\n                  both Ingress and Egress rules.
-    \\n When the policy is read back again,\n                  Types will always be
-    one of these values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: globalnetworksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: GlobalNetworkSet\n    listKind: GlobalNetworkSetList\n    plural:
-    globalnetworksets\n    singular: globalnetworkset\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs\n            that
-    share labels to allow rules to refer to them via selectors.  The labels\n            of
-    GlobalNetworkSet are not namespaced.\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: GlobalNetworkSetSpec contains the
-    specification for a NetworkSet\n                resource.\n              properties:\n
-    \               nets:\n                  description: The list of IP networks
-    that belong to this set.\n                  items:\n                    type:
-    string\n                  type: array\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: hostendpoints.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: HostEndpoint\n    listKind: HostEndpointList\n    plural:
-    hostendpoints\n    singular: hostendpoint\n  scope: Cluster\n  versions:\n    -
-    name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: HostEndpointSpec contains the specification
-    for a HostEndpoint\n                resource.\n              properties:\n                expectedIPs:\n
-    \                 description: \"The expected IP addresses (IPv4 and IPv6) of
-    the endpoint.\n                  If \\\"InterfaceName\\\" is not present, Calico
-    will look for an interface\n                  matching any of the IPs in the list
-    and apply policy to that. Note:\n                  \\tWhen using the selector
-    match criteria in an ingress or egress\n                  security Policy \\tor
-    Profile, Calico converts the selector into\n                  a set of IP addresses.
-    For host \\tendpoints, the ExpectedIPs field\n                  is used for that
-    purpose. (If only the interface \\tname is specified,\n                  Calico
-    does not learn the IPs of the interface for use in match\n                  \\tcriteria.)\"\n
-    \                 items:\n                    type: string\n                  type:
-    array\n                interfaceName:\n                  description: \"Either
-    \\\"*\\\", or the name of a specific Linux interface\n                  to apply
-    policy to; or empty.  \\\"*\\\" indicates that this HostEndpoint\n                  governs
-    all traffic to, from or through the default network namespace\n                  of
-    the host named by the \\\"Node\\\" field; entering and leaving that\n                  namespace
-    via any interface, including those from/to non-host-networked\n                  local
-    workloads. \\n If InterfaceName is not \\\"*\\\", this HostEndpoint\n                  only
-    governs traffic that enters or leaves the host through the\n                  specific
-    interface named by InterfaceName, or - when InterfaceName\n                  is
-    empty - through the specific interface that has one of the IPs\n                  in
-    ExpectedIPs. Therefore, when InterfaceName is empty, at least\n                  one
-    expected IP must be specified.  Only external interfaces (such\n                  as
-    “eth0”) are supported here; it isn't possible for a HostEndpoint\n                  to
-    protect traffic through a specific local workload interface.\n                  \\n
-    Note: Only some kinds of policy are implemented for \\\"*\\\" HostEndpoints;\n
-    \                 initially just pre-DNAT policy.  Please check Calico documentation\n
-    \                 for the latest position.\"\n                  type: string\n
-    \               node:\n                  description: The node name identifying
-    the Calico node instance.\n                  type: string\n                ports:\n
-    \                 description: Ports contains the endpoint's named ports, which
-    may\n                    be referenced in security policy rules.\n                  items:\n
-    \                   properties:\n                      name:\n                        type:
-    string\n                      port:\n                        type: integer\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                    required:\n                      - name\n                      -
-    port\n                      - protocol\n                    type: object\n                  type:
-    array\n                profiles:\n                  description: A list of identifiers
-    of security Profile objects that\n                    apply to this endpoint.
-    Each profile is applied in the order that\n                    they appear in
-    this list.  Profile rules are applied after the selector-based\n                    security
-    policy.\n                  items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: ipamblocks.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMBlock\n    listKind: IPAMBlockList\n
-    \   plural: ipamblocks\n    singular: ipamblock\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMBlockSpec contains the specification
-    for an IPAMBlock\n                resource.\n              properties:\n                affinity:\n
-    \                 type: string\n                allocations:\n                  items:\n
-    \                   type: integer\n                    # TODO: This nullable is
-    manually added in. We should update controller-gen\n                    # to handle
-    []*int properly itself.\n                    nullable: true\n                  type:
-    array\n                attributes:\n                  items:\n                    properties:\n
-    \                     handle_id:\n                        type: string\n                      secondary:\n
-    \                       additionalProperties:\n                          type:
-    string\n                        type: object\n                    type: object\n
-    \                 type: array\n                cidr:\n                  type:
-    string\n                deleted:\n                  type: boolean\n                strictAffinity:\n
-    \                 type: boolean\n                unallocated:\n                  items:\n
-    \                   type: integer\n                  type: array\n              required:\n
-    \               - allocations\n                - attributes\n                -
-    cidr\n                - strictAffinity\n                - unallocated\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMConfig\n    listKind: IPAMConfigList\n    plural: ipamconfigs\n
-    \   singular: ipamconfig\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMConfigSpec contains the specification
-    for an IPAMConfig\n                resource.\n              properties:\n                autoAllocateBlocks:\n
-    \                 type: boolean\n                maxBlocksPerHost:\n                  description:
-    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                    that
-    can be affine to each host.\n                  type: integer\n                strictAffinity:\n
-    \                 type: boolean\n              required:\n                - autoAllocateBlocks\n
-    \               - strictAffinity\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ipamhandles.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMHandle\n    listKind: IPAMHandleList\n    plural: ipamhandles\n
-    \   singular: ipamhandle\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMHandleSpec contains the specification
-    for an IPAMHandle\n                resource.\n              properties:\n                block:\n
-    \                 additionalProperties:\n                    type: integer\n                  type:
-    object\n                deleted:\n                  type: boolean\n                handleID:\n
-    \                 type: string\n              required:\n                - block\n
-    \               - handleID\n              type: object\n          type: object\n
-    \     served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ippools.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPPool\n    listKind: IPPoolList\n    plural: ippools\n    singular:
-    ippool\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPPoolSpec contains the specification
-    for an IPPool resource.\n              properties:\n                blockSize:\n
-    \                 description: The block size to use for IP address assignments
-    from\n                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.\n
-    \                 type: integer\n                cidr:\n                  description:
-    The pool CIDR.\n                  type: string\n                disabled:\n                  description:
-    When disabled is true, Calico IPAM will not assign addresses\n                    from
-    this pool.\n                  type: boolean\n                ipip:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  properties:\n                    enabled:\n                      description:
-    When enabled is true, ipip tunneling will be used\n                        to
-    deliver packets to destinations within this pool.\n                      type:
-    boolean\n                    mode:\n                      description: The IPIP
-    mode.  This can be one of \"always\" or \"cross-subnet\".  A\n                        mode
-    of \"always\" will also use IPIP tunneling for routing to\n                        destination
-    IP addresses within this pool.  A mode of \"cross-subnet\"\n                        will
-    only use IPIP tunneling when the destination node is on\n                        a
-    different subnet to the originating node.  The default value\n                        (if
-    not specified) is \"always\".\n                      type: string\n                  type:
-    object\n                ipipMode:\n                  description: Contains configuration
-    for IPIP tunneling for this pool.\n                    If not specified, then
-    this is defaulted to \"Never\" (i.e. IPIP tunneling\n                    is disabled).\n
-    \                 type: string\n                nat-outgoing:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  type: boolean\n                natOutgoing:\n                  description:
-    When nat-outgoing is true, packets sent from Calico networked\n                    containers
-    in this pool to destinations outside of this pool will\n                    be
-    masqueraded.\n                  type: boolean\n                nodeSelector:\n
-    \                 description: Allows IPPool to allocate for a specific node by
-    label\n                    selector.\n                  type: string\n                vxlanMode:\n
-    \                 description: Contains configuration for VXLAN tunneling for
-    this pool.\n                    If not specified, then this is defaulted to \"Never\"
-    (i.e. VXLAN\n                    tunneling is disabled).\n                  type:
-    string\n              required:\n                - cidr\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: kubecontrollersconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: KubeControllersConfiguration\n    listKind: KubeControllersConfigurationList\n
-    \   plural: kubecontrollersconfigurations\n    singular: kubecontrollersconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: KubeControllersConfigurationSpec
-    contains the values of the\n                Kubernetes controllers configuration.\n
-    \             properties:\n                controllers:\n                  description:
-    Controllers enables and configures individual Kubernetes\n                    controllers\n
-    \                 properties:\n                    namespace:\n                      description:
-    Namespace enables and configures the namespace controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   node:\n                      description: Node enables and
-    configures the node controller.\n                        Enabled by default, set
-    to nil to disable.\n                      properties:\n                        hostEndpoint:\n
-    \                         description: HostEndpoint controls syncing nodes to
-    host endpoints.\n                            Disabled by default, set to nil to
-    disable.\n                          properties:\n                            autoCreate:\n
-    \                             description: 'AutoCreate enables automatic creation
-    of\n                              host endpoints for every node. [Default: Disabled]'\n
-    \                             type: string\n                          type: object\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                       syncLabels:\n                          description: 'SyncLabels
-    controls whether to copy Kubernetes\n                          node labels to
-    Calico nodes. [Default: Enabled]'\n                          type: string\n                      type:
-    object\n                    policy:\n                      description: Policy
-    enables and configures the policy controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   serviceAccount:\n                      description: ServiceAccount
-    enables and configures the service\n                        account controller.
-    Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                    workloadEndpoint:\n                      description:
-    WorkloadEndpoint enables and configures the workload\n                        endpoint
-    controller. Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                  type: object\n                etcdV3CompactionPeriod:\n
-    \                 description: 'EtcdV3CompactionPeriod is the period between etcdv3\n
-    \                 compaction requests. Set to 0 to disable. [Default: 10m]'\n
-    \                 type: string\n                healthChecks:\n                  description:
-    'HealthChecks enables or disables support for health\n                  checks
-    [Default: Enabled]'\n                  type: string\n                logSeverityScreen:\n
-    \                 description: 'LogSeverityScreen is the log severity above which
-    logs\n                  are sent to the stdout. [Default: Info]'\n                  type:
-    string\n                prometheusMetricsPort:\n                  description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                    metrics
-    server should bind to. Set to 0 to disable. [Default: 9094]'\n                  type:
-    integer\n              required:\n                - controllers\n              type:
-    object\n            status:\n              description: KubeControllersConfigurationStatus
-    represents the status\n                of the configuration. It's useful for admins
-    to be able to see the actual\n                config that was applied, which can
-    be modified by environment variables\n                on the kube-controllers
-    process.\n              properties:\n                environmentVars:\n                  additionalProperties:\n
-    \                   type: string\n                  description: EnvironmentVars
-    contains the environment variables on\n                    the kube-controllers
-    that influenced the RunningConfig.\n                  type: object\n                runningConfig:\n
-    \                 description: RunningConfig contains the effective config that
-    is running\n                    in the kube-controllers pod, after merging the
-    API resource with\n                    any environment variables.\n                  properties:\n
-    \                   controllers:\n                      description: Controllers
-    enables and configures individual Kubernetes\n                        controllers\n
-    \                     properties:\n                        namespace:\n                          description:
-    Namespace enables and configures the namespace\n                            controller.
-    Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        node:\n
-    \                         description: Node enables and configures the node controller.\n
-    \                           Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           hostEndpoint:\n                              description:
-    HostEndpoint controls syncing nodes to host\n                                endpoints.
-    Disabled by default, set to nil to disable.\n                              properties:\n
-    \                               autoCreate:\n                                  description:
-    'AutoCreate enables automatic creation\n                                  of host
-    endpoints for every node. [Default: Disabled]'\n                                  type:
-    string\n                              type: object\n                            leakGracePeriod:\n
-    \                             description: 'LeakGracePeriod is the period used
-    by the\n                                controller to determine if an IP address
-    has been leaked.\n                                Set to 0 to disable IP garbage
-    collection. [Default:\n                                15m]'\n                              type:
-    string\n                            reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                            syncLabels:\n                              description:
-    'SyncLabels controls whether to copy Kubernetes\n                              node
-    labels to Calico nodes. [Default: Enabled]'\n                              type:
-    string\n                          type: object\n                        policy:\n
-    \                         description: Policy enables and configures the policy
-    controller.\n                            Enabled by default, set to nil to disable.\n
-    \                         properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        serviceAccount:\n
-    \                         description: ServiceAccount enables and configures the
-    service\n                            account controller. Enabled by default, set
-    to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        workloadEndpoint:\n
-    \                         description: WorkloadEndpoint enables and configures
-    the workload\n                            endpoint controller. Enabled by default,
-    set to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                      type: object\n
-    \                   etcdV3CompactionPeriod:\n                      description:
-    'EtcdV3CompactionPeriod is the period between etcdv3\n                      compaction
-    requests. Set to 0 to disable. [Default: 10m]'\n                      type: string\n
-    \                   healthChecks:\n                      description: 'HealthChecks
-    enables or disables support for health\n                      checks [Default:
-    Enabled]'\n                      type: string\n                    logSeverityScreen:\n
-    \                     description: 'LogSeverityScreen is the log severity above
-    which\n                      logs are sent to the stdout. [Default: Info]'\n                      type:
-    string\n                    prometheusMetricsPort:\n                      description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                        metrics
-    server should bind to. Set to 0 to disable. [Default:\n                        9094]'\n
-    \                     type: integer\n                  required:\n                    -
-    controllers\n                  type: object\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: networkpolicies.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkPolicy\n    listKind: NetworkPolicyList\n    plural:
-    networkpolicies\n    singular: networkpolicy\n  scope: Namespaced\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                egress:\n                  description:
-    The ordered set of egress rules.  Each rule contains\n                    a set
-    of packet match criteria and a corresponding action to apply.\n                  items:\n
-    \                   description: \"A Rule encapsulates a set of match criteria
-    and an\n                    action.  Both selector-based security Policy and security
-    Profiles\n                    reference rules - separated out as a list of rules
-    for both ingress\n                    and egress packet matching. \\n Each positive
-    match criteria has\n                    a negated version, prefixed with ”Not”.
-    All the match criteria\n                    within a rule must be satisfied for
-    a packet to match. A single\n                    rule can contain the positive
-    and negative version of a match\n                    and both must be satisfied
-    for the rule to match.\"\n                    properties:\n                      action:\n
-    \                       type: string\n                      destination:\n                        description:
-    Destination contains the match criteria that apply\n                          to
-    destination entity.\n                        properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                order:\n                  description: Order is an optional
-    field that specifies the order in\n                    which the policy is applied.
-    Policies with higher \"order\" are applied\n                    after those with
-    lower order.  If the order is omitted, it may be\n                    considered
-    to be \"infinite\" - i.e. the policy will be applied last.  Policies\n                    with
-    identical order will be applied in alphanumerical order based\n                    on
-    the Policy \"Name\".\n                  type: number\n                selector:\n
-    \                 description: \"The selector is an expression used to pick pick
-    out\n                  the endpoints that the policy should be applied to. \\n
-    Selector\n                  expressions follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n
-    \                 \\ ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel
-    != \\\"string_literal\\\"\n                  \\  ->  not equal; also matches if
-    label is not present \\tlabel in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\",
-    ... }  ->  true if the value of label X is\n                  one of \\\"a\\\",
-    \\\"b\\\", \\\"c\\\" \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ...
-    }  ->  true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress are present in the
-    policy.  The default\n                  is: \\n - [ PolicyTypeIngress ], if there
-    are no Egress rules (including\n                  the case where there are   also
-    no Ingress rules) \\n - [ PolicyTypeEgress\n                  ], if there are
-    Egress rules but no Ingress rules \\n - [ PolicyTypeIngress,\n                  PolicyTypeEgress
-    ], if there are both Ingress and Egress rules.\n                  \\n When the
-    policy is read back again, Types will always be one\n                  of these
-    values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: networksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkSet\n    listKind: NetworkSetList\n    plural: networksets\n
-    \   singular: networkset\n  scope: Namespaced\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          description: NetworkSet is the Namespaced-equivalent
-    of the GlobalNetworkSet.\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: NetworkSetSpec contains the specification
-    for a NetworkSet\n                resource.\n              properties:\n                nets:\n
-    \                 description: The list of IP networks that belong to this set.\n
-    \                 items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n---\n# Source: calico/templates/calico-kube-controllers-rbac.yaml\n\n#
-    Include a clusterrole for the kube-controllers component,\n# and bind it to the
-    calico-kube-controllers serviceaccount.\nkind: ClusterRole\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nrules:\n  # Nodes are watched to monitor for
-    deletions.\n  - apiGroups: [\"\"]\n    resources:\n      - nodes\n    verbs:\n
-    \     - watch\n      - list\n      - get\n  # Pods are watched to check for existence
-    as part of IPAM controller.\n  - apiGroups: [\"\"]\n    resources:\n      - pods\n
-    \   verbs:\n      - get\n      - list\n      - watch\n  # IPAM resources are manipulated
-    when nodes are deleted.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - ippools\n    verbs:\n      - list\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - blockaffinities\n      - ipamblocks\n      - ipamhandles\n
-    \   verbs:\n      - get\n      - list\n      - create\n      - update\n      -
-    delete\n      - watch\n  # kube-controllers manages hostendpoints.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - hostendpoints\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  #
-    Needs access to update clusterinformations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - clusterinformations\n    verbs:\n      - get\n      -
-    create\n      - update\n  # KubeControllersConfiguration is where it gets its
-    config\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - kubecontrollersconfigurations\n
-    \   verbs:\n      # read its own config\n      - get\n      # create a default
-    if none exists\n      - create\n      # update status\n      - update\n      #
-    watch for changes\n      - watch\n---\nkind: ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-kube-controllers\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-kube-controllers\n    namespace: kube-system\n---\n\n---\n# Source:
-    calico/templates/calico-node-rbac.yaml\n# Include a clusterrole for the calico-node
-    DaemonSet,\n# and bind it to the calico-node serviceaccount.\nkind: ClusterRole\napiVersion:
-    rbac.authorization.k8s.io/v1\nmetadata:\n  name: calico-node\nrules:\n  # The
-    CNI plugin needs to get pods, nodes, and namespaces.\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - pods\n      - nodes\n      - namespaces\n    verbs:\n
-    \     - get\n  # EndpointSlices are used for Service-based network policy rule\n
-    \ # enforcement.\n  - apiGroups: [\"discovery.k8s.io\"]\n    resources:\n      -
-    endpointslices\n    verbs:\n      - watch\n      - list\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - endpoints\n      - services\n    verbs:\n      # Used
-    to discover service IPs for advertisement.\n      - watch\n      - list\n      #
-    Used to discover Typhas.\n      - get\n  # Pod CIDR auto-detection on kubeadm
-    needs access to config maps.\n  - apiGroups: [\"\"]\n    resources:\n      - configmaps\n
-    \   verbs:\n      - get\n  - apiGroups: [\"\"]\n    resources:\n      - nodes/status\n
-    \   verbs:\n      # Needed for clearing NodeNetworkUnavailable flag.\n      -
-    patch\n      # Calico stores some configuration information in node annotations.\n
-    \     - update\n  # Watch for changes to Kubernetes NetworkPolicies.\n  - apiGroups:
-    [\"networking.k8s.io\"]\n    resources:\n      - networkpolicies\n    verbs:\n
-    \     - watch\n      - list\n  # Used by Calico for policy information.\n  - apiGroups:
-    [\"\"]\n    resources:\n      - pods\n      - namespaces\n      - serviceaccounts\n
-    \   verbs:\n      - list\n      - watch\n  # The CNI plugin patches pods/status.\n
-    \ - apiGroups: [\"\"]\n    resources:\n      - pods/status\n    verbs:\n      -
-    patch\n  # Calico monitors various CRDs for config.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - globalfelixconfigs\n      - felixconfigurations\n      -
-    bgppeers\n      - globalbgpconfigs\n      - bgpconfigurations\n      - ippools\n
-    \     - ipamblocks\n      - globalnetworkpolicies\n      - globalnetworksets\n
-    \     - networkpolicies\n      - networksets\n      - clusterinformations\n      -
-    hostendpoints\n      - blockaffinities\n    verbs:\n      - get\n      - list\n
-    \     - watch\n  # Calico must create and update some CRDs on startup.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - ippools\n      - felixconfigurations\n
-    \     - clusterinformations\n    verbs:\n      - create\n      - update\n  # Calico
-    stores some configuration information on the node.\n  - apiGroups: [\"\"]\n    resources:\n
-    \     - nodes\n    verbs:\n      - get\n      - list\n      - watch\n  # These
-    permissions are only required for upgrade from v2.6, and can\n  # be removed after
-    upgrade or on fresh installations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - bgpconfigurations\n      - bgppeers\n    verbs:\n      -
-    create\n      - update\n  # These permissions are required for Calico CNI to perform
-    IPAM allocations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n      - ipamblocks\n      - ipamhandles\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  -
-    apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - ipamconfigs\n
-    \   verbs:\n      - get\n  # Block affinities must also be watchable by confd
-    for route aggregation.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n    verbs:\n      - watch\n  # The Calico IPAM migration
-    needs to get daemonsets. These permissions can be\n  # removed if not upgrading
-    from an installation using host-local IPAM.\n  - apiGroups: [\"apps\"]\n    resources:\n
-    \     - daemonsets\n    verbs:\n      - get\n\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:
-    ClusterRoleBinding\nmetadata:\n  name: calico-node\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-node\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-node\n    namespace: kube-system\n\n---\n# Source: calico/templates/calico-node.yaml\n#
-    This manifest installs the calico-node container, as well\n# as the CNI plugins
-    and network config on\n# each master and worker node in a Kubernetes cluster.\nkind:
-    DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: calico-node\n  namespace: kube-system\n
-    \ labels:\n    k8s-app: calico-node\nspec:\n  selector:\n    matchLabels:\n      k8s-app:
-    calico-node\n  updateStrategy:\n    type: RollingUpdate\n    rollingUpdate:\n
-    \     maxUnavailable: 1\n  template:\n    metadata:\n      labels:\n        k8s-app:
-    calico-node\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n
-    \     hostNetwork: true\n      tolerations:\n        # Make sure calico-node gets
-    scheduled on all nodes.\n        - effect: NoSchedule\n          operator: Exists\n
-    \       # Mark the pod as a critical add-on for rescheduling.\n        - key:
-    CriticalAddonsOnly\n          operator: Exists\n        - effect: NoExecute\n
-    \         operator: Exists\n      serviceAccountName: calico-node\n      # Minimize
-    downtime during a rolling upgrade or deletion; tell Kubernetes to do a \"force\n
-    \     # deletion\": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.\n
-    \     terminationGracePeriodSeconds: 0\n      priorityClassName: system-node-critical\n
-    \     initContainers:\n        # This container performs upgrade from host-local
-    IPAM to calico-ipam.\n        # It can be deleted if this is a fresh installation,
-    or if you have already\n        # upgraded to use calico-ipam.\n        - name:
-    upgrade-ipam\n          image: calico/cni:v3.20.0\n          command: [\"/opt/cni/bin/calico-ipam\",
-    \"-upgrade\"]\n          envFrom:\n            - configMapRef:\n                #
-    Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for
-    eBPF mode.\n                name: kubernetes-services-endpoint\n                optional:
-    true\n          env:\n            - name: KUBERNETES_NODE_NAME\n              valueFrom:\n
-    \               fieldRef:\n                  fieldPath: spec.nodeName\n            -
-    name: CALICO_NETWORKING_BACKEND\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: calico_backend\n
-    \         volumeMounts:\n            - mountPath: /var/lib/cni/networks\n              name:
-    host-local-net-dir\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n          securityContext:\n            privileged: true\n        #
-    This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: calico/cni:v3.20.0\n
-    \         command: [\"/opt/cni/bin/install\"]\n          envFrom:\n            -
-    configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
-    to be overridden for eBPF mode.\n                name: kubernetes-services-endpoint\n
-    \               optional: true\n          env:\n            # Name of the CNI
-    config file to create.\n            - name: CNI_CONF_NAME\n              value:
-    \"10-calico.conflist\"\n            # The CNI network config to install on each
-    node.\n            - name: CNI_NETWORK_CONFIG\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: cni_network_config\n
-    \           # Set the hostname based on the k8s node name.\n            - name:
-    KUBERNETES_NODE_NAME\n              valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # CNI MTU Config variable\n            - name: CNI_MTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Prevents the container
-    from sleeping forever.\n            - name: SLEEP\n              value: \"false\"\n
-    \         volumeMounts:\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n            - mountPath: /host/etc/cni/net.d\n              name:
-    cni-net-dir\n          securityContext:\n            privileged: true\n        #
-    Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes\n
-    \       # to communicate with Felix over the Policy Sync API.\n        - name:
-    flexvol-driver\n          image: calico/pod2daemon-flexvol:v3.20.0\n          volumeMounts:\n
-    \           - name: flexvol-driver-host\n              mountPath: /host/driver\n
-    \         securityContext:\n            privileged: true\n      containers:\n
-    \       # Runs calico-node container on each Kubernetes node. This\n        #
-    container programs network policy and routes on each\n        # host.\n        -
-    name: calico-node\n          image: calico/node:v3.20.0\n          envFrom:\n
-    \           - configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and
-    KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.\n                name:
-    kubernetes-services-endpoint\n                optional: true\n          env:\n
-    \           # Use Kubernetes API as the backing datastore.\n            - name:
-    DATASTORE_TYPE\n              value: \"kubernetes\"\n            # Wait for the
-    datastore.\n            - name: WAIT_FOR_DATASTORE\n              value: \"true\"\n
-    \           # Set based on the k8s node name.\n            - name: NODENAME\n
-    \             valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # Choose the backend to use.\n            - name: CALICO_NETWORKING_BACKEND\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: calico_backend\n            # Cluster type
-    to identify the deployment type\n            - name: CLUSTER_TYPE\n              value:
-    \"k8s,bgp\"\n            # Auto-detect the BGP IP address.\n            - name:
-    IP\n              value: \"autodetect\"\n            # Enable VXLAN\n            -
-    name: CALICO_IPV4POOL_VXLAN\n              value: \"Always\"\n            # Set
-    MTU for tunnel device used if ipip is enabled\n            - name: FELIX_IPINIPMTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Set MTU for the
-    VXLAN tunnel device.\n            - name: FELIX_VXLANMTU\n              valueFrom:\n
-    \               configMapKeyRef:\n                  name: calico-config\n                  key:
-    veth_mtu\n            # Set MTU for the Wireguard tunnel device.\n            -
-    name: FELIX_WIREGUARDMTU\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: veth_mtu\n            #
-    The default IPv4 pool to create on startup if none exists. Pod IPs will be\n            #
-    chosen from this range. Changing this value after installation will have\n            #
-    no effect. This should fall within `--cluster-cidr`.\n            # - name: CALICO_IPV4POOL_CIDR\n
-    \           #   value: \"192.168.0.0/16\"\n            # Disable file logging
-    so `kubectl logs` works.\n            - name: CALICO_DISABLE_FILE_LOGGING\n              value:
-    \"true\"\n            # Set Felix endpoint to host default action to ACCEPT.\n
-    \           - name: FELIX_DEFAULTENDPOINTTOHOSTACTION\n              value: \"ACCEPT\"\n
-    \           # Disable IPv6 on Kubernetes.\n            - name: FELIX_IPV6SUPPORT\n
-    \             value: \"false\"\n            - name: FELIX_FEATUREDETECTOVERRIDE\n
-    \             value: \"ChecksumOffloadBroken=true\"\n            - name: FELIX_HEALTHENABLED\n
-    \             value: \"true\"\n          securityContext:\n            privileged:
-    true\n          resources:\n            requests:\n              cpu: 250m\n          livenessProbe:\n
-    \           exec:\n              command:\n                - /bin/calico-node\n
-    \               - -felix-live\n            periodSeconds: 10\n            initialDelaySeconds:
-    10\n            failureThreshold: 6\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /bin/calico-node\n                -
-    -felix-ready\n            periodSeconds: 10\n          volumeMounts:\n            -
-    mountPath: /host/etc/cni/net.d\n              name: cni-net-dir\n              readOnly:
-    false\n            - mountPath: /lib/modules\n              name: lib-modules\n
-    \             readOnly: true\n            - mountPath: /run/xtables.lock\n              name:
-    xtables-lock\n              readOnly: false\n            - mountPath: /var/run/calico\n
-    \             name: var-run-calico\n              readOnly: false\n            -
-    mountPath: /var/lib/calico\n              name: var-lib-calico\n              readOnly:
-    false\n            - name: policysync\n              mountPath: /var/run/nodeagent\n
-    \           # For eBPF mode, we need to be able to mount the BPF filesystem at
-    /sys/fs/bpf so we mount in the\n            # parent directory.\n            -
-    name: sysfs\n              mountPath: /sys/fs/\n              # Bidirectional
-    means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to
-    the host.\n              # If the host is known to mount that filesystem already
-    then Bidirectional can be omitted.\n              mountPropagation: Bidirectional\n
-    \           - name: cni-log-dir\n              mountPath: /var/log/calico/cni\n
-    \             readOnly: true\n      volumes:\n        # Used by calico-node.\n
-    \       - name: lib-modules\n          hostPath:\n            path: /lib/modules\n
-    \       - name: var-run-calico\n          hostPath:\n            path: /var/run/calico\n
-    \       - name: var-lib-calico\n          hostPath:\n            path: /var/lib/calico\n
-    \       - name: xtables-lock\n          hostPath:\n            path: /run/xtables.lock\n
-    \           type: FileOrCreate\n        - name: sysfs\n          hostPath:\n            path:
-    /sys/fs/\n            type: DirectoryOrCreate\n        # Used to install CNI.\n
-    \       - name: cni-bin-dir\n          hostPath:\n            path: /opt/cni/bin\n
-    \       - name: cni-net-dir\n          hostPath:\n            path: /etc/cni/net.d\n
-    \       # Used to access CNI logs.\n        - name: cni-log-dir\n          hostPath:\n
-    \           path: /var/log/calico/cni\n        # Mount in the directory for host-local
-    IPAM allocations. This is\n        # used when upgrading from host-local to calico-ipam,
-    and can be removed\n        # if not using the upgrade-ipam init container.\n
-    \       - name: host-local-net-dir\n          hostPath:\n            path: /var/lib/cni/networks\n
-    \       # Used to create per-pod Unix Domain Sockets\n        - name: policysync\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /var/run/nodeagent\n
-    \       # Used to install Flex Volume Driver\n        - name: flexvol-driver-host\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds\n---\n\napiVersion:
-    v1\nkind: ServiceAccount\nmetadata:\n  name: calico-node\n  namespace: kube-system\n\n---\n#
-    Source: calico/templates/calico-kube-controllers.yaml\n# See https://github.com/projectcalico/kube-controllers\napiVersion:
-    apps/v1\nkind: Deployment\nmetadata:\n  name: calico-kube-controllers\n  namespace:
-    kube-system\n  labels:\n    k8s-app: calico-kube-controllers\nspec:\n  # The controllers
-    can only have a single active instance.\n  replicas: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n  strategy:\n    type: Recreate\n  template:\n
-    \   metadata:\n      name: calico-kube-controllers\n      namespace: kube-system\n
-    \     labels:\n        k8s-app: calico-kube-controllers\n    spec:\n      nodeSelector:\n
-    \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
-    a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
-    Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
-    \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
-    \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
-    \         env:\n            # Choose which controllers to run.\n            -
-    name: ENABLED_CONTROLLERS\n              value: node\n            - name: DATASTORE_TYPE\n
-    \             value: kubernetes\n          livenessProbe:\n            exec:\n
-    \             command:\n              - /usr/bin/check-status\n              -
-    -l\n            periodSeconds: 10\n            initialDelaySeconds: 10\n            failureThreshold:
-    6\n            timeoutSeconds: 10\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /usr/bin/check-status\n                -
-    -r\n            periodSeconds: 10\n\n---\n\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n\n---\n\n# This manifest
-    creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler
-    to evict\n\napiVersion: policy/v1beta1\nkind: PodDisruptionBudget\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n  labels:\n    k8s-app:
-    calico-kube-controllers\nspec:\n  maxUnavailable: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n---\n# Source: calico/templates/calico-etcd-secrets.yaml\n\n---\n#
-    Source: calico/templates/calico-typha.yaml\n\n---\n# Source: calico/templates/configure-canal.yaml\n"
+  resources: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgpconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPConfiguration
+        listKind: BGPConfigurationList
+        plural: bgpconfigurations
+        singular: bgpconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: BGPConfiguration contains the configuration for any BGP routing.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPConfigurationSpec contains the values of the BGP configuration.
+                properties:
+                  asNumber:
+                    description: 'ASNumber is the default AS number used by a node. [Default:
+                      64512]'
+                    format: int32
+                    type: integer
+                  communities:
+                    description: Communities is a list of BGP community values and their
+                      arbitrary names for tagging routes.
+                    items:
+                      description: Community contains standard or large community value
+                        and its name.
+                      properties:
+                        name:
+                          description: Name given to community value.
+                          type: string
+                        value:
+                          description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                            For standard community use `aa:nn` format, where `aa` and
+                            `nn` are 16 bit number. For large community use `aa:nn:mm`
+                            format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                            `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                          pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                          type: string
+                      type: object
+                    type: array
+                  listenPort:
+                    description: ListenPort is the port where BGP protocol should listen.
+                      Defaults to 179
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: INFO]'
+                    type: string
+                  nodeToNodeMeshEnabled:
+                    description: 'NodeToNodeMeshEnabled sets whether full node to node
+                      BGP mesh is enabled. [Default: true]'
+                    type: boolean
+                  prefixAdvertisements:
+                    description: PrefixAdvertisements contains per-prefix advertisement
+                      configuration.
+                    items:
+                      description: PrefixAdvertisement configures advertisement properties
+                        for the specified CIDR.
+                      properties:
+                        cidr:
+                          description: CIDR for which properties should be advertised.
+                          type: string
+                        communities:
+                          description: Communities can be list of either community names
+                            already defined in `Specs.Communities` or community value
+                            of format `aa:nn` or `aa:nn:mm`. For standard community use
+                            `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                            large community use `aa:nn:mm` format, where `aa`, `nn` and
+                            `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                            `mm` are per-AS identifier.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  serviceClusterIPs:
+                    description: ServiceClusterIPs are the CIDR blocks from which service
+                      cluster IPs are allocated. If specified, Calico will advertise these
+                      blocks, as well as any cluster IPs within them.
+                    items:
+                      description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                        CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceExternalIPs:
+                    description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                      Service External IPs. Kubernetes Service ExternalIPs will only be
+                      advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceExternalIPBlock represents a single allowed
+                        External IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceLoadBalancerIPs:
+                    description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                      Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                      IPs will only be advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceLoadBalancerIPBlock represents a single allowed
+                        LoadBalancer IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgppeers.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPPeer
+        listKind: BGPPeerList
+        plural: bgppeers
+        singular: bgppeer
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPPeerSpec contains the specification for a BGPPeer resource.
+                properties:
+                  asNumber:
+                    description: The AS Number of the peer.
+                    format: int32
+                    type: integer
+                  keepOriginalNextHop:
+                    description: Option to keep the original nexthop field when routes
+                      are sent to a BGP Peer. Setting "true" configures the selected BGP
+                      Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                      in the specific branch of the Node on "bird.cfg".
+                    type: boolean
+                  maxRestartTime:
+                    description: Time to allow for software restart.  When specified,
+                      this is configured as the graceful restart timeout.  When not specified,
+                      the BIRD default of 120s is used.
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance that
+                      is targeted by this peer. If this is not set, and no nodeSelector
+                      is specified, then this BGP peer selects all nodes in the cluster.
+                    type: string
+                  nodeSelector:
+                    description: Selector for the nodes that should have this peering.  When
+                      this is set, the Node field must be empty.
+                    type: string
+                  password:
+                    description: Optional BGP password for the peerings generated by this
+                      BGPPeer resource.
+                    properties:
+                      secretKeyRef:
+                        description: Selects a key of a secret in the node pod's namespace.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be
+                              a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be
+                              defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  peerIP:
+                    description: The IP address of the peer followed by an optional port
+                      number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                      or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                      and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                      set in BGPConfiguration, then we use that port to peer.
+                    type: string
+                  peerSelector:
+                    description: Selector for the remote nodes to peer with.  When this
+                      is set, the PeerIP and ASNumber fields must be empty.  For each
+                      peering between the local node and selected remote nodes, we configure
+                      an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                      and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                      remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                      or the global default if that is not set.
+                    type: string
+                  sourceAddress:
+                    description: Specifies whether and how to configure a source address
+                      for the peerings generated by this BGPPeer resource.  Default value
+                      "UseNodeIP" means to configure the node IP as the source address.  "None"
+                      means not to configure a source address.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: blockaffinities.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BlockAffinity
+        listKind: BlockAffinityList
+        plural: blockaffinities
+        singular: blockaffinity
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BlockAffinitySpec contains the specification for a BlockAffinity
+                  resource.
+                properties:
+                  cidr:
+                    type: string
+                  deleted:
+                    description: Deleted indicates that this block affinity is being deleted.
+                      This field is a string for compatibility with older releases that
+                      mistakenly treat this field as a string.
+                    type: string
+                  node:
+                    type: string
+                  state:
+                    type: string
+                required:
+                - cidr
+                - deleted
+                - node
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: clusterinformations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: ClusterInformation
+        listKind: ClusterInformationList
+        plural: clusterinformations
+        singular: clusterinformation
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterInformation contains the cluster specific information.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterInformationSpec contains the values of describing
+                  the cluster.
+                properties:
+                  calicoVersion:
+                    description: CalicoVersion is the version of Calico that the cluster
+                      is running
+                    type: string
+                  clusterGUID:
+                    description: ClusterGUID is the GUID of the cluster
+                    type: string
+                  clusterType:
+                    description: ClusterType describes the type of the cluster
+                    type: string
+                  datastoreReady:
+                    description: DatastoreReady is used during significant datastore migrations
+                      to signal to components such as Felix that it should wait before
+                      accessing the datastore.
+                    type: boolean
+                  variant:
+                    description: Variant declares which variant of Calico should be active.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: felixconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: FelixConfiguration
+        listKind: FelixConfigurationList
+        plural: felixconfigurations
+        singular: felixconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: Felix Configuration contains the configuration for Felix.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: FelixConfigurationSpec contains the values of the Felix configuration.
+                properties:
+                  allowIPIPPacketsFromWorkloads:
+                    description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop IPIP encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  allowVXLANPacketsFromWorkloads:
+                    description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop VXLAN encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  awsSrcDstCheck:
+                    description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                      value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                      DoNothing]'
+                    enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                    type: string
+                  bpfConnectTimeLoadBalancingEnabled:
+                    description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                      controls whether Felix installs the connection-time load balancer.  The
+                      connect-time load balancer is required for the host to be able to
+                      reach Kubernetes services and it improves the performance of pod-to-service
+                      connections.  The only reason to disable it is for debugging purposes.  [Default:
+                      true]'
+                    type: boolean
+                  bpfDataIfacePattern:
+                    description: BPFDataIfacePattern is a regular expression that controls
+                      which interfaces Felix should attach BPF programs to in order to
+                      catch traffic to/from the network.  This needs to match the interfaces
+                      that Calico workload traffic flows over as well as any interfaces
+                      that handle incoming traffic to nodeports and services from outside
+                      the cluster.  It should not match the workload interfaces (usually
+                      named cali...).
+                    type: string
+                  bpfDisableUnprivileged:
+                    description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                      sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                      users cannot access Calico''s BPF maps and cannot insert their own
+                      BPF programs to interfere with Calico''s. [Default: true]'
+                    type: boolean
+                  bpfEnabled:
+                    description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                      [Default: false]'
+                    type: boolean
+                  bpfExtToServiceConnmark:
+                    description: 'BPFExtToServiceConnmark in BPF mode, controls a 32bit
+                      mark that is set on connections from an external client to a local
+                      service. This mark allows us to control how packets of that connection
+                      are routed within the host and how is routing intepreted by RPF
+                      check. [Default: 0]'
+                    type: integer
+                  bpfExternalServiceMode:
+                    description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                      from outside the cluster to services (node ports and cluster IPs)
+                      are forwarded to remote workloads.  If set to "Tunnel" then both
+                      request and response traffic is tunneled to the remote node.  If
+                      set to "DSR", the request traffic is tunneled but the response traffic
+                      is sent directly from the remote node.  In "DSR" mode, the remote
+                      node appears to use the IP of the ingress node; this requires a
+                      permissive L2 network.  [Default: Tunnel]'
+                    type: string
+                  bpfKubeProxyEndpointSlicesEnabled:
+                    description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                      whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                    type: boolean
+                  bpfKubeProxyIptablesCleanupEnabled:
+                    description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                      mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                      iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                      true]'
+                    type: boolean
+                  bpfKubeProxyMinSyncPeriod:
+                    description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                      minimum time between updates to the dataplane for Felix''s embedded
+                      kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                      reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                    type: string
+                  bpfLogLevel:
+                    description: 'BPFLogLevel controls the log level of the BPF programs
+                      when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                      logs are emitted to the BPF trace pipe, accessible with the command
+                      `tc exec bpf debug`. [Default: Off].'
+                    type: string
+                  chainInsertMode:
+                    description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                      top-level iptables chains by inserting a rule at the top of the
+                      chain or by appending a rule at the bottom. insert is the safe default
+                      since it prevents Calico''s rules from being bypassed. If you switch
+                      to append mode, be sure that the other rules in the chains signal
+                      acceptance by falling through to the Calico rules, otherwise the
+                      Calico policy will be bypassed. [Default: insert]'
+                    type: string
+                  dataplaneDriver:
+                    type: string
+                  debugDisableLogDropping:
+                    type: boolean
+                  debugMemoryProfilePath:
+                    type: string
+                  debugSimulateCalcGraphHangAfter:
+                    type: string
+                  debugSimulateDataplaneHangAfter:
+                    type: string
+                  defaultEndpointToHostAction:
+                    description: 'DefaultEndpointToHostAction controls what happens to
+                      traffic that goes from a workload endpoint to the host itself (after
+                      the traffic hits the endpoint egress policy). By default Calico
+                      blocks traffic from workload endpoints to the host itself with an
+                      iptables "DROP" action. If you want to allow some or all traffic
+                      from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                      RETURN if you have your own rules in the iptables "INPUT" chain;
+                      Calico will insert its rules at the top of that chain, then "RETURN"
+                      packets to the "INPUT" chain once it has completed processing workload
+                      endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                      from workloads after processing workload endpoint egress policy.
+                      [Default: Drop]'
+                    type: string
+                  deviceRouteProtocol:
+                    description: This defines the route protocol added to programmed device
+                      routes, by default this will be RTPROT_BOOT when left blank.
+                    type: integer
+                  deviceRouteSourceAddress:
+                    description: This is the source address to use on programmed device
+                      routes. By default the source address is left blank, leaving the
+                      kernel to choose the source address used.
+                    type: string
+                  disableConntrackInvalidCheck:
+                    type: boolean
+                  endpointReportingDelay:
+                    type: string
+                  endpointReportingEnabled:
+                    type: boolean
+                  externalNodesList:
+                    description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                      which may source tunnel traffic and have the tunneled traffic be
+                      accepted at calico nodes.
+                    items:
+                      type: string
+                    type: array
+                  failsafeInboundHostPorts:
+                    description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow incoming traffic to host endpoints
+                      on irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all inbound host ports, use the value
+                      none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                      udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  failsafeOutboundHostPorts:
+                    description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow outgoing traffic from host endpoints
+                      to irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all outbound host ports, use the value
+                      none. The default value opens etcd''s standard ports to ensure that
+                      Felix does not get cut off from etcd as well as allowing DHCP and
+                      DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                      tcp:6667, udp:53, udp:67]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  featureDetectOverride:
+                    description: FeatureDetectOverride is used to override the feature
+                      detection. Values are specified in a comma separated list with no
+                      spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                      "true" or "false" will force the feature, empty or omitted values
+                      are auto-detected.
+                    type: string
+                  genericXDPEnabled:
+                    description: 'GenericXDPEnabled enables Generic XDP so network cards
+                      that don''t support XDP offload or driver modes can use XDP. This
+                      is not recommended since it doesn''t provide better performance
+                      than iptables. [Default: false]'
+                    type: boolean
+                  healthEnabled:
+                    type: boolean
+                  healthHost:
+                    type: string
+                  healthPort:
+                    type: integer
+                  interfaceExclude:
+                    description: 'InterfaceExclude is a comma-separated list of interfaces
+                      that Felix should exclude when monitoring for host endpoints. The
+                      default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                      interface, which is used internally by kube-proxy. If you want to
+                      exclude multiple interface names using a single value, the list
+                      supports regular expressions. For regular expressions you must wrap
+                      the value with ''/''. For example having values ''/^kube/,veth1''
+                      will exclude all interfaces that begin with ''kube'' and also the
+                      interface ''veth1''. [Default: kube-ipvs0]'
+                    type: string
+                  interfacePrefix:
+                    description: 'InterfacePrefix is the interface name prefix that identifies
+                      workload endpoints and so distinguishes them from host endpoint
+                      interfaces. Note: in environments other than bare metal, the orchestrators
+                      configure this appropriately. For example our Kubernetes and Docker
+                      integrations set the ''cali'' value, and our OpenStack integration
+                      sets the ''tap'' value. [Default: cali]'
+                    type: string
+                  interfaceRefreshInterval:
+                    description: InterfaceRefreshInterval is the period at which Felix
+                      rescans local interfaces to verify their state. The rescan can be
+                      disabled by setting the interval to 0.
+                    type: string
+                  ipipEnabled:
+                    type: boolean
+                  ipipMTU:
+                    description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  ipsetsRefreshInterval:
+                    description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                      all iptables state to ensure that no other process has accidentally
+                      broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                      90s]'
+                    type: string
+                  iptablesBackend:
+                    description: IptablesBackend specifies which backend of iptables will
+                      be used. The default is legacy.
+                    type: string
+                  iptablesFilterAllowAction:
+                    type: string
+                  iptablesLockFilePath:
+                    description: 'IptablesLockFilePath is the location of the iptables
+                      lock file. You may need to change this if the lock file is not in
+                      its standard location (for example if you have mapped it into Felix''s
+                      container at a different path). [Default: /run/xtables.lock]'
+                    type: string
+                  iptablesLockProbeInterval:
+                    description: 'IptablesLockProbeInterval is the time that Felix will
+                      wait between attempts to acquire the iptables lock if it is not
+                      available. Lower values make Felix more responsive when the lock
+                      is contended, but use more CPU. [Default: 50ms]'
+                    type: string
+                  iptablesLockTimeout:
+                    description: 'IptablesLockTimeout is the time that Felix will wait
+                      for the iptables lock, or 0, to disable. To use this feature, Felix
+                      must share the iptables lock file with all other processes that
+                      also take the lock. When running Felix inside a container, this
+                      requires the /run directory of the host to be mounted into the calico/node
+                      or calico/felix container. [Default: 0s disabled]'
+                    type: string
+                  iptablesMangleAllowAction:
+                    type: string
+                  iptablesMarkMask:
+                    description: 'IptablesMarkMask is the mask that Felix selects its
+                      IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                      at least 8 bits set, none of which clash with any other mark bits
+                      in use on the system. [Default: 0xff000000]'
+                    format: int32
+                    type: integer
+                  iptablesNATOutgoingInterfaceFilter:
+                    type: string
+                  iptablesPostWriteCheckInterval:
+                    description: 'IptablesPostWriteCheckInterval is the period after Felix
+                      has done a write to the dataplane that it schedules an extra read
+                      back in order to check the write was not clobbered by another process.
+                      This should only occur if another application on the system doesn''t
+                      respect the iptables lock. [Default: 1s]'
+                    type: string
+                  iptablesRefreshInterval:
+                    description: 'IptablesRefreshInterval is the period at which Felix
+                      re-checks the IP sets in the dataplane to ensure that no other process
+                      has accidentally broken Calico''s rules. Set to 0 to disable IP
+                      sets refresh. Note: the default for this value is lower than the
+                      other refresh intervals as a workaround for a Linux kernel bug that
+                      was fixed in kernel version 4.11. If you are using v4.11 or greater
+                      you may want to set this to, a higher value to reduce Felix CPU
+                      usage. [Default: 10s]'
+                    type: string
+                  ipv6Support:
+                    type: boolean
+                  kubeNodePortRanges:
+                    description: 'KubeNodePortRanges holds list of port ranges used for
+                      service node ports. Only used if felix detects kube-proxy running
+                      in ipvs mode. Felix uses these ranges to separate host and workload
+                      traffic. [Default: 30000:32767].'
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  logFilePath:
+                    description: 'LogFilePath is the full path to the Felix log. Set to
+                      none to disable file logging. [Default: /var/log/calico/felix.log]'
+                    type: string
+                  logPrefix:
+                    description: 'LogPrefix is the log prefix that Felix uses when rendering
+                      LOG rules. [Default: calico-packet]'
+                    type: string
+                  logSeverityFile:
+                    description: 'LogSeverityFile is the log severity above which logs
+                      are sent to the log file. [Default: Info]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  logSeveritySys:
+                    description: 'LogSeveritySys is the log severity above which logs
+                      are sent to the syslog. Set to None for no logging to syslog. [Default:
+                      Info]'
+                    type: string
+                  maxIpsetSize:
+                    type: integer
+                  metadataAddr:
+                    description: 'MetadataAddr is the IP address or domain name of the
+                      server that can answer VM queries for cloud-init metadata. In OpenStack,
+                      this corresponds to the machine running nova-api (or in Ubuntu,
+                      nova-api-metadata). A value of none (case insensitive) means that
+                      Felix should not set up any NAT rule for the metadata path. [Default:
+                      127.0.0.1]'
+                    type: string
+                  metadataPort:
+                    description: 'MetadataPort is the port of the metadata server. This,
+                      combined with global.MetadataAddr (if not ''None''), is used to
+                      set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                      In most cases this should not need to be changed [Default: 8775].'
+                    type: integer
+                  mtuIfacePattern:
+                    description: MTUIfacePattern is a regular expression that controls
+                      which interfaces Felix should scan in order to calculate the host's
+                      MTU. This should not match workload interfaces (usually named cali...).
+                    type: string
+                  natOutgoingAddress:
+                    description: NATOutgoingAddress specifies an address to use when performing
+                      source NAT for traffic in a natOutgoing pool that is leaving the
+                      network. By default the address used is an address on the interface
+                      the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                    type: string
+                  natPortRange:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NATPortRange specifies the range of ports that is used
+                      for port mapping when doing outgoing NAT. When unset the default
+                      behavior of the network stack is used.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  netlinkTimeout:
+                    type: string
+                  openstackRegion:
+                    description: 'OpenstackRegion is the name of the region that a particular
+                      Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                      this must be configured somehow for each Felix (here in the datamodel,
+                      or in felix.cfg or the environment on each compute node), and must
+                      match the [calico] openstack_region value configured in neutron.conf
+                      on each node. [Default: Empty]'
+                    type: string
+                  policySyncPathPrefix:
+                    description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                      policy changes to external services, like Application layer policy.
+                      [Default: Empty]'
+                    type: string
+                  prometheusGoMetricsEnabled:
+                    description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusMetricsEnabled:
+                    description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                      server in Felix if set to true. [Default: false]'
+                    type: boolean
+                  prometheusMetricsHost:
+                    description: 'PrometheusMetricsHost is the host that the Prometheus
+                      metrics server should bind to. [Default: empty]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. [Default: 9091]'
+                    type: integer
+                  prometheusProcessMetricsEnabled:
+                    description: 'PrometheusProcessMetricsEnabled disables process metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusWireGuardMetricsEnabled:
+                    description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                      metrics collection, which the Prometheus client does by default,
+                      when set to false. This reduces the number of metrics reported,
+                      reducing Prometheus load. [Default: true]'
+                    type: boolean
+                  removeExternalRoutes:
+                    description: Whether or not to remove device routes that have not
+                      been programmed by Felix. Disabling this will allow external applications
+                      to also add device routes. This is enabled by default which means
+                      we will remove externally added routes.
+                    type: boolean
+                  reportingInterval:
+                    description: 'ReportingInterval is the interval at which Felix reports
+                      its status into the datastore or 0 to disable. Must be non-zero
+                      in OpenStack deployments. [Default: 30s]'
+                    type: string
+                  reportingTTL:
+                    description: 'ReportingTTL is the time-to-live setting for process-wide
+                      status reports. [Default: 90s]'
+                    type: string
+                  routeRefreshInterval:
+                    description: 'RouteRefreshInterval is the period at which Felix re-checks
+                      the routes in the dataplane to ensure that no other process has
+                      accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                      [Default: 90s]'
+                    type: string
+                  routeSource:
+                    description: 'RouteSource configures where Felix gets its routing
+                      information. - WorkloadIPs: use workload endpoints to construct
+                      routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                    type: string
+                  routeTableRange:
+                    description: Calico programs additional Linux route tables for various
+                      purposes.  RouteTableRange specifies the indices of the route tables
+                      that Calico should use.
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                    - max
+                    - min
+                    type: object
+                  serviceLoopPrevention:
+                    description: 'When service IP advertisement is enabled, prevent routing
+                      loops to service IPs that are not in use, by dropping or rejecting
+                      packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                      in which case such routing loops continue to be allowed. [Default:
+                      Drop]'
+                    type: string
+                  sidecarAccelerationEnabled:
+                    description: 'SidecarAccelerationEnabled enables experimental sidecar
+                      acceleration [Default: false]'
+                    type: boolean
+                  usageReportingEnabled:
+                    description: 'UsageReportingEnabled reports anonymous Calico version
+                      number and cluster size to projectcalico.org. Logs warnings returned
+                      by the usage server. For example, if a significant security vulnerability
+                      has been discovered in the version of Calico being used. [Default:
+                      true]'
+                    type: boolean
+                  usageReportingInitialDelay:
+                    description: 'UsageReportingInitialDelay controls the minimum delay
+                      before Felix makes a report. [Default: 300s]'
+                    type: string
+                  usageReportingInterval:
+                    description: 'UsageReportingInterval controls the interval at which
+                      Felix makes reports. [Default: 86400s]'
+                    type: string
+                  useInternalDataplaneDriver:
+                    type: boolean
+                  vxlanEnabled:
+                    type: boolean
+                  vxlanMTU:
+                    description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  vxlanPort:
+                    type: integer
+                  vxlanVNI:
+                    type: integer
+                  wireguardEnabled:
+                    description: 'WireguardEnabled controls whether Wireguard is enabled.
+                      [Default: false]'
+                    type: boolean
+                  wireguardHostEncryptionEnabled:
+                    description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                      host-to-host encryption is enabled. [Default: false]'
+                    type: boolean
+                  wireguardInterfaceName:
+                    description: 'WireguardInterfaceName specifies the name to use for
+                      the Wireguard interface. [Default: wg.calico]'
+                    type: string
+                  wireguardListeningPort:
+                    description: 'WireguardListeningPort controls the listening port used
+                      by Wireguard. [Default: 51820]'
+                    type: integer
+                  wireguardMTU:
+                    description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                      See Configuring MTU [Default: 1420]'
+                    type: integer
+                  wireguardRoutingRulePriority:
+                    description: 'WireguardRoutingRulePriority controls the priority value
+                      to use for the Wireguard routing rule. [Default: 99]'
+                    type: integer
+                  xdpEnabled:
+                    description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                      incoming deny rules. [Default: true]'
+                    type: boolean
+                  xdpRefreshInterval:
+                    description: 'XDPRefreshInterval is the period at which Felix re-checks
+                      all XDP state to ensure that no other process has accidentally broken
+                      Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                      refresh. [Default: 90s]'
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkPolicy
+        listKind: GlobalNetworkPolicyList
+        plural: globalnetworkpolicies
+        singular: globalnetworkpolicy
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  applyOnForward:
+                    description: ApplyOnForward indicates to apply the rules in this policy
+                      on forward traffic.
+                    type: boolean
+                  doNotTrack:
+                    description: DoNotTrack indicates whether packets matched by the rules
+                      in this policy should go through the data plane's connection tracking,
+                      such as Linux conntrack.  If True, the rules in this policy are
+                      applied before any data plane connection tracking, and packets allowed
+                      by this policy are marked as not to be tracked.
+                    type: boolean
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    description: NamespaceSelector is an optional field for an expression
+                      used to select a pod based on namespaces.
+                    type: string
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  preDNAT:
+                    description: PreDNAT indicates to apply the rules in this policy before
+                      any DNAT.
+                    type: boolean
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress rules are present in the policy.  The
+                      default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                      (including the case where there are   also no Ingress rules) \n
+                      - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                      rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                      both Ingress and Egress rules. \n When the policy is read back again,
+                      Types will always be one of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkSet
+        listKind: GlobalNetworkSetList
+        plural: globalnetworksets
+        singular: globalnetworkset
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+              that share labels to allow rules to refer to them via selectors.  The labels
+              of GlobalNetworkSet are not namespaced.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: hostendpoints.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: HostEndpoint
+        listKind: HostEndpointList
+        plural: hostendpoints
+        singular: hostendpoint
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: HostEndpointSpec contains the specification for a HostEndpoint
+                  resource.
+                properties:
+                  expectedIPs:
+                    description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                      If \"InterfaceName\" is not present, Calico will look for an interface
+                      matching any of the IPs in the list and apply policy to that. Note:
+                      \tWhen using the selector match criteria in an ingress or egress
+                      security Policy \tor Profile, Calico converts the selector into
+                      a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                      is used for that purpose. (If only the interface \tname is specified,
+                      Calico does not learn the IPs of the interface for use in match
+                      \tcriteria.)"
+                    items:
+                      type: string
+                    type: array
+                  interfaceName:
+                    description: "Either \"*\", or the name of a specific Linux interface
+                      to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                      governs all traffic to, from or through the default network namespace
+                      of the host named by the \"Node\" field; entering and leaving that
+                      namespace via any interface, including those from/to non-host-networked
+                      local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                      only governs traffic that enters or leaves the host through the
+                      specific interface named by InterfaceName, or - when InterfaceName
+                      is empty - through the specific interface that has one of the IPs
+                      in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                      one expected IP must be specified.  Only external interfaces (such
+                      as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                      to protect traffic through a specific local workload interface.
+                      \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                      initially just pre-DNAT policy.  Please check Calico documentation
+                      for the latest position."
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance.
+                    type: string
+                  ports:
+                    description: Ports contains the endpoint's named ports, which may
+                      be referenced in security policy rules.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  profiles:
+                    description: A list of identifiers of security Profile objects that
+                      apply to this endpoint. Each profile is applied in the order that
+                      they appear in this list.  Profile rules are applied after the selector-based
+                      security policy.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamblocks.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMBlock
+        listKind: IPAMBlockList
+        plural: ipamblocks
+        singular: ipamblock
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMBlockSpec contains the specification for an IPAMBlock
+                  resource.
+                properties:
+                  affinity:
+                    type: string
+                  allocations:
+                    items:
+                      nullable: true
+                      type: integer
+                    type: array
+                  attributes:
+                    items:
+                      properties:
+                        handle_id:
+                          type: string
+                        secondary:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    type: array
+                  cidr:
+                    type: string
+                  deleted:
+                    type: boolean
+                  strictAffinity:
+                    type: boolean
+                  unallocated:
+                    items:
+                      type: integer
+                    type: array
+                required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamconfigs.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMConfig
+        listKind: IPAMConfigList
+        plural: ipamconfigs
+        singular: ipamconfig
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMConfigSpec contains the specification for an IPAMConfig
+                  resource.
+                properties:
+                  autoAllocateBlocks:
+                    type: boolean
+                  maxBlocksPerHost:
+                    description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                      that can be affine to each host.
+                    type: integer
+                  strictAffinity:
+                    type: boolean
+                required:
+                - autoAllocateBlocks
+                - strictAffinity
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamhandles.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMHandle
+        listKind: IPAMHandleList
+        plural: ipamhandles
+        singular: ipamhandle
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMHandleSpec contains the specification for an IPAMHandle
+                  resource.
+                properties:
+                  block:
+                    additionalProperties:
+                      type: integer
+                    type: object
+                  deleted:
+                    type: boolean
+                  handleID:
+                    type: string
+                required:
+                - block
+                - handleID
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ippools.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPPool
+        listKind: IPPoolList
+        plural: ippools
+        singular: ippool
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPPoolSpec contains the specification for an IPPool resource.
+                properties:
+                  blockSize:
+                    description: The block size to use for IP address assignments from
+                      this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                    type: integer
+                  cidr:
+                    description: The pool CIDR.
+                    type: string
+                  disabled:
+                    description: When disabled is true, Calico IPAM will not assign addresses
+                      from this pool.
+                    type: boolean
+                  ipip:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    properties:
+                      enabled:
+                        description: When enabled is true, ipip tunneling will be used
+                          to deliver packets to destinations within this pool.
+                        type: boolean
+                      mode:
+                        description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                          mode of "always" will also use IPIP tunneling for routing to
+                          destination IP addresses within this pool.  A mode of "cross-subnet"
+                          will only use IPIP tunneling when the destination node is on
+                          a different subnet to the originating node.  The default value
+                          (if not specified) is "always".
+                        type: string
+                    type: object
+                  ipipMode:
+                    description: Contains configuration for IPIP tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                      is disabled).
+                    type: string
+                  nat-outgoing:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    type: boolean
+                  natOutgoing:
+                    description: When nat-outgoing is true, packets sent from Calico networked
+                      containers in this pool to destinations outside of this pool will
+                      be masqueraded.
+                    type: boolean
+                  nodeSelector:
+                    description: Allows IPPool to allocate for a specific node by label
+                      selector.
+                    type: string
+                  vxlanMode:
+                    description: Contains configuration for VXLAN tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                      tunneling is disabled).
+                    type: string
+                required:
+                - cidr
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubecontrollersconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: KubeControllersConfiguration
+        listKind: KubeControllersConfigurationList
+        plural: kubecontrollersconfigurations
+        singular: kubecontrollersconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeControllersConfigurationSpec contains the values of the
+                  Kubernetes controllers configuration.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host endpoints.
+                              Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation of
+                                  host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the controller
+                              to determine if an IP address has been leaked. Set to 0
+                              to disable IP garbage collection. [Default: 15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+              status:
+                description: KubeControllersConfigurationStatus represents the status
+                  of the configuration. It's useful for admins to be able to see the actual
+                  config that was applied, which can be modified by environment variables
+                  on the kube-controllers process.
+                properties:
+                  environmentVars:
+                    additionalProperties:
+                      type: string
+                    description: EnvironmentVars contains the environment variables on
+                      the kube-controllers that influenced the RunningConfig.
+                    type: object
+                  runningConfig:
+                    description: RunningConfig contains the effective config that is running
+                      in the kube-controllers pod, after merging the API resource with
+                      any environment variables.
+                    properties:
+                      controllers:
+                        description: Controllers enables and configures individual Kubernetes
+                          controllers
+                        properties:
+                          namespace:
+                            description: Namespace enables and configures the namespace
+                              controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          node:
+                            description: Node enables and configures the node controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              hostEndpoint:
+                                description: HostEndpoint controls syncing nodes to host
+                                  endpoints. Disabled by default, set to nil to disable.
+                                properties:
+                                  autoCreate:
+                                    description: 'AutoCreate enables automatic creation
+                                      of host endpoints for every node. [Default: Disabled]'
+                                    type: string
+                                type: object
+                              leakGracePeriod:
+                                description: 'LeakGracePeriod is the period used by the
+                                  controller to determine if an IP address has been leaked.
+                                  Set to 0 to disable IP garbage collection. [Default:
+                                  15m]'
+                                type: string
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                              syncLabels:
+                                description: 'SyncLabels controls whether to copy Kubernetes
+                                  node labels to Calico nodes. [Default: Enabled]'
+                                type: string
+                            type: object
+                          policy:
+                            description: Policy enables and configures the policy controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          serviceAccount:
+                            description: ServiceAccount enables and configures the service
+                              account controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          workloadEndpoint:
+                            description: WorkloadEndpoint enables and configures the workload
+                              endpoint controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                        type: object
+                      etcdV3CompactionPeriod:
+                        description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                          compaction requests. Set to 0 to disable. [Default: 10m]'
+                        type: string
+                      healthChecks:
+                        description: 'HealthChecks enables or disables support for health
+                          checks [Default: Enabled]'
+                        type: string
+                      logSeverityScreen:
+                        description: 'LogSeverityScreen is the log severity above which
+                          logs are sent to the stdout. [Default: Info]'
+                        type: string
+                      prometheusMetricsPort:
+                        description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                          metrics server should bind to. Set to 0 to disable. [Default:
+                          9094]'
+                        type: integer
+                    required:
+                    - controllers
+                    type: object
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkPolicy
+        listKind: NetworkPolicyList
+        plural: networkpolicies
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress are present in the policy.  The default
+                      is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                      the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                      ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                      PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                      \n When the policy is read back again, Types will always be one
+                      of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkSet
+        listKind: NetworkSetList
+        plural: networksets
+        singular: networkset
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: NetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-kube-controllers
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      verbs:
+      - list
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - hostendpoints
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - clusterinformations
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - kubecontrollersconfigurations
+      verbs:
+      - get
+      - create
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-node
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - namespaces
+      verbs:
+      - get
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - patch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - bgpconfigurations
+      - bgppeers
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ipamconfigs
+      verbs:
+      - get
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      verbs:
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - daemonsets
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-kube-controllers
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      calico_backend: vxlan
+      cni_network_config: |-
+        {
+          "name": "k8s-pod-network",
+          "cniVersion": "0.3.1",
+          "plugins": [
+            {
+              "type": "calico",
+              "log_level": "info",
+              "log_file_path": "/var/log/calico/cni/cni.log",
+              "datastore_type": "kubernetes",
+              "nodename": "__KUBERNETES_NODE_NAME__",
+              "mtu": __CNI_MTU__,
+              "ipam": {
+                  "type": "calico-ipam"
+              },
+              "policy": {
+                  "type": "k8s"
+              },
+              "kubernetes": {
+                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              }
+            },
+            {
+              "type": "portmap",
+              "snat": true,
+              "capabilities": {"portMappings": true}
+            },
+            {
+              "type": "bandwidth",
+              "capabilities": {"bandwidth": true}
+            }
+          ]
+        }
+      typha_service_name: none
+      veth_mtu: "1350"
+    kind: ConfigMap
+    metadata:
+      name: calico-config
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-kube-controllers
+          name: calico-kube-controllers
+          namespace: kube-system
+        spec:
+          containers:
+          - env:
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            image: docker.io/calico/kube-controllers:v3.20.3
+            livenessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -l
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-kube-controllers
+            readinessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -r
+              periodSeconds: 10
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: calico-kube-controllers
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: calico-node
+      name: calico-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+        spec:
+          containers:
+          - env:
+            - name: FELIX_FEATUREDETECTOVERRIDE
+              value: ChecksumOffloadBroken=true
+            - name: CALICO_IPV4POOL_VXLAN
+              value: Always
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            - name: CLUSTER_TYPE
+              value: k8s,bgp
+            - name: IP
+              value: autodetect
+            - name: CALICO_IPV4POOL_IPIP
+              value: Never
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_WIREGUARDMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_AWSSRCDSTCHECK
+              value: Disable
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: ACCEPT
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/node:v3.20.3
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -shutdown
+            livenessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-live
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-node
+            readinessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-ready
+              periodSeconds: 10
+              timeoutSeconds: 10
+            resources:
+              requests:
+                cpu: 250m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /var/run/nodeagent
+              name: policysync
+            - mountPath: /sys/fs/
+              mountPropagation: Bidirectional
+              name: sysfs
+            - mountPath: /var/log/calico/cni
+              name: cni-log-dir
+              readOnly: true
+          hostNetwork: true
+          initContainers:
+          - command:
+            - /opt/cni/bin/calico-ipam
+            - -upgrade
+            env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: upgrade-ipam
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          - command:
+            - /opt/cni/bin/install
+            env:
+            - name: CNI_CONF_NAME
+              value: 10-calico.conflist
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  key: cni_network_config
+                  name: calico-config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: SLEEP
+              value: "false"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: install-cni
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+            name: flexvol-driver
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/driver
+              name: flexvol-driver-host
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: calico-node
+          terminationGracePeriodSeconds: 0
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /lib/modules
+            name: lib-modules
+          - hostPath:
+              path: /var/run/calico
+            name: var-run-calico
+          - hostPath:
+              path: /var/lib/calico
+            name: var-lib-calico
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+          - hostPath:
+              path: /sys/fs/
+              type: DirectoryOrCreate
+            name: sysfs
+          - hostPath:
+              path: /opt/cni/bin
+            name: cni-bin-dir
+          - hostPath:
+              path: /etc/cni/net.d
+            name: cni-net-dir
+          - hostPath:
+              path: /var/log/calico/cni
+            name: cni-log-dir
+          - hostPath:
+              path: /var/lib/cni/networks
+            name: host-local-net-dir
+          - hostPath:
+              path: /var/run/nodeagent
+              type: DirectoryOrCreate
+            name: policysync
+          - hostPath:
+              path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+              type: DirectoryOrCreate
+            name: flexvol-driver-host
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
   windows-cni: "# strictAffinity required for windows\napiVersion: crd.projectcalico.org/v1\nkind:
     IPAMConfig\nmetadata:\n  name: default\nspec:\n  autoAllocateBlocks: true\n  strictAffinity:
     true\n---\nkind: ConfigMap\napiVersion: v1\nmetadata:\n  name: calico-static-rules\n

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -4043,7 +4043,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.20.3
+            image: docker.io/calico/kube-controllers:v3.20.4
             livenessProbe:
               exec:
                 command:
@@ -4153,7 +4153,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.20.3
+            image: docker.io/calico/node:v3.20.4
             lifecycle:
               preStop:
                 exec:
@@ -4225,7 +4225,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: upgrade-ipam
             securityContext:
               privileged: true
@@ -4259,7 +4259,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: install-cni
             securityContext:
               privileged: true
@@ -4268,7 +4268,7 @@ data:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.4
             name: flexvol-driver
             securityContext:
               privileged: true
@@ -4376,7 +4376,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.20.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.20.4-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -4395,7 +4395,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.20.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.20.4-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -4406,7 +4406,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.20.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.20.4-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -350,2440 +350,3985 @@ data:
     \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
     kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
     \   type: RollingUpdate\n"
-  resources: "---\n# Source: calico/templates/calico-config.yaml\n# This ConfigMap
-    is used to configure a self-hosted Calico installation.\nkind: ConfigMap\napiVersion:
-    v1\nmetadata:\n  name: calico-config\n  namespace: kube-system\ndata:\n  # Typha
-    is disabled.\n  typha_service_name: \"none\"\n  # Configure the backend to use.\n
-    \ calico_backend: \"vxlan\"\n  # On Azure, the underlying network has an MTU of
-    1400, even though the network interface will have an MTU of 1500.\n  # We set
-    this value to 1350 for “physical network MTU size minus 50” since we use VXLAN,
-    which uses a 50-byte header.\n  # If enabling Wireguard, this value should be
-    changed to 1340 (Wireguard uses a 60-byte header).\n  # https://docs.projectcalico.org/networking/mtu#determine-mtu-size\n
-    \ veth_mtu: \"1350\"\n  \n  # The CNI network configuration to install on each
-    node. The special\n  # values in this config will be automatically populated.\n
-    \ cni_network_config: |-\n    {\n      \"name\": \"k8s-pod-network\",\n      \"cniVersion\":
-    \"0.3.1\",\n      \"plugins\": [\n        {\n          \"type\": \"calico\",\n
-    \         \"log_level\": \"info\",\n          \"log_file_path\": \"/var/log/calico/cni/cni.log\",\n
-    \         \"datastore_type\": \"kubernetes\",\n          \"nodename\": \"__KUBERNETES_NODE_NAME__\",\n
-    \         \"mtu\": __CNI_MTU__,\n          \"ipam\": {\n              \"type\":
-    \"calico-ipam\"\n          },\n          \"policy\": {\n              \"type\":
-    \"k8s\"\n          },\n          \"kubernetes\": {\n              \"kubeconfig\":
-    \"__KUBECONFIG_FILEPATH__\"\n          }\n        },\n        {\n          \"type\":
-    \"portmap\",\n          \"snat\": true,\n          \"capabilities\": {\"portMappings\":
-    true}\n        },\n        {\n          \"type\": \"bandwidth\",\n          \"capabilities\":
-    {\"bandwidth\": true}\n        }\n      ]\n    }\n\n---\n# Source: calico/templates/kdd-crds.yaml\n\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: bgpconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPConfiguration\n    listKind: BGPConfigurationList\n    plural:
-    bgpconfigurations\n    singular: bgpconfiguration\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    BGPConfiguration contains the configuration for any BGP routing.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPConfigurationSpec contains the
-    values of the BGP configuration.\n              properties:\n                asNumber:\n
-    \                 description: 'ASNumber is the default AS number used by a node.
-    [Default:\n                  64512]'\n                  format: int32\n                  type:
-    integer\n                communities:\n                  description: Communities
-    is a list of BGP community values and their\n                    arbitrary names
-    for tagging routes.\n                  items:\n                    description:
-    Community contains standard or large community value\n                      and
-    its name.\n                    properties:\n                      name:\n                        description:
-    Name given to community value.\n                        type: string\n                      value:\n
-    \                       description: Value must be of format `aa:nn` or `aa:nn:mm`.\n
-    \                         For standard community use `aa:nn` format, where `aa`
-    and\n                          `nn` are 16 bit number. For large community use
-    `aa:nn:mm`\n                          format, where `aa`, `nn` and `mm` are 32
-    bit number. Where,\n                          `aa` is an AS Number, `nn` and `mm`
-    are per-AS identifier.\n                        pattern: ^(\\d+):(\\d+)$|^(\\d+):(\\d+):(\\d+)$\n
-    \                       type: string\n                    type: object\n                  type:
-    array\n                listenPort:\n                  description: ListenPort
-    is the port where BGP protocol should listen.\n                    Defaults to
-    179\n                  maximum: 65535\n                  minimum: 1\n                  type:
-    integer\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: INFO]'\n                  type: string\n                nodeToNodeMeshEnabled:\n
-    \                 description: 'NodeToNodeMeshEnabled sets whether full node to
-    node\n                  BGP mesh is enabled. [Default: true]'\n                  type:
-    boolean\n                prefixAdvertisements:\n                  description:
-    PrefixAdvertisements contains per-prefix advertisement\n                    configuration.\n
-    \                 items:\n                    description: PrefixAdvertisement
-    configures advertisement properties\n                      for the specified CIDR.\n
-    \                   properties:\n                      cidr:\n                        description:
-    CIDR for which properties should be advertised.\n                        type:
-    string\n                      communities:\n                        description:
-    Communities can be list of either community names\n                          already
-    defined in `Specs.Communities` or community value\n                          of
-    format `aa:nn` or `aa:nn:mm`. For standard community use\n                          `aa:nn`
-    format, where `aa` and `nn` are 16 bit number. For\n                          large
-    community use `aa:nn:mm` format, where `aa`, `nn` and\n                          `mm`
-    are 32 bit number. Where,`aa` is an AS Number, `nn` and\n                          `mm`
-    are per-AS identifier.\n                        items:\n                          type:
-    string\n                        type: array\n                    type: object\n
-    \                 type: array\n                serviceClusterIPs:\n                  description:
-    ServiceClusterIPs are the CIDR blocks from which service\n                    cluster
-    IPs are allocated. If specified, Calico will advertise these\n                    blocks,
-    as well as any cluster IPs within them.\n                  items:\n                    description:
-    ServiceClusterIPBlock represents a single allowed ClusterIP\n                      CIDR
-    block.\n                    properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n                serviceExternalIPs:\n
-    \                 description: ServiceExternalIPs are the CIDR blocks for Kubernetes\n
-    \                   Service External IPs. Kubernetes Service ExternalIPs will
-    only be\n                    advertised if they are within one of these blocks.\n
-    \                 items:\n                    description: ServiceExternalIPBlock
-    represents a single allowed\n                      External IP CIDR block.\n                    properties:\n
-    \                     cidr:\n                        type: string\n                    type:
-    object\n                  type: array\n                serviceLoadBalancerIPs:\n
-    \                 description: ServiceLoadBalancerIPs are the CIDR blocks for
-    Kubernetes\n                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress\n
-    \                   IPs will only be advertised if they are within one of these
-    blocks.\n                  items:\n                    description: ServiceLoadBalancerIPBlock
-    represents a single allowed\n                      LoadBalancer IP CIDR block.\n
-    \                   properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: bgppeers.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPPeer\n    listKind: BGPPeerList\n    plural: bgppeers\n
-    \   singular: bgppeer\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPPeerSpec contains the specification
-    for a BGPPeer resource.\n              properties:\n                asNumber:\n
-    \                 description: The AS Number of the peer.\n                  format:
-    int32\n                  type: integer\n                keepOriginalNextHop:\n
-    \                 description: Option to keep the original nexthop field when
-    routes\n                    are sent to a BGP Peer. Setting \"true\" configures
-    the selected BGP\n                    Peers node to use the \"next hop keep;\"
-    instead of \"next hop self;\"(default)\n                    in the specific branch
-    of the Node on \"bird.cfg\".\n                  type: boolean\n                maxRestartTime:\n
-    \                 description: Time to allow for software restart.  When specified,
-    this\n                    is configured as the graceful restart timeout.  When
-    not specified,\n                    the BIRD default of 120s is used.\n                  type:
-    string\n                node:\n                  description: The node name identifying
-    the Calico node instance that\n                    is targeted by this peer. If
-    this is not set, and no nodeSelector\n                    is specified, then this
-    BGP peer selects all nodes in the cluster.\n                  type: string\n                nodeSelector:\n
-    \                 description: Selector for the nodes that should have this peering.
-    \ When\n                    this is set, the Node field must be empty.\n                  type:
-    string\n                password:\n                  description: Optional BGP
-    password for the peerings generated by this\n                    BGPPeer resource.\n
-    \                 properties:\n                    secretKeyRef:\n                      description:
-    Selects a key of a secret in the node pod's namespace.\n                      properties:\n
-    \                       key:\n                          description: The key of
-    the secret to select from.  Must be\n                            a valid secret
-    key.\n                          type: string\n                        name:\n
-    \                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n
-    \                         TODO: Add other useful fields. apiVersion, kind, uid?'\n
-    \                         type: string\n                        optional:\n                          description:
-    Specify whether the Secret or its key must be\n                            defined\n
-    \                         type: boolean\n                      required:\n                        -
-    key\n                      type: object\n                  type: object\n                peerIP:\n
-    \                 description: The IP address of the peer followed by an optional
-    port\n                    number to peer with. If port number is given, format
-    should be `[<IPv6>]:port`\n                    or `<IPv4>:<port>` for IPv4. If
-    optional port number is not set,\n                    and this peer IP and ASNumber
-    belongs to a calico/node with ListenPort\n                    set in BGPConfiguration,
-    then we use that port to peer.\n                  type: string\n                peerSelector:\n
-    \                 description: Selector for the remote nodes to peer with.  When
-    this\n                    is set, the PeerIP and ASNumber fields must be empty.
-    \ For each\n                    peering between the local node and selected remote
-    nodes, we configure\n                    an IPv4 peering if both ends have NodeBGPSpec.IPv4Address
-    specified,\n                    and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address
-    specified.  The\n                    remote AS number comes from the remote node’s
-    NodeBGPSpec.ASNumber,\n                    or the global default if that is not
-    set.\n                  type: string\n                sourceAddress:\n                  description:
-    Specifies whether and how to configure a source address\n                    for
-    the peerings generated by this BGPPeer resource.  Default value\n                    \"UseNodeIP\"
-    means to configure the node IP as the source address.  \"None\"\n                    means
-    not to configure a source address.\n                  type: string\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: blockaffinities.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BlockAffinity\n    listKind: BlockAffinityList\n    plural:
-    blockaffinities\n    singular: blockaffinity\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BlockAffinitySpec contains the specification
-    for a BlockAffinity\n                resource.\n              properties:\n                cidr:\n
-    \                 type: string\n                deleted:\n                  description:
-    Deleted indicates that this block affinity is being deleted.\n                    This
-    field is a string for compatibility with older releases that\n                    mistakenly
-    treat this field as a string.\n                  type: string\n                node:\n
-    \                 type: string\n                state:\n                  type:
-    string\n              required:\n                - cidr\n                - deleted\n
-    \               - node\n                - state\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: clusterinformations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: ClusterInformation\n    listKind: ClusterInformationList\n
-    \   plural: clusterinformations\n    singular: clusterinformation\n  scope: Cluster\n
-    \ versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    ClusterInformation contains the cluster specific information.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: ClusterInformationSpec contains
-    the values of describing\n                the cluster.\n              properties:\n
-    \               calicoVersion:\n                  description: CalicoVersion is
-    the version of Calico that the cluster\n                    is running\n                  type:
-    string\n                clusterGUID:\n                  description: ClusterGUID
-    is the GUID of the cluster\n                  type: string\n                clusterType:\n
-    \                 description: ClusterType describes the type of the cluster\n
-    \                 type: string\n                datastoreReady:\n                  description:
-    DatastoreReady is used during significant datastore migrations\n                    to
-    signal to components such as Felix that it should wait before\n                    accessing
-    the datastore.\n                  type: boolean\n                variant:\n                  description:
-    Variant declares which variant of Calico should be active.\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: felixconfigurations.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: FelixConfiguration\n    listKind:
-    FelixConfigurationList\n    plural: felixconfigurations\n    singular: felixconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         description: Felix Configuration contains the configuration for Felix.\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: FelixConfigurationSpec contains
-    the values of the Felix configuration.\n              properties:\n                allowIPIPPacketsFromWorkloads:\n
-    \                 description: 'AllowIPIPPacketsFromWorkloads controls whether
-    Felix\n                  will add a rule to drop IPIP encapsulated traffic from
-    workloads\n                  [Default: false]'\n                  type: boolean\n
-    \               allowVXLANPacketsFromWorkloads:\n                  description:
-    'AllowVXLANPacketsFromWorkloads controls whether Felix\n                  will
-    add a rule to drop VXLAN encapsulated traffic from workloads\n                  [Default:
-    false]'\n                  type: boolean\n                awsSrcDstCheck:\n                  description:
-    'Set source-destination-check on AWS EC2 instances. Accepted\n                  value
-    must be one of \"DoNothing\", \"Enabled\" or \"Disabled\". [Default:\n                  DoNothing]'\n
-    \                 enum:\n                    - DoNothing\n                    -
-    Enable\n                    - Disable\n                  type: string\n                bpfConnectTimeLoadBalancingEnabled:\n
-    \                 description: 'BPFConnectTimeLoadBalancingEnabled when in BPF
-    mode,\n                  controls whether Felix installs the connection-time load
-    balancer.  The\n                  connect-time load balancer is required for the
-    host to be able to\n                  reach Kubernetes services and it improves
-    the performance of pod-to-service\n                  connections.  The only reason
-    to disable it is for debugging purposes.  [Default:\n                  true]'\n
-    \                 type: boolean\n                bpfDataIfacePattern:\n                  description:
-    'BPFDataIfacePattern is a regular expression that controls\n                  which
-    interfaces Felix should attach BPF programs to in order to\n                  catch
-    traffic to/from the network.  This needs to match the interfaces\n                  that
-    Calico workload traffic flows over as well as any interfaces\n                  that
-    handle incoming traffic to nodeports and services from outside\n                  the
-    cluster.  It should not match the workload interfaces (usually\n                  named
-    cali...). [Default: ^(en.*|eth.*|tunl0$)]'\n                  type: string\n                bpfDisableUnprivileged:\n
-    \                 description: 'BPFDisableUnprivileged, if enabled, Felix sets
-    the kernel.unprivileged_bpf_disabled\n                  sysctl to disable unprivileged
-    use of BPF.  This ensures that unprivileged\n                  users cannot access
-    Calico''s BPF maps and cannot insert their own\n                  BPF programs
-    to interfere with Calico''s. [Default: true]'\n                  type: boolean\n
-    \               bpfEnabled:\n                  description: 'BPFEnabled, if enabled
-    Felix will use the BPF dataplane.\n                  [Default: false]'\n                  type:
-    boolean\n                bpfExtToServiceConnmark:\n                  description:
-    'BPFExtToServiceConnmark in BPF mode, control a 32bit\n                    mark
-    that is set on connections from an external client to a local\n                    service.
-    This mark allows us to control how packets of that connection\n                    are
-    routed within the host and how is routing intepreted by RPF\n                    check.
-    [Default: 0]'\n                  type: integer\n                bpfExternalServiceMode:\n
-    \                 description: 'BPFExternalServiceMode in BPF mode, controls how
-    connections\n                  from outside the cluster to services (node ports
-    and cluster IPs)\n                  are forwarded to remote workloads.  If set
-    to \"Tunnel\" then both\n                  request and response traffic is tunneled
-    to the remote node.  If\n                  set to \"DSR\", the request traffic
-    is tunneled but the response traffic\n                  is sent directly from
-    the remote node.  In \"DSR\" mode, the remote\n                  node appears
-    to use the IP of the ingress node; this requires a\n                  permissive
-    L2 network.  [Default: Tunnel]'\n                  type: string\n                bpfKubeProxyEndpointSlicesEnabled:\n
-    \                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode,
-    controls\n                    whether Felix's embedded kube-proxy accepts EndpointSlices
-    or not.\n                  type: boolean\n                bpfKubeProxyIptablesCleanupEnabled:\n
-    \                 description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled
-    in BPF\n                  mode, Felix will proactively clean up the upstream Kubernetes
-    kube-proxy''s\n                  iptables chains.  Should only be enabled if kube-proxy
-    is not running.  [Default:\n                  true]'\n                  type:
-    boolean\n                bpfKubeProxyMinSyncPeriod:\n                  description:
-    'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the\n                  minimum
-    time between updates to the dataplane for Felix''s embedded\n                  kube-proxy.
-    \ Lower values give reduced set-up latency.  Higher values\n                  reduce
-    Felix CPU usage by batching up more work.  [Default: 1s]'\n                  type:
-    string\n                bpfLogLevel:\n                  description: 'BPFLogLevel
-    controls the log level of the BPF programs\n                  when in BPF dataplane
-    mode.  One of \"Off\", \"Info\", or \"Debug\".  The\n                  logs are
-    emitted to the BPF trace pipe, accessible with the command\n                  `tc
-    exec bpf debug`. [Default: Off].'\n                  type: string\n                chainInsertMode:\n
-    \                 description: 'ChainInsertMode controls whether Felix hooks the
-    kernel’s\n                  top-level iptables chains by inserting a rule at the
-    top of the\n                  chain or by appending a rule at the bottom. insert
-    is the safe default\n                  since it prevents Calico’s rules from being
-    bypassed. If you switch\n                  to append mode, be sure that the other
-    rules in the chains signal\n                  acceptance by falling through to
-    the Calico rules, otherwise the\n                  Calico policy will be bypassed.
-    [Default: insert]'\n                  type: string\n                dataplaneDriver:\n
-    \                 type: string\n                debugDisableLogDropping:\n                  type:
-    boolean\n                debugMemoryProfilePath:\n                  type: string\n
-    \               debugSimulateCalcGraphHangAfter:\n                  type: string\n
-    \               debugSimulateDataplaneHangAfter:\n                  type: string\n
-    \               defaultEndpointToHostAction:\n                  description: 'DefaultEndpointToHostAction
-    controls what happens to\n                  traffic that goes from a workload
-    endpoint to the host itself (after\n                  the traffic hits the endpoint
-    egress policy). By default Calico\n                  blocks traffic from workload
-    endpoints to the host itself with an\n                  iptables “DROP” action.
-    If you want to allow some or all traffic\n                  from endpoint to host,
-    set this parameter to RETURN or ACCEPT. Use\n                  RETURN if you have
-    your own rules in the iptables “INPUT” chain;\n                  Calico will insert
-    its rules at the top of that chain, then “RETURN”\n                  packets to
-    the “INPUT” chain once it has completed processing workload\n                  endpoint
-    egress policy. Use ACCEPT to unconditionally accept packets\n                  from
-    workloads after processing workload endpoint egress policy.\n                  [Default:
-    Drop]'\n                  type: string\n                deviceRouteProtocol:\n
-    \                 description: This defines the route protocol added to programmed
-    device\n                    routes, by default this will be RTPROT_BOOT when left
-    blank.\n                  type: integer\n                deviceRouteSourceAddress:\n
-    \                 description: This is the source address to use on programmed
-    device\n                    routes. By default the source address is left blank,
-    leaving the\n                    kernel to choose the source address used.\n                  type:
-    string\n                disableConntrackInvalidCheck:\n                  type:
-    boolean\n                endpointReportingDelay:\n                  type: string\n
-    \               endpointReportingEnabled:\n                  type: boolean\n                externalNodesList:\n
-    \                 description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes\n
-    \                   which may source tunnel traffic and have the tunneled traffic
-    be\n                    accepted at calico nodes.\n                  items:\n
-    \                   type: string\n                  type: array\n                failsafeInboundHostPorts:\n
-    \                 description: 'FailsafeInboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow incoming traffic to
-    host endpoints\n                    on irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    inbound host ports, use the value\n                    none. The default value
-    allows ssh access and DHCP. [Default: tcp:22,\n                    udp:68, tcp:179,
-    tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'\n                  items:\n
-    \                   description: ProtoPort is combination of protocol, port, and
-    CIDR.\n                      Protocol and port must be specified.\n                    properties:\n
-    \                     net:\n                        type: string\n                      port:\n
-    \                       type: integer\n                      protocol:\n                        type:
-    string\n                    required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                failsafeOutboundHostPorts:\n
-    \                 description: 'FailsafeOutboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow outgoing traffic from
-    host endpoints\n                    to irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    outbound host ports, use the value\n                    none. The default value
-    opens etcd''s standard ports to ensure that\n                    Felix does not
-    get cut off from etcd as well as allowing DHCP and\n                    DNS. [Default:
-    tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,\n                    tcp:6667,
-    udp:53, udp:67]'\n                  items:\n                    description: ProtoPort
-    is combination of protocol, port, and CIDR.\n                      Protocol and
-    port must be specified.\n                    properties:\n                      net:\n
-    \                       type: string\n                      port:\n                        type:
-    integer\n                      protocol:\n                        type: string\n
-    \                   required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                featureDetectOverride:\n
-    \                 description: FeatureDetectOverride is used to override the feature\n
-    \                   detection. Values are specified in a comma separated list
-    with no\n                    spaces, example; \"SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=\".\n
-    \                   \"true\" or \"false\" will force the feature, empty or omitted
-    values\n                    are auto-detected.\n                  type: string\n
-    \               genericXDPEnabled:\n                  description: 'GenericXDPEnabled
-    enables Generic XDP so network cards\n                  that don''t support XDP
-    offload or driver modes can use XDP. This\n                  is not recommended
-    since it doesn''t provide better performance\n                  than iptables.
-    [Default: false]'\n                  type: boolean\n                healthEnabled:\n
-    \                 type: boolean\n                healthHost:\n                  type:
-    string\n                healthPort:\n                  type: integer\n                interfaceExclude:\n
-    \                 description: 'InterfaceExclude is a comma-separated list of
-    interfaces\n                  that Felix should exclude when monitoring for host
-    endpoints. The\n                  default value ensures that Felix ignores Kubernetes''
-    IPVS dummy\n                  interface, which is used internally by kube-proxy.
-    If you want to\n                  exclude multiple interface names using a single
-    value, the list\n                  supports regular expressions. For regular expressions
-    you must wrap\n                  the value with ''/''. For example having values
-    ''/^kube/,veth1''\n                  will exclude all interfaces that begin with
-    ''kube'' and also the\n                  interface ''veth1''. [Default: kube-ipvs0]'\n
-    \                 type: string\n                interfacePrefix:\n                  description:
-    'InterfacePrefix is the interface name prefix that identifies\n                  workload
-    endpoints and so distinguishes them from host endpoint\n                  interfaces.
-    Note: in environments other than bare metal, the orchestrators\n                  configure
-    this appropriately. For example our Kubernetes and Docker\n                  integrations
-    set the ‘cali’ value, and our OpenStack integration\n                  sets the
-    ‘tap’ value. [Default: cali]'\n                  type: string\n                interfaceRefreshInterval:\n
-    \                 description: InterfaceRefreshInterval is the period at which
-    Felix\n                    rescans local interfaces to verify their state. The
-    rescan can be\n                    disabled by setting the interval to 0.\n                  type:
-    string\n                ipipEnabled:\n                  type: boolean\n                ipipMTU:\n
-    \                 description: 'IPIPMTU is the MTU to set on the tunnel device.
-    See\n                  Configuring MTU [Default: 1440]'\n                  type:
-    integer\n                ipsetsRefreshInterval:\n                  description:
-    'IpsetsRefreshInterval is the period at which Felix re-checks\n                  all
-    iptables state to ensure that no other process has accidentally\n                  broken
-    Calico’s rules. Set to 0 to disable iptables refresh. [Default:\n                  90s]'\n
-    \                 type: string\n                iptablesBackend:\n                  description:
-    IptablesBackend specifies which backend of iptables will\n                    be
-    used. The default is legacy.\n                  type: string\n                iptablesFilterAllowAction:\n
-    \                 type: string\n                iptablesLockFilePath:\n                  description:
-    'IptablesLockFilePath is the location of the iptables\n                  lock
-    file. You may need to change this if the lock file is not in\n                  its
-    standard location (for example if you have mapped it into Felix’s\n                  container
-    at a different path). [Default: /run/xtables.lock]'\n                  type: string\n
-    \               iptablesLockProbeInterval:\n                  description: 'IptablesLockProbeInterval
-    is the time that Felix will\n                  wait between attempts to acquire
-    the iptables lock if it is not\n                  available. Lower values make
-    Felix more responsive when the lock\n                  is contended, but use more
-    CPU. [Default: 50ms]'\n                  type: string\n                iptablesLockTimeout:\n
-    \                 description: 'IptablesLockTimeout is the time that Felix will
-    wait\n                  for the iptables lock, or 0, to disable. To use this feature,
-    Felix\n                  must share the iptables lock file with all other processes
-    that\n                  also take the lock. When running Felix inside a container,
-    this\n                  requires the /run directory of the host to be mounted
-    into the calico/node\n                  or calico/felix container. [Default: 0s
-    disabled]'\n                  type: string\n                iptablesMangleAllowAction:\n
-    \                 type: string\n                iptablesMarkMask:\n                  description:
-    'IptablesMarkMask is the mask that Felix selects its\n                  IPTables
-    Mark bits from. Should be a 32 bit hexadecimal number with\n                  at
-    least 8 bits set, none of which clash with any other mark bits\n                  in
-    use on the system. [Default: 0xff000000]'\n                  format: int32\n                  type:
-    integer\n                iptablesNATOutgoingInterfaceFilter:\n                  type:
-    string\n                iptablesPostWriteCheckInterval:\n                  description:
-    'IptablesPostWriteCheckInterval is the period after Felix\n                  has
-    done a write to the dataplane that it schedules an extra read\n                  back
-    in order to check the write was not clobbered by another process.\n                  This
-    should only occur if another application on the system doesn’t\n                  respect
-    the iptables lock. [Default: 1s]'\n                  type: string\n                iptablesRefreshInterval:\n
-    \                 description: 'IptablesRefreshInterval is the period at which
-    Felix\n                    re-checks the IP sets in the dataplane to ensure that
-    no other process\n                    has accidentally broken Calico''s rules.
-    Set to 0 to disable IP\n                    sets refresh. Note: the default for
-    this value is lower than the\n                    other refresh intervals as a
-    workaround for a Linux kernel bug that\n                    was fixed in kernel
-    version 4.11. If you are using v4.11 or greater\n                    you may want
-    to set this to, a higher value to reduce Felix CPU\n                    usage.
-    [Default: 10s]'\n                  type: string\n                ipv6Support:\n
-    \                 type: boolean\n                kubeNodePortRanges:\n                  description:
-    'KubeNodePortRanges holds list of port ranges used for\n                  service
-    node ports. Only used if felix detects kube-proxy running\n                  in
-    ipvs mode. Felix uses these ranges to separate host and workload\n                  traffic.
-    [Default: 30000:32767].'\n                  items:\n                    anyOf:\n
-    \                     - type: integer\n                      - type: string\n
-    \                   pattern: ^.*\n                    x-kubernetes-int-or-string:
-    true\n                  type: array\n                logFilePath:\n                  description:
-    'LogFilePath is the full path to the Felix log. Set to\n                  none
-    to disable file logging. [Default: /var/log/calico/felix.log]'\n                  type:
-    string\n                logPrefix:\n                  description: 'LogPrefix
-    is the log prefix that Felix uses when rendering\n                  LOG rules.
-    [Default: calico-packet]'\n                  type: string\n                logSeverityFile:\n
-    \                 description: 'LogSeverityFile is the log severity above which
-    logs\n                  are sent to the log file. [Default: Info]'\n                  type:
-    string\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: Info]'\n                  type: string\n                logSeveritySys:\n
-    \                 description: 'LogSeveritySys is the log severity above which
-    logs\n                  are sent to the syslog. Set to None for no logging to
-    syslog. [Default:\n                  Info]'\n                  type: string\n
-    \               maxIpsetSize:\n                  type: integer\n                metadataAddr:\n
-    \                 description: 'MetadataAddr is the IP address or domain name
-    of the\n                  server that can answer VM queries for cloud-init metadata.
-    In OpenStack,\n                  this corresponds to the machine running nova-api
-    (or in Ubuntu,\n                  nova-api-metadata). A value of none (case insensitive)
-    means that\n                  Felix should not set up any NAT rule for the metadata
-    path. [Default:\n                  127.0.0.1]'\n                  type: string\n
-    \               metadataPort:\n                  description: 'MetadataPort is
-    the port of the metadata server. This,\n                  combined with global.MetadataAddr
-    (if not ‘None’), is used to set\n                  up a NAT rule, from 169.254.169.254:80
-    to MetadataAddr:MetadataPort.\n                  In most cases this should not
-    need to be changed [Default: 8775].'\n                  type: integer\n                mtuIfacePattern:\n
-    \                 description: MTUIfacePattern is a regular expression that controls\n
-    \                   which interfaces Felix should scan in order to calculate the
-    host's\n                    MTU. This should not match workload interfaces (usually
-    named cali...).\n                  type: string\n                natOutgoingAddress:\n
-    \                 description: NATOutgoingAddress specifies an address to use
-    when performing\n                    source NAT for traffic in a natOutgoing pool
-    that is leaving the\n                    network. By default the address used
-    is an address on the interface\n                    the traffic is leaving on
-    (ie it uses the iptables MASQUERADE target)\n                  type: string\n
-    \               natPortRange:\n                  anyOf:\n                    -
-    type: integer\n                    - type: string\n                  description:
-    NATPortRange specifies the range of ports that is used\n                    for
-    port mapping when doing outgoing NAT. When unset the default\n                    behavior
-    of the network stack is used.\n                  pattern: ^.*\n                  x-kubernetes-int-or-string:
-    true\n                netlinkTimeout:\n                  type: string\n                openstackRegion:\n
-    \                 description: 'OpenstackRegion is the name of the region that
-    a particular\n                  Felix belongs to. In a multi-region Calico/OpenStack
-    deployment,\n                  this must be configured somehow for each Felix
-    (here in the datamodel,\n                  or in felix.cfg or the environment
-    on each compute node), and must\n                  match the [calico] openstack_region
-    value configured in neutron.conf\n                  on each node. [Default: Empty]'\n
-    \                 type: string\n                policySyncPathPrefix:\n                  description:
-    'PolicySyncPathPrefix is used to by Felix to communicate\n                  policy
-    changes to external services, like Application layer policy.\n                  [Default:
-    Empty]'\n                  type: string\n                prometheusGoMetricsEnabled:\n
-    \                 description: 'PrometheusGoMetricsEnabled disables Go runtime
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                prometheusMetricsEnabled:\n                  description:
-    'PrometheusMetricsEnabled enables the Prometheus metrics\n                  server
-    in Felix if set to true. [Default: false]'\n                  type: boolean\n
-    \               prometheusMetricsHost:\n                  description: 'PrometheusMetricsHost
-    is the host that the Prometheus\n                  metrics server should bind
-    to. [Default: empty]'\n                  type: string\n                prometheusMetricsPort:\n
-    \                 description: 'PrometheusMetricsPort is the TCP port that the
-    Prometheus\n                  metrics server should bind to. [Default: 9091]'\n
-    \                 type: integer\n                prometheusProcessMetricsEnabled:\n
-    \                 description: 'PrometheusProcessMetricsEnabled disables process
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                removeExternalRoutes:\n                  description:
-    Whether or not to remove device routes that have not\n                    been
-    programmed by Felix. Disabling this will allow external applications\n                    to
-    also add device routes. This is enabled by default which means\n                    we
-    will remove externally added routes.\n                  type: boolean\n                reportingInterval:\n
-    \                 description: 'ReportingInterval is the interval at which Felix
-    reports\n                  its status into the datastore or 0 to disable. Must
-    be non-zero\n                  in OpenStack deployments. [Default: 30s]'\n                  type:
-    string\n                reportingTTL:\n                  description: 'ReportingTTL
-    is the time-to-live setting for process-wide\n                  status reports.
-    [Default: 90s]'\n                  type: string\n                routeRefreshInterval:\n
-    \                 description: 'RouterefreshInterval is the period at which Felix
-    re-checks\n                  the routes in the dataplane to ensure that no other
-    process has\n                  accidentally broken Calico’s rules. Set to 0 to
-    disable route refresh.\n                  [Default: 90s]'\n                  type:
-    string\n                routeSource:\n                  description: 'RouteSource
-    configures where Felix gets its routing\n                  information. - WorkloadIPs:
-    use workload endpoints to construct\n                  routes. - CalicoIPAM: the
-    default - use IPAM data to construct routes.'\n                  type: string\n
-    \               routeTableRange:\n                  description: Calico programs
-    additional Linux route tables for various\n                    purposes.  RouteTableRange
-    specifies the indices of the route tables\n                    that Calico should
-    use.\n                  properties:\n                    max:\n                      type:
-    integer\n                    min:\n                      type: integer\n                  required:\n
-    \                   - max\n                    - min\n                  type:
-    object\n                serviceLoopPrevention:\n                  description:
-    'When service IP advertisement is enabled, prevent routing\n                    loops
-    to service IPs that are not in use, by dropping or rejecting\n                    packets
-    that do not get DNAT''d by kube-proxy. Unless set to \"Disabled\",\n                    in
-    which case such routing loops continue to be allowed. [Default:\n                    Drop]'\n
-    \                 type: string\n                sidecarAccelerationEnabled:\n
-    \                 description: 'SidecarAccelerationEnabled enables experimental
-    sidecar\n                  acceleration [Default: false]'\n                  type:
-    boolean\n                usageReportingEnabled:\n                  description:
-    'UsageReportingEnabled reports anonymous Calico version\n                  number
-    and cluster size to projectcalico.org. Logs warnings returned\n                  by
-    the usage server. For example, if a significant security vulnerability\n                  has
-    been discovered in the version of Calico being used. [Default:\n                  true]'\n
-    \                 type: boolean\n                usageReportingInitialDelay:\n
-    \                 description: 'UsageReportingInitialDelay controls the minimum
-    delay\n                  before Felix makes a report. [Default: 300s]'\n                  type:
-    string\n                usageReportingInterval:\n                  description:
-    'UsageReportingInterval controls the interval at which\n                  Felix
-    makes reports. [Default: 86400s]'\n                  type: string\n                useInternalDataplaneDriver:\n
-    \                 type: boolean\n                vxlanEnabled:\n                  type:
-    boolean\n                vxlanMTU:\n                  description: 'VXLANMTU is
-    the MTU to set on the tunnel device. See\n                  Configuring MTU [Default:
-    1440]'\n                  type: integer\n                vxlanPort:\n                  type:
-    integer\n                vxlanVNI:\n                  type: integer\n                wireguardEnabled:\n
-    \                 description: 'WireguardEnabled controls whether Wireguard is
-    enabled.\n                  [Default: false]'\n                  type: boolean\n
-    \               wireguardInterfaceName:\n                  description: 'WireguardInterfaceName
-    specifies the name to use for\n                  the Wireguard interface. [Default:
-    wg.calico]'\n                  type: string\n                wireguardListeningPort:\n
-    \                 description: 'WireguardListeningPort controls the listening
-    port used\n                  by Wireguard. [Default: 51820]'\n                  type:
-    integer\n                wireguardMTU:\n                  description: 'WireguardMTU
-    controls the MTU on the Wireguard interface.\n                  See Configuring
-    MTU [Default: 1420]'\n                  type: integer\n                wireguardRoutingRulePriority:\n
-    \                 description: 'WireguardRoutingRulePriority controls the priority
-    value\n                  to use for the Wireguard routing rule. [Default: 99]'\n
-    \                 type: integer\n                xdpEnabled:\n                  description:
-    'XDPEnabled enables XDP acceleration for suitable untracked\n                  incoming
-    deny rules. [Default: true]'\n                  type: boolean\n                xdpRefreshInterval:\n
-    \                 description: 'XDPRefreshInterval is the period at which Felix
-    re-checks\n                  all XDP state to ensure that no other process has
-    accidentally broken\n                  Calico''s BPF maps or attached programs.
-    Set to 0 to disable XDP\n                  refresh. [Default: 90s]'\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: globalnetworkpolicies.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: GlobalNetworkPolicy\n    listKind:
-    GlobalNetworkPolicyList\n    plural: globalnetworkpolicies\n    singular: globalnetworkpolicy\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                applyOnForward:\n
-    \                 description: ApplyOnForward indicates to apply the rules in
-    this policy\n                    on forward traffic.\n                  type:
-    boolean\n                doNotTrack:\n                  description: DoNotTrack
-    indicates whether packets matched by the rules\n                    in this policy
-    should go through the data plane's connection tracking,\n                    such
-    as Linux conntrack.  If True, the rules in this policy are\n                    applied
-    before any data plane connection tracking, and packets allowed\n                    by
-    this policy are marked as not to be tracked.\n                  type: boolean\n
-    \               egress:\n                  description: The ordered set of egress
-    rules.  Each rule contains\n                    a set of packet match criteria
-    and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                namespaceSelector:\n                  description: NamespaceSelector
-    is an optional field for an expression\n                    used to select a pod
-    based on namespaces.\n                  type: string\n                order:\n
-    \                 description: Order is an optional field that specifies the order
-    in\n                    which the policy is applied. Policies with higher \"order\"
-    are applied\n                    after those with lower order.  If the order is
-    omitted, it may be\n                    considered to be \"infinite\" - i.e. the
-    policy will be applied last.  Policies\n                    with identical order
-    will be applied in alphanumerical order based\n                    on the Policy
-    \"Name\".\n                  type: number\n                preDNAT:\n                  description:
-    PreDNAT indicates to apply the rules in this policy before\n                    any
-    DNAT.\n                  type: boolean\n                selector:\n                  description:
-    \"The selector is an expression used to pick pick out\n                  the endpoints
-    that the policy should be applied to. \\n Selector\n                  expressions
-    follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n                  \\
-    ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel != \\\"string_literal\\\"\n
-    \                 \\  ->  not equal; also matches if label is not present \\tlabel
-    in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\", ... }  ->  true if the
-    value of label X is\n                  one of \\\"a\\\", \\\"b\\\", \\\"c\\\"
-    \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ... }  ->
-    \ true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress rules are present
-    in the policy.  The\n                  default is: \\n - [ PolicyTypeIngress ],
-    if there are no Egress rules\n                  (including the case where there
-    are   also no Ingress rules) \\n\n                  - [ PolicyTypeEgress ], if
-    there are Egress rules but no Ingress\n                  rules \\n - [ PolicyTypeIngress,
-    PolicyTypeEgress ], if there are\n                  both Ingress and Egress rules.
-    \\n When the policy is read back again,\n                  Types will always be
-    one of these values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: globalnetworksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: GlobalNetworkSet\n    listKind: GlobalNetworkSetList\n    plural:
-    globalnetworksets\n    singular: globalnetworkset\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs\n            that
-    share labels to allow rules to refer to them via selectors.  The labels\n            of
-    GlobalNetworkSet are not namespaced.\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: GlobalNetworkSetSpec contains the
-    specification for a NetworkSet\n                resource.\n              properties:\n
-    \               nets:\n                  description: The list of IP networks
-    that belong to this set.\n                  items:\n                    type:
-    string\n                  type: array\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: hostendpoints.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: HostEndpoint\n    listKind: HostEndpointList\n    plural:
-    hostendpoints\n    singular: hostendpoint\n  scope: Cluster\n  versions:\n    -
-    name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: HostEndpointSpec contains the specification
-    for a HostEndpoint\n                resource.\n              properties:\n                expectedIPs:\n
-    \                 description: \"The expected IP addresses (IPv4 and IPv6) of
-    the endpoint.\n                  If \\\"InterfaceName\\\" is not present, Calico
-    will look for an interface\n                  matching any of the IPs in the list
-    and apply policy to that. Note:\n                  \\tWhen using the selector
-    match criteria in an ingress or egress\n                  security Policy \\tor
-    Profile, Calico converts the selector into\n                  a set of IP addresses.
-    For host \\tendpoints, the ExpectedIPs field\n                  is used for that
-    purpose. (If only the interface \\tname is specified,\n                  Calico
-    does not learn the IPs of the interface for use in match\n                  \\tcriteria.)\"\n
-    \                 items:\n                    type: string\n                  type:
-    array\n                interfaceName:\n                  description: \"Either
-    \\\"*\\\", or the name of a specific Linux interface\n                  to apply
-    policy to; or empty.  \\\"*\\\" indicates that this HostEndpoint\n                  governs
-    all traffic to, from or through the default network namespace\n                  of
-    the host named by the \\\"Node\\\" field; entering and leaving that\n                  namespace
-    via any interface, including those from/to non-host-networked\n                  local
-    workloads. \\n If InterfaceName is not \\\"*\\\", this HostEndpoint\n                  only
-    governs traffic that enters or leaves the host through the\n                  specific
-    interface named by InterfaceName, or - when InterfaceName\n                  is
-    empty - through the specific interface that has one of the IPs\n                  in
-    ExpectedIPs. Therefore, when InterfaceName is empty, at least\n                  one
-    expected IP must be specified.  Only external interfaces (such\n                  as
-    “eth0”) are supported here; it isn't possible for a HostEndpoint\n                  to
-    protect traffic through a specific local workload interface.\n                  \\n
-    Note: Only some kinds of policy are implemented for \\\"*\\\" HostEndpoints;\n
-    \                 initially just pre-DNAT policy.  Please check Calico documentation\n
-    \                 for the latest position.\"\n                  type: string\n
-    \               node:\n                  description: The node name identifying
-    the Calico node instance.\n                  type: string\n                ports:\n
-    \                 description: Ports contains the endpoint's named ports, which
-    may\n                    be referenced in security policy rules.\n                  items:\n
-    \                   properties:\n                      name:\n                        type:
-    string\n                      port:\n                        type: integer\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                    required:\n                      - name\n                      -
-    port\n                      - protocol\n                    type: object\n                  type:
-    array\n                profiles:\n                  description: A list of identifiers
-    of security Profile objects that\n                    apply to this endpoint.
-    Each profile is applied in the order that\n                    they appear in
-    this list.  Profile rules are applied after the selector-based\n                    security
-    policy.\n                  items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: ipamblocks.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMBlock\n    listKind: IPAMBlockList\n
-    \   plural: ipamblocks\n    singular: ipamblock\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMBlockSpec contains the specification
-    for an IPAMBlock\n                resource.\n              properties:\n                affinity:\n
-    \                 type: string\n                allocations:\n                  items:\n
-    \                   type: integer\n                    # TODO: This nullable is
-    manually added in. We should update controller-gen\n                    # to handle
-    []*int properly itself.\n                    nullable: true\n                  type:
-    array\n                attributes:\n                  items:\n                    properties:\n
-    \                     handle_id:\n                        type: string\n                      secondary:\n
-    \                       additionalProperties:\n                          type:
-    string\n                        type: object\n                    type: object\n
-    \                 type: array\n                cidr:\n                  type:
-    string\n                deleted:\n                  type: boolean\n                strictAffinity:\n
-    \                 type: boolean\n                unallocated:\n                  items:\n
-    \                   type: integer\n                  type: array\n              required:\n
-    \               - allocations\n                - attributes\n                -
-    cidr\n                - strictAffinity\n                - unallocated\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMConfig\n    listKind: IPAMConfigList\n    plural: ipamconfigs\n
-    \   singular: ipamconfig\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMConfigSpec contains the specification
-    for an IPAMConfig\n                resource.\n              properties:\n                autoAllocateBlocks:\n
-    \                 type: boolean\n                maxBlocksPerHost:\n                  description:
-    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                    that
-    can be affine to each host.\n                  type: integer\n                strictAffinity:\n
-    \                 type: boolean\n              required:\n                - autoAllocateBlocks\n
-    \               - strictAffinity\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ipamhandles.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMHandle\n    listKind: IPAMHandleList\n    plural: ipamhandles\n
-    \   singular: ipamhandle\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMHandleSpec contains the specification
-    for an IPAMHandle\n                resource.\n              properties:\n                block:\n
-    \                 additionalProperties:\n                    type: integer\n                  type:
-    object\n                deleted:\n                  type: boolean\n                handleID:\n
-    \                 type: string\n              required:\n                - block\n
-    \               - handleID\n              type: object\n          type: object\n
-    \     served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ippools.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPPool\n    listKind: IPPoolList\n    plural: ippools\n    singular:
-    ippool\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPPoolSpec contains the specification
-    for an IPPool resource.\n              properties:\n                blockSize:\n
-    \                 description: The block size to use for IP address assignments
-    from\n                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.\n
-    \                 type: integer\n                cidr:\n                  description:
-    The pool CIDR.\n                  type: string\n                disabled:\n                  description:
-    When disabled is true, Calico IPAM will not assign addresses\n                    from
-    this pool.\n                  type: boolean\n                ipip:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  properties:\n                    enabled:\n                      description:
-    When enabled is true, ipip tunneling will be used\n                        to
-    deliver packets to destinations within this pool.\n                      type:
-    boolean\n                    mode:\n                      description: The IPIP
-    mode.  This can be one of \"always\" or \"cross-subnet\".  A\n                        mode
-    of \"always\" will also use IPIP tunneling for routing to\n                        destination
-    IP addresses within this pool.  A mode of \"cross-subnet\"\n                        will
-    only use IPIP tunneling when the destination node is on\n                        a
-    different subnet to the originating node.  The default value\n                        (if
-    not specified) is \"always\".\n                      type: string\n                  type:
-    object\n                ipipMode:\n                  description: Contains configuration
-    for IPIP tunneling for this pool.\n                    If not specified, then
-    this is defaulted to \"Never\" (i.e. IPIP tunneling\n                    is disabled).\n
-    \                 type: string\n                nat-outgoing:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  type: boolean\n                natOutgoing:\n                  description:
-    When nat-outgoing is true, packets sent from Calico networked\n                    containers
-    in this pool to destinations outside of this pool will\n                    be
-    masqueraded.\n                  type: boolean\n                nodeSelector:\n
-    \                 description: Allows IPPool to allocate for a specific node by
-    label\n                    selector.\n                  type: string\n                vxlanMode:\n
-    \                 description: Contains configuration for VXLAN tunneling for
-    this pool.\n                    If not specified, then this is defaulted to \"Never\"
-    (i.e. VXLAN\n                    tunneling is disabled).\n                  type:
-    string\n              required:\n                - cidr\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: kubecontrollersconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: KubeControllersConfiguration\n    listKind: KubeControllersConfigurationList\n
-    \   plural: kubecontrollersconfigurations\n    singular: kubecontrollersconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: KubeControllersConfigurationSpec
-    contains the values of the\n                Kubernetes controllers configuration.\n
-    \             properties:\n                controllers:\n                  description:
-    Controllers enables and configures individual Kubernetes\n                    controllers\n
-    \                 properties:\n                    namespace:\n                      description:
-    Namespace enables and configures the namespace controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   node:\n                      description: Node enables and
-    configures the node controller.\n                        Enabled by default, set
-    to nil to disable.\n                      properties:\n                        hostEndpoint:\n
-    \                         description: HostEndpoint controls syncing nodes to
-    host endpoints.\n                            Disabled by default, set to nil to
-    disable.\n                          properties:\n                            autoCreate:\n
-    \                             description: 'AutoCreate enables automatic creation
-    of\n                              host endpoints for every node. [Default: Disabled]'\n
-    \                             type: string\n                          type: object\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                       syncLabels:\n                          description: 'SyncLabels
-    controls whether to copy Kubernetes\n                          node labels to
-    Calico nodes. [Default: Enabled]'\n                          type: string\n                      type:
-    object\n                    policy:\n                      description: Policy
-    enables and configures the policy controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   serviceAccount:\n                      description: ServiceAccount
-    enables and configures the service\n                        account controller.
-    Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                    workloadEndpoint:\n                      description:
-    WorkloadEndpoint enables and configures the workload\n                        endpoint
-    controller. Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                  type: object\n                etcdV3CompactionPeriod:\n
-    \                 description: 'EtcdV3CompactionPeriod is the period between etcdv3\n
-    \                 compaction requests. Set to 0 to disable. [Default: 10m]'\n
-    \                 type: string\n                healthChecks:\n                  description:
-    'HealthChecks enables or disables support for health\n                  checks
-    [Default: Enabled]'\n                  type: string\n                logSeverityScreen:\n
-    \                 description: 'LogSeverityScreen is the log severity above which
-    logs\n                  are sent to the stdout. [Default: Info]'\n                  type:
-    string\n                prometheusMetricsPort:\n                  description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                    metrics
-    server should bind to. Set to 0 to disable. [Default: 9094]'\n                  type:
-    integer\n              required:\n                - controllers\n              type:
-    object\n            status:\n              description: KubeControllersConfigurationStatus
-    represents the status\n                of the configuration. It's useful for admins
-    to be able to see the actual\n                config that was applied, which can
-    be modified by environment variables\n                on the kube-controllers
-    process.\n              properties:\n                environmentVars:\n                  additionalProperties:\n
-    \                   type: string\n                  description: EnvironmentVars
-    contains the environment variables on\n                    the kube-controllers
-    that influenced the RunningConfig.\n                  type: object\n                runningConfig:\n
-    \                 description: RunningConfig contains the effective config that
-    is running\n                    in the kube-controllers pod, after merging the
-    API resource with\n                    any environment variables.\n                  properties:\n
-    \                   controllers:\n                      description: Controllers
-    enables and configures individual Kubernetes\n                        controllers\n
-    \                     properties:\n                        namespace:\n                          description:
-    Namespace enables and configures the namespace\n                            controller.
-    Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        node:\n
-    \                         description: Node enables and configures the node controller.\n
-    \                           Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           hostEndpoint:\n                              description:
-    HostEndpoint controls syncing nodes to host\n                                endpoints.
-    Disabled by default, set to nil to disable.\n                              properties:\n
-    \                               autoCreate:\n                                  description:
-    'AutoCreate enables automatic creation\n                                  of host
-    endpoints for every node. [Default: Disabled]'\n                                  type:
-    string\n                              type: object\n                            leakGracePeriod:\n
-    \                             description: 'LeakGracePeriod is the period used
-    by the\n                                controller to determine if an IP address
-    has been leaked.\n                                Set to 0 to disable IP garbage
-    collection. [Default:\n                                15m]'\n                              type:
-    string\n                            reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                            syncLabels:\n                              description:
-    'SyncLabels controls whether to copy Kubernetes\n                              node
-    labels to Calico nodes. [Default: Enabled]'\n                              type:
-    string\n                          type: object\n                        policy:\n
-    \                         description: Policy enables and configures the policy
-    controller.\n                            Enabled by default, set to nil to disable.\n
-    \                         properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        serviceAccount:\n
-    \                         description: ServiceAccount enables and configures the
-    service\n                            account controller. Enabled by default, set
-    to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        workloadEndpoint:\n
-    \                         description: WorkloadEndpoint enables and configures
-    the workload\n                            endpoint controller. Enabled by default,
-    set to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                      type: object\n
-    \                   etcdV3CompactionPeriod:\n                      description:
-    'EtcdV3CompactionPeriod is the period between etcdv3\n                      compaction
-    requests. Set to 0 to disable. [Default: 10m]'\n                      type: string\n
-    \                   healthChecks:\n                      description: 'HealthChecks
-    enables or disables support for health\n                      checks [Default:
-    Enabled]'\n                      type: string\n                    logSeverityScreen:\n
-    \                     description: 'LogSeverityScreen is the log severity above
-    which\n                      logs are sent to the stdout. [Default: Info]'\n                      type:
-    string\n                    prometheusMetricsPort:\n                      description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                        metrics
-    server should bind to. Set to 0 to disable. [Default:\n                        9094]'\n
-    \                     type: integer\n                  required:\n                    -
-    controllers\n                  type: object\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: networkpolicies.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkPolicy\n    listKind: NetworkPolicyList\n    plural:
-    networkpolicies\n    singular: networkpolicy\n  scope: Namespaced\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                egress:\n                  description:
-    The ordered set of egress rules.  Each rule contains\n                    a set
-    of packet match criteria and a corresponding action to apply.\n                  items:\n
-    \                   description: \"A Rule encapsulates a set of match criteria
-    and an\n                    action.  Both selector-based security Policy and security
-    Profiles\n                    reference rules - separated out as a list of rules
-    for both ingress\n                    and egress packet matching. \\n Each positive
-    match criteria has\n                    a negated version, prefixed with ”Not”.
-    All the match criteria\n                    within a rule must be satisfied for
-    a packet to match. A single\n                    rule can contain the positive
-    and negative version of a match\n                    and both must be satisfied
-    for the rule to match.\"\n                    properties:\n                      action:\n
-    \                       type: string\n                      destination:\n                        description:
-    Destination contains the match criteria that apply\n                          to
-    destination entity.\n                        properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                order:\n                  description: Order is an optional
-    field that specifies the order in\n                    which the policy is applied.
-    Policies with higher \"order\" are applied\n                    after those with
-    lower order.  If the order is omitted, it may be\n                    considered
-    to be \"infinite\" - i.e. the policy will be applied last.  Policies\n                    with
-    identical order will be applied in alphanumerical order based\n                    on
-    the Policy \"Name\".\n                  type: number\n                selector:\n
-    \                 description: \"The selector is an expression used to pick pick
-    out\n                  the endpoints that the policy should be applied to. \\n
-    Selector\n                  expressions follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n
-    \                 \\ ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel
-    != \\\"string_literal\\\"\n                  \\  ->  not equal; also matches if
-    label is not present \\tlabel in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\",
-    ... }  ->  true if the value of label X is\n                  one of \\\"a\\\",
-    \\\"b\\\", \\\"c\\\" \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ...
-    }  ->  true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress are present in the
-    policy.  The default\n                  is: \\n - [ PolicyTypeIngress ], if there
-    are no Egress rules (including\n                  the case where there are   also
-    no Ingress rules) \\n - [ PolicyTypeEgress\n                  ], if there are
-    Egress rules but no Ingress rules \\n - [ PolicyTypeIngress,\n                  PolicyTypeEgress
-    ], if there are both Ingress and Egress rules.\n                  \\n When the
-    policy is read back again, Types will always be one\n                  of these
-    values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: networksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkSet\n    listKind: NetworkSetList\n    plural: networksets\n
-    \   singular: networkset\n  scope: Namespaced\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          description: NetworkSet is the Namespaced-equivalent
-    of the GlobalNetworkSet.\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: NetworkSetSpec contains the specification
-    for a NetworkSet\n                resource.\n              properties:\n                nets:\n
-    \                 description: The list of IP networks that belong to this set.\n
-    \                 items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n---\n# Source: calico/templates/calico-kube-controllers-rbac.yaml\n\n#
-    Include a clusterrole for the kube-controllers component,\n# and bind it to the
-    calico-kube-controllers serviceaccount.\nkind: ClusterRole\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nrules:\n  # Nodes are watched to monitor for
-    deletions.\n  - apiGroups: [\"\"]\n    resources:\n      - nodes\n    verbs:\n
-    \     - watch\n      - list\n      - get\n  # Pods are watched to check for existence
-    as part of IPAM controller.\n  - apiGroups: [\"\"]\n    resources:\n      - pods\n
-    \   verbs:\n      - get\n      - list\n      - watch\n  # IPAM resources are manipulated
-    when nodes are deleted.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - ippools\n    verbs:\n      - list\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - blockaffinities\n      - ipamblocks\n      - ipamhandles\n
-    \   verbs:\n      - get\n      - list\n      - create\n      - update\n      -
-    delete\n      - watch\n  # kube-controllers manages hostendpoints.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - hostendpoints\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  #
-    Needs access to update clusterinformations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - clusterinformations\n    verbs:\n      - get\n      -
-    create\n      - update\n  # KubeControllersConfiguration is where it gets its
-    config\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - kubecontrollersconfigurations\n
-    \   verbs:\n      # read its own config\n      - get\n      # create a default
-    if none exists\n      - create\n      # update status\n      - update\n      #
-    watch for changes\n      - watch\n---\nkind: ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-kube-controllers\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-kube-controllers\n    namespace: kube-system\n---\n\n---\n# Source:
-    calico/templates/calico-node-rbac.yaml\n# Include a clusterrole for the calico-node
-    DaemonSet,\n# and bind it to the calico-node serviceaccount.\nkind: ClusterRole\napiVersion:
-    rbac.authorization.k8s.io/v1\nmetadata:\n  name: calico-node\nrules:\n  # The
-    CNI plugin needs to get pods, nodes, and namespaces.\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - pods\n      - nodes\n      - namespaces\n    verbs:\n
-    \     - get\n  # EndpointSlices are used for Service-based network policy rule\n
-    \ # enforcement.\n  - apiGroups: [\"discovery.k8s.io\"]\n    resources:\n      -
-    endpointslices\n    verbs:\n      - watch\n      - list\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - endpoints\n      - services\n    verbs:\n      # Used
-    to discover service IPs for advertisement.\n      - watch\n      - list\n      #
-    Used to discover Typhas.\n      - get\n  # Pod CIDR auto-detection on kubeadm
-    needs access to config maps.\n  - apiGroups: [\"\"]\n    resources:\n      - configmaps\n
-    \   verbs:\n      - get\n  - apiGroups: [\"\"]\n    resources:\n      - nodes/status\n
-    \   verbs:\n      # Needed for clearing NodeNetworkUnavailable flag.\n      -
-    patch\n      # Calico stores some configuration information in node annotations.\n
-    \     - update\n  # Watch for changes to Kubernetes NetworkPolicies.\n  - apiGroups:
-    [\"networking.k8s.io\"]\n    resources:\n      - networkpolicies\n    verbs:\n
-    \     - watch\n      - list\n  # Used by Calico for policy information.\n  - apiGroups:
-    [\"\"]\n    resources:\n      - pods\n      - namespaces\n      - serviceaccounts\n
-    \   verbs:\n      - list\n      - watch\n  # The CNI plugin patches pods/status.\n
-    \ - apiGroups: [\"\"]\n    resources:\n      - pods/status\n    verbs:\n      -
-    patch\n  # Calico monitors various CRDs for config.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - globalfelixconfigs\n      - felixconfigurations\n      -
-    bgppeers\n      - globalbgpconfigs\n      - bgpconfigurations\n      - ippools\n
-    \     - ipamblocks\n      - globalnetworkpolicies\n      - globalnetworksets\n
-    \     - networkpolicies\n      - networksets\n      - clusterinformations\n      -
-    hostendpoints\n      - blockaffinities\n    verbs:\n      - get\n      - list\n
-    \     - watch\n  # Calico must create and update some CRDs on startup.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - ippools\n      - felixconfigurations\n
-    \     - clusterinformations\n    verbs:\n      - create\n      - update\n  # Calico
-    stores some configuration information on the node.\n  - apiGroups: [\"\"]\n    resources:\n
-    \     - nodes\n    verbs:\n      - get\n      - list\n      - watch\n  # These
-    permissions are only required for upgrade from v2.6, and can\n  # be removed after
-    upgrade or on fresh installations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - bgpconfigurations\n      - bgppeers\n    verbs:\n      -
-    create\n      - update\n  # These permissions are required for Calico CNI to perform
-    IPAM allocations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n      - ipamblocks\n      - ipamhandles\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  -
-    apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - ipamconfigs\n
-    \   verbs:\n      - get\n  # Block affinities must also be watchable by confd
-    for route aggregation.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n    verbs:\n      - watch\n  # The Calico IPAM migration
-    needs to get daemonsets. These permissions can be\n  # removed if not upgrading
-    from an installation using host-local IPAM.\n  - apiGroups: [\"apps\"]\n    resources:\n
-    \     - daemonsets\n    verbs:\n      - get\n\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:
-    ClusterRoleBinding\nmetadata:\n  name: calico-node\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-node\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-node\n    namespace: kube-system\n\n---\n# Source: calico/templates/calico-node.yaml\n#
-    This manifest installs the calico-node container, as well\n# as the CNI plugins
-    and network config on\n# each master and worker node in a Kubernetes cluster.\nkind:
-    DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: calico-node\n  namespace: kube-system\n
-    \ labels:\n    k8s-app: calico-node\nspec:\n  selector:\n    matchLabels:\n      k8s-app:
-    calico-node\n  updateStrategy:\n    type: RollingUpdate\n    rollingUpdate:\n
-    \     maxUnavailable: 1\n  template:\n    metadata:\n      labels:\n        k8s-app:
-    calico-node\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n
-    \     hostNetwork: true\n      tolerations:\n        # Make sure calico-node gets
-    scheduled on all nodes.\n        - effect: NoSchedule\n          operator: Exists\n
-    \       # Mark the pod as a critical add-on for rescheduling.\n        - key:
-    CriticalAddonsOnly\n          operator: Exists\n        - effect: NoExecute\n
-    \         operator: Exists\n      serviceAccountName: calico-node\n      # Minimize
-    downtime during a rolling upgrade or deletion; tell Kubernetes to do a \"force\n
-    \     # deletion\": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.\n
-    \     terminationGracePeriodSeconds: 0\n      priorityClassName: system-node-critical\n
-    \     initContainers:\n        # This container performs upgrade from host-local
-    IPAM to calico-ipam.\n        # It can be deleted if this is a fresh installation,
-    or if you have already\n        # upgraded to use calico-ipam.\n        - name:
-    upgrade-ipam\n          image: calico/cni:v3.20.0\n          command: [\"/opt/cni/bin/calico-ipam\",
-    \"-upgrade\"]\n          envFrom:\n            - configMapRef:\n                #
-    Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for
-    eBPF mode.\n                name: kubernetes-services-endpoint\n                optional:
-    true\n          env:\n            - name: KUBERNETES_NODE_NAME\n              valueFrom:\n
-    \               fieldRef:\n                  fieldPath: spec.nodeName\n            -
-    name: CALICO_NETWORKING_BACKEND\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: calico_backend\n
-    \         volumeMounts:\n            - mountPath: /var/lib/cni/networks\n              name:
-    host-local-net-dir\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n          securityContext:\n            privileged: true\n        #
-    This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: calico/cni:v3.20.0\n
-    \         command: [\"/opt/cni/bin/install\"]\n          envFrom:\n            -
-    configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
-    to be overridden for eBPF mode.\n                name: kubernetes-services-endpoint\n
-    \               optional: true\n          env:\n            # Name of the CNI
-    config file to create.\n            - name: CNI_CONF_NAME\n              value:
-    \"10-calico.conflist\"\n            # The CNI network config to install on each
-    node.\n            - name: CNI_NETWORK_CONFIG\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: cni_network_config\n
-    \           # Set the hostname based on the k8s node name.\n            - name:
-    KUBERNETES_NODE_NAME\n              valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # CNI MTU Config variable\n            - name: CNI_MTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Prevents the container
-    from sleeping forever.\n            - name: SLEEP\n              value: \"false\"\n
-    \         volumeMounts:\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n            - mountPath: /host/etc/cni/net.d\n              name:
-    cni-net-dir\n          securityContext:\n            privileged: true\n        #
-    Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes\n
-    \       # to communicate with Felix over the Policy Sync API.\n        - name:
-    flexvol-driver\n          image: calico/pod2daemon-flexvol:v3.20.0\n          volumeMounts:\n
-    \           - name: flexvol-driver-host\n              mountPath: /host/driver\n
-    \         securityContext:\n            privileged: true\n      containers:\n
-    \       # Runs calico-node container on each Kubernetes node. This\n        #
-    container programs network policy and routes on each\n        # host.\n        -
-    name: calico-node\n          image: calico/node:v3.20.0\n          envFrom:\n
-    \           - configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and
-    KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.\n                name:
-    kubernetes-services-endpoint\n                optional: true\n          env:\n
-    \           # Use Kubernetes API as the backing datastore.\n            - name:
-    DATASTORE_TYPE\n              value: \"kubernetes\"\n            # Wait for the
-    datastore.\n            - name: WAIT_FOR_DATASTORE\n              value: \"true\"\n
-    \           # Set based on the k8s node name.\n            - name: NODENAME\n
-    \             valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # Choose the backend to use.\n            - name: CALICO_NETWORKING_BACKEND\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: calico_backend\n            # Cluster type
-    to identify the deployment type\n            - name: CLUSTER_TYPE\n              value:
-    \"k8s,bgp\"\n            # Auto-detect the BGP IP address.\n            - name:
-    IP\n              value: \"autodetect\"\n            # Enable VXLAN\n            -
-    name: CALICO_IPV4POOL_VXLAN\n              value: \"Always\"\n            # Set
-    MTU for tunnel device used if ipip is enabled\n            - name: FELIX_IPINIPMTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Set MTU for the
-    VXLAN tunnel device.\n            - name: FELIX_VXLANMTU\n              valueFrom:\n
-    \               configMapKeyRef:\n                  name: calico-config\n                  key:
-    veth_mtu\n            # Set MTU for the Wireguard tunnel device.\n            -
-    name: FELIX_WIREGUARDMTU\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: veth_mtu\n            #
-    The default IPv4 pool to create on startup if none exists. Pod IPs will be\n            #
-    chosen from this range. Changing this value after installation will have\n            #
-    no effect. This should fall within `--cluster-cidr`.\n            # - name: CALICO_IPV4POOL_CIDR\n
-    \           #   value: \"192.168.0.0/16\"\n            # Disable file logging
-    so `kubectl logs` works.\n            - name: CALICO_DISABLE_FILE_LOGGING\n              value:
-    \"true\"\n            # Set Felix endpoint to host default action to ACCEPT.\n
-    \           - name: FELIX_DEFAULTENDPOINTTOHOSTACTION\n              value: \"ACCEPT\"\n
-    \           # Disable IPv6 on Kubernetes.\n            - name: FELIX_IPV6SUPPORT\n
-    \             value: \"false\"\n            - name: FELIX_FEATUREDETECTOVERRIDE\n
-    \             value: \"ChecksumOffloadBroken=true\"\n            - name: FELIX_HEALTHENABLED\n
-    \             value: \"true\"\n          securityContext:\n            privileged:
-    true\n          resources:\n            requests:\n              cpu: 250m\n          livenessProbe:\n
-    \           exec:\n              command:\n                - /bin/calico-node\n
-    \               - -felix-live\n            periodSeconds: 10\n            initialDelaySeconds:
-    10\n            failureThreshold: 6\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /bin/calico-node\n                -
-    -felix-ready\n            periodSeconds: 10\n          volumeMounts:\n            -
-    mountPath: /host/etc/cni/net.d\n              name: cni-net-dir\n              readOnly:
-    false\n            - mountPath: /lib/modules\n              name: lib-modules\n
-    \             readOnly: true\n            - mountPath: /run/xtables.lock\n              name:
-    xtables-lock\n              readOnly: false\n            - mountPath: /var/run/calico\n
-    \             name: var-run-calico\n              readOnly: false\n            -
-    mountPath: /var/lib/calico\n              name: var-lib-calico\n              readOnly:
-    false\n            - name: policysync\n              mountPath: /var/run/nodeagent\n
-    \           # For eBPF mode, we need to be able to mount the BPF filesystem at
-    /sys/fs/bpf so we mount in the\n            # parent directory.\n            -
-    name: sysfs\n              mountPath: /sys/fs/\n              # Bidirectional
-    means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to
-    the host.\n              # If the host is known to mount that filesystem already
-    then Bidirectional can be omitted.\n              mountPropagation: Bidirectional\n
-    \           - name: cni-log-dir\n              mountPath: /var/log/calico/cni\n
-    \             readOnly: true\n      volumes:\n        # Used by calico-node.\n
-    \       - name: lib-modules\n          hostPath:\n            path: /lib/modules\n
-    \       - name: var-run-calico\n          hostPath:\n            path: /var/run/calico\n
-    \       - name: var-lib-calico\n          hostPath:\n            path: /var/lib/calico\n
-    \       - name: xtables-lock\n          hostPath:\n            path: /run/xtables.lock\n
-    \           type: FileOrCreate\n        - name: sysfs\n          hostPath:\n            path:
-    /sys/fs/\n            type: DirectoryOrCreate\n        # Used to install CNI.\n
-    \       - name: cni-bin-dir\n          hostPath:\n            path: /opt/cni/bin\n
-    \       - name: cni-net-dir\n          hostPath:\n            path: /etc/cni/net.d\n
-    \       # Used to access CNI logs.\n        - name: cni-log-dir\n          hostPath:\n
-    \           path: /var/log/calico/cni\n        # Mount in the directory for host-local
-    IPAM allocations. This is\n        # used when upgrading from host-local to calico-ipam,
-    and can be removed\n        # if not using the upgrade-ipam init container.\n
-    \       - name: host-local-net-dir\n          hostPath:\n            path: /var/lib/cni/networks\n
-    \       # Used to create per-pod Unix Domain Sockets\n        - name: policysync\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /var/run/nodeagent\n
-    \       # Used to install Flex Volume Driver\n        - name: flexvol-driver-host\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds\n---\n\napiVersion:
-    v1\nkind: ServiceAccount\nmetadata:\n  name: calico-node\n  namespace: kube-system\n\n---\n#
-    Source: calico/templates/calico-kube-controllers.yaml\n# See https://github.com/projectcalico/kube-controllers\napiVersion:
-    apps/v1\nkind: Deployment\nmetadata:\n  name: calico-kube-controllers\n  namespace:
-    kube-system\n  labels:\n    k8s-app: calico-kube-controllers\nspec:\n  # The controllers
-    can only have a single active instance.\n  replicas: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n  strategy:\n    type: Recreate\n  template:\n
-    \   metadata:\n      name: calico-kube-controllers\n      namespace: kube-system\n
-    \     labels:\n        k8s-app: calico-kube-controllers\n    spec:\n      nodeSelector:\n
-    \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
-    a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
-    Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
-    \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
-    \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
-    \         env:\n            # Choose which controllers to run.\n            -
-    name: ENABLED_CONTROLLERS\n              value: node\n            - name: DATASTORE_TYPE\n
-    \             value: kubernetes\n          livenessProbe:\n            exec:\n
-    \             command:\n              - /usr/bin/check-status\n              -
-    -l\n            periodSeconds: 10\n            initialDelaySeconds: 10\n            failureThreshold:
-    6\n            timeoutSeconds: 10\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /usr/bin/check-status\n                -
-    -r\n            periodSeconds: 10\n\n---\n\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n\n---\n\n# This manifest
-    creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler
-    to evict\n\napiVersion: policy/v1beta1\nkind: PodDisruptionBudget\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n  labels:\n    k8s-app:
-    calico-kube-controllers\nspec:\n  maxUnavailable: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n---\n# Source: calico/templates/calico-etcd-secrets.yaml\n\n---\n#
-    Source: calico/templates/calico-typha.yaml\n\n---\n# Source: calico/templates/configure-canal.yaml\n"
+  resources: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgpconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPConfiguration
+        listKind: BGPConfigurationList
+        plural: bgpconfigurations
+        singular: bgpconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: BGPConfiguration contains the configuration for any BGP routing.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPConfigurationSpec contains the values of the BGP configuration.
+                properties:
+                  asNumber:
+                    description: 'ASNumber is the default AS number used by a node. [Default:
+                      64512]'
+                    format: int32
+                    type: integer
+                  communities:
+                    description: Communities is a list of BGP community values and their
+                      arbitrary names for tagging routes.
+                    items:
+                      description: Community contains standard or large community value
+                        and its name.
+                      properties:
+                        name:
+                          description: Name given to community value.
+                          type: string
+                        value:
+                          description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                            For standard community use `aa:nn` format, where `aa` and
+                            `nn` are 16 bit number. For large community use `aa:nn:mm`
+                            format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                            `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                          pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                          type: string
+                      type: object
+                    type: array
+                  listenPort:
+                    description: ListenPort is the port where BGP protocol should listen.
+                      Defaults to 179
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: INFO]'
+                    type: string
+                  nodeToNodeMeshEnabled:
+                    description: 'NodeToNodeMeshEnabled sets whether full node to node
+                      BGP mesh is enabled. [Default: true]'
+                    type: boolean
+                  prefixAdvertisements:
+                    description: PrefixAdvertisements contains per-prefix advertisement
+                      configuration.
+                    items:
+                      description: PrefixAdvertisement configures advertisement properties
+                        for the specified CIDR.
+                      properties:
+                        cidr:
+                          description: CIDR for which properties should be advertised.
+                          type: string
+                        communities:
+                          description: Communities can be list of either community names
+                            already defined in `Specs.Communities` or community value
+                            of format `aa:nn` or `aa:nn:mm`. For standard community use
+                            `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                            large community use `aa:nn:mm` format, where `aa`, `nn` and
+                            `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                            `mm` are per-AS identifier.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  serviceClusterIPs:
+                    description: ServiceClusterIPs are the CIDR blocks from which service
+                      cluster IPs are allocated. If specified, Calico will advertise these
+                      blocks, as well as any cluster IPs within them.
+                    items:
+                      description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                        CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceExternalIPs:
+                    description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                      Service External IPs. Kubernetes Service ExternalIPs will only be
+                      advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceExternalIPBlock represents a single allowed
+                        External IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceLoadBalancerIPs:
+                    description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                      Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                      IPs will only be advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceLoadBalancerIPBlock represents a single allowed
+                        LoadBalancer IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgppeers.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPPeer
+        listKind: BGPPeerList
+        plural: bgppeers
+        singular: bgppeer
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPPeerSpec contains the specification for a BGPPeer resource.
+                properties:
+                  asNumber:
+                    description: The AS Number of the peer.
+                    format: int32
+                    type: integer
+                  keepOriginalNextHop:
+                    description: Option to keep the original nexthop field when routes
+                      are sent to a BGP Peer. Setting "true" configures the selected BGP
+                      Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                      in the specific branch of the Node on "bird.cfg".
+                    type: boolean
+                  maxRestartTime:
+                    description: Time to allow for software restart.  When specified,
+                      this is configured as the graceful restart timeout.  When not specified,
+                      the BIRD default of 120s is used.
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance that
+                      is targeted by this peer. If this is not set, and no nodeSelector
+                      is specified, then this BGP peer selects all nodes in the cluster.
+                    type: string
+                  nodeSelector:
+                    description: Selector for the nodes that should have this peering.  When
+                      this is set, the Node field must be empty.
+                    type: string
+                  password:
+                    description: Optional BGP password for the peerings generated by this
+                      BGPPeer resource.
+                    properties:
+                      secretKeyRef:
+                        description: Selects a key of a secret in the node pod's namespace.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be
+                              a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be
+                              defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  peerIP:
+                    description: The IP address of the peer followed by an optional port
+                      number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                      or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                      and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                      set in BGPConfiguration, then we use that port to peer.
+                    type: string
+                  peerSelector:
+                    description: Selector for the remote nodes to peer with.  When this
+                      is set, the PeerIP and ASNumber fields must be empty.  For each
+                      peering between the local node and selected remote nodes, we configure
+                      an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                      and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                      remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                      or the global default if that is not set.
+                    type: string
+                  sourceAddress:
+                    description: Specifies whether and how to configure a source address
+                      for the peerings generated by this BGPPeer resource.  Default value
+                      "UseNodeIP" means to configure the node IP as the source address.  "None"
+                      means not to configure a source address.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: blockaffinities.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BlockAffinity
+        listKind: BlockAffinityList
+        plural: blockaffinities
+        singular: blockaffinity
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BlockAffinitySpec contains the specification for a BlockAffinity
+                  resource.
+                properties:
+                  cidr:
+                    type: string
+                  deleted:
+                    description: Deleted indicates that this block affinity is being deleted.
+                      This field is a string for compatibility with older releases that
+                      mistakenly treat this field as a string.
+                    type: string
+                  node:
+                    type: string
+                  state:
+                    type: string
+                required:
+                - cidr
+                - deleted
+                - node
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: clusterinformations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: ClusterInformation
+        listKind: ClusterInformationList
+        plural: clusterinformations
+        singular: clusterinformation
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterInformation contains the cluster specific information.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterInformationSpec contains the values of describing
+                  the cluster.
+                properties:
+                  calicoVersion:
+                    description: CalicoVersion is the version of Calico that the cluster
+                      is running
+                    type: string
+                  clusterGUID:
+                    description: ClusterGUID is the GUID of the cluster
+                    type: string
+                  clusterType:
+                    description: ClusterType describes the type of the cluster
+                    type: string
+                  datastoreReady:
+                    description: DatastoreReady is used during significant datastore migrations
+                      to signal to components such as Felix that it should wait before
+                      accessing the datastore.
+                    type: boolean
+                  variant:
+                    description: Variant declares which variant of Calico should be active.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: felixconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: FelixConfiguration
+        listKind: FelixConfigurationList
+        plural: felixconfigurations
+        singular: felixconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: Felix Configuration contains the configuration for Felix.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: FelixConfigurationSpec contains the values of the Felix configuration.
+                properties:
+                  allowIPIPPacketsFromWorkloads:
+                    description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop IPIP encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  allowVXLANPacketsFromWorkloads:
+                    description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop VXLAN encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  awsSrcDstCheck:
+                    description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                      value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                      DoNothing]'
+                    enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                    type: string
+                  bpfConnectTimeLoadBalancingEnabled:
+                    description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                      controls whether Felix installs the connection-time load balancer.  The
+                      connect-time load balancer is required for the host to be able to
+                      reach Kubernetes services and it improves the performance of pod-to-service
+                      connections.  The only reason to disable it is for debugging purposes.  [Default:
+                      true]'
+                    type: boolean
+                  bpfDataIfacePattern:
+                    description: BPFDataIfacePattern is a regular expression that controls
+                      which interfaces Felix should attach BPF programs to in order to
+                      catch traffic to/from the network.  This needs to match the interfaces
+                      that Calico workload traffic flows over as well as any interfaces
+                      that handle incoming traffic to nodeports and services from outside
+                      the cluster.  It should not match the workload interfaces (usually
+                      named cali...).
+                    type: string
+                  bpfDisableUnprivileged:
+                    description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                      sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                      users cannot access Calico''s BPF maps and cannot insert their own
+                      BPF programs to interfere with Calico''s. [Default: true]'
+                    type: boolean
+                  bpfEnabled:
+                    description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                      [Default: false]'
+                    type: boolean
+                  bpfExtToServiceConnmark:
+                    description: 'BPFExtToServiceConnmark in BPF mode, controls a 32bit
+                      mark that is set on connections from an external client to a local
+                      service. This mark allows us to control how packets of that connection
+                      are routed within the host and how is routing intepreted by RPF
+                      check. [Default: 0]'
+                    type: integer
+                  bpfExternalServiceMode:
+                    description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                      from outside the cluster to services (node ports and cluster IPs)
+                      are forwarded to remote workloads.  If set to "Tunnel" then both
+                      request and response traffic is tunneled to the remote node.  If
+                      set to "DSR", the request traffic is tunneled but the response traffic
+                      is sent directly from the remote node.  In "DSR" mode, the remote
+                      node appears to use the IP of the ingress node; this requires a
+                      permissive L2 network.  [Default: Tunnel]'
+                    type: string
+                  bpfKubeProxyEndpointSlicesEnabled:
+                    description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                      whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                    type: boolean
+                  bpfKubeProxyIptablesCleanupEnabled:
+                    description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                      mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                      iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                      true]'
+                    type: boolean
+                  bpfKubeProxyMinSyncPeriod:
+                    description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                      minimum time between updates to the dataplane for Felix''s embedded
+                      kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                      reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                    type: string
+                  bpfLogLevel:
+                    description: 'BPFLogLevel controls the log level of the BPF programs
+                      when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                      logs are emitted to the BPF trace pipe, accessible with the command
+                      `tc exec bpf debug`. [Default: Off].'
+                    type: string
+                  chainInsertMode:
+                    description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                      top-level iptables chains by inserting a rule at the top of the
+                      chain or by appending a rule at the bottom. insert is the safe default
+                      since it prevents Calico''s rules from being bypassed. If you switch
+                      to append mode, be sure that the other rules in the chains signal
+                      acceptance by falling through to the Calico rules, otherwise the
+                      Calico policy will be bypassed. [Default: insert]'
+                    type: string
+                  dataplaneDriver:
+                    type: string
+                  debugDisableLogDropping:
+                    type: boolean
+                  debugMemoryProfilePath:
+                    type: string
+                  debugSimulateCalcGraphHangAfter:
+                    type: string
+                  debugSimulateDataplaneHangAfter:
+                    type: string
+                  defaultEndpointToHostAction:
+                    description: 'DefaultEndpointToHostAction controls what happens to
+                      traffic that goes from a workload endpoint to the host itself (after
+                      the traffic hits the endpoint egress policy). By default Calico
+                      blocks traffic from workload endpoints to the host itself with an
+                      iptables "DROP" action. If you want to allow some or all traffic
+                      from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                      RETURN if you have your own rules in the iptables "INPUT" chain;
+                      Calico will insert its rules at the top of that chain, then "RETURN"
+                      packets to the "INPUT" chain once it has completed processing workload
+                      endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                      from workloads after processing workload endpoint egress policy.
+                      [Default: Drop]'
+                    type: string
+                  deviceRouteProtocol:
+                    description: This defines the route protocol added to programmed device
+                      routes, by default this will be RTPROT_BOOT when left blank.
+                    type: integer
+                  deviceRouteSourceAddress:
+                    description: This is the source address to use on programmed device
+                      routes. By default the source address is left blank, leaving the
+                      kernel to choose the source address used.
+                    type: string
+                  disableConntrackInvalidCheck:
+                    type: boolean
+                  endpointReportingDelay:
+                    type: string
+                  endpointReportingEnabled:
+                    type: boolean
+                  externalNodesList:
+                    description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                      which may source tunnel traffic and have the tunneled traffic be
+                      accepted at calico nodes.
+                    items:
+                      type: string
+                    type: array
+                  failsafeInboundHostPorts:
+                    description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow incoming traffic to host endpoints
+                      on irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all inbound host ports, use the value
+                      none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                      udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  failsafeOutboundHostPorts:
+                    description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow outgoing traffic from host endpoints
+                      to irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all outbound host ports, use the value
+                      none. The default value opens etcd''s standard ports to ensure that
+                      Felix does not get cut off from etcd as well as allowing DHCP and
+                      DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                      tcp:6667, udp:53, udp:67]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  featureDetectOverride:
+                    description: FeatureDetectOverride is used to override the feature
+                      detection. Values are specified in a comma separated list with no
+                      spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                      "true" or "false" will force the feature, empty or omitted values
+                      are auto-detected.
+                    type: string
+                  genericXDPEnabled:
+                    description: 'GenericXDPEnabled enables Generic XDP so network cards
+                      that don''t support XDP offload or driver modes can use XDP. This
+                      is not recommended since it doesn''t provide better performance
+                      than iptables. [Default: false]'
+                    type: boolean
+                  healthEnabled:
+                    type: boolean
+                  healthHost:
+                    type: string
+                  healthPort:
+                    type: integer
+                  interfaceExclude:
+                    description: 'InterfaceExclude is a comma-separated list of interfaces
+                      that Felix should exclude when monitoring for host endpoints. The
+                      default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                      interface, which is used internally by kube-proxy. If you want to
+                      exclude multiple interface names using a single value, the list
+                      supports regular expressions. For regular expressions you must wrap
+                      the value with ''/''. For example having values ''/^kube/,veth1''
+                      will exclude all interfaces that begin with ''kube'' and also the
+                      interface ''veth1''. [Default: kube-ipvs0]'
+                    type: string
+                  interfacePrefix:
+                    description: 'InterfacePrefix is the interface name prefix that identifies
+                      workload endpoints and so distinguishes them from host endpoint
+                      interfaces. Note: in environments other than bare metal, the orchestrators
+                      configure this appropriately. For example our Kubernetes and Docker
+                      integrations set the ''cali'' value, and our OpenStack integration
+                      sets the ''tap'' value. [Default: cali]'
+                    type: string
+                  interfaceRefreshInterval:
+                    description: InterfaceRefreshInterval is the period at which Felix
+                      rescans local interfaces to verify their state. The rescan can be
+                      disabled by setting the interval to 0.
+                    type: string
+                  ipipEnabled:
+                    type: boolean
+                  ipipMTU:
+                    description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  ipsetsRefreshInterval:
+                    description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                      all iptables state to ensure that no other process has accidentally
+                      broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                      90s]'
+                    type: string
+                  iptablesBackend:
+                    description: IptablesBackend specifies which backend of iptables will
+                      be used. The default is legacy.
+                    type: string
+                  iptablesFilterAllowAction:
+                    type: string
+                  iptablesLockFilePath:
+                    description: 'IptablesLockFilePath is the location of the iptables
+                      lock file. You may need to change this if the lock file is not in
+                      its standard location (for example if you have mapped it into Felix''s
+                      container at a different path). [Default: /run/xtables.lock]'
+                    type: string
+                  iptablesLockProbeInterval:
+                    description: 'IptablesLockProbeInterval is the time that Felix will
+                      wait between attempts to acquire the iptables lock if it is not
+                      available. Lower values make Felix more responsive when the lock
+                      is contended, but use more CPU. [Default: 50ms]'
+                    type: string
+                  iptablesLockTimeout:
+                    description: 'IptablesLockTimeout is the time that Felix will wait
+                      for the iptables lock, or 0, to disable. To use this feature, Felix
+                      must share the iptables lock file with all other processes that
+                      also take the lock. When running Felix inside a container, this
+                      requires the /run directory of the host to be mounted into the calico/node
+                      or calico/felix container. [Default: 0s disabled]'
+                    type: string
+                  iptablesMangleAllowAction:
+                    type: string
+                  iptablesMarkMask:
+                    description: 'IptablesMarkMask is the mask that Felix selects its
+                      IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                      at least 8 bits set, none of which clash with any other mark bits
+                      in use on the system. [Default: 0xff000000]'
+                    format: int32
+                    type: integer
+                  iptablesNATOutgoingInterfaceFilter:
+                    type: string
+                  iptablesPostWriteCheckInterval:
+                    description: 'IptablesPostWriteCheckInterval is the period after Felix
+                      has done a write to the dataplane that it schedules an extra read
+                      back in order to check the write was not clobbered by another process.
+                      This should only occur if another application on the system doesn''t
+                      respect the iptables lock. [Default: 1s]'
+                    type: string
+                  iptablesRefreshInterval:
+                    description: 'IptablesRefreshInterval is the period at which Felix
+                      re-checks the IP sets in the dataplane to ensure that no other process
+                      has accidentally broken Calico''s rules. Set to 0 to disable IP
+                      sets refresh. Note: the default for this value is lower than the
+                      other refresh intervals as a workaround for a Linux kernel bug that
+                      was fixed in kernel version 4.11. If you are using v4.11 or greater
+                      you may want to set this to, a higher value to reduce Felix CPU
+                      usage. [Default: 10s]'
+                    type: string
+                  ipv6Support:
+                    type: boolean
+                  kubeNodePortRanges:
+                    description: 'KubeNodePortRanges holds list of port ranges used for
+                      service node ports. Only used if felix detects kube-proxy running
+                      in ipvs mode. Felix uses these ranges to separate host and workload
+                      traffic. [Default: 30000:32767].'
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  logFilePath:
+                    description: 'LogFilePath is the full path to the Felix log. Set to
+                      none to disable file logging. [Default: /var/log/calico/felix.log]'
+                    type: string
+                  logPrefix:
+                    description: 'LogPrefix is the log prefix that Felix uses when rendering
+                      LOG rules. [Default: calico-packet]'
+                    type: string
+                  logSeverityFile:
+                    description: 'LogSeverityFile is the log severity above which logs
+                      are sent to the log file. [Default: Info]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  logSeveritySys:
+                    description: 'LogSeveritySys is the log severity above which logs
+                      are sent to the syslog. Set to None for no logging to syslog. [Default:
+                      Info]'
+                    type: string
+                  maxIpsetSize:
+                    type: integer
+                  metadataAddr:
+                    description: 'MetadataAddr is the IP address or domain name of the
+                      server that can answer VM queries for cloud-init metadata. In OpenStack,
+                      this corresponds to the machine running nova-api (or in Ubuntu,
+                      nova-api-metadata). A value of none (case insensitive) means that
+                      Felix should not set up any NAT rule for the metadata path. [Default:
+                      127.0.0.1]'
+                    type: string
+                  metadataPort:
+                    description: 'MetadataPort is the port of the metadata server. This,
+                      combined with global.MetadataAddr (if not ''None''), is used to
+                      set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                      In most cases this should not need to be changed [Default: 8775].'
+                    type: integer
+                  mtuIfacePattern:
+                    description: MTUIfacePattern is a regular expression that controls
+                      which interfaces Felix should scan in order to calculate the host's
+                      MTU. This should not match workload interfaces (usually named cali...).
+                    type: string
+                  natOutgoingAddress:
+                    description: NATOutgoingAddress specifies an address to use when performing
+                      source NAT for traffic in a natOutgoing pool that is leaving the
+                      network. By default the address used is an address on the interface
+                      the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                    type: string
+                  natPortRange:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NATPortRange specifies the range of ports that is used
+                      for port mapping when doing outgoing NAT. When unset the default
+                      behavior of the network stack is used.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  netlinkTimeout:
+                    type: string
+                  openstackRegion:
+                    description: 'OpenstackRegion is the name of the region that a particular
+                      Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                      this must be configured somehow for each Felix (here in the datamodel,
+                      or in felix.cfg or the environment on each compute node), and must
+                      match the [calico] openstack_region value configured in neutron.conf
+                      on each node. [Default: Empty]'
+                    type: string
+                  policySyncPathPrefix:
+                    description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                      policy changes to external services, like Application layer policy.
+                      [Default: Empty]'
+                    type: string
+                  prometheusGoMetricsEnabled:
+                    description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusMetricsEnabled:
+                    description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                      server in Felix if set to true. [Default: false]'
+                    type: boolean
+                  prometheusMetricsHost:
+                    description: 'PrometheusMetricsHost is the host that the Prometheus
+                      metrics server should bind to. [Default: empty]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. [Default: 9091]'
+                    type: integer
+                  prometheusProcessMetricsEnabled:
+                    description: 'PrometheusProcessMetricsEnabled disables process metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusWireGuardMetricsEnabled:
+                    description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                      metrics collection, which the Prometheus client does by default,
+                      when set to false. This reduces the number of metrics reported,
+                      reducing Prometheus load. [Default: true]'
+                    type: boolean
+                  removeExternalRoutes:
+                    description: Whether or not to remove device routes that have not
+                      been programmed by Felix. Disabling this will allow external applications
+                      to also add device routes. This is enabled by default which means
+                      we will remove externally added routes.
+                    type: boolean
+                  reportingInterval:
+                    description: 'ReportingInterval is the interval at which Felix reports
+                      its status into the datastore or 0 to disable. Must be non-zero
+                      in OpenStack deployments. [Default: 30s]'
+                    type: string
+                  reportingTTL:
+                    description: 'ReportingTTL is the time-to-live setting for process-wide
+                      status reports. [Default: 90s]'
+                    type: string
+                  routeRefreshInterval:
+                    description: 'RouteRefreshInterval is the period at which Felix re-checks
+                      the routes in the dataplane to ensure that no other process has
+                      accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                      [Default: 90s]'
+                    type: string
+                  routeSource:
+                    description: 'RouteSource configures where Felix gets its routing
+                      information. - WorkloadIPs: use workload endpoints to construct
+                      routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                    type: string
+                  routeTableRange:
+                    description: Calico programs additional Linux route tables for various
+                      purposes.  RouteTableRange specifies the indices of the route tables
+                      that Calico should use.
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                    - max
+                    - min
+                    type: object
+                  serviceLoopPrevention:
+                    description: 'When service IP advertisement is enabled, prevent routing
+                      loops to service IPs that are not in use, by dropping or rejecting
+                      packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                      in which case such routing loops continue to be allowed. [Default:
+                      Drop]'
+                    type: string
+                  sidecarAccelerationEnabled:
+                    description: 'SidecarAccelerationEnabled enables experimental sidecar
+                      acceleration [Default: false]'
+                    type: boolean
+                  usageReportingEnabled:
+                    description: 'UsageReportingEnabled reports anonymous Calico version
+                      number and cluster size to projectcalico.org. Logs warnings returned
+                      by the usage server. For example, if a significant security vulnerability
+                      has been discovered in the version of Calico being used. [Default:
+                      true]'
+                    type: boolean
+                  usageReportingInitialDelay:
+                    description: 'UsageReportingInitialDelay controls the minimum delay
+                      before Felix makes a report. [Default: 300s]'
+                    type: string
+                  usageReportingInterval:
+                    description: 'UsageReportingInterval controls the interval at which
+                      Felix makes reports. [Default: 86400s]'
+                    type: string
+                  useInternalDataplaneDriver:
+                    type: boolean
+                  vxlanEnabled:
+                    type: boolean
+                  vxlanMTU:
+                    description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  vxlanPort:
+                    type: integer
+                  vxlanVNI:
+                    type: integer
+                  wireguardEnabled:
+                    description: 'WireguardEnabled controls whether Wireguard is enabled.
+                      [Default: false]'
+                    type: boolean
+                  wireguardHostEncryptionEnabled:
+                    description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                      host-to-host encryption is enabled. [Default: false]'
+                    type: boolean
+                  wireguardInterfaceName:
+                    description: 'WireguardInterfaceName specifies the name to use for
+                      the Wireguard interface. [Default: wg.calico]'
+                    type: string
+                  wireguardListeningPort:
+                    description: 'WireguardListeningPort controls the listening port used
+                      by Wireguard. [Default: 51820]'
+                    type: integer
+                  wireguardMTU:
+                    description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                      See Configuring MTU [Default: 1420]'
+                    type: integer
+                  wireguardRoutingRulePriority:
+                    description: 'WireguardRoutingRulePriority controls the priority value
+                      to use for the Wireguard routing rule. [Default: 99]'
+                    type: integer
+                  xdpEnabled:
+                    description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                      incoming deny rules. [Default: true]'
+                    type: boolean
+                  xdpRefreshInterval:
+                    description: 'XDPRefreshInterval is the period at which Felix re-checks
+                      all XDP state to ensure that no other process has accidentally broken
+                      Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                      refresh. [Default: 90s]'
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkPolicy
+        listKind: GlobalNetworkPolicyList
+        plural: globalnetworkpolicies
+        singular: globalnetworkpolicy
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  applyOnForward:
+                    description: ApplyOnForward indicates to apply the rules in this policy
+                      on forward traffic.
+                    type: boolean
+                  doNotTrack:
+                    description: DoNotTrack indicates whether packets matched by the rules
+                      in this policy should go through the data plane's connection tracking,
+                      such as Linux conntrack.  If True, the rules in this policy are
+                      applied before any data plane connection tracking, and packets allowed
+                      by this policy are marked as not to be tracked.
+                    type: boolean
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    description: NamespaceSelector is an optional field for an expression
+                      used to select a pod based on namespaces.
+                    type: string
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  preDNAT:
+                    description: PreDNAT indicates to apply the rules in this policy before
+                      any DNAT.
+                    type: boolean
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress rules are present in the policy.  The
+                      default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                      (including the case where there are   also no Ingress rules) \n
+                      - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                      rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                      both Ingress and Egress rules. \n When the policy is read back again,
+                      Types will always be one of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkSet
+        listKind: GlobalNetworkSetList
+        plural: globalnetworksets
+        singular: globalnetworkset
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+              that share labels to allow rules to refer to them via selectors.  The labels
+              of GlobalNetworkSet are not namespaced.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: hostendpoints.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: HostEndpoint
+        listKind: HostEndpointList
+        plural: hostendpoints
+        singular: hostendpoint
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: HostEndpointSpec contains the specification for a HostEndpoint
+                  resource.
+                properties:
+                  expectedIPs:
+                    description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                      If \"InterfaceName\" is not present, Calico will look for an interface
+                      matching any of the IPs in the list and apply policy to that. Note:
+                      \tWhen using the selector match criteria in an ingress or egress
+                      security Policy \tor Profile, Calico converts the selector into
+                      a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                      is used for that purpose. (If only the interface \tname is specified,
+                      Calico does not learn the IPs of the interface for use in match
+                      \tcriteria.)"
+                    items:
+                      type: string
+                    type: array
+                  interfaceName:
+                    description: "Either \"*\", or the name of a specific Linux interface
+                      to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                      governs all traffic to, from or through the default network namespace
+                      of the host named by the \"Node\" field; entering and leaving that
+                      namespace via any interface, including those from/to non-host-networked
+                      local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                      only governs traffic that enters or leaves the host through the
+                      specific interface named by InterfaceName, or - when InterfaceName
+                      is empty - through the specific interface that has one of the IPs
+                      in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                      one expected IP must be specified.  Only external interfaces (such
+                      as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                      to protect traffic through a specific local workload interface.
+                      \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                      initially just pre-DNAT policy.  Please check Calico documentation
+                      for the latest position."
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance.
+                    type: string
+                  ports:
+                    description: Ports contains the endpoint's named ports, which may
+                      be referenced in security policy rules.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  profiles:
+                    description: A list of identifiers of security Profile objects that
+                      apply to this endpoint. Each profile is applied in the order that
+                      they appear in this list.  Profile rules are applied after the selector-based
+                      security policy.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamblocks.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMBlock
+        listKind: IPAMBlockList
+        plural: ipamblocks
+        singular: ipamblock
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMBlockSpec contains the specification for an IPAMBlock
+                  resource.
+                properties:
+                  affinity:
+                    type: string
+                  allocations:
+                    items:
+                      nullable: true
+                      type: integer
+                    type: array
+                  attributes:
+                    items:
+                      properties:
+                        handle_id:
+                          type: string
+                        secondary:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    type: array
+                  cidr:
+                    type: string
+                  deleted:
+                    type: boolean
+                  strictAffinity:
+                    type: boolean
+                  unallocated:
+                    items:
+                      type: integer
+                    type: array
+                required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamconfigs.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMConfig
+        listKind: IPAMConfigList
+        plural: ipamconfigs
+        singular: ipamconfig
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMConfigSpec contains the specification for an IPAMConfig
+                  resource.
+                properties:
+                  autoAllocateBlocks:
+                    type: boolean
+                  maxBlocksPerHost:
+                    description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                      that can be affine to each host.
+                    type: integer
+                  strictAffinity:
+                    type: boolean
+                required:
+                - autoAllocateBlocks
+                - strictAffinity
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamhandles.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMHandle
+        listKind: IPAMHandleList
+        plural: ipamhandles
+        singular: ipamhandle
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMHandleSpec contains the specification for an IPAMHandle
+                  resource.
+                properties:
+                  block:
+                    additionalProperties:
+                      type: integer
+                    type: object
+                  deleted:
+                    type: boolean
+                  handleID:
+                    type: string
+                required:
+                - block
+                - handleID
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ippools.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPPool
+        listKind: IPPoolList
+        plural: ippools
+        singular: ippool
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPPoolSpec contains the specification for an IPPool resource.
+                properties:
+                  blockSize:
+                    description: The block size to use for IP address assignments from
+                      this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                    type: integer
+                  cidr:
+                    description: The pool CIDR.
+                    type: string
+                  disabled:
+                    description: When disabled is true, Calico IPAM will not assign addresses
+                      from this pool.
+                    type: boolean
+                  ipip:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    properties:
+                      enabled:
+                        description: When enabled is true, ipip tunneling will be used
+                          to deliver packets to destinations within this pool.
+                        type: boolean
+                      mode:
+                        description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                          mode of "always" will also use IPIP tunneling for routing to
+                          destination IP addresses within this pool.  A mode of "cross-subnet"
+                          will only use IPIP tunneling when the destination node is on
+                          a different subnet to the originating node.  The default value
+                          (if not specified) is "always".
+                        type: string
+                    type: object
+                  ipipMode:
+                    description: Contains configuration for IPIP tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                      is disabled).
+                    type: string
+                  nat-outgoing:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    type: boolean
+                  natOutgoing:
+                    description: When nat-outgoing is true, packets sent from Calico networked
+                      containers in this pool to destinations outside of this pool will
+                      be masqueraded.
+                    type: boolean
+                  nodeSelector:
+                    description: Allows IPPool to allocate for a specific node by label
+                      selector.
+                    type: string
+                  vxlanMode:
+                    description: Contains configuration for VXLAN tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                      tunneling is disabled).
+                    type: string
+                required:
+                - cidr
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubecontrollersconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: KubeControllersConfiguration
+        listKind: KubeControllersConfigurationList
+        plural: kubecontrollersconfigurations
+        singular: kubecontrollersconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeControllersConfigurationSpec contains the values of the
+                  Kubernetes controllers configuration.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host endpoints.
+                              Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation of
+                                  host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the controller
+                              to determine if an IP address has been leaked. Set to 0
+                              to disable IP garbage collection. [Default: 15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+              status:
+                description: KubeControllersConfigurationStatus represents the status
+                  of the configuration. It's useful for admins to be able to see the actual
+                  config that was applied, which can be modified by environment variables
+                  on the kube-controllers process.
+                properties:
+                  environmentVars:
+                    additionalProperties:
+                      type: string
+                    description: EnvironmentVars contains the environment variables on
+                      the kube-controllers that influenced the RunningConfig.
+                    type: object
+                  runningConfig:
+                    description: RunningConfig contains the effective config that is running
+                      in the kube-controllers pod, after merging the API resource with
+                      any environment variables.
+                    properties:
+                      controllers:
+                        description: Controllers enables and configures individual Kubernetes
+                          controllers
+                        properties:
+                          namespace:
+                            description: Namespace enables and configures the namespace
+                              controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          node:
+                            description: Node enables and configures the node controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              hostEndpoint:
+                                description: HostEndpoint controls syncing nodes to host
+                                  endpoints. Disabled by default, set to nil to disable.
+                                properties:
+                                  autoCreate:
+                                    description: 'AutoCreate enables automatic creation
+                                      of host endpoints for every node. [Default: Disabled]'
+                                    type: string
+                                type: object
+                              leakGracePeriod:
+                                description: 'LeakGracePeriod is the period used by the
+                                  controller to determine if an IP address has been leaked.
+                                  Set to 0 to disable IP garbage collection. [Default:
+                                  15m]'
+                                type: string
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                              syncLabels:
+                                description: 'SyncLabels controls whether to copy Kubernetes
+                                  node labels to Calico nodes. [Default: Enabled]'
+                                type: string
+                            type: object
+                          policy:
+                            description: Policy enables and configures the policy controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          serviceAccount:
+                            description: ServiceAccount enables and configures the service
+                              account controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          workloadEndpoint:
+                            description: WorkloadEndpoint enables and configures the workload
+                              endpoint controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                        type: object
+                      etcdV3CompactionPeriod:
+                        description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                          compaction requests. Set to 0 to disable. [Default: 10m]'
+                        type: string
+                      healthChecks:
+                        description: 'HealthChecks enables or disables support for health
+                          checks [Default: Enabled]'
+                        type: string
+                      logSeverityScreen:
+                        description: 'LogSeverityScreen is the log severity above which
+                          logs are sent to the stdout. [Default: Info]'
+                        type: string
+                      prometheusMetricsPort:
+                        description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                          metrics server should bind to. Set to 0 to disable. [Default:
+                          9094]'
+                        type: integer
+                    required:
+                    - controllers
+                    type: object
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkPolicy
+        listKind: NetworkPolicyList
+        plural: networkpolicies
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress are present in the policy.  The default
+                      is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                      the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                      ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                      PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                      \n When the policy is read back again, Types will always be one
+                      of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkSet
+        listKind: NetworkSetList
+        plural: networksets
+        singular: networkset
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: NetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-kube-controllers
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      verbs:
+      - list
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - hostendpoints
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - clusterinformations
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - kubecontrollersconfigurations
+      verbs:
+      - get
+      - create
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-node
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - namespaces
+      verbs:
+      - get
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - patch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - bgpconfigurations
+      - bgppeers
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ipamconfigs
+      verbs:
+      - get
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      verbs:
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - daemonsets
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-kube-controllers
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      calico_backend: vxlan
+      cni_network_config: |-
+        {
+          "name": "k8s-pod-network",
+          "cniVersion": "0.3.1",
+          "plugins": [
+            {
+              "type": "calico",
+              "log_level": "info",
+              "log_file_path": "/var/log/calico/cni/cni.log",
+              "datastore_type": "kubernetes",
+              "nodename": "__KUBERNETES_NODE_NAME__",
+              "mtu": __CNI_MTU__,
+              "ipam": {
+                  "type": "calico-ipam"
+              },
+              "policy": {
+                  "type": "k8s"
+              },
+              "kubernetes": {
+                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              }
+            },
+            {
+              "type": "portmap",
+              "snat": true,
+              "capabilities": {"portMappings": true}
+            },
+            {
+              "type": "bandwidth",
+              "capabilities": {"bandwidth": true}
+            }
+          ]
+        }
+      typha_service_name: none
+      veth_mtu: "1350"
+    kind: ConfigMap
+    metadata:
+      name: calico-config
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-kube-controllers
+          name: calico-kube-controllers
+          namespace: kube-system
+        spec:
+          containers:
+          - env:
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            image: docker.io/calico/kube-controllers:v3.20.3
+            livenessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -l
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-kube-controllers
+            readinessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -r
+              periodSeconds: 10
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: calico-kube-controllers
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: calico-node
+      name: calico-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+        spec:
+          containers:
+          - env:
+            - name: FELIX_FEATUREDETECTOVERRIDE
+              value: ChecksumOffloadBroken=true
+            - name: CALICO_IPV4POOL_VXLAN
+              value: Always
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            - name: CLUSTER_TYPE
+              value: k8s,bgp
+            - name: IP
+              value: autodetect
+            - name: CALICO_IPV4POOL_IPIP
+              value: Never
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_WIREGUARDMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_AWSSRCDSTCHECK
+              value: Disable
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: ACCEPT
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/node:v3.20.3
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -shutdown
+            livenessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-live
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-node
+            readinessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-ready
+              periodSeconds: 10
+              timeoutSeconds: 10
+            resources:
+              requests:
+                cpu: 250m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /var/run/nodeagent
+              name: policysync
+            - mountPath: /sys/fs/
+              mountPropagation: Bidirectional
+              name: sysfs
+            - mountPath: /var/log/calico/cni
+              name: cni-log-dir
+              readOnly: true
+          hostNetwork: true
+          initContainers:
+          - command:
+            - /opt/cni/bin/calico-ipam
+            - -upgrade
+            env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: upgrade-ipam
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          - command:
+            - /opt/cni/bin/install
+            env:
+            - name: CNI_CONF_NAME
+              value: 10-calico.conflist
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  key: cni_network_config
+                  name: calico-config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: SLEEP
+              value: "false"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: install-cni
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+            name: flexvol-driver
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/driver
+              name: flexvol-driver-host
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: calico-node
+          terminationGracePeriodSeconds: 0
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /lib/modules
+            name: lib-modules
+          - hostPath:
+              path: /var/run/calico
+            name: var-run-calico
+          - hostPath:
+              path: /var/lib/calico
+            name: var-lib-calico
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+          - hostPath:
+              path: /sys/fs/
+              type: DirectoryOrCreate
+            name: sysfs
+          - hostPath:
+              path: /opt/cni/bin
+            name: cni-bin-dir
+          - hostPath:
+              path: /etc/cni/net.d
+            name: cni-net-dir
+          - hostPath:
+              path: /var/log/calico/cni
+            name: cni-log-dir
+          - hostPath:
+              path: /var/lib/cni/networks
+            name: host-local-net-dir
+          - hostPath:
+              path: /var/run/nodeagent
+              type: DirectoryOrCreate
+            name: policysync
+          - hostPath:
+              path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+              type: DirectoryOrCreate
+            name: flexvol-driver-host
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
   windows-cni: "# strictAffinity required for windows\napiVersion: crd.projectcalico.org/v1\nkind:
     IPAMConfig\nmetadata:\n  name: default\nspec:\n  autoAllocateBlocks: true\n  strictAffinity:
     true\n---\nkind: ConfigMap\napiVersion: v1\nmetadata:\n  name: calico-static-rules\n

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -4179,2440 +4179,3985 @@ spec:
 ---
 apiVersion: v1
 data:
-  resources: "---\n# Source: calico/templates/calico-config.yaml\n# This ConfigMap
-    is used to configure a self-hosted Calico installation.\nkind: ConfigMap\napiVersion:
-    v1\nmetadata:\n  name: calico-config\n  namespace: kube-system\ndata:\n  # Typha
-    is disabled.\n  typha_service_name: \"none\"\n  # Configure the backend to use.\n
-    \ calico_backend: \"vxlan\"\n  # On Azure, the underlying network has an MTU of
-    1400, even though the network interface will have an MTU of 1500.\n  # We set
-    this value to 1350 for “physical network MTU size minus 50” since we use VXLAN,
-    which uses a 50-byte header.\n  # If enabling Wireguard, this value should be
-    changed to 1340 (Wireguard uses a 60-byte header).\n  # https://docs.projectcalico.org/networking/mtu#determine-mtu-size\n
-    \ veth_mtu: \"1350\"\n  \n  # The CNI network configuration to install on each
-    node. The special\n  # values in this config will be automatically populated.\n
-    \ cni_network_config: |-\n    {\n      \"name\": \"k8s-pod-network\",\n      \"cniVersion\":
-    \"0.3.1\",\n      \"plugins\": [\n        {\n          \"type\": \"calico\",\n
-    \         \"log_level\": \"info\",\n          \"log_file_path\": \"/var/log/calico/cni/cni.log\",\n
-    \         \"datastore_type\": \"kubernetes\",\n          \"nodename\": \"__KUBERNETES_NODE_NAME__\",\n
-    \         \"mtu\": __CNI_MTU__,\n          \"ipam\": {\n              \"type\":
-    \"calico-ipam\"\n          },\n          \"policy\": {\n              \"type\":
-    \"k8s\"\n          },\n          \"kubernetes\": {\n              \"kubeconfig\":
-    \"__KUBECONFIG_FILEPATH__\"\n          }\n        },\n        {\n          \"type\":
-    \"portmap\",\n          \"snat\": true,\n          \"capabilities\": {\"portMappings\":
-    true}\n        },\n        {\n          \"type\": \"bandwidth\",\n          \"capabilities\":
-    {\"bandwidth\": true}\n        }\n      ]\n    }\n\n---\n# Source: calico/templates/kdd-crds.yaml\n\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: bgpconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPConfiguration\n    listKind: BGPConfigurationList\n    plural:
-    bgpconfigurations\n    singular: bgpconfiguration\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    BGPConfiguration contains the configuration for any BGP routing.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPConfigurationSpec contains the
-    values of the BGP configuration.\n              properties:\n                asNumber:\n
-    \                 description: 'ASNumber is the default AS number used by a node.
-    [Default:\n                  64512]'\n                  format: int32\n                  type:
-    integer\n                communities:\n                  description: Communities
-    is a list of BGP community values and their\n                    arbitrary names
-    for tagging routes.\n                  items:\n                    description:
-    Community contains standard or large community value\n                      and
-    its name.\n                    properties:\n                      name:\n                        description:
-    Name given to community value.\n                        type: string\n                      value:\n
-    \                       description: Value must be of format `aa:nn` or `aa:nn:mm`.\n
-    \                         For standard community use `aa:nn` format, where `aa`
-    and\n                          `nn` are 16 bit number. For large community use
-    `aa:nn:mm`\n                          format, where `aa`, `nn` and `mm` are 32
-    bit number. Where,\n                          `aa` is an AS Number, `nn` and `mm`
-    are per-AS identifier.\n                        pattern: ^(\\d+):(\\d+)$|^(\\d+):(\\d+):(\\d+)$\n
-    \                       type: string\n                    type: object\n                  type:
-    array\n                listenPort:\n                  description: ListenPort
-    is the port where BGP protocol should listen.\n                    Defaults to
-    179\n                  maximum: 65535\n                  minimum: 1\n                  type:
-    integer\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: INFO]'\n                  type: string\n                nodeToNodeMeshEnabled:\n
-    \                 description: 'NodeToNodeMeshEnabled sets whether full node to
-    node\n                  BGP mesh is enabled. [Default: true]'\n                  type:
-    boolean\n                prefixAdvertisements:\n                  description:
-    PrefixAdvertisements contains per-prefix advertisement\n                    configuration.\n
-    \                 items:\n                    description: PrefixAdvertisement
-    configures advertisement properties\n                      for the specified CIDR.\n
-    \                   properties:\n                      cidr:\n                        description:
-    CIDR for which properties should be advertised.\n                        type:
-    string\n                      communities:\n                        description:
-    Communities can be list of either community names\n                          already
-    defined in `Specs.Communities` or community value\n                          of
-    format `aa:nn` or `aa:nn:mm`. For standard community use\n                          `aa:nn`
-    format, where `aa` and `nn` are 16 bit number. For\n                          large
-    community use `aa:nn:mm` format, where `aa`, `nn` and\n                          `mm`
-    are 32 bit number. Where,`aa` is an AS Number, `nn` and\n                          `mm`
-    are per-AS identifier.\n                        items:\n                          type:
-    string\n                        type: array\n                    type: object\n
-    \                 type: array\n                serviceClusterIPs:\n                  description:
-    ServiceClusterIPs are the CIDR blocks from which service\n                    cluster
-    IPs are allocated. If specified, Calico will advertise these\n                    blocks,
-    as well as any cluster IPs within them.\n                  items:\n                    description:
-    ServiceClusterIPBlock represents a single allowed ClusterIP\n                      CIDR
-    block.\n                    properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n                serviceExternalIPs:\n
-    \                 description: ServiceExternalIPs are the CIDR blocks for Kubernetes\n
-    \                   Service External IPs. Kubernetes Service ExternalIPs will
-    only be\n                    advertised if they are within one of these blocks.\n
-    \                 items:\n                    description: ServiceExternalIPBlock
-    represents a single allowed\n                      External IP CIDR block.\n                    properties:\n
-    \                     cidr:\n                        type: string\n                    type:
-    object\n                  type: array\n                serviceLoadBalancerIPs:\n
-    \                 description: ServiceLoadBalancerIPs are the CIDR blocks for
-    Kubernetes\n                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress\n
-    \                   IPs will only be advertised if they are within one of these
-    blocks.\n                  items:\n                    description: ServiceLoadBalancerIPBlock
-    represents a single allowed\n                      LoadBalancer IP CIDR block.\n
-    \                   properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: bgppeers.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPPeer\n    listKind: BGPPeerList\n    plural: bgppeers\n
-    \   singular: bgppeer\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPPeerSpec contains the specification
-    for a BGPPeer resource.\n              properties:\n                asNumber:\n
-    \                 description: The AS Number of the peer.\n                  format:
-    int32\n                  type: integer\n                keepOriginalNextHop:\n
-    \                 description: Option to keep the original nexthop field when
-    routes\n                    are sent to a BGP Peer. Setting \"true\" configures
-    the selected BGP\n                    Peers node to use the \"next hop keep;\"
-    instead of \"next hop self;\"(default)\n                    in the specific branch
-    of the Node on \"bird.cfg\".\n                  type: boolean\n                maxRestartTime:\n
-    \                 description: Time to allow for software restart.  When specified,
-    this\n                    is configured as the graceful restart timeout.  When
-    not specified,\n                    the BIRD default of 120s is used.\n                  type:
-    string\n                node:\n                  description: The node name identifying
-    the Calico node instance that\n                    is targeted by this peer. If
-    this is not set, and no nodeSelector\n                    is specified, then this
-    BGP peer selects all nodes in the cluster.\n                  type: string\n                nodeSelector:\n
-    \                 description: Selector for the nodes that should have this peering.
-    \ When\n                    this is set, the Node field must be empty.\n                  type:
-    string\n                password:\n                  description: Optional BGP
-    password for the peerings generated by this\n                    BGPPeer resource.\n
-    \                 properties:\n                    secretKeyRef:\n                      description:
-    Selects a key of a secret in the node pod's namespace.\n                      properties:\n
-    \                       key:\n                          description: The key of
-    the secret to select from.  Must be\n                            a valid secret
-    key.\n                          type: string\n                        name:\n
-    \                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n
-    \                         TODO: Add other useful fields. apiVersion, kind, uid?'\n
-    \                         type: string\n                        optional:\n                          description:
-    Specify whether the Secret or its key must be\n                            defined\n
-    \                         type: boolean\n                      required:\n                        -
-    key\n                      type: object\n                  type: object\n                peerIP:\n
-    \                 description: The IP address of the peer followed by an optional
-    port\n                    number to peer with. If port number is given, format
-    should be `[<IPv6>]:port`\n                    or `<IPv4>:<port>` for IPv4. If
-    optional port number is not set,\n                    and this peer IP and ASNumber
-    belongs to a calico/node with ListenPort\n                    set in BGPConfiguration,
-    then we use that port to peer.\n                  type: string\n                peerSelector:\n
-    \                 description: Selector for the remote nodes to peer with.  When
-    this\n                    is set, the PeerIP and ASNumber fields must be empty.
-    \ For each\n                    peering between the local node and selected remote
-    nodes, we configure\n                    an IPv4 peering if both ends have NodeBGPSpec.IPv4Address
-    specified,\n                    and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address
-    specified.  The\n                    remote AS number comes from the remote node’s
-    NodeBGPSpec.ASNumber,\n                    or the global default if that is not
-    set.\n                  type: string\n                sourceAddress:\n                  description:
-    Specifies whether and how to configure a source address\n                    for
-    the peerings generated by this BGPPeer resource.  Default value\n                    \"UseNodeIP\"
-    means to configure the node IP as the source address.  \"None\"\n                    means
-    not to configure a source address.\n                  type: string\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: blockaffinities.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BlockAffinity\n    listKind: BlockAffinityList\n    plural:
-    blockaffinities\n    singular: blockaffinity\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BlockAffinitySpec contains the specification
-    for a BlockAffinity\n                resource.\n              properties:\n                cidr:\n
-    \                 type: string\n                deleted:\n                  description:
-    Deleted indicates that this block affinity is being deleted.\n                    This
-    field is a string for compatibility with older releases that\n                    mistakenly
-    treat this field as a string.\n                  type: string\n                node:\n
-    \                 type: string\n                state:\n                  type:
-    string\n              required:\n                - cidr\n                - deleted\n
-    \               - node\n                - state\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: clusterinformations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: ClusterInformation\n    listKind: ClusterInformationList\n
-    \   plural: clusterinformations\n    singular: clusterinformation\n  scope: Cluster\n
-    \ versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    ClusterInformation contains the cluster specific information.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: ClusterInformationSpec contains
-    the values of describing\n                the cluster.\n              properties:\n
-    \               calicoVersion:\n                  description: CalicoVersion is
-    the version of Calico that the cluster\n                    is running\n                  type:
-    string\n                clusterGUID:\n                  description: ClusterGUID
-    is the GUID of the cluster\n                  type: string\n                clusterType:\n
-    \                 description: ClusterType describes the type of the cluster\n
-    \                 type: string\n                datastoreReady:\n                  description:
-    DatastoreReady is used during significant datastore migrations\n                    to
-    signal to components such as Felix that it should wait before\n                    accessing
-    the datastore.\n                  type: boolean\n                variant:\n                  description:
-    Variant declares which variant of Calico should be active.\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: felixconfigurations.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: FelixConfiguration\n    listKind:
-    FelixConfigurationList\n    plural: felixconfigurations\n    singular: felixconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         description: Felix Configuration contains the configuration for Felix.\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: FelixConfigurationSpec contains
-    the values of the Felix configuration.\n              properties:\n                allowIPIPPacketsFromWorkloads:\n
-    \                 description: 'AllowIPIPPacketsFromWorkloads controls whether
-    Felix\n                  will add a rule to drop IPIP encapsulated traffic from
-    workloads\n                  [Default: false]'\n                  type: boolean\n
-    \               allowVXLANPacketsFromWorkloads:\n                  description:
-    'AllowVXLANPacketsFromWorkloads controls whether Felix\n                  will
-    add a rule to drop VXLAN encapsulated traffic from workloads\n                  [Default:
-    false]'\n                  type: boolean\n                awsSrcDstCheck:\n                  description:
-    'Set source-destination-check on AWS EC2 instances. Accepted\n                  value
-    must be one of \"DoNothing\", \"Enabled\" or \"Disabled\". [Default:\n                  DoNothing]'\n
-    \                 enum:\n                    - DoNothing\n                    -
-    Enable\n                    - Disable\n                  type: string\n                bpfConnectTimeLoadBalancingEnabled:\n
-    \                 description: 'BPFConnectTimeLoadBalancingEnabled when in BPF
-    mode,\n                  controls whether Felix installs the connection-time load
-    balancer.  The\n                  connect-time load balancer is required for the
-    host to be able to\n                  reach Kubernetes services and it improves
-    the performance of pod-to-service\n                  connections.  The only reason
-    to disable it is for debugging purposes.  [Default:\n                  true]'\n
-    \                 type: boolean\n                bpfDataIfacePattern:\n                  description:
-    'BPFDataIfacePattern is a regular expression that controls\n                  which
-    interfaces Felix should attach BPF programs to in order to\n                  catch
-    traffic to/from the network.  This needs to match the interfaces\n                  that
-    Calico workload traffic flows over as well as any interfaces\n                  that
-    handle incoming traffic to nodeports and services from outside\n                  the
-    cluster.  It should not match the workload interfaces (usually\n                  named
-    cali...). [Default: ^(en.*|eth.*|tunl0$)]'\n                  type: string\n                bpfDisableUnprivileged:\n
-    \                 description: 'BPFDisableUnprivileged, if enabled, Felix sets
-    the kernel.unprivileged_bpf_disabled\n                  sysctl to disable unprivileged
-    use of BPF.  This ensures that unprivileged\n                  users cannot access
-    Calico''s BPF maps and cannot insert their own\n                  BPF programs
-    to interfere with Calico''s. [Default: true]'\n                  type: boolean\n
-    \               bpfEnabled:\n                  description: 'BPFEnabled, if enabled
-    Felix will use the BPF dataplane.\n                  [Default: false]'\n                  type:
-    boolean\n                bpfExtToServiceConnmark:\n                  description:
-    'BPFExtToServiceConnmark in BPF mode, control a 32bit\n                    mark
-    that is set on connections from an external client to a local\n                    service.
-    This mark allows us to control how packets of that connection\n                    are
-    routed within the host and how is routing intepreted by RPF\n                    check.
-    [Default: 0]'\n                  type: integer\n                bpfExternalServiceMode:\n
-    \                 description: 'BPFExternalServiceMode in BPF mode, controls how
-    connections\n                  from outside the cluster to services (node ports
-    and cluster IPs)\n                  are forwarded to remote workloads.  If set
-    to \"Tunnel\" then both\n                  request and response traffic is tunneled
-    to the remote node.  If\n                  set to \"DSR\", the request traffic
-    is tunneled but the response traffic\n                  is sent directly from
-    the remote node.  In \"DSR\" mode, the remote\n                  node appears
-    to use the IP of the ingress node; this requires a\n                  permissive
-    L2 network.  [Default: Tunnel]'\n                  type: string\n                bpfKubeProxyEndpointSlicesEnabled:\n
-    \                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode,
-    controls\n                    whether Felix's embedded kube-proxy accepts EndpointSlices
-    or not.\n                  type: boolean\n                bpfKubeProxyIptablesCleanupEnabled:\n
-    \                 description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled
-    in BPF\n                  mode, Felix will proactively clean up the upstream Kubernetes
-    kube-proxy''s\n                  iptables chains.  Should only be enabled if kube-proxy
-    is not running.  [Default:\n                  true]'\n                  type:
-    boolean\n                bpfKubeProxyMinSyncPeriod:\n                  description:
-    'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the\n                  minimum
-    time between updates to the dataplane for Felix''s embedded\n                  kube-proxy.
-    \ Lower values give reduced set-up latency.  Higher values\n                  reduce
-    Felix CPU usage by batching up more work.  [Default: 1s]'\n                  type:
-    string\n                bpfLogLevel:\n                  description: 'BPFLogLevel
-    controls the log level of the BPF programs\n                  when in BPF dataplane
-    mode.  One of \"Off\", \"Info\", or \"Debug\".  The\n                  logs are
-    emitted to the BPF trace pipe, accessible with the command\n                  `tc
-    exec bpf debug`. [Default: Off].'\n                  type: string\n                chainInsertMode:\n
-    \                 description: 'ChainInsertMode controls whether Felix hooks the
-    kernel’s\n                  top-level iptables chains by inserting a rule at the
-    top of the\n                  chain or by appending a rule at the bottom. insert
-    is the safe default\n                  since it prevents Calico’s rules from being
-    bypassed. If you switch\n                  to append mode, be sure that the other
-    rules in the chains signal\n                  acceptance by falling through to
-    the Calico rules, otherwise the\n                  Calico policy will be bypassed.
-    [Default: insert]'\n                  type: string\n                dataplaneDriver:\n
-    \                 type: string\n                debugDisableLogDropping:\n                  type:
-    boolean\n                debugMemoryProfilePath:\n                  type: string\n
-    \               debugSimulateCalcGraphHangAfter:\n                  type: string\n
-    \               debugSimulateDataplaneHangAfter:\n                  type: string\n
-    \               defaultEndpointToHostAction:\n                  description: 'DefaultEndpointToHostAction
-    controls what happens to\n                  traffic that goes from a workload
-    endpoint to the host itself (after\n                  the traffic hits the endpoint
-    egress policy). By default Calico\n                  blocks traffic from workload
-    endpoints to the host itself with an\n                  iptables “DROP” action.
-    If you want to allow some or all traffic\n                  from endpoint to host,
-    set this parameter to RETURN or ACCEPT. Use\n                  RETURN if you have
-    your own rules in the iptables “INPUT” chain;\n                  Calico will insert
-    its rules at the top of that chain, then “RETURN”\n                  packets to
-    the “INPUT” chain once it has completed processing workload\n                  endpoint
-    egress policy. Use ACCEPT to unconditionally accept packets\n                  from
-    workloads after processing workload endpoint egress policy.\n                  [Default:
-    Drop]'\n                  type: string\n                deviceRouteProtocol:\n
-    \                 description: This defines the route protocol added to programmed
-    device\n                    routes, by default this will be RTPROT_BOOT when left
-    blank.\n                  type: integer\n                deviceRouteSourceAddress:\n
-    \                 description: This is the source address to use on programmed
-    device\n                    routes. By default the source address is left blank,
-    leaving the\n                    kernel to choose the source address used.\n                  type:
-    string\n                disableConntrackInvalidCheck:\n                  type:
-    boolean\n                endpointReportingDelay:\n                  type: string\n
-    \               endpointReportingEnabled:\n                  type: boolean\n                externalNodesList:\n
-    \                 description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes\n
-    \                   which may source tunnel traffic and have the tunneled traffic
-    be\n                    accepted at calico nodes.\n                  items:\n
-    \                   type: string\n                  type: array\n                failsafeInboundHostPorts:\n
-    \                 description: 'FailsafeInboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow incoming traffic to
-    host endpoints\n                    on irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    inbound host ports, use the value\n                    none. The default value
-    allows ssh access and DHCP. [Default: tcp:22,\n                    udp:68, tcp:179,
-    tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'\n                  items:\n
-    \                   description: ProtoPort is combination of protocol, port, and
-    CIDR.\n                      Protocol and port must be specified.\n                    properties:\n
-    \                     net:\n                        type: string\n                      port:\n
-    \                       type: integer\n                      protocol:\n                        type:
-    string\n                    required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                failsafeOutboundHostPorts:\n
-    \                 description: 'FailsafeOutboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow outgoing traffic from
-    host endpoints\n                    to irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    outbound host ports, use the value\n                    none. The default value
-    opens etcd''s standard ports to ensure that\n                    Felix does not
-    get cut off from etcd as well as allowing DHCP and\n                    DNS. [Default:
-    tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,\n                    tcp:6667,
-    udp:53, udp:67]'\n                  items:\n                    description: ProtoPort
-    is combination of protocol, port, and CIDR.\n                      Protocol and
-    port must be specified.\n                    properties:\n                      net:\n
-    \                       type: string\n                      port:\n                        type:
-    integer\n                      protocol:\n                        type: string\n
-    \                   required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                featureDetectOverride:\n
-    \                 description: FeatureDetectOverride is used to override the feature\n
-    \                   detection. Values are specified in a comma separated list
-    with no\n                    spaces, example; \"SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=\".\n
-    \                   \"true\" or \"false\" will force the feature, empty or omitted
-    values\n                    are auto-detected.\n                  type: string\n
-    \               genericXDPEnabled:\n                  description: 'GenericXDPEnabled
-    enables Generic XDP so network cards\n                  that don''t support XDP
-    offload or driver modes can use XDP. This\n                  is not recommended
-    since it doesn''t provide better performance\n                  than iptables.
-    [Default: false]'\n                  type: boolean\n                healthEnabled:\n
-    \                 type: boolean\n                healthHost:\n                  type:
-    string\n                healthPort:\n                  type: integer\n                interfaceExclude:\n
-    \                 description: 'InterfaceExclude is a comma-separated list of
-    interfaces\n                  that Felix should exclude when monitoring for host
-    endpoints. The\n                  default value ensures that Felix ignores Kubernetes''
-    IPVS dummy\n                  interface, which is used internally by kube-proxy.
-    If you want to\n                  exclude multiple interface names using a single
-    value, the list\n                  supports regular expressions. For regular expressions
-    you must wrap\n                  the value with ''/''. For example having values
-    ''/^kube/,veth1''\n                  will exclude all interfaces that begin with
-    ''kube'' and also the\n                  interface ''veth1''. [Default: kube-ipvs0]'\n
-    \                 type: string\n                interfacePrefix:\n                  description:
-    'InterfacePrefix is the interface name prefix that identifies\n                  workload
-    endpoints and so distinguishes them from host endpoint\n                  interfaces.
-    Note: in environments other than bare metal, the orchestrators\n                  configure
-    this appropriately. For example our Kubernetes and Docker\n                  integrations
-    set the ‘cali’ value, and our OpenStack integration\n                  sets the
-    ‘tap’ value. [Default: cali]'\n                  type: string\n                interfaceRefreshInterval:\n
-    \                 description: InterfaceRefreshInterval is the period at which
-    Felix\n                    rescans local interfaces to verify their state. The
-    rescan can be\n                    disabled by setting the interval to 0.\n                  type:
-    string\n                ipipEnabled:\n                  type: boolean\n                ipipMTU:\n
-    \                 description: 'IPIPMTU is the MTU to set on the tunnel device.
-    See\n                  Configuring MTU [Default: 1440]'\n                  type:
-    integer\n                ipsetsRefreshInterval:\n                  description:
-    'IpsetsRefreshInterval is the period at which Felix re-checks\n                  all
-    iptables state to ensure that no other process has accidentally\n                  broken
-    Calico’s rules. Set to 0 to disable iptables refresh. [Default:\n                  90s]'\n
-    \                 type: string\n                iptablesBackend:\n                  description:
-    IptablesBackend specifies which backend of iptables will\n                    be
-    used. The default is legacy.\n                  type: string\n                iptablesFilterAllowAction:\n
-    \                 type: string\n                iptablesLockFilePath:\n                  description:
-    'IptablesLockFilePath is the location of the iptables\n                  lock
-    file. You may need to change this if the lock file is not in\n                  its
-    standard location (for example if you have mapped it into Felix’s\n                  container
-    at a different path). [Default: /run/xtables.lock]'\n                  type: string\n
-    \               iptablesLockProbeInterval:\n                  description: 'IptablesLockProbeInterval
-    is the time that Felix will\n                  wait between attempts to acquire
-    the iptables lock if it is not\n                  available. Lower values make
-    Felix more responsive when the lock\n                  is contended, but use more
-    CPU. [Default: 50ms]'\n                  type: string\n                iptablesLockTimeout:\n
-    \                 description: 'IptablesLockTimeout is the time that Felix will
-    wait\n                  for the iptables lock, or 0, to disable. To use this feature,
-    Felix\n                  must share the iptables lock file with all other processes
-    that\n                  also take the lock. When running Felix inside a container,
-    this\n                  requires the /run directory of the host to be mounted
-    into the calico/node\n                  or calico/felix container. [Default: 0s
-    disabled]'\n                  type: string\n                iptablesMangleAllowAction:\n
-    \                 type: string\n                iptablesMarkMask:\n                  description:
-    'IptablesMarkMask is the mask that Felix selects its\n                  IPTables
-    Mark bits from. Should be a 32 bit hexadecimal number with\n                  at
-    least 8 bits set, none of which clash with any other mark bits\n                  in
-    use on the system. [Default: 0xff000000]'\n                  format: int32\n                  type:
-    integer\n                iptablesNATOutgoingInterfaceFilter:\n                  type:
-    string\n                iptablesPostWriteCheckInterval:\n                  description:
-    'IptablesPostWriteCheckInterval is the period after Felix\n                  has
-    done a write to the dataplane that it schedules an extra read\n                  back
-    in order to check the write was not clobbered by another process.\n                  This
-    should only occur if another application on the system doesn’t\n                  respect
-    the iptables lock. [Default: 1s]'\n                  type: string\n                iptablesRefreshInterval:\n
-    \                 description: 'IptablesRefreshInterval is the period at which
-    Felix\n                    re-checks the IP sets in the dataplane to ensure that
-    no other process\n                    has accidentally broken Calico''s rules.
-    Set to 0 to disable IP\n                    sets refresh. Note: the default for
-    this value is lower than the\n                    other refresh intervals as a
-    workaround for a Linux kernel bug that\n                    was fixed in kernel
-    version 4.11. If you are using v4.11 or greater\n                    you may want
-    to set this to, a higher value to reduce Felix CPU\n                    usage.
-    [Default: 10s]'\n                  type: string\n                ipv6Support:\n
-    \                 type: boolean\n                kubeNodePortRanges:\n                  description:
-    'KubeNodePortRanges holds list of port ranges used for\n                  service
-    node ports. Only used if felix detects kube-proxy running\n                  in
-    ipvs mode. Felix uses these ranges to separate host and workload\n                  traffic.
-    [Default: 30000:32767].'\n                  items:\n                    anyOf:\n
-    \                     - type: integer\n                      - type: string\n
-    \                   pattern: ^.*\n                    x-kubernetes-int-or-string:
-    true\n                  type: array\n                logFilePath:\n                  description:
-    'LogFilePath is the full path to the Felix log. Set to\n                  none
-    to disable file logging. [Default: /var/log/calico/felix.log]'\n                  type:
-    string\n                logPrefix:\n                  description: 'LogPrefix
-    is the log prefix that Felix uses when rendering\n                  LOG rules.
-    [Default: calico-packet]'\n                  type: string\n                logSeverityFile:\n
-    \                 description: 'LogSeverityFile is the log severity above which
-    logs\n                  are sent to the log file. [Default: Info]'\n                  type:
-    string\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: Info]'\n                  type: string\n                logSeveritySys:\n
-    \                 description: 'LogSeveritySys is the log severity above which
-    logs\n                  are sent to the syslog. Set to None for no logging to
-    syslog. [Default:\n                  Info]'\n                  type: string\n
-    \               maxIpsetSize:\n                  type: integer\n                metadataAddr:\n
-    \                 description: 'MetadataAddr is the IP address or domain name
-    of the\n                  server that can answer VM queries for cloud-init metadata.
-    In OpenStack,\n                  this corresponds to the machine running nova-api
-    (or in Ubuntu,\n                  nova-api-metadata). A value of none (case insensitive)
-    means that\n                  Felix should not set up any NAT rule for the metadata
-    path. [Default:\n                  127.0.0.1]'\n                  type: string\n
-    \               metadataPort:\n                  description: 'MetadataPort is
-    the port of the metadata server. This,\n                  combined with global.MetadataAddr
-    (if not ‘None’), is used to set\n                  up a NAT rule, from 169.254.169.254:80
-    to MetadataAddr:MetadataPort.\n                  In most cases this should not
-    need to be changed [Default: 8775].'\n                  type: integer\n                mtuIfacePattern:\n
-    \                 description: MTUIfacePattern is a regular expression that controls\n
-    \                   which interfaces Felix should scan in order to calculate the
-    host's\n                    MTU. This should not match workload interfaces (usually
-    named cali...).\n                  type: string\n                natOutgoingAddress:\n
-    \                 description: NATOutgoingAddress specifies an address to use
-    when performing\n                    source NAT for traffic in a natOutgoing pool
-    that is leaving the\n                    network. By default the address used
-    is an address on the interface\n                    the traffic is leaving on
-    (ie it uses the iptables MASQUERADE target)\n                  type: string\n
-    \               natPortRange:\n                  anyOf:\n                    -
-    type: integer\n                    - type: string\n                  description:
-    NATPortRange specifies the range of ports that is used\n                    for
-    port mapping when doing outgoing NAT. When unset the default\n                    behavior
-    of the network stack is used.\n                  pattern: ^.*\n                  x-kubernetes-int-or-string:
-    true\n                netlinkTimeout:\n                  type: string\n                openstackRegion:\n
-    \                 description: 'OpenstackRegion is the name of the region that
-    a particular\n                  Felix belongs to. In a multi-region Calico/OpenStack
-    deployment,\n                  this must be configured somehow for each Felix
-    (here in the datamodel,\n                  or in felix.cfg or the environment
-    on each compute node), and must\n                  match the [calico] openstack_region
-    value configured in neutron.conf\n                  on each node. [Default: Empty]'\n
-    \                 type: string\n                policySyncPathPrefix:\n                  description:
-    'PolicySyncPathPrefix is used to by Felix to communicate\n                  policy
-    changes to external services, like Application layer policy.\n                  [Default:
-    Empty]'\n                  type: string\n                prometheusGoMetricsEnabled:\n
-    \                 description: 'PrometheusGoMetricsEnabled disables Go runtime
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                prometheusMetricsEnabled:\n                  description:
-    'PrometheusMetricsEnabled enables the Prometheus metrics\n                  server
-    in Felix if set to true. [Default: false]'\n                  type: boolean\n
-    \               prometheusMetricsHost:\n                  description: 'PrometheusMetricsHost
-    is the host that the Prometheus\n                  metrics server should bind
-    to. [Default: empty]'\n                  type: string\n                prometheusMetricsPort:\n
-    \                 description: 'PrometheusMetricsPort is the TCP port that the
-    Prometheus\n                  metrics server should bind to. [Default: 9091]'\n
-    \                 type: integer\n                prometheusProcessMetricsEnabled:\n
-    \                 description: 'PrometheusProcessMetricsEnabled disables process
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                removeExternalRoutes:\n                  description:
-    Whether or not to remove device routes that have not\n                    been
-    programmed by Felix. Disabling this will allow external applications\n                    to
-    also add device routes. This is enabled by default which means\n                    we
-    will remove externally added routes.\n                  type: boolean\n                reportingInterval:\n
-    \                 description: 'ReportingInterval is the interval at which Felix
-    reports\n                  its status into the datastore or 0 to disable. Must
-    be non-zero\n                  in OpenStack deployments. [Default: 30s]'\n                  type:
-    string\n                reportingTTL:\n                  description: 'ReportingTTL
-    is the time-to-live setting for process-wide\n                  status reports.
-    [Default: 90s]'\n                  type: string\n                routeRefreshInterval:\n
-    \                 description: 'RouterefreshInterval is the period at which Felix
-    re-checks\n                  the routes in the dataplane to ensure that no other
-    process has\n                  accidentally broken Calico’s rules. Set to 0 to
-    disable route refresh.\n                  [Default: 90s]'\n                  type:
-    string\n                routeSource:\n                  description: 'RouteSource
-    configures where Felix gets its routing\n                  information. - WorkloadIPs:
-    use workload endpoints to construct\n                  routes. - CalicoIPAM: the
-    default - use IPAM data to construct routes.'\n                  type: string\n
-    \               routeTableRange:\n                  description: Calico programs
-    additional Linux route tables for various\n                    purposes.  RouteTableRange
-    specifies the indices of the route tables\n                    that Calico should
-    use.\n                  properties:\n                    max:\n                      type:
-    integer\n                    min:\n                      type: integer\n                  required:\n
-    \                   - max\n                    - min\n                  type:
-    object\n                serviceLoopPrevention:\n                  description:
-    'When service IP advertisement is enabled, prevent routing\n                    loops
-    to service IPs that are not in use, by dropping or rejecting\n                    packets
-    that do not get DNAT''d by kube-proxy. Unless set to \"Disabled\",\n                    in
-    which case such routing loops continue to be allowed. [Default:\n                    Drop]'\n
-    \                 type: string\n                sidecarAccelerationEnabled:\n
-    \                 description: 'SidecarAccelerationEnabled enables experimental
-    sidecar\n                  acceleration [Default: false]'\n                  type:
-    boolean\n                usageReportingEnabled:\n                  description:
-    'UsageReportingEnabled reports anonymous Calico version\n                  number
-    and cluster size to projectcalico.org. Logs warnings returned\n                  by
-    the usage server. For example, if a significant security vulnerability\n                  has
-    been discovered in the version of Calico being used. [Default:\n                  true]'\n
-    \                 type: boolean\n                usageReportingInitialDelay:\n
-    \                 description: 'UsageReportingInitialDelay controls the minimum
-    delay\n                  before Felix makes a report. [Default: 300s]'\n                  type:
-    string\n                usageReportingInterval:\n                  description:
-    'UsageReportingInterval controls the interval at which\n                  Felix
-    makes reports. [Default: 86400s]'\n                  type: string\n                useInternalDataplaneDriver:\n
-    \                 type: boolean\n                vxlanEnabled:\n                  type:
-    boolean\n                vxlanMTU:\n                  description: 'VXLANMTU is
-    the MTU to set on the tunnel device. See\n                  Configuring MTU [Default:
-    1440]'\n                  type: integer\n                vxlanPort:\n                  type:
-    integer\n                vxlanVNI:\n                  type: integer\n                wireguardEnabled:\n
-    \                 description: 'WireguardEnabled controls whether Wireguard is
-    enabled.\n                  [Default: false]'\n                  type: boolean\n
-    \               wireguardInterfaceName:\n                  description: 'WireguardInterfaceName
-    specifies the name to use for\n                  the Wireguard interface. [Default:
-    wg.calico]'\n                  type: string\n                wireguardListeningPort:\n
-    \                 description: 'WireguardListeningPort controls the listening
-    port used\n                  by Wireguard. [Default: 51820]'\n                  type:
-    integer\n                wireguardMTU:\n                  description: 'WireguardMTU
-    controls the MTU on the Wireguard interface.\n                  See Configuring
-    MTU [Default: 1420]'\n                  type: integer\n                wireguardRoutingRulePriority:\n
-    \                 description: 'WireguardRoutingRulePriority controls the priority
-    value\n                  to use for the Wireguard routing rule. [Default: 99]'\n
-    \                 type: integer\n                xdpEnabled:\n                  description:
-    'XDPEnabled enables XDP acceleration for suitable untracked\n                  incoming
-    deny rules. [Default: true]'\n                  type: boolean\n                xdpRefreshInterval:\n
-    \                 description: 'XDPRefreshInterval is the period at which Felix
-    re-checks\n                  all XDP state to ensure that no other process has
-    accidentally broken\n                  Calico''s BPF maps or attached programs.
-    Set to 0 to disable XDP\n                  refresh. [Default: 90s]'\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: globalnetworkpolicies.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: GlobalNetworkPolicy\n    listKind:
-    GlobalNetworkPolicyList\n    plural: globalnetworkpolicies\n    singular: globalnetworkpolicy\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                applyOnForward:\n
-    \                 description: ApplyOnForward indicates to apply the rules in
-    this policy\n                    on forward traffic.\n                  type:
-    boolean\n                doNotTrack:\n                  description: DoNotTrack
-    indicates whether packets matched by the rules\n                    in this policy
-    should go through the data plane's connection tracking,\n                    such
-    as Linux conntrack.  If True, the rules in this policy are\n                    applied
-    before any data plane connection tracking, and packets allowed\n                    by
-    this policy are marked as not to be tracked.\n                  type: boolean\n
-    \               egress:\n                  description: The ordered set of egress
-    rules.  Each rule contains\n                    a set of packet match criteria
-    and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                namespaceSelector:\n                  description: NamespaceSelector
-    is an optional field for an expression\n                    used to select a pod
-    based on namespaces.\n                  type: string\n                order:\n
-    \                 description: Order is an optional field that specifies the order
-    in\n                    which the policy is applied. Policies with higher \"order\"
-    are applied\n                    after those with lower order.  If the order is
-    omitted, it may be\n                    considered to be \"infinite\" - i.e. the
-    policy will be applied last.  Policies\n                    with identical order
-    will be applied in alphanumerical order based\n                    on the Policy
-    \"Name\".\n                  type: number\n                preDNAT:\n                  description:
-    PreDNAT indicates to apply the rules in this policy before\n                    any
-    DNAT.\n                  type: boolean\n                selector:\n                  description:
-    \"The selector is an expression used to pick pick out\n                  the endpoints
-    that the policy should be applied to. \\n Selector\n                  expressions
-    follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n                  \\
-    ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel != \\\"string_literal\\\"\n
-    \                 \\  ->  not equal; also matches if label is not present \\tlabel
-    in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\", ... }  ->  true if the
-    value of label X is\n                  one of \\\"a\\\", \\\"b\\\", \\\"c\\\"
-    \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ... }  ->
-    \ true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress rules are present
-    in the policy.  The\n                  default is: \\n - [ PolicyTypeIngress ],
-    if there are no Egress rules\n                  (including the case where there
-    are   also no Ingress rules) \\n\n                  - [ PolicyTypeEgress ], if
-    there are Egress rules but no Ingress\n                  rules \\n - [ PolicyTypeIngress,
-    PolicyTypeEgress ], if there are\n                  both Ingress and Egress rules.
-    \\n When the policy is read back again,\n                  Types will always be
-    one of these values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: globalnetworksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: GlobalNetworkSet\n    listKind: GlobalNetworkSetList\n    plural:
-    globalnetworksets\n    singular: globalnetworkset\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs\n            that
-    share labels to allow rules to refer to them via selectors.  The labels\n            of
-    GlobalNetworkSet are not namespaced.\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: GlobalNetworkSetSpec contains the
-    specification for a NetworkSet\n                resource.\n              properties:\n
-    \               nets:\n                  description: The list of IP networks
-    that belong to this set.\n                  items:\n                    type:
-    string\n                  type: array\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: hostendpoints.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: HostEndpoint\n    listKind: HostEndpointList\n    plural:
-    hostendpoints\n    singular: hostendpoint\n  scope: Cluster\n  versions:\n    -
-    name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: HostEndpointSpec contains the specification
-    for a HostEndpoint\n                resource.\n              properties:\n                expectedIPs:\n
-    \                 description: \"The expected IP addresses (IPv4 and IPv6) of
-    the endpoint.\n                  If \\\"InterfaceName\\\" is not present, Calico
-    will look for an interface\n                  matching any of the IPs in the list
-    and apply policy to that. Note:\n                  \\tWhen using the selector
-    match criteria in an ingress or egress\n                  security Policy \\tor
-    Profile, Calico converts the selector into\n                  a set of IP addresses.
-    For host \\tendpoints, the ExpectedIPs field\n                  is used for that
-    purpose. (If only the interface \\tname is specified,\n                  Calico
-    does not learn the IPs of the interface for use in match\n                  \\tcriteria.)\"\n
-    \                 items:\n                    type: string\n                  type:
-    array\n                interfaceName:\n                  description: \"Either
-    \\\"*\\\", or the name of a specific Linux interface\n                  to apply
-    policy to; or empty.  \\\"*\\\" indicates that this HostEndpoint\n                  governs
-    all traffic to, from or through the default network namespace\n                  of
-    the host named by the \\\"Node\\\" field; entering and leaving that\n                  namespace
-    via any interface, including those from/to non-host-networked\n                  local
-    workloads. \\n If InterfaceName is not \\\"*\\\", this HostEndpoint\n                  only
-    governs traffic that enters or leaves the host through the\n                  specific
-    interface named by InterfaceName, or - when InterfaceName\n                  is
-    empty - through the specific interface that has one of the IPs\n                  in
-    ExpectedIPs. Therefore, when InterfaceName is empty, at least\n                  one
-    expected IP must be specified.  Only external interfaces (such\n                  as
-    “eth0”) are supported here; it isn't possible for a HostEndpoint\n                  to
-    protect traffic through a specific local workload interface.\n                  \\n
-    Note: Only some kinds of policy are implemented for \\\"*\\\" HostEndpoints;\n
-    \                 initially just pre-DNAT policy.  Please check Calico documentation\n
-    \                 for the latest position.\"\n                  type: string\n
-    \               node:\n                  description: The node name identifying
-    the Calico node instance.\n                  type: string\n                ports:\n
-    \                 description: Ports contains the endpoint's named ports, which
-    may\n                    be referenced in security policy rules.\n                  items:\n
-    \                   properties:\n                      name:\n                        type:
-    string\n                      port:\n                        type: integer\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                    required:\n                      - name\n                      -
-    port\n                      - protocol\n                    type: object\n                  type:
-    array\n                profiles:\n                  description: A list of identifiers
-    of security Profile objects that\n                    apply to this endpoint.
-    Each profile is applied in the order that\n                    they appear in
-    this list.  Profile rules are applied after the selector-based\n                    security
-    policy.\n                  items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: ipamblocks.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMBlock\n    listKind: IPAMBlockList\n
-    \   plural: ipamblocks\n    singular: ipamblock\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMBlockSpec contains the specification
-    for an IPAMBlock\n                resource.\n              properties:\n                affinity:\n
-    \                 type: string\n                allocations:\n                  items:\n
-    \                   type: integer\n                    # TODO: This nullable is
-    manually added in. We should update controller-gen\n                    # to handle
-    []*int properly itself.\n                    nullable: true\n                  type:
-    array\n                attributes:\n                  items:\n                    properties:\n
-    \                     handle_id:\n                        type: string\n                      secondary:\n
-    \                       additionalProperties:\n                          type:
-    string\n                        type: object\n                    type: object\n
-    \                 type: array\n                cidr:\n                  type:
-    string\n                deleted:\n                  type: boolean\n                strictAffinity:\n
-    \                 type: boolean\n                unallocated:\n                  items:\n
-    \                   type: integer\n                  type: array\n              required:\n
-    \               - allocations\n                - attributes\n                -
-    cidr\n                - strictAffinity\n                - unallocated\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMConfig\n    listKind: IPAMConfigList\n    plural: ipamconfigs\n
-    \   singular: ipamconfig\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMConfigSpec contains the specification
-    for an IPAMConfig\n                resource.\n              properties:\n                autoAllocateBlocks:\n
-    \                 type: boolean\n                maxBlocksPerHost:\n                  description:
-    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                    that
-    can be affine to each host.\n                  type: integer\n                strictAffinity:\n
-    \                 type: boolean\n              required:\n                - autoAllocateBlocks\n
-    \               - strictAffinity\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ipamhandles.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMHandle\n    listKind: IPAMHandleList\n    plural: ipamhandles\n
-    \   singular: ipamhandle\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMHandleSpec contains the specification
-    for an IPAMHandle\n                resource.\n              properties:\n                block:\n
-    \                 additionalProperties:\n                    type: integer\n                  type:
-    object\n                deleted:\n                  type: boolean\n                handleID:\n
-    \                 type: string\n              required:\n                - block\n
-    \               - handleID\n              type: object\n          type: object\n
-    \     served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ippools.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPPool\n    listKind: IPPoolList\n    plural: ippools\n    singular:
-    ippool\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPPoolSpec contains the specification
-    for an IPPool resource.\n              properties:\n                blockSize:\n
-    \                 description: The block size to use for IP address assignments
-    from\n                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.\n
-    \                 type: integer\n                cidr:\n                  description:
-    The pool CIDR.\n                  type: string\n                disabled:\n                  description:
-    When disabled is true, Calico IPAM will not assign addresses\n                    from
-    this pool.\n                  type: boolean\n                ipip:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  properties:\n                    enabled:\n                      description:
-    When enabled is true, ipip tunneling will be used\n                        to
-    deliver packets to destinations within this pool.\n                      type:
-    boolean\n                    mode:\n                      description: The IPIP
-    mode.  This can be one of \"always\" or \"cross-subnet\".  A\n                        mode
-    of \"always\" will also use IPIP tunneling for routing to\n                        destination
-    IP addresses within this pool.  A mode of \"cross-subnet\"\n                        will
-    only use IPIP tunneling when the destination node is on\n                        a
-    different subnet to the originating node.  The default value\n                        (if
-    not specified) is \"always\".\n                      type: string\n                  type:
-    object\n                ipipMode:\n                  description: Contains configuration
-    for IPIP tunneling for this pool.\n                    If not specified, then
-    this is defaulted to \"Never\" (i.e. IPIP tunneling\n                    is disabled).\n
-    \                 type: string\n                nat-outgoing:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  type: boolean\n                natOutgoing:\n                  description:
-    When nat-outgoing is true, packets sent from Calico networked\n                    containers
-    in this pool to destinations outside of this pool will\n                    be
-    masqueraded.\n                  type: boolean\n                nodeSelector:\n
-    \                 description: Allows IPPool to allocate for a specific node by
-    label\n                    selector.\n                  type: string\n                vxlanMode:\n
-    \                 description: Contains configuration for VXLAN tunneling for
-    this pool.\n                    If not specified, then this is defaulted to \"Never\"
-    (i.e. VXLAN\n                    tunneling is disabled).\n                  type:
-    string\n              required:\n                - cidr\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: kubecontrollersconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: KubeControllersConfiguration\n    listKind: KubeControllersConfigurationList\n
-    \   plural: kubecontrollersconfigurations\n    singular: kubecontrollersconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: KubeControllersConfigurationSpec
-    contains the values of the\n                Kubernetes controllers configuration.\n
-    \             properties:\n                controllers:\n                  description:
-    Controllers enables and configures individual Kubernetes\n                    controllers\n
-    \                 properties:\n                    namespace:\n                      description:
-    Namespace enables and configures the namespace controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   node:\n                      description: Node enables and
-    configures the node controller.\n                        Enabled by default, set
-    to nil to disable.\n                      properties:\n                        hostEndpoint:\n
-    \                         description: HostEndpoint controls syncing nodes to
-    host endpoints.\n                            Disabled by default, set to nil to
-    disable.\n                          properties:\n                            autoCreate:\n
-    \                             description: 'AutoCreate enables automatic creation
-    of\n                              host endpoints for every node. [Default: Disabled]'\n
-    \                             type: string\n                          type: object\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                       syncLabels:\n                          description: 'SyncLabels
-    controls whether to copy Kubernetes\n                          node labels to
-    Calico nodes. [Default: Enabled]'\n                          type: string\n                      type:
-    object\n                    policy:\n                      description: Policy
-    enables and configures the policy controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   serviceAccount:\n                      description: ServiceAccount
-    enables and configures the service\n                        account controller.
-    Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                    workloadEndpoint:\n                      description:
-    WorkloadEndpoint enables and configures the workload\n                        endpoint
-    controller. Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                  type: object\n                etcdV3CompactionPeriod:\n
-    \                 description: 'EtcdV3CompactionPeriod is the period between etcdv3\n
-    \                 compaction requests. Set to 0 to disable. [Default: 10m]'\n
-    \                 type: string\n                healthChecks:\n                  description:
-    'HealthChecks enables or disables support for health\n                  checks
-    [Default: Enabled]'\n                  type: string\n                logSeverityScreen:\n
-    \                 description: 'LogSeverityScreen is the log severity above which
-    logs\n                  are sent to the stdout. [Default: Info]'\n                  type:
-    string\n                prometheusMetricsPort:\n                  description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                    metrics
-    server should bind to. Set to 0 to disable. [Default: 9094]'\n                  type:
-    integer\n              required:\n                - controllers\n              type:
-    object\n            status:\n              description: KubeControllersConfigurationStatus
-    represents the status\n                of the configuration. It's useful for admins
-    to be able to see the actual\n                config that was applied, which can
-    be modified by environment variables\n                on the kube-controllers
-    process.\n              properties:\n                environmentVars:\n                  additionalProperties:\n
-    \                   type: string\n                  description: EnvironmentVars
-    contains the environment variables on\n                    the kube-controllers
-    that influenced the RunningConfig.\n                  type: object\n                runningConfig:\n
-    \                 description: RunningConfig contains the effective config that
-    is running\n                    in the kube-controllers pod, after merging the
-    API resource with\n                    any environment variables.\n                  properties:\n
-    \                   controllers:\n                      description: Controllers
-    enables and configures individual Kubernetes\n                        controllers\n
-    \                     properties:\n                        namespace:\n                          description:
-    Namespace enables and configures the namespace\n                            controller.
-    Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        node:\n
-    \                         description: Node enables and configures the node controller.\n
-    \                           Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           hostEndpoint:\n                              description:
-    HostEndpoint controls syncing nodes to host\n                                endpoints.
-    Disabled by default, set to nil to disable.\n                              properties:\n
-    \                               autoCreate:\n                                  description:
-    'AutoCreate enables automatic creation\n                                  of host
-    endpoints for every node. [Default: Disabled]'\n                                  type:
-    string\n                              type: object\n                            leakGracePeriod:\n
-    \                             description: 'LeakGracePeriod is the period used
-    by the\n                                controller to determine if an IP address
-    has been leaked.\n                                Set to 0 to disable IP garbage
-    collection. [Default:\n                                15m]'\n                              type:
-    string\n                            reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                            syncLabels:\n                              description:
-    'SyncLabels controls whether to copy Kubernetes\n                              node
-    labels to Calico nodes. [Default: Enabled]'\n                              type:
-    string\n                          type: object\n                        policy:\n
-    \                         description: Policy enables and configures the policy
-    controller.\n                            Enabled by default, set to nil to disable.\n
-    \                         properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        serviceAccount:\n
-    \                         description: ServiceAccount enables and configures the
-    service\n                            account controller. Enabled by default, set
-    to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        workloadEndpoint:\n
-    \                         description: WorkloadEndpoint enables and configures
-    the workload\n                            endpoint controller. Enabled by default,
-    set to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                      type: object\n
-    \                   etcdV3CompactionPeriod:\n                      description:
-    'EtcdV3CompactionPeriod is the period between etcdv3\n                      compaction
-    requests. Set to 0 to disable. [Default: 10m]'\n                      type: string\n
-    \                   healthChecks:\n                      description: 'HealthChecks
-    enables or disables support for health\n                      checks [Default:
-    Enabled]'\n                      type: string\n                    logSeverityScreen:\n
-    \                     description: 'LogSeverityScreen is the log severity above
-    which\n                      logs are sent to the stdout. [Default: Info]'\n                      type:
-    string\n                    prometheusMetricsPort:\n                      description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                        metrics
-    server should bind to. Set to 0 to disable. [Default:\n                        9094]'\n
-    \                     type: integer\n                  required:\n                    -
-    controllers\n                  type: object\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: networkpolicies.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkPolicy\n    listKind: NetworkPolicyList\n    plural:
-    networkpolicies\n    singular: networkpolicy\n  scope: Namespaced\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                egress:\n                  description:
-    The ordered set of egress rules.  Each rule contains\n                    a set
-    of packet match criteria and a corresponding action to apply.\n                  items:\n
-    \                   description: \"A Rule encapsulates a set of match criteria
-    and an\n                    action.  Both selector-based security Policy and security
-    Profiles\n                    reference rules - separated out as a list of rules
-    for both ingress\n                    and egress packet matching. \\n Each positive
-    match criteria has\n                    a negated version, prefixed with ”Not”.
-    All the match criteria\n                    within a rule must be satisfied for
-    a packet to match. A single\n                    rule can contain the positive
-    and negative version of a match\n                    and both must be satisfied
-    for the rule to match.\"\n                    properties:\n                      action:\n
-    \                       type: string\n                      destination:\n                        description:
-    Destination contains the match criteria that apply\n                          to
-    destination entity.\n                        properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                order:\n                  description: Order is an optional
-    field that specifies the order in\n                    which the policy is applied.
-    Policies with higher \"order\" are applied\n                    after those with
-    lower order.  If the order is omitted, it may be\n                    considered
-    to be \"infinite\" - i.e. the policy will be applied last.  Policies\n                    with
-    identical order will be applied in alphanumerical order based\n                    on
-    the Policy \"Name\".\n                  type: number\n                selector:\n
-    \                 description: \"The selector is an expression used to pick pick
-    out\n                  the endpoints that the policy should be applied to. \\n
-    Selector\n                  expressions follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n
-    \                 \\ ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel
-    != \\\"string_literal\\\"\n                  \\  ->  not equal; also matches if
-    label is not present \\tlabel in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\",
-    ... }  ->  true if the value of label X is\n                  one of \\\"a\\\",
-    \\\"b\\\", \\\"c\\\" \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ...
-    }  ->  true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress are present in the
-    policy.  The default\n                  is: \\n - [ PolicyTypeIngress ], if there
-    are no Egress rules (including\n                  the case where there are   also
-    no Ingress rules) \\n - [ PolicyTypeEgress\n                  ], if there are
-    Egress rules but no Ingress rules \\n - [ PolicyTypeIngress,\n                  PolicyTypeEgress
-    ], if there are both Ingress and Egress rules.\n                  \\n When the
-    policy is read back again, Types will always be one\n                  of these
-    values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: networksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkSet\n    listKind: NetworkSetList\n    plural: networksets\n
-    \   singular: networkset\n  scope: Namespaced\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          description: NetworkSet is the Namespaced-equivalent
-    of the GlobalNetworkSet.\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: NetworkSetSpec contains the specification
-    for a NetworkSet\n                resource.\n              properties:\n                nets:\n
-    \                 description: The list of IP networks that belong to this set.\n
-    \                 items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n---\n# Source: calico/templates/calico-kube-controllers-rbac.yaml\n\n#
-    Include a clusterrole for the kube-controllers component,\n# and bind it to the
-    calico-kube-controllers serviceaccount.\nkind: ClusterRole\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nrules:\n  # Nodes are watched to monitor for
-    deletions.\n  - apiGroups: [\"\"]\n    resources:\n      - nodes\n    verbs:\n
-    \     - watch\n      - list\n      - get\n  # Pods are watched to check for existence
-    as part of IPAM controller.\n  - apiGroups: [\"\"]\n    resources:\n      - pods\n
-    \   verbs:\n      - get\n      - list\n      - watch\n  # IPAM resources are manipulated
-    when nodes are deleted.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - ippools\n    verbs:\n      - list\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - blockaffinities\n      - ipamblocks\n      - ipamhandles\n
-    \   verbs:\n      - get\n      - list\n      - create\n      - update\n      -
-    delete\n      - watch\n  # kube-controllers manages hostendpoints.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - hostendpoints\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  #
-    Needs access to update clusterinformations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - clusterinformations\n    verbs:\n      - get\n      -
-    create\n      - update\n  # KubeControllersConfiguration is where it gets its
-    config\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - kubecontrollersconfigurations\n
-    \   verbs:\n      # read its own config\n      - get\n      # create a default
-    if none exists\n      - create\n      # update status\n      - update\n      #
-    watch for changes\n      - watch\n---\nkind: ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-kube-controllers\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-kube-controllers\n    namespace: kube-system\n---\n\n---\n# Source:
-    calico/templates/calico-node-rbac.yaml\n# Include a clusterrole for the calico-node
-    DaemonSet,\n# and bind it to the calico-node serviceaccount.\nkind: ClusterRole\napiVersion:
-    rbac.authorization.k8s.io/v1\nmetadata:\n  name: calico-node\nrules:\n  # The
-    CNI plugin needs to get pods, nodes, and namespaces.\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - pods\n      - nodes\n      - namespaces\n    verbs:\n
-    \     - get\n  # EndpointSlices are used for Service-based network policy rule\n
-    \ # enforcement.\n  - apiGroups: [\"discovery.k8s.io\"]\n    resources:\n      -
-    endpointslices\n    verbs:\n      - watch\n      - list\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - endpoints\n      - services\n    verbs:\n      # Used
-    to discover service IPs for advertisement.\n      - watch\n      - list\n      #
-    Used to discover Typhas.\n      - get\n  # Pod CIDR auto-detection on kubeadm
-    needs access to config maps.\n  - apiGroups: [\"\"]\n    resources:\n      - configmaps\n
-    \   verbs:\n      - get\n  - apiGroups: [\"\"]\n    resources:\n      - nodes/status\n
-    \   verbs:\n      # Needed for clearing NodeNetworkUnavailable flag.\n      -
-    patch\n      # Calico stores some configuration information in node annotations.\n
-    \     - update\n  # Watch for changes to Kubernetes NetworkPolicies.\n  - apiGroups:
-    [\"networking.k8s.io\"]\n    resources:\n      - networkpolicies\n    verbs:\n
-    \     - watch\n      - list\n  # Used by Calico for policy information.\n  - apiGroups:
-    [\"\"]\n    resources:\n      - pods\n      - namespaces\n      - serviceaccounts\n
-    \   verbs:\n      - list\n      - watch\n  # The CNI plugin patches pods/status.\n
-    \ - apiGroups: [\"\"]\n    resources:\n      - pods/status\n    verbs:\n      -
-    patch\n  # Calico monitors various CRDs for config.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - globalfelixconfigs\n      - felixconfigurations\n      -
-    bgppeers\n      - globalbgpconfigs\n      - bgpconfigurations\n      - ippools\n
-    \     - ipamblocks\n      - globalnetworkpolicies\n      - globalnetworksets\n
-    \     - networkpolicies\n      - networksets\n      - clusterinformations\n      -
-    hostendpoints\n      - blockaffinities\n    verbs:\n      - get\n      - list\n
-    \     - watch\n  # Calico must create and update some CRDs on startup.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - ippools\n      - felixconfigurations\n
-    \     - clusterinformations\n    verbs:\n      - create\n      - update\n  # Calico
-    stores some configuration information on the node.\n  - apiGroups: [\"\"]\n    resources:\n
-    \     - nodes\n    verbs:\n      - get\n      - list\n      - watch\n  # These
-    permissions are only required for upgrade from v2.6, and can\n  # be removed after
-    upgrade or on fresh installations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - bgpconfigurations\n      - bgppeers\n    verbs:\n      -
-    create\n      - update\n  # These permissions are required for Calico CNI to perform
-    IPAM allocations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n      - ipamblocks\n      - ipamhandles\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  -
-    apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - ipamconfigs\n
-    \   verbs:\n      - get\n  # Block affinities must also be watchable by confd
-    for route aggregation.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n    verbs:\n      - watch\n  # The Calico IPAM migration
-    needs to get daemonsets. These permissions can be\n  # removed if not upgrading
-    from an installation using host-local IPAM.\n  - apiGroups: [\"apps\"]\n    resources:\n
-    \     - daemonsets\n    verbs:\n      - get\n\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:
-    ClusterRoleBinding\nmetadata:\n  name: calico-node\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-node\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-node\n    namespace: kube-system\n\n---\n# Source: calico/templates/calico-node.yaml\n#
-    This manifest installs the calico-node container, as well\n# as the CNI plugins
-    and network config on\n# each master and worker node in a Kubernetes cluster.\nkind:
-    DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: calico-node\n  namespace: kube-system\n
-    \ labels:\n    k8s-app: calico-node\nspec:\n  selector:\n    matchLabels:\n      k8s-app:
-    calico-node\n  updateStrategy:\n    type: RollingUpdate\n    rollingUpdate:\n
-    \     maxUnavailable: 1\n  template:\n    metadata:\n      labels:\n        k8s-app:
-    calico-node\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n
-    \     hostNetwork: true\n      tolerations:\n        # Make sure calico-node gets
-    scheduled on all nodes.\n        - effect: NoSchedule\n          operator: Exists\n
-    \       # Mark the pod as a critical add-on for rescheduling.\n        - key:
-    CriticalAddonsOnly\n          operator: Exists\n        - effect: NoExecute\n
-    \         operator: Exists\n      serviceAccountName: calico-node\n      # Minimize
-    downtime during a rolling upgrade or deletion; tell Kubernetes to do a \"force\n
-    \     # deletion\": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.\n
-    \     terminationGracePeriodSeconds: 0\n      priorityClassName: system-node-critical\n
-    \     initContainers:\n        # This container performs upgrade from host-local
-    IPAM to calico-ipam.\n        # It can be deleted if this is a fresh installation,
-    or if you have already\n        # upgraded to use calico-ipam.\n        - name:
-    upgrade-ipam\n          image: calico/cni:v3.20.0\n          command: [\"/opt/cni/bin/calico-ipam\",
-    \"-upgrade\"]\n          envFrom:\n            - configMapRef:\n                #
-    Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for
-    eBPF mode.\n                name: kubernetes-services-endpoint\n                optional:
-    true\n          env:\n            - name: KUBERNETES_NODE_NAME\n              valueFrom:\n
-    \               fieldRef:\n                  fieldPath: spec.nodeName\n            -
-    name: CALICO_NETWORKING_BACKEND\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: calico_backend\n
-    \         volumeMounts:\n            - mountPath: /var/lib/cni/networks\n              name:
-    host-local-net-dir\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n          securityContext:\n            privileged: true\n        #
-    This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: calico/cni:v3.20.0\n
-    \         command: [\"/opt/cni/bin/install\"]\n          envFrom:\n            -
-    configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
-    to be overridden for eBPF mode.\n                name: kubernetes-services-endpoint\n
-    \               optional: true\n          env:\n            # Name of the CNI
-    config file to create.\n            - name: CNI_CONF_NAME\n              value:
-    \"10-calico.conflist\"\n            # The CNI network config to install on each
-    node.\n            - name: CNI_NETWORK_CONFIG\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: cni_network_config\n
-    \           # Set the hostname based on the k8s node name.\n            - name:
-    KUBERNETES_NODE_NAME\n              valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # CNI MTU Config variable\n            - name: CNI_MTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Prevents the container
-    from sleeping forever.\n            - name: SLEEP\n              value: \"false\"\n
-    \         volumeMounts:\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n            - mountPath: /host/etc/cni/net.d\n              name:
-    cni-net-dir\n          securityContext:\n            privileged: true\n        #
-    Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes\n
-    \       # to communicate with Felix over the Policy Sync API.\n        - name:
-    flexvol-driver\n          image: calico/pod2daemon-flexvol:v3.20.0\n          volumeMounts:\n
-    \           - name: flexvol-driver-host\n              mountPath: /host/driver\n
-    \         securityContext:\n            privileged: true\n      containers:\n
-    \       # Runs calico-node container on each Kubernetes node. This\n        #
-    container programs network policy and routes on each\n        # host.\n        -
-    name: calico-node\n          image: calico/node:v3.20.0\n          envFrom:\n
-    \           - configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and
-    KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.\n                name:
-    kubernetes-services-endpoint\n                optional: true\n          env:\n
-    \           # Use Kubernetes API as the backing datastore.\n            - name:
-    DATASTORE_TYPE\n              value: \"kubernetes\"\n            # Wait for the
-    datastore.\n            - name: WAIT_FOR_DATASTORE\n              value: \"true\"\n
-    \           # Set based on the k8s node name.\n            - name: NODENAME\n
-    \             valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # Choose the backend to use.\n            - name: CALICO_NETWORKING_BACKEND\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: calico_backend\n            # Cluster type
-    to identify the deployment type\n            - name: CLUSTER_TYPE\n              value:
-    \"k8s,bgp\"\n            # Auto-detect the BGP IP address.\n            - name:
-    IP\n              value: \"autodetect\"\n            # Enable VXLAN\n            -
-    name: CALICO_IPV4POOL_VXLAN\n              value: \"Always\"\n            # Set
-    MTU for tunnel device used if ipip is enabled\n            - name: FELIX_IPINIPMTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Set MTU for the
-    VXLAN tunnel device.\n            - name: FELIX_VXLANMTU\n              valueFrom:\n
-    \               configMapKeyRef:\n                  name: calico-config\n                  key:
-    veth_mtu\n            # Set MTU for the Wireguard tunnel device.\n            -
-    name: FELIX_WIREGUARDMTU\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: veth_mtu\n            #
-    The default IPv4 pool to create on startup if none exists. Pod IPs will be\n            #
-    chosen from this range. Changing this value after installation will have\n            #
-    no effect. This should fall within `--cluster-cidr`.\n            # - name: CALICO_IPV4POOL_CIDR\n
-    \           #   value: \"192.168.0.0/16\"\n            # Disable file logging
-    so `kubectl logs` works.\n            - name: CALICO_DISABLE_FILE_LOGGING\n              value:
-    \"true\"\n            # Set Felix endpoint to host default action to ACCEPT.\n
-    \           - name: FELIX_DEFAULTENDPOINTTOHOSTACTION\n              value: \"ACCEPT\"\n
-    \           # Disable IPv6 on Kubernetes.\n            - name: FELIX_IPV6SUPPORT\n
-    \             value: \"false\"\n            - name: FELIX_FEATUREDETECTOVERRIDE\n
-    \             value: \"ChecksumOffloadBroken=true\"\n            - name: FELIX_HEALTHENABLED\n
-    \             value: \"true\"\n          securityContext:\n            privileged:
-    true\n          resources:\n            requests:\n              cpu: 250m\n          livenessProbe:\n
-    \           exec:\n              command:\n                - /bin/calico-node\n
-    \               - -felix-live\n            periodSeconds: 10\n            initialDelaySeconds:
-    10\n            failureThreshold: 6\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /bin/calico-node\n                -
-    -felix-ready\n            periodSeconds: 10\n          volumeMounts:\n            -
-    mountPath: /host/etc/cni/net.d\n              name: cni-net-dir\n              readOnly:
-    false\n            - mountPath: /lib/modules\n              name: lib-modules\n
-    \             readOnly: true\n            - mountPath: /run/xtables.lock\n              name:
-    xtables-lock\n              readOnly: false\n            - mountPath: /var/run/calico\n
-    \             name: var-run-calico\n              readOnly: false\n            -
-    mountPath: /var/lib/calico\n              name: var-lib-calico\n              readOnly:
-    false\n            - name: policysync\n              mountPath: /var/run/nodeagent\n
-    \           # For eBPF mode, we need to be able to mount the BPF filesystem at
-    /sys/fs/bpf so we mount in the\n            # parent directory.\n            -
-    name: sysfs\n              mountPath: /sys/fs/\n              # Bidirectional
-    means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to
-    the host.\n              # If the host is known to mount that filesystem already
-    then Bidirectional can be omitted.\n              mountPropagation: Bidirectional\n
-    \           - name: cni-log-dir\n              mountPath: /var/log/calico/cni\n
-    \             readOnly: true\n      volumes:\n        # Used by calico-node.\n
-    \       - name: lib-modules\n          hostPath:\n            path: /lib/modules\n
-    \       - name: var-run-calico\n          hostPath:\n            path: /var/run/calico\n
-    \       - name: var-lib-calico\n          hostPath:\n            path: /var/lib/calico\n
-    \       - name: xtables-lock\n          hostPath:\n            path: /run/xtables.lock\n
-    \           type: FileOrCreate\n        - name: sysfs\n          hostPath:\n            path:
-    /sys/fs/\n            type: DirectoryOrCreate\n        # Used to install CNI.\n
-    \       - name: cni-bin-dir\n          hostPath:\n            path: /opt/cni/bin\n
-    \       - name: cni-net-dir\n          hostPath:\n            path: /etc/cni/net.d\n
-    \       # Used to access CNI logs.\n        - name: cni-log-dir\n          hostPath:\n
-    \           path: /var/log/calico/cni\n        # Mount in the directory for host-local
-    IPAM allocations. This is\n        # used when upgrading from host-local to calico-ipam,
-    and can be removed\n        # if not using the upgrade-ipam init container.\n
-    \       - name: host-local-net-dir\n          hostPath:\n            path: /var/lib/cni/networks\n
-    \       # Used to create per-pod Unix Domain Sockets\n        - name: policysync\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /var/run/nodeagent\n
-    \       # Used to install Flex Volume Driver\n        - name: flexvol-driver-host\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds\n---\n\napiVersion:
-    v1\nkind: ServiceAccount\nmetadata:\n  name: calico-node\n  namespace: kube-system\n\n---\n#
-    Source: calico/templates/calico-kube-controllers.yaml\n# See https://github.com/projectcalico/kube-controllers\napiVersion:
-    apps/v1\nkind: Deployment\nmetadata:\n  name: calico-kube-controllers\n  namespace:
-    kube-system\n  labels:\n    k8s-app: calico-kube-controllers\nspec:\n  # The controllers
-    can only have a single active instance.\n  replicas: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n  strategy:\n    type: Recreate\n  template:\n
-    \   metadata:\n      name: calico-kube-controllers\n      namespace: kube-system\n
-    \     labels:\n        k8s-app: calico-kube-controllers\n    spec:\n      nodeSelector:\n
-    \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
-    a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
-    Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
-    \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
-    \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
-    \         env:\n            # Choose which controllers to run.\n            -
-    name: ENABLED_CONTROLLERS\n              value: node\n            - name: DATASTORE_TYPE\n
-    \             value: kubernetes\n          livenessProbe:\n            exec:\n
-    \             command:\n              - /usr/bin/check-status\n              -
-    -l\n            periodSeconds: 10\n            initialDelaySeconds: 10\n            failureThreshold:
-    6\n            timeoutSeconds: 10\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /usr/bin/check-status\n                -
-    -r\n            periodSeconds: 10\n\n---\n\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n\n---\n\n# This manifest
-    creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler
-    to evict\n\napiVersion: policy/v1beta1\nkind: PodDisruptionBudget\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n  labels:\n    k8s-app:
-    calico-kube-controllers\nspec:\n  maxUnavailable: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n---\n# Source: calico/templates/calico-etcd-secrets.yaml\n\n---\n#
-    Source: calico/templates/calico-typha.yaml\n\n---\n# Source: calico/templates/configure-canal.yaml\n"
+  resources: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgpconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPConfiguration
+        listKind: BGPConfigurationList
+        plural: bgpconfigurations
+        singular: bgpconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: BGPConfiguration contains the configuration for any BGP routing.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPConfigurationSpec contains the values of the BGP configuration.
+                properties:
+                  asNumber:
+                    description: 'ASNumber is the default AS number used by a node. [Default:
+                      64512]'
+                    format: int32
+                    type: integer
+                  communities:
+                    description: Communities is a list of BGP community values and their
+                      arbitrary names for tagging routes.
+                    items:
+                      description: Community contains standard or large community value
+                        and its name.
+                      properties:
+                        name:
+                          description: Name given to community value.
+                          type: string
+                        value:
+                          description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                            For standard community use `aa:nn` format, where `aa` and
+                            `nn` are 16 bit number. For large community use `aa:nn:mm`
+                            format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                            `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                          pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                          type: string
+                      type: object
+                    type: array
+                  listenPort:
+                    description: ListenPort is the port where BGP protocol should listen.
+                      Defaults to 179
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: INFO]'
+                    type: string
+                  nodeToNodeMeshEnabled:
+                    description: 'NodeToNodeMeshEnabled sets whether full node to node
+                      BGP mesh is enabled. [Default: true]'
+                    type: boolean
+                  prefixAdvertisements:
+                    description: PrefixAdvertisements contains per-prefix advertisement
+                      configuration.
+                    items:
+                      description: PrefixAdvertisement configures advertisement properties
+                        for the specified CIDR.
+                      properties:
+                        cidr:
+                          description: CIDR for which properties should be advertised.
+                          type: string
+                        communities:
+                          description: Communities can be list of either community names
+                            already defined in `Specs.Communities` or community value
+                            of format `aa:nn` or `aa:nn:mm`. For standard community use
+                            `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                            large community use `aa:nn:mm` format, where `aa`, `nn` and
+                            `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                            `mm` are per-AS identifier.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  serviceClusterIPs:
+                    description: ServiceClusterIPs are the CIDR blocks from which service
+                      cluster IPs are allocated. If specified, Calico will advertise these
+                      blocks, as well as any cluster IPs within them.
+                    items:
+                      description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                        CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceExternalIPs:
+                    description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                      Service External IPs. Kubernetes Service ExternalIPs will only be
+                      advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceExternalIPBlock represents a single allowed
+                        External IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceLoadBalancerIPs:
+                    description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                      Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                      IPs will only be advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceLoadBalancerIPBlock represents a single allowed
+                        LoadBalancer IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgppeers.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPPeer
+        listKind: BGPPeerList
+        plural: bgppeers
+        singular: bgppeer
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPPeerSpec contains the specification for a BGPPeer resource.
+                properties:
+                  asNumber:
+                    description: The AS Number of the peer.
+                    format: int32
+                    type: integer
+                  keepOriginalNextHop:
+                    description: Option to keep the original nexthop field when routes
+                      are sent to a BGP Peer. Setting "true" configures the selected BGP
+                      Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                      in the specific branch of the Node on "bird.cfg".
+                    type: boolean
+                  maxRestartTime:
+                    description: Time to allow for software restart.  When specified,
+                      this is configured as the graceful restart timeout.  When not specified,
+                      the BIRD default of 120s is used.
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance that
+                      is targeted by this peer. If this is not set, and no nodeSelector
+                      is specified, then this BGP peer selects all nodes in the cluster.
+                    type: string
+                  nodeSelector:
+                    description: Selector for the nodes that should have this peering.  When
+                      this is set, the Node field must be empty.
+                    type: string
+                  password:
+                    description: Optional BGP password for the peerings generated by this
+                      BGPPeer resource.
+                    properties:
+                      secretKeyRef:
+                        description: Selects a key of a secret in the node pod's namespace.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be
+                              a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be
+                              defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  peerIP:
+                    description: The IP address of the peer followed by an optional port
+                      number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                      or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                      and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                      set in BGPConfiguration, then we use that port to peer.
+                    type: string
+                  peerSelector:
+                    description: Selector for the remote nodes to peer with.  When this
+                      is set, the PeerIP and ASNumber fields must be empty.  For each
+                      peering between the local node and selected remote nodes, we configure
+                      an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                      and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                      remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                      or the global default if that is not set.
+                    type: string
+                  sourceAddress:
+                    description: Specifies whether and how to configure a source address
+                      for the peerings generated by this BGPPeer resource.  Default value
+                      "UseNodeIP" means to configure the node IP as the source address.  "None"
+                      means not to configure a source address.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: blockaffinities.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BlockAffinity
+        listKind: BlockAffinityList
+        plural: blockaffinities
+        singular: blockaffinity
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BlockAffinitySpec contains the specification for a BlockAffinity
+                  resource.
+                properties:
+                  cidr:
+                    type: string
+                  deleted:
+                    description: Deleted indicates that this block affinity is being deleted.
+                      This field is a string for compatibility with older releases that
+                      mistakenly treat this field as a string.
+                    type: string
+                  node:
+                    type: string
+                  state:
+                    type: string
+                required:
+                - cidr
+                - deleted
+                - node
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: clusterinformations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: ClusterInformation
+        listKind: ClusterInformationList
+        plural: clusterinformations
+        singular: clusterinformation
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterInformation contains the cluster specific information.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterInformationSpec contains the values of describing
+                  the cluster.
+                properties:
+                  calicoVersion:
+                    description: CalicoVersion is the version of Calico that the cluster
+                      is running
+                    type: string
+                  clusterGUID:
+                    description: ClusterGUID is the GUID of the cluster
+                    type: string
+                  clusterType:
+                    description: ClusterType describes the type of the cluster
+                    type: string
+                  datastoreReady:
+                    description: DatastoreReady is used during significant datastore migrations
+                      to signal to components such as Felix that it should wait before
+                      accessing the datastore.
+                    type: boolean
+                  variant:
+                    description: Variant declares which variant of Calico should be active.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: felixconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: FelixConfiguration
+        listKind: FelixConfigurationList
+        plural: felixconfigurations
+        singular: felixconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: Felix Configuration contains the configuration for Felix.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: FelixConfigurationSpec contains the values of the Felix configuration.
+                properties:
+                  allowIPIPPacketsFromWorkloads:
+                    description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop IPIP encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  allowVXLANPacketsFromWorkloads:
+                    description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop VXLAN encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  awsSrcDstCheck:
+                    description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                      value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                      DoNothing]'
+                    enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                    type: string
+                  bpfConnectTimeLoadBalancingEnabled:
+                    description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                      controls whether Felix installs the connection-time load balancer.  The
+                      connect-time load balancer is required for the host to be able to
+                      reach Kubernetes services and it improves the performance of pod-to-service
+                      connections.  The only reason to disable it is for debugging purposes.  [Default:
+                      true]'
+                    type: boolean
+                  bpfDataIfacePattern:
+                    description: BPFDataIfacePattern is a regular expression that controls
+                      which interfaces Felix should attach BPF programs to in order to
+                      catch traffic to/from the network.  This needs to match the interfaces
+                      that Calico workload traffic flows over as well as any interfaces
+                      that handle incoming traffic to nodeports and services from outside
+                      the cluster.  It should not match the workload interfaces (usually
+                      named cali...).
+                    type: string
+                  bpfDisableUnprivileged:
+                    description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                      sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                      users cannot access Calico''s BPF maps and cannot insert their own
+                      BPF programs to interfere with Calico''s. [Default: true]'
+                    type: boolean
+                  bpfEnabled:
+                    description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                      [Default: false]'
+                    type: boolean
+                  bpfExtToServiceConnmark:
+                    description: 'BPFExtToServiceConnmark in BPF mode, controls a 32bit
+                      mark that is set on connections from an external client to a local
+                      service. This mark allows us to control how packets of that connection
+                      are routed within the host and how is routing intepreted by RPF
+                      check. [Default: 0]'
+                    type: integer
+                  bpfExternalServiceMode:
+                    description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                      from outside the cluster to services (node ports and cluster IPs)
+                      are forwarded to remote workloads.  If set to "Tunnel" then both
+                      request and response traffic is tunneled to the remote node.  If
+                      set to "DSR", the request traffic is tunneled but the response traffic
+                      is sent directly from the remote node.  In "DSR" mode, the remote
+                      node appears to use the IP of the ingress node; this requires a
+                      permissive L2 network.  [Default: Tunnel]'
+                    type: string
+                  bpfKubeProxyEndpointSlicesEnabled:
+                    description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                      whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                    type: boolean
+                  bpfKubeProxyIptablesCleanupEnabled:
+                    description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                      mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                      iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                      true]'
+                    type: boolean
+                  bpfKubeProxyMinSyncPeriod:
+                    description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                      minimum time between updates to the dataplane for Felix''s embedded
+                      kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                      reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                    type: string
+                  bpfLogLevel:
+                    description: 'BPFLogLevel controls the log level of the BPF programs
+                      when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                      logs are emitted to the BPF trace pipe, accessible with the command
+                      `tc exec bpf debug`. [Default: Off].'
+                    type: string
+                  chainInsertMode:
+                    description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                      top-level iptables chains by inserting a rule at the top of the
+                      chain or by appending a rule at the bottom. insert is the safe default
+                      since it prevents Calico''s rules from being bypassed. If you switch
+                      to append mode, be sure that the other rules in the chains signal
+                      acceptance by falling through to the Calico rules, otherwise the
+                      Calico policy will be bypassed. [Default: insert]'
+                    type: string
+                  dataplaneDriver:
+                    type: string
+                  debugDisableLogDropping:
+                    type: boolean
+                  debugMemoryProfilePath:
+                    type: string
+                  debugSimulateCalcGraphHangAfter:
+                    type: string
+                  debugSimulateDataplaneHangAfter:
+                    type: string
+                  defaultEndpointToHostAction:
+                    description: 'DefaultEndpointToHostAction controls what happens to
+                      traffic that goes from a workload endpoint to the host itself (after
+                      the traffic hits the endpoint egress policy). By default Calico
+                      blocks traffic from workload endpoints to the host itself with an
+                      iptables "DROP" action. If you want to allow some or all traffic
+                      from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                      RETURN if you have your own rules in the iptables "INPUT" chain;
+                      Calico will insert its rules at the top of that chain, then "RETURN"
+                      packets to the "INPUT" chain once it has completed processing workload
+                      endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                      from workloads after processing workload endpoint egress policy.
+                      [Default: Drop]'
+                    type: string
+                  deviceRouteProtocol:
+                    description: This defines the route protocol added to programmed device
+                      routes, by default this will be RTPROT_BOOT when left blank.
+                    type: integer
+                  deviceRouteSourceAddress:
+                    description: This is the source address to use on programmed device
+                      routes. By default the source address is left blank, leaving the
+                      kernel to choose the source address used.
+                    type: string
+                  disableConntrackInvalidCheck:
+                    type: boolean
+                  endpointReportingDelay:
+                    type: string
+                  endpointReportingEnabled:
+                    type: boolean
+                  externalNodesList:
+                    description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                      which may source tunnel traffic and have the tunneled traffic be
+                      accepted at calico nodes.
+                    items:
+                      type: string
+                    type: array
+                  failsafeInboundHostPorts:
+                    description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow incoming traffic to host endpoints
+                      on irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all inbound host ports, use the value
+                      none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                      udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  failsafeOutboundHostPorts:
+                    description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow outgoing traffic from host endpoints
+                      to irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all outbound host ports, use the value
+                      none. The default value opens etcd''s standard ports to ensure that
+                      Felix does not get cut off from etcd as well as allowing DHCP and
+                      DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                      tcp:6667, udp:53, udp:67]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  featureDetectOverride:
+                    description: FeatureDetectOverride is used to override the feature
+                      detection. Values are specified in a comma separated list with no
+                      spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                      "true" or "false" will force the feature, empty or omitted values
+                      are auto-detected.
+                    type: string
+                  genericXDPEnabled:
+                    description: 'GenericXDPEnabled enables Generic XDP so network cards
+                      that don''t support XDP offload or driver modes can use XDP. This
+                      is not recommended since it doesn''t provide better performance
+                      than iptables. [Default: false]'
+                    type: boolean
+                  healthEnabled:
+                    type: boolean
+                  healthHost:
+                    type: string
+                  healthPort:
+                    type: integer
+                  interfaceExclude:
+                    description: 'InterfaceExclude is a comma-separated list of interfaces
+                      that Felix should exclude when monitoring for host endpoints. The
+                      default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                      interface, which is used internally by kube-proxy. If you want to
+                      exclude multiple interface names using a single value, the list
+                      supports regular expressions. For regular expressions you must wrap
+                      the value with ''/''. For example having values ''/^kube/,veth1''
+                      will exclude all interfaces that begin with ''kube'' and also the
+                      interface ''veth1''. [Default: kube-ipvs0]'
+                    type: string
+                  interfacePrefix:
+                    description: 'InterfacePrefix is the interface name prefix that identifies
+                      workload endpoints and so distinguishes them from host endpoint
+                      interfaces. Note: in environments other than bare metal, the orchestrators
+                      configure this appropriately. For example our Kubernetes and Docker
+                      integrations set the ''cali'' value, and our OpenStack integration
+                      sets the ''tap'' value. [Default: cali]'
+                    type: string
+                  interfaceRefreshInterval:
+                    description: InterfaceRefreshInterval is the period at which Felix
+                      rescans local interfaces to verify their state. The rescan can be
+                      disabled by setting the interval to 0.
+                    type: string
+                  ipipEnabled:
+                    type: boolean
+                  ipipMTU:
+                    description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  ipsetsRefreshInterval:
+                    description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                      all iptables state to ensure that no other process has accidentally
+                      broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                      90s]'
+                    type: string
+                  iptablesBackend:
+                    description: IptablesBackend specifies which backend of iptables will
+                      be used. The default is legacy.
+                    type: string
+                  iptablesFilterAllowAction:
+                    type: string
+                  iptablesLockFilePath:
+                    description: 'IptablesLockFilePath is the location of the iptables
+                      lock file. You may need to change this if the lock file is not in
+                      its standard location (for example if you have mapped it into Felix''s
+                      container at a different path). [Default: /run/xtables.lock]'
+                    type: string
+                  iptablesLockProbeInterval:
+                    description: 'IptablesLockProbeInterval is the time that Felix will
+                      wait between attempts to acquire the iptables lock if it is not
+                      available. Lower values make Felix more responsive when the lock
+                      is contended, but use more CPU. [Default: 50ms]'
+                    type: string
+                  iptablesLockTimeout:
+                    description: 'IptablesLockTimeout is the time that Felix will wait
+                      for the iptables lock, or 0, to disable. To use this feature, Felix
+                      must share the iptables lock file with all other processes that
+                      also take the lock. When running Felix inside a container, this
+                      requires the /run directory of the host to be mounted into the calico/node
+                      or calico/felix container. [Default: 0s disabled]'
+                    type: string
+                  iptablesMangleAllowAction:
+                    type: string
+                  iptablesMarkMask:
+                    description: 'IptablesMarkMask is the mask that Felix selects its
+                      IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                      at least 8 bits set, none of which clash with any other mark bits
+                      in use on the system. [Default: 0xff000000]'
+                    format: int32
+                    type: integer
+                  iptablesNATOutgoingInterfaceFilter:
+                    type: string
+                  iptablesPostWriteCheckInterval:
+                    description: 'IptablesPostWriteCheckInterval is the period after Felix
+                      has done a write to the dataplane that it schedules an extra read
+                      back in order to check the write was not clobbered by another process.
+                      This should only occur if another application on the system doesn''t
+                      respect the iptables lock. [Default: 1s]'
+                    type: string
+                  iptablesRefreshInterval:
+                    description: 'IptablesRefreshInterval is the period at which Felix
+                      re-checks the IP sets in the dataplane to ensure that no other process
+                      has accidentally broken Calico''s rules. Set to 0 to disable IP
+                      sets refresh. Note: the default for this value is lower than the
+                      other refresh intervals as a workaround for a Linux kernel bug that
+                      was fixed in kernel version 4.11. If you are using v4.11 or greater
+                      you may want to set this to, a higher value to reduce Felix CPU
+                      usage. [Default: 10s]'
+                    type: string
+                  ipv6Support:
+                    type: boolean
+                  kubeNodePortRanges:
+                    description: 'KubeNodePortRanges holds list of port ranges used for
+                      service node ports. Only used if felix detects kube-proxy running
+                      in ipvs mode. Felix uses these ranges to separate host and workload
+                      traffic. [Default: 30000:32767].'
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  logFilePath:
+                    description: 'LogFilePath is the full path to the Felix log. Set to
+                      none to disable file logging. [Default: /var/log/calico/felix.log]'
+                    type: string
+                  logPrefix:
+                    description: 'LogPrefix is the log prefix that Felix uses when rendering
+                      LOG rules. [Default: calico-packet]'
+                    type: string
+                  logSeverityFile:
+                    description: 'LogSeverityFile is the log severity above which logs
+                      are sent to the log file. [Default: Info]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  logSeveritySys:
+                    description: 'LogSeveritySys is the log severity above which logs
+                      are sent to the syslog. Set to None for no logging to syslog. [Default:
+                      Info]'
+                    type: string
+                  maxIpsetSize:
+                    type: integer
+                  metadataAddr:
+                    description: 'MetadataAddr is the IP address or domain name of the
+                      server that can answer VM queries for cloud-init metadata. In OpenStack,
+                      this corresponds to the machine running nova-api (or in Ubuntu,
+                      nova-api-metadata). A value of none (case insensitive) means that
+                      Felix should not set up any NAT rule for the metadata path. [Default:
+                      127.0.0.1]'
+                    type: string
+                  metadataPort:
+                    description: 'MetadataPort is the port of the metadata server. This,
+                      combined with global.MetadataAddr (if not ''None''), is used to
+                      set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                      In most cases this should not need to be changed [Default: 8775].'
+                    type: integer
+                  mtuIfacePattern:
+                    description: MTUIfacePattern is a regular expression that controls
+                      which interfaces Felix should scan in order to calculate the host's
+                      MTU. This should not match workload interfaces (usually named cali...).
+                    type: string
+                  natOutgoingAddress:
+                    description: NATOutgoingAddress specifies an address to use when performing
+                      source NAT for traffic in a natOutgoing pool that is leaving the
+                      network. By default the address used is an address on the interface
+                      the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                    type: string
+                  natPortRange:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NATPortRange specifies the range of ports that is used
+                      for port mapping when doing outgoing NAT. When unset the default
+                      behavior of the network stack is used.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  netlinkTimeout:
+                    type: string
+                  openstackRegion:
+                    description: 'OpenstackRegion is the name of the region that a particular
+                      Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                      this must be configured somehow for each Felix (here in the datamodel,
+                      or in felix.cfg or the environment on each compute node), and must
+                      match the [calico] openstack_region value configured in neutron.conf
+                      on each node. [Default: Empty]'
+                    type: string
+                  policySyncPathPrefix:
+                    description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                      policy changes to external services, like Application layer policy.
+                      [Default: Empty]'
+                    type: string
+                  prometheusGoMetricsEnabled:
+                    description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusMetricsEnabled:
+                    description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                      server in Felix if set to true. [Default: false]'
+                    type: boolean
+                  prometheusMetricsHost:
+                    description: 'PrometheusMetricsHost is the host that the Prometheus
+                      metrics server should bind to. [Default: empty]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. [Default: 9091]'
+                    type: integer
+                  prometheusProcessMetricsEnabled:
+                    description: 'PrometheusProcessMetricsEnabled disables process metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusWireGuardMetricsEnabled:
+                    description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                      metrics collection, which the Prometheus client does by default,
+                      when set to false. This reduces the number of metrics reported,
+                      reducing Prometheus load. [Default: true]'
+                    type: boolean
+                  removeExternalRoutes:
+                    description: Whether or not to remove device routes that have not
+                      been programmed by Felix. Disabling this will allow external applications
+                      to also add device routes. This is enabled by default which means
+                      we will remove externally added routes.
+                    type: boolean
+                  reportingInterval:
+                    description: 'ReportingInterval is the interval at which Felix reports
+                      its status into the datastore or 0 to disable. Must be non-zero
+                      in OpenStack deployments. [Default: 30s]'
+                    type: string
+                  reportingTTL:
+                    description: 'ReportingTTL is the time-to-live setting for process-wide
+                      status reports. [Default: 90s]'
+                    type: string
+                  routeRefreshInterval:
+                    description: 'RouteRefreshInterval is the period at which Felix re-checks
+                      the routes in the dataplane to ensure that no other process has
+                      accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                      [Default: 90s]'
+                    type: string
+                  routeSource:
+                    description: 'RouteSource configures where Felix gets its routing
+                      information. - WorkloadIPs: use workload endpoints to construct
+                      routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                    type: string
+                  routeTableRange:
+                    description: Calico programs additional Linux route tables for various
+                      purposes.  RouteTableRange specifies the indices of the route tables
+                      that Calico should use.
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                    - max
+                    - min
+                    type: object
+                  serviceLoopPrevention:
+                    description: 'When service IP advertisement is enabled, prevent routing
+                      loops to service IPs that are not in use, by dropping or rejecting
+                      packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                      in which case such routing loops continue to be allowed. [Default:
+                      Drop]'
+                    type: string
+                  sidecarAccelerationEnabled:
+                    description: 'SidecarAccelerationEnabled enables experimental sidecar
+                      acceleration [Default: false]'
+                    type: boolean
+                  usageReportingEnabled:
+                    description: 'UsageReportingEnabled reports anonymous Calico version
+                      number and cluster size to projectcalico.org. Logs warnings returned
+                      by the usage server. For example, if a significant security vulnerability
+                      has been discovered in the version of Calico being used. [Default:
+                      true]'
+                    type: boolean
+                  usageReportingInitialDelay:
+                    description: 'UsageReportingInitialDelay controls the minimum delay
+                      before Felix makes a report. [Default: 300s]'
+                    type: string
+                  usageReportingInterval:
+                    description: 'UsageReportingInterval controls the interval at which
+                      Felix makes reports. [Default: 86400s]'
+                    type: string
+                  useInternalDataplaneDriver:
+                    type: boolean
+                  vxlanEnabled:
+                    type: boolean
+                  vxlanMTU:
+                    description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  vxlanPort:
+                    type: integer
+                  vxlanVNI:
+                    type: integer
+                  wireguardEnabled:
+                    description: 'WireguardEnabled controls whether Wireguard is enabled.
+                      [Default: false]'
+                    type: boolean
+                  wireguardHostEncryptionEnabled:
+                    description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                      host-to-host encryption is enabled. [Default: false]'
+                    type: boolean
+                  wireguardInterfaceName:
+                    description: 'WireguardInterfaceName specifies the name to use for
+                      the Wireguard interface. [Default: wg.calico]'
+                    type: string
+                  wireguardListeningPort:
+                    description: 'WireguardListeningPort controls the listening port used
+                      by Wireguard. [Default: 51820]'
+                    type: integer
+                  wireguardMTU:
+                    description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                      See Configuring MTU [Default: 1420]'
+                    type: integer
+                  wireguardRoutingRulePriority:
+                    description: 'WireguardRoutingRulePriority controls the priority value
+                      to use for the Wireguard routing rule. [Default: 99]'
+                    type: integer
+                  xdpEnabled:
+                    description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                      incoming deny rules. [Default: true]'
+                    type: boolean
+                  xdpRefreshInterval:
+                    description: 'XDPRefreshInterval is the period at which Felix re-checks
+                      all XDP state to ensure that no other process has accidentally broken
+                      Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                      refresh. [Default: 90s]'
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkPolicy
+        listKind: GlobalNetworkPolicyList
+        plural: globalnetworkpolicies
+        singular: globalnetworkpolicy
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  applyOnForward:
+                    description: ApplyOnForward indicates to apply the rules in this policy
+                      on forward traffic.
+                    type: boolean
+                  doNotTrack:
+                    description: DoNotTrack indicates whether packets matched by the rules
+                      in this policy should go through the data plane's connection tracking,
+                      such as Linux conntrack.  If True, the rules in this policy are
+                      applied before any data plane connection tracking, and packets allowed
+                      by this policy are marked as not to be tracked.
+                    type: boolean
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    description: NamespaceSelector is an optional field for an expression
+                      used to select a pod based on namespaces.
+                    type: string
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  preDNAT:
+                    description: PreDNAT indicates to apply the rules in this policy before
+                      any DNAT.
+                    type: boolean
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress rules are present in the policy.  The
+                      default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                      (including the case where there are   also no Ingress rules) \n
+                      - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                      rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                      both Ingress and Egress rules. \n When the policy is read back again,
+                      Types will always be one of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkSet
+        listKind: GlobalNetworkSetList
+        plural: globalnetworksets
+        singular: globalnetworkset
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+              that share labels to allow rules to refer to them via selectors.  The labels
+              of GlobalNetworkSet are not namespaced.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: hostendpoints.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: HostEndpoint
+        listKind: HostEndpointList
+        plural: hostendpoints
+        singular: hostendpoint
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: HostEndpointSpec contains the specification for a HostEndpoint
+                  resource.
+                properties:
+                  expectedIPs:
+                    description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                      If \"InterfaceName\" is not present, Calico will look for an interface
+                      matching any of the IPs in the list and apply policy to that. Note:
+                      \tWhen using the selector match criteria in an ingress or egress
+                      security Policy \tor Profile, Calico converts the selector into
+                      a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                      is used for that purpose. (If only the interface \tname is specified,
+                      Calico does not learn the IPs of the interface for use in match
+                      \tcriteria.)"
+                    items:
+                      type: string
+                    type: array
+                  interfaceName:
+                    description: "Either \"*\", or the name of a specific Linux interface
+                      to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                      governs all traffic to, from or through the default network namespace
+                      of the host named by the \"Node\" field; entering and leaving that
+                      namespace via any interface, including those from/to non-host-networked
+                      local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                      only governs traffic that enters or leaves the host through the
+                      specific interface named by InterfaceName, or - when InterfaceName
+                      is empty - through the specific interface that has one of the IPs
+                      in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                      one expected IP must be specified.  Only external interfaces (such
+                      as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                      to protect traffic through a specific local workload interface.
+                      \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                      initially just pre-DNAT policy.  Please check Calico documentation
+                      for the latest position."
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance.
+                    type: string
+                  ports:
+                    description: Ports contains the endpoint's named ports, which may
+                      be referenced in security policy rules.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  profiles:
+                    description: A list of identifiers of security Profile objects that
+                      apply to this endpoint. Each profile is applied in the order that
+                      they appear in this list.  Profile rules are applied after the selector-based
+                      security policy.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamblocks.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMBlock
+        listKind: IPAMBlockList
+        plural: ipamblocks
+        singular: ipamblock
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMBlockSpec contains the specification for an IPAMBlock
+                  resource.
+                properties:
+                  affinity:
+                    type: string
+                  allocations:
+                    items:
+                      nullable: true
+                      type: integer
+                    type: array
+                  attributes:
+                    items:
+                      properties:
+                        handle_id:
+                          type: string
+                        secondary:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    type: array
+                  cidr:
+                    type: string
+                  deleted:
+                    type: boolean
+                  strictAffinity:
+                    type: boolean
+                  unallocated:
+                    items:
+                      type: integer
+                    type: array
+                required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamconfigs.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMConfig
+        listKind: IPAMConfigList
+        plural: ipamconfigs
+        singular: ipamconfig
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMConfigSpec contains the specification for an IPAMConfig
+                  resource.
+                properties:
+                  autoAllocateBlocks:
+                    type: boolean
+                  maxBlocksPerHost:
+                    description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                      that can be affine to each host.
+                    type: integer
+                  strictAffinity:
+                    type: boolean
+                required:
+                - autoAllocateBlocks
+                - strictAffinity
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamhandles.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMHandle
+        listKind: IPAMHandleList
+        plural: ipamhandles
+        singular: ipamhandle
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMHandleSpec contains the specification for an IPAMHandle
+                  resource.
+                properties:
+                  block:
+                    additionalProperties:
+                      type: integer
+                    type: object
+                  deleted:
+                    type: boolean
+                  handleID:
+                    type: string
+                required:
+                - block
+                - handleID
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ippools.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPPool
+        listKind: IPPoolList
+        plural: ippools
+        singular: ippool
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPPoolSpec contains the specification for an IPPool resource.
+                properties:
+                  blockSize:
+                    description: The block size to use for IP address assignments from
+                      this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                    type: integer
+                  cidr:
+                    description: The pool CIDR.
+                    type: string
+                  disabled:
+                    description: When disabled is true, Calico IPAM will not assign addresses
+                      from this pool.
+                    type: boolean
+                  ipip:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    properties:
+                      enabled:
+                        description: When enabled is true, ipip tunneling will be used
+                          to deliver packets to destinations within this pool.
+                        type: boolean
+                      mode:
+                        description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                          mode of "always" will also use IPIP tunneling for routing to
+                          destination IP addresses within this pool.  A mode of "cross-subnet"
+                          will only use IPIP tunneling when the destination node is on
+                          a different subnet to the originating node.  The default value
+                          (if not specified) is "always".
+                        type: string
+                    type: object
+                  ipipMode:
+                    description: Contains configuration for IPIP tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                      is disabled).
+                    type: string
+                  nat-outgoing:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    type: boolean
+                  natOutgoing:
+                    description: When nat-outgoing is true, packets sent from Calico networked
+                      containers in this pool to destinations outside of this pool will
+                      be masqueraded.
+                    type: boolean
+                  nodeSelector:
+                    description: Allows IPPool to allocate for a specific node by label
+                      selector.
+                    type: string
+                  vxlanMode:
+                    description: Contains configuration for VXLAN tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                      tunneling is disabled).
+                    type: string
+                required:
+                - cidr
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubecontrollersconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: KubeControllersConfiguration
+        listKind: KubeControllersConfigurationList
+        plural: kubecontrollersconfigurations
+        singular: kubecontrollersconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeControllersConfigurationSpec contains the values of the
+                  Kubernetes controllers configuration.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host endpoints.
+                              Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation of
+                                  host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the controller
+                              to determine if an IP address has been leaked. Set to 0
+                              to disable IP garbage collection. [Default: 15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+              status:
+                description: KubeControllersConfigurationStatus represents the status
+                  of the configuration. It's useful for admins to be able to see the actual
+                  config that was applied, which can be modified by environment variables
+                  on the kube-controllers process.
+                properties:
+                  environmentVars:
+                    additionalProperties:
+                      type: string
+                    description: EnvironmentVars contains the environment variables on
+                      the kube-controllers that influenced the RunningConfig.
+                    type: object
+                  runningConfig:
+                    description: RunningConfig contains the effective config that is running
+                      in the kube-controllers pod, after merging the API resource with
+                      any environment variables.
+                    properties:
+                      controllers:
+                        description: Controllers enables and configures individual Kubernetes
+                          controllers
+                        properties:
+                          namespace:
+                            description: Namespace enables and configures the namespace
+                              controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          node:
+                            description: Node enables and configures the node controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              hostEndpoint:
+                                description: HostEndpoint controls syncing nodes to host
+                                  endpoints. Disabled by default, set to nil to disable.
+                                properties:
+                                  autoCreate:
+                                    description: 'AutoCreate enables automatic creation
+                                      of host endpoints for every node. [Default: Disabled]'
+                                    type: string
+                                type: object
+                              leakGracePeriod:
+                                description: 'LeakGracePeriod is the period used by the
+                                  controller to determine if an IP address has been leaked.
+                                  Set to 0 to disable IP garbage collection. [Default:
+                                  15m]'
+                                type: string
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                              syncLabels:
+                                description: 'SyncLabels controls whether to copy Kubernetes
+                                  node labels to Calico nodes. [Default: Enabled]'
+                                type: string
+                            type: object
+                          policy:
+                            description: Policy enables and configures the policy controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          serviceAccount:
+                            description: ServiceAccount enables and configures the service
+                              account controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          workloadEndpoint:
+                            description: WorkloadEndpoint enables and configures the workload
+                              endpoint controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                        type: object
+                      etcdV3CompactionPeriod:
+                        description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                          compaction requests. Set to 0 to disable. [Default: 10m]'
+                        type: string
+                      healthChecks:
+                        description: 'HealthChecks enables or disables support for health
+                          checks [Default: Enabled]'
+                        type: string
+                      logSeverityScreen:
+                        description: 'LogSeverityScreen is the log severity above which
+                          logs are sent to the stdout. [Default: Info]'
+                        type: string
+                      prometheusMetricsPort:
+                        description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                          metrics server should bind to. Set to 0 to disable. [Default:
+                          9094]'
+                        type: integer
+                    required:
+                    - controllers
+                    type: object
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkPolicy
+        listKind: NetworkPolicyList
+        plural: networkpolicies
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress are present in the policy.  The default
+                      is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                      the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                      ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                      PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                      \n When the policy is read back again, Types will always be one
+                      of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkSet
+        listKind: NetworkSetList
+        plural: networksets
+        singular: networkset
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: NetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-kube-controllers
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      verbs:
+      - list
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - hostendpoints
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - clusterinformations
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - kubecontrollersconfigurations
+      verbs:
+      - get
+      - create
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-node
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - namespaces
+      verbs:
+      - get
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - patch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - bgpconfigurations
+      - bgppeers
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ipamconfigs
+      verbs:
+      - get
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      verbs:
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - daemonsets
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-kube-controllers
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      calico_backend: vxlan
+      cni_network_config: |-
+        {
+          "name": "k8s-pod-network",
+          "cniVersion": "0.3.1",
+          "plugins": [
+            {
+              "type": "calico",
+              "log_level": "info",
+              "log_file_path": "/var/log/calico/cni/cni.log",
+              "datastore_type": "kubernetes",
+              "nodename": "__KUBERNETES_NODE_NAME__",
+              "mtu": __CNI_MTU__,
+              "ipam": {
+                  "type": "calico-ipam"
+              },
+              "policy": {
+                  "type": "k8s"
+              },
+              "kubernetes": {
+                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              }
+            },
+            {
+              "type": "portmap",
+              "snat": true,
+              "capabilities": {"portMappings": true}
+            },
+            {
+              "type": "bandwidth",
+              "capabilities": {"bandwidth": true}
+            }
+          ]
+        }
+      typha_service_name: none
+      veth_mtu: "1350"
+    kind: ConfigMap
+    metadata:
+      name: calico-config
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-kube-controllers
+          name: calico-kube-controllers
+          namespace: kube-system
+        spec:
+          containers:
+          - env:
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            image: docker.io/calico/kube-controllers:v3.20.3
+            livenessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -l
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-kube-controllers
+            readinessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -r
+              periodSeconds: 10
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: calico-kube-controllers
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: calico-node
+      name: calico-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+        spec:
+          containers:
+          - env:
+            - name: FELIX_FEATUREDETECTOVERRIDE
+              value: ChecksumOffloadBroken=true
+            - name: CALICO_IPV4POOL_VXLAN
+              value: Always
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            - name: CLUSTER_TYPE
+              value: k8s,bgp
+            - name: IP
+              value: autodetect
+            - name: CALICO_IPV4POOL_IPIP
+              value: Never
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_WIREGUARDMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_AWSSRCDSTCHECK
+              value: Disable
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: ACCEPT
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/node:v3.20.3
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -shutdown
+            livenessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-live
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-node
+            readinessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-ready
+              periodSeconds: 10
+              timeoutSeconds: 10
+            resources:
+              requests:
+                cpu: 250m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /var/run/nodeagent
+              name: policysync
+            - mountPath: /sys/fs/
+              mountPropagation: Bidirectional
+              name: sysfs
+            - mountPath: /var/log/calico/cni
+              name: cni-log-dir
+              readOnly: true
+          hostNetwork: true
+          initContainers:
+          - command:
+            - /opt/cni/bin/calico-ipam
+            - -upgrade
+            env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: upgrade-ipam
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          - command:
+            - /opt/cni/bin/install
+            env:
+            - name: CNI_CONF_NAME
+              value: 10-calico.conflist
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  key: cni_network_config
+                  name: calico-config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: SLEEP
+              value: "false"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: install-cni
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+            name: flexvol-driver
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/driver
+              name: flexvol-driver-host
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: calico-node
+          terminationGracePeriodSeconds: 0
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /lib/modules
+            name: lib-modules
+          - hostPath:
+              path: /var/run/calico
+            name: var-run-calico
+          - hostPath:
+              path: /var/lib/calico
+            name: var-lib-calico
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+          - hostPath:
+              path: /sys/fs/
+              type: DirectoryOrCreate
+            name: sysfs
+          - hostPath:
+              path: /opt/cni/bin
+            name: cni-bin-dir
+          - hostPath:
+              path: /etc/cni/net.d
+            name: cni-net-dir
+          - hostPath:
+              path: /var/log/calico/cni
+            name: cni-log-dir
+          - hostPath:
+              path: /var/lib/cni/networks
+            name: host-local-net-dir
+          - hostPath:
+              path: /var/run/nodeagent
+              type: DirectoryOrCreate
+            name: policysync
+          - hostPath:
+              path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+              type: DirectoryOrCreate
+            name: flexvol-driver-host
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -7872,7 +7872,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.20.3
+            image: docker.io/calico/kube-controllers:v3.20.4
             livenessProbe:
               exec:
                 command:
@@ -7982,7 +7982,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.20.3
+            image: docker.io/calico/node:v3.20.4
             lifecycle:
               preStop:
                 exec:
@@ -8054,7 +8054,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: upgrade-ipam
             securityContext:
               privileged: true
@@ -8088,7 +8088,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: install-cni
             securityContext:
               privileged: true
@@ -8097,7 +8097,7 @@ data:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.4
             name: flexvol-driver
             securityContext:
               privileged: true

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -3972,7 +3972,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.20.3
+            image: docker.io/calico/kube-controllers:v3.20.4
             livenessProbe:
               exec:
                 command:
@@ -4082,7 +4082,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.20.3
+            image: docker.io/calico/node:v3.20.4
             lifecycle:
               preStop:
                 exec:
@@ -4154,7 +4154,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: upgrade-ipam
             securityContext:
               privileged: true
@@ -4188,7 +4188,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: install-cni
             securityContext:
               privileged: true
@@ -4197,7 +4197,7 @@ data:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.4
             name: flexvol-driver
             securityContext:
               privileged: true

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -279,2440 +279,3985 @@ spec:
 ---
 apiVersion: v1
 data:
-  resources: "---\n# Source: calico/templates/calico-config.yaml\n# This ConfigMap
-    is used to configure a self-hosted Calico installation.\nkind: ConfigMap\napiVersion:
-    v1\nmetadata:\n  name: calico-config\n  namespace: kube-system\ndata:\n  # Typha
-    is disabled.\n  typha_service_name: \"none\"\n  # Configure the backend to use.\n
-    \ calico_backend: \"vxlan\"\n  # On Azure, the underlying network has an MTU of
-    1400, even though the network interface will have an MTU of 1500.\n  # We set
-    this value to 1350 for “physical network MTU size minus 50” since we use VXLAN,
-    which uses a 50-byte header.\n  # If enabling Wireguard, this value should be
-    changed to 1340 (Wireguard uses a 60-byte header).\n  # https://docs.projectcalico.org/networking/mtu#determine-mtu-size\n
-    \ veth_mtu: \"1350\"\n  \n  # The CNI network configuration to install on each
-    node. The special\n  # values in this config will be automatically populated.\n
-    \ cni_network_config: |-\n    {\n      \"name\": \"k8s-pod-network\",\n      \"cniVersion\":
-    \"0.3.1\",\n      \"plugins\": [\n        {\n          \"type\": \"calico\",\n
-    \         \"log_level\": \"info\",\n          \"log_file_path\": \"/var/log/calico/cni/cni.log\",\n
-    \         \"datastore_type\": \"kubernetes\",\n          \"nodename\": \"__KUBERNETES_NODE_NAME__\",\n
-    \         \"mtu\": __CNI_MTU__,\n          \"ipam\": {\n              \"type\":
-    \"calico-ipam\"\n          },\n          \"policy\": {\n              \"type\":
-    \"k8s\"\n          },\n          \"kubernetes\": {\n              \"kubeconfig\":
-    \"__KUBECONFIG_FILEPATH__\"\n          }\n        },\n        {\n          \"type\":
-    \"portmap\",\n          \"snat\": true,\n          \"capabilities\": {\"portMappings\":
-    true}\n        },\n        {\n          \"type\": \"bandwidth\",\n          \"capabilities\":
-    {\"bandwidth\": true}\n        }\n      ]\n    }\n\n---\n# Source: calico/templates/kdd-crds.yaml\n\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: bgpconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPConfiguration\n    listKind: BGPConfigurationList\n    plural:
-    bgpconfigurations\n    singular: bgpconfiguration\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    BGPConfiguration contains the configuration for any BGP routing.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPConfigurationSpec contains the
-    values of the BGP configuration.\n              properties:\n                asNumber:\n
-    \                 description: 'ASNumber is the default AS number used by a node.
-    [Default:\n                  64512]'\n                  format: int32\n                  type:
-    integer\n                communities:\n                  description: Communities
-    is a list of BGP community values and their\n                    arbitrary names
-    for tagging routes.\n                  items:\n                    description:
-    Community contains standard or large community value\n                      and
-    its name.\n                    properties:\n                      name:\n                        description:
-    Name given to community value.\n                        type: string\n                      value:\n
-    \                       description: Value must be of format `aa:nn` or `aa:nn:mm`.\n
-    \                         For standard community use `aa:nn` format, where `aa`
-    and\n                          `nn` are 16 bit number. For large community use
-    `aa:nn:mm`\n                          format, where `aa`, `nn` and `mm` are 32
-    bit number. Where,\n                          `aa` is an AS Number, `nn` and `mm`
-    are per-AS identifier.\n                        pattern: ^(\\d+):(\\d+)$|^(\\d+):(\\d+):(\\d+)$\n
-    \                       type: string\n                    type: object\n                  type:
-    array\n                listenPort:\n                  description: ListenPort
-    is the port where BGP protocol should listen.\n                    Defaults to
-    179\n                  maximum: 65535\n                  minimum: 1\n                  type:
-    integer\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: INFO]'\n                  type: string\n                nodeToNodeMeshEnabled:\n
-    \                 description: 'NodeToNodeMeshEnabled sets whether full node to
-    node\n                  BGP mesh is enabled. [Default: true]'\n                  type:
-    boolean\n                prefixAdvertisements:\n                  description:
-    PrefixAdvertisements contains per-prefix advertisement\n                    configuration.\n
-    \                 items:\n                    description: PrefixAdvertisement
-    configures advertisement properties\n                      for the specified CIDR.\n
-    \                   properties:\n                      cidr:\n                        description:
-    CIDR for which properties should be advertised.\n                        type:
-    string\n                      communities:\n                        description:
-    Communities can be list of either community names\n                          already
-    defined in `Specs.Communities` or community value\n                          of
-    format `aa:nn` or `aa:nn:mm`. For standard community use\n                          `aa:nn`
-    format, where `aa` and `nn` are 16 bit number. For\n                          large
-    community use `aa:nn:mm` format, where `aa`, `nn` and\n                          `mm`
-    are 32 bit number. Where,`aa` is an AS Number, `nn` and\n                          `mm`
-    are per-AS identifier.\n                        items:\n                          type:
-    string\n                        type: array\n                    type: object\n
-    \                 type: array\n                serviceClusterIPs:\n                  description:
-    ServiceClusterIPs are the CIDR blocks from which service\n                    cluster
-    IPs are allocated. If specified, Calico will advertise these\n                    blocks,
-    as well as any cluster IPs within them.\n                  items:\n                    description:
-    ServiceClusterIPBlock represents a single allowed ClusterIP\n                      CIDR
-    block.\n                    properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n                serviceExternalIPs:\n
-    \                 description: ServiceExternalIPs are the CIDR blocks for Kubernetes\n
-    \                   Service External IPs. Kubernetes Service ExternalIPs will
-    only be\n                    advertised if they are within one of these blocks.\n
-    \                 items:\n                    description: ServiceExternalIPBlock
-    represents a single allowed\n                      External IP CIDR block.\n                    properties:\n
-    \                     cidr:\n                        type: string\n                    type:
-    object\n                  type: array\n                serviceLoadBalancerIPs:\n
-    \                 description: ServiceLoadBalancerIPs are the CIDR blocks for
-    Kubernetes\n                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress\n
-    \                   IPs will only be advertised if they are within one of these
-    blocks.\n                  items:\n                    description: ServiceLoadBalancerIPBlock
-    represents a single allowed\n                      LoadBalancer IP CIDR block.\n
-    \                   properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: bgppeers.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPPeer\n    listKind: BGPPeerList\n    plural: bgppeers\n
-    \   singular: bgppeer\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPPeerSpec contains the specification
-    for a BGPPeer resource.\n              properties:\n                asNumber:\n
-    \                 description: The AS Number of the peer.\n                  format:
-    int32\n                  type: integer\n                keepOriginalNextHop:\n
-    \                 description: Option to keep the original nexthop field when
-    routes\n                    are sent to a BGP Peer. Setting \"true\" configures
-    the selected BGP\n                    Peers node to use the \"next hop keep;\"
-    instead of \"next hop self;\"(default)\n                    in the specific branch
-    of the Node on \"bird.cfg\".\n                  type: boolean\n                maxRestartTime:\n
-    \                 description: Time to allow for software restart.  When specified,
-    this\n                    is configured as the graceful restart timeout.  When
-    not specified,\n                    the BIRD default of 120s is used.\n                  type:
-    string\n                node:\n                  description: The node name identifying
-    the Calico node instance that\n                    is targeted by this peer. If
-    this is not set, and no nodeSelector\n                    is specified, then this
-    BGP peer selects all nodes in the cluster.\n                  type: string\n                nodeSelector:\n
-    \                 description: Selector for the nodes that should have this peering.
-    \ When\n                    this is set, the Node field must be empty.\n                  type:
-    string\n                password:\n                  description: Optional BGP
-    password for the peerings generated by this\n                    BGPPeer resource.\n
-    \                 properties:\n                    secretKeyRef:\n                      description:
-    Selects a key of a secret in the node pod's namespace.\n                      properties:\n
-    \                       key:\n                          description: The key of
-    the secret to select from.  Must be\n                            a valid secret
-    key.\n                          type: string\n                        name:\n
-    \                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n
-    \                         TODO: Add other useful fields. apiVersion, kind, uid?'\n
-    \                         type: string\n                        optional:\n                          description:
-    Specify whether the Secret or its key must be\n                            defined\n
-    \                         type: boolean\n                      required:\n                        -
-    key\n                      type: object\n                  type: object\n                peerIP:\n
-    \                 description: The IP address of the peer followed by an optional
-    port\n                    number to peer with. If port number is given, format
-    should be `[<IPv6>]:port`\n                    or `<IPv4>:<port>` for IPv4. If
-    optional port number is not set,\n                    and this peer IP and ASNumber
-    belongs to a calico/node with ListenPort\n                    set in BGPConfiguration,
-    then we use that port to peer.\n                  type: string\n                peerSelector:\n
-    \                 description: Selector for the remote nodes to peer with.  When
-    this\n                    is set, the PeerIP and ASNumber fields must be empty.
-    \ For each\n                    peering between the local node and selected remote
-    nodes, we configure\n                    an IPv4 peering if both ends have NodeBGPSpec.IPv4Address
-    specified,\n                    and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address
-    specified.  The\n                    remote AS number comes from the remote node’s
-    NodeBGPSpec.ASNumber,\n                    or the global default if that is not
-    set.\n                  type: string\n                sourceAddress:\n                  description:
-    Specifies whether and how to configure a source address\n                    for
-    the peerings generated by this BGPPeer resource.  Default value\n                    \"UseNodeIP\"
-    means to configure the node IP as the source address.  \"None\"\n                    means
-    not to configure a source address.\n                  type: string\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: blockaffinities.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BlockAffinity\n    listKind: BlockAffinityList\n    plural:
-    blockaffinities\n    singular: blockaffinity\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BlockAffinitySpec contains the specification
-    for a BlockAffinity\n                resource.\n              properties:\n                cidr:\n
-    \                 type: string\n                deleted:\n                  description:
-    Deleted indicates that this block affinity is being deleted.\n                    This
-    field is a string for compatibility with older releases that\n                    mistakenly
-    treat this field as a string.\n                  type: string\n                node:\n
-    \                 type: string\n                state:\n                  type:
-    string\n              required:\n                - cidr\n                - deleted\n
-    \               - node\n                - state\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: clusterinformations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: ClusterInformation\n    listKind: ClusterInformationList\n
-    \   plural: clusterinformations\n    singular: clusterinformation\n  scope: Cluster\n
-    \ versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    ClusterInformation contains the cluster specific information.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: ClusterInformationSpec contains
-    the values of describing\n                the cluster.\n              properties:\n
-    \               calicoVersion:\n                  description: CalicoVersion is
-    the version of Calico that the cluster\n                    is running\n                  type:
-    string\n                clusterGUID:\n                  description: ClusterGUID
-    is the GUID of the cluster\n                  type: string\n                clusterType:\n
-    \                 description: ClusterType describes the type of the cluster\n
-    \                 type: string\n                datastoreReady:\n                  description:
-    DatastoreReady is used during significant datastore migrations\n                    to
-    signal to components such as Felix that it should wait before\n                    accessing
-    the datastore.\n                  type: boolean\n                variant:\n                  description:
-    Variant declares which variant of Calico should be active.\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: felixconfigurations.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: FelixConfiguration\n    listKind:
-    FelixConfigurationList\n    plural: felixconfigurations\n    singular: felixconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         description: Felix Configuration contains the configuration for Felix.\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: FelixConfigurationSpec contains
-    the values of the Felix configuration.\n              properties:\n                allowIPIPPacketsFromWorkloads:\n
-    \                 description: 'AllowIPIPPacketsFromWorkloads controls whether
-    Felix\n                  will add a rule to drop IPIP encapsulated traffic from
-    workloads\n                  [Default: false]'\n                  type: boolean\n
-    \               allowVXLANPacketsFromWorkloads:\n                  description:
-    'AllowVXLANPacketsFromWorkloads controls whether Felix\n                  will
-    add a rule to drop VXLAN encapsulated traffic from workloads\n                  [Default:
-    false]'\n                  type: boolean\n                awsSrcDstCheck:\n                  description:
-    'Set source-destination-check on AWS EC2 instances. Accepted\n                  value
-    must be one of \"DoNothing\", \"Enabled\" or \"Disabled\". [Default:\n                  DoNothing]'\n
-    \                 enum:\n                    - DoNothing\n                    -
-    Enable\n                    - Disable\n                  type: string\n                bpfConnectTimeLoadBalancingEnabled:\n
-    \                 description: 'BPFConnectTimeLoadBalancingEnabled when in BPF
-    mode,\n                  controls whether Felix installs the connection-time load
-    balancer.  The\n                  connect-time load balancer is required for the
-    host to be able to\n                  reach Kubernetes services and it improves
-    the performance of pod-to-service\n                  connections.  The only reason
-    to disable it is for debugging purposes.  [Default:\n                  true]'\n
-    \                 type: boolean\n                bpfDataIfacePattern:\n                  description:
-    'BPFDataIfacePattern is a regular expression that controls\n                  which
-    interfaces Felix should attach BPF programs to in order to\n                  catch
-    traffic to/from the network.  This needs to match the interfaces\n                  that
-    Calico workload traffic flows over as well as any interfaces\n                  that
-    handle incoming traffic to nodeports and services from outside\n                  the
-    cluster.  It should not match the workload interfaces (usually\n                  named
-    cali...). [Default: ^(en.*|eth.*|tunl0$)]'\n                  type: string\n                bpfDisableUnprivileged:\n
-    \                 description: 'BPFDisableUnprivileged, if enabled, Felix sets
-    the kernel.unprivileged_bpf_disabled\n                  sysctl to disable unprivileged
-    use of BPF.  This ensures that unprivileged\n                  users cannot access
-    Calico''s BPF maps and cannot insert their own\n                  BPF programs
-    to interfere with Calico''s. [Default: true]'\n                  type: boolean\n
-    \               bpfEnabled:\n                  description: 'BPFEnabled, if enabled
-    Felix will use the BPF dataplane.\n                  [Default: false]'\n                  type:
-    boolean\n                bpfExtToServiceConnmark:\n                  description:
-    'BPFExtToServiceConnmark in BPF mode, control a 32bit\n                    mark
-    that is set on connections from an external client to a local\n                    service.
-    This mark allows us to control how packets of that connection\n                    are
-    routed within the host and how is routing intepreted by RPF\n                    check.
-    [Default: 0]'\n                  type: integer\n                bpfExternalServiceMode:\n
-    \                 description: 'BPFExternalServiceMode in BPF mode, controls how
-    connections\n                  from outside the cluster to services (node ports
-    and cluster IPs)\n                  are forwarded to remote workloads.  If set
-    to \"Tunnel\" then both\n                  request and response traffic is tunneled
-    to the remote node.  If\n                  set to \"DSR\", the request traffic
-    is tunneled but the response traffic\n                  is sent directly from
-    the remote node.  In \"DSR\" mode, the remote\n                  node appears
-    to use the IP of the ingress node; this requires a\n                  permissive
-    L2 network.  [Default: Tunnel]'\n                  type: string\n                bpfKubeProxyEndpointSlicesEnabled:\n
-    \                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode,
-    controls\n                    whether Felix's embedded kube-proxy accepts EndpointSlices
-    or not.\n                  type: boolean\n                bpfKubeProxyIptablesCleanupEnabled:\n
-    \                 description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled
-    in BPF\n                  mode, Felix will proactively clean up the upstream Kubernetes
-    kube-proxy''s\n                  iptables chains.  Should only be enabled if kube-proxy
-    is not running.  [Default:\n                  true]'\n                  type:
-    boolean\n                bpfKubeProxyMinSyncPeriod:\n                  description:
-    'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the\n                  minimum
-    time between updates to the dataplane for Felix''s embedded\n                  kube-proxy.
-    \ Lower values give reduced set-up latency.  Higher values\n                  reduce
-    Felix CPU usage by batching up more work.  [Default: 1s]'\n                  type:
-    string\n                bpfLogLevel:\n                  description: 'BPFLogLevel
-    controls the log level of the BPF programs\n                  when in BPF dataplane
-    mode.  One of \"Off\", \"Info\", or \"Debug\".  The\n                  logs are
-    emitted to the BPF trace pipe, accessible with the command\n                  `tc
-    exec bpf debug`. [Default: Off].'\n                  type: string\n                chainInsertMode:\n
-    \                 description: 'ChainInsertMode controls whether Felix hooks the
-    kernel’s\n                  top-level iptables chains by inserting a rule at the
-    top of the\n                  chain or by appending a rule at the bottom. insert
-    is the safe default\n                  since it prevents Calico’s rules from being
-    bypassed. If you switch\n                  to append mode, be sure that the other
-    rules in the chains signal\n                  acceptance by falling through to
-    the Calico rules, otherwise the\n                  Calico policy will be bypassed.
-    [Default: insert]'\n                  type: string\n                dataplaneDriver:\n
-    \                 type: string\n                debugDisableLogDropping:\n                  type:
-    boolean\n                debugMemoryProfilePath:\n                  type: string\n
-    \               debugSimulateCalcGraphHangAfter:\n                  type: string\n
-    \               debugSimulateDataplaneHangAfter:\n                  type: string\n
-    \               defaultEndpointToHostAction:\n                  description: 'DefaultEndpointToHostAction
-    controls what happens to\n                  traffic that goes from a workload
-    endpoint to the host itself (after\n                  the traffic hits the endpoint
-    egress policy). By default Calico\n                  blocks traffic from workload
-    endpoints to the host itself with an\n                  iptables “DROP” action.
-    If you want to allow some or all traffic\n                  from endpoint to host,
-    set this parameter to RETURN or ACCEPT. Use\n                  RETURN if you have
-    your own rules in the iptables “INPUT” chain;\n                  Calico will insert
-    its rules at the top of that chain, then “RETURN”\n                  packets to
-    the “INPUT” chain once it has completed processing workload\n                  endpoint
-    egress policy. Use ACCEPT to unconditionally accept packets\n                  from
-    workloads after processing workload endpoint egress policy.\n                  [Default:
-    Drop]'\n                  type: string\n                deviceRouteProtocol:\n
-    \                 description: This defines the route protocol added to programmed
-    device\n                    routes, by default this will be RTPROT_BOOT when left
-    blank.\n                  type: integer\n                deviceRouteSourceAddress:\n
-    \                 description: This is the source address to use on programmed
-    device\n                    routes. By default the source address is left blank,
-    leaving the\n                    kernel to choose the source address used.\n                  type:
-    string\n                disableConntrackInvalidCheck:\n                  type:
-    boolean\n                endpointReportingDelay:\n                  type: string\n
-    \               endpointReportingEnabled:\n                  type: boolean\n                externalNodesList:\n
-    \                 description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes\n
-    \                   which may source tunnel traffic and have the tunneled traffic
-    be\n                    accepted at calico nodes.\n                  items:\n
-    \                   type: string\n                  type: array\n                failsafeInboundHostPorts:\n
-    \                 description: 'FailsafeInboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow incoming traffic to
-    host endpoints\n                    on irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    inbound host ports, use the value\n                    none. The default value
-    allows ssh access and DHCP. [Default: tcp:22,\n                    udp:68, tcp:179,
-    tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'\n                  items:\n
-    \                   description: ProtoPort is combination of protocol, port, and
-    CIDR.\n                      Protocol and port must be specified.\n                    properties:\n
-    \                     net:\n                        type: string\n                      port:\n
-    \                       type: integer\n                      protocol:\n                        type:
-    string\n                    required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                failsafeOutboundHostPorts:\n
-    \                 description: 'FailsafeOutboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow outgoing traffic from
-    host endpoints\n                    to irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    outbound host ports, use the value\n                    none. The default value
-    opens etcd''s standard ports to ensure that\n                    Felix does not
-    get cut off from etcd as well as allowing DHCP and\n                    DNS. [Default:
-    tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,\n                    tcp:6667,
-    udp:53, udp:67]'\n                  items:\n                    description: ProtoPort
-    is combination of protocol, port, and CIDR.\n                      Protocol and
-    port must be specified.\n                    properties:\n                      net:\n
-    \                       type: string\n                      port:\n                        type:
-    integer\n                      protocol:\n                        type: string\n
-    \                   required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                featureDetectOverride:\n
-    \                 description: FeatureDetectOverride is used to override the feature\n
-    \                   detection. Values are specified in a comma separated list
-    with no\n                    spaces, example; \"SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=\".\n
-    \                   \"true\" or \"false\" will force the feature, empty or omitted
-    values\n                    are auto-detected.\n                  type: string\n
-    \               genericXDPEnabled:\n                  description: 'GenericXDPEnabled
-    enables Generic XDP so network cards\n                  that don''t support XDP
-    offload or driver modes can use XDP. This\n                  is not recommended
-    since it doesn''t provide better performance\n                  than iptables.
-    [Default: false]'\n                  type: boolean\n                healthEnabled:\n
-    \                 type: boolean\n                healthHost:\n                  type:
-    string\n                healthPort:\n                  type: integer\n                interfaceExclude:\n
-    \                 description: 'InterfaceExclude is a comma-separated list of
-    interfaces\n                  that Felix should exclude when monitoring for host
-    endpoints. The\n                  default value ensures that Felix ignores Kubernetes''
-    IPVS dummy\n                  interface, which is used internally by kube-proxy.
-    If you want to\n                  exclude multiple interface names using a single
-    value, the list\n                  supports regular expressions. For regular expressions
-    you must wrap\n                  the value with ''/''. For example having values
-    ''/^kube/,veth1''\n                  will exclude all interfaces that begin with
-    ''kube'' and also the\n                  interface ''veth1''. [Default: kube-ipvs0]'\n
-    \                 type: string\n                interfacePrefix:\n                  description:
-    'InterfacePrefix is the interface name prefix that identifies\n                  workload
-    endpoints and so distinguishes them from host endpoint\n                  interfaces.
-    Note: in environments other than bare metal, the orchestrators\n                  configure
-    this appropriately. For example our Kubernetes and Docker\n                  integrations
-    set the ‘cali’ value, and our OpenStack integration\n                  sets the
-    ‘tap’ value. [Default: cali]'\n                  type: string\n                interfaceRefreshInterval:\n
-    \                 description: InterfaceRefreshInterval is the period at which
-    Felix\n                    rescans local interfaces to verify their state. The
-    rescan can be\n                    disabled by setting the interval to 0.\n                  type:
-    string\n                ipipEnabled:\n                  type: boolean\n                ipipMTU:\n
-    \                 description: 'IPIPMTU is the MTU to set on the tunnel device.
-    See\n                  Configuring MTU [Default: 1440]'\n                  type:
-    integer\n                ipsetsRefreshInterval:\n                  description:
-    'IpsetsRefreshInterval is the period at which Felix re-checks\n                  all
-    iptables state to ensure that no other process has accidentally\n                  broken
-    Calico’s rules. Set to 0 to disable iptables refresh. [Default:\n                  90s]'\n
-    \                 type: string\n                iptablesBackend:\n                  description:
-    IptablesBackend specifies which backend of iptables will\n                    be
-    used. The default is legacy.\n                  type: string\n                iptablesFilterAllowAction:\n
-    \                 type: string\n                iptablesLockFilePath:\n                  description:
-    'IptablesLockFilePath is the location of the iptables\n                  lock
-    file. You may need to change this if the lock file is not in\n                  its
-    standard location (for example if you have mapped it into Felix’s\n                  container
-    at a different path). [Default: /run/xtables.lock]'\n                  type: string\n
-    \               iptablesLockProbeInterval:\n                  description: 'IptablesLockProbeInterval
-    is the time that Felix will\n                  wait between attempts to acquire
-    the iptables lock if it is not\n                  available. Lower values make
-    Felix more responsive when the lock\n                  is contended, but use more
-    CPU. [Default: 50ms]'\n                  type: string\n                iptablesLockTimeout:\n
-    \                 description: 'IptablesLockTimeout is the time that Felix will
-    wait\n                  for the iptables lock, or 0, to disable. To use this feature,
-    Felix\n                  must share the iptables lock file with all other processes
-    that\n                  also take the lock. When running Felix inside a container,
-    this\n                  requires the /run directory of the host to be mounted
-    into the calico/node\n                  or calico/felix container. [Default: 0s
-    disabled]'\n                  type: string\n                iptablesMangleAllowAction:\n
-    \                 type: string\n                iptablesMarkMask:\n                  description:
-    'IptablesMarkMask is the mask that Felix selects its\n                  IPTables
-    Mark bits from. Should be a 32 bit hexadecimal number with\n                  at
-    least 8 bits set, none of which clash with any other mark bits\n                  in
-    use on the system. [Default: 0xff000000]'\n                  format: int32\n                  type:
-    integer\n                iptablesNATOutgoingInterfaceFilter:\n                  type:
-    string\n                iptablesPostWriteCheckInterval:\n                  description:
-    'IptablesPostWriteCheckInterval is the period after Felix\n                  has
-    done a write to the dataplane that it schedules an extra read\n                  back
-    in order to check the write was not clobbered by another process.\n                  This
-    should only occur if another application on the system doesn’t\n                  respect
-    the iptables lock. [Default: 1s]'\n                  type: string\n                iptablesRefreshInterval:\n
-    \                 description: 'IptablesRefreshInterval is the period at which
-    Felix\n                    re-checks the IP sets in the dataplane to ensure that
-    no other process\n                    has accidentally broken Calico''s rules.
-    Set to 0 to disable IP\n                    sets refresh. Note: the default for
-    this value is lower than the\n                    other refresh intervals as a
-    workaround for a Linux kernel bug that\n                    was fixed in kernel
-    version 4.11. If you are using v4.11 or greater\n                    you may want
-    to set this to, a higher value to reduce Felix CPU\n                    usage.
-    [Default: 10s]'\n                  type: string\n                ipv6Support:\n
-    \                 type: boolean\n                kubeNodePortRanges:\n                  description:
-    'KubeNodePortRanges holds list of port ranges used for\n                  service
-    node ports. Only used if felix detects kube-proxy running\n                  in
-    ipvs mode. Felix uses these ranges to separate host and workload\n                  traffic.
-    [Default: 30000:32767].'\n                  items:\n                    anyOf:\n
-    \                     - type: integer\n                      - type: string\n
-    \                   pattern: ^.*\n                    x-kubernetes-int-or-string:
-    true\n                  type: array\n                logFilePath:\n                  description:
-    'LogFilePath is the full path to the Felix log. Set to\n                  none
-    to disable file logging. [Default: /var/log/calico/felix.log]'\n                  type:
-    string\n                logPrefix:\n                  description: 'LogPrefix
-    is the log prefix that Felix uses when rendering\n                  LOG rules.
-    [Default: calico-packet]'\n                  type: string\n                logSeverityFile:\n
-    \                 description: 'LogSeverityFile is the log severity above which
-    logs\n                  are sent to the log file. [Default: Info]'\n                  type:
-    string\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: Info]'\n                  type: string\n                logSeveritySys:\n
-    \                 description: 'LogSeveritySys is the log severity above which
-    logs\n                  are sent to the syslog. Set to None for no logging to
-    syslog. [Default:\n                  Info]'\n                  type: string\n
-    \               maxIpsetSize:\n                  type: integer\n                metadataAddr:\n
-    \                 description: 'MetadataAddr is the IP address or domain name
-    of the\n                  server that can answer VM queries for cloud-init metadata.
-    In OpenStack,\n                  this corresponds to the machine running nova-api
-    (or in Ubuntu,\n                  nova-api-metadata). A value of none (case insensitive)
-    means that\n                  Felix should not set up any NAT rule for the metadata
-    path. [Default:\n                  127.0.0.1]'\n                  type: string\n
-    \               metadataPort:\n                  description: 'MetadataPort is
-    the port of the metadata server. This,\n                  combined with global.MetadataAddr
-    (if not ‘None’), is used to set\n                  up a NAT rule, from 169.254.169.254:80
-    to MetadataAddr:MetadataPort.\n                  In most cases this should not
-    need to be changed [Default: 8775].'\n                  type: integer\n                mtuIfacePattern:\n
-    \                 description: MTUIfacePattern is a regular expression that controls\n
-    \                   which interfaces Felix should scan in order to calculate the
-    host's\n                    MTU. This should not match workload interfaces (usually
-    named cali...).\n                  type: string\n                natOutgoingAddress:\n
-    \                 description: NATOutgoingAddress specifies an address to use
-    when performing\n                    source NAT for traffic in a natOutgoing pool
-    that is leaving the\n                    network. By default the address used
-    is an address on the interface\n                    the traffic is leaving on
-    (ie it uses the iptables MASQUERADE target)\n                  type: string\n
-    \               natPortRange:\n                  anyOf:\n                    -
-    type: integer\n                    - type: string\n                  description:
-    NATPortRange specifies the range of ports that is used\n                    for
-    port mapping when doing outgoing NAT. When unset the default\n                    behavior
-    of the network stack is used.\n                  pattern: ^.*\n                  x-kubernetes-int-or-string:
-    true\n                netlinkTimeout:\n                  type: string\n                openstackRegion:\n
-    \                 description: 'OpenstackRegion is the name of the region that
-    a particular\n                  Felix belongs to. In a multi-region Calico/OpenStack
-    deployment,\n                  this must be configured somehow for each Felix
-    (here in the datamodel,\n                  or in felix.cfg or the environment
-    on each compute node), and must\n                  match the [calico] openstack_region
-    value configured in neutron.conf\n                  on each node. [Default: Empty]'\n
-    \                 type: string\n                policySyncPathPrefix:\n                  description:
-    'PolicySyncPathPrefix is used to by Felix to communicate\n                  policy
-    changes to external services, like Application layer policy.\n                  [Default:
-    Empty]'\n                  type: string\n                prometheusGoMetricsEnabled:\n
-    \                 description: 'PrometheusGoMetricsEnabled disables Go runtime
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                prometheusMetricsEnabled:\n                  description:
-    'PrometheusMetricsEnabled enables the Prometheus metrics\n                  server
-    in Felix if set to true. [Default: false]'\n                  type: boolean\n
-    \               prometheusMetricsHost:\n                  description: 'PrometheusMetricsHost
-    is the host that the Prometheus\n                  metrics server should bind
-    to. [Default: empty]'\n                  type: string\n                prometheusMetricsPort:\n
-    \                 description: 'PrometheusMetricsPort is the TCP port that the
-    Prometheus\n                  metrics server should bind to. [Default: 9091]'\n
-    \                 type: integer\n                prometheusProcessMetricsEnabled:\n
-    \                 description: 'PrometheusProcessMetricsEnabled disables process
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                removeExternalRoutes:\n                  description:
-    Whether or not to remove device routes that have not\n                    been
-    programmed by Felix. Disabling this will allow external applications\n                    to
-    also add device routes. This is enabled by default which means\n                    we
-    will remove externally added routes.\n                  type: boolean\n                reportingInterval:\n
-    \                 description: 'ReportingInterval is the interval at which Felix
-    reports\n                  its status into the datastore or 0 to disable. Must
-    be non-zero\n                  in OpenStack deployments. [Default: 30s]'\n                  type:
-    string\n                reportingTTL:\n                  description: 'ReportingTTL
-    is the time-to-live setting for process-wide\n                  status reports.
-    [Default: 90s]'\n                  type: string\n                routeRefreshInterval:\n
-    \                 description: 'RouterefreshInterval is the period at which Felix
-    re-checks\n                  the routes in the dataplane to ensure that no other
-    process has\n                  accidentally broken Calico’s rules. Set to 0 to
-    disable route refresh.\n                  [Default: 90s]'\n                  type:
-    string\n                routeSource:\n                  description: 'RouteSource
-    configures where Felix gets its routing\n                  information. - WorkloadIPs:
-    use workload endpoints to construct\n                  routes. - CalicoIPAM: the
-    default - use IPAM data to construct routes.'\n                  type: string\n
-    \               routeTableRange:\n                  description: Calico programs
-    additional Linux route tables for various\n                    purposes.  RouteTableRange
-    specifies the indices of the route tables\n                    that Calico should
-    use.\n                  properties:\n                    max:\n                      type:
-    integer\n                    min:\n                      type: integer\n                  required:\n
-    \                   - max\n                    - min\n                  type:
-    object\n                serviceLoopPrevention:\n                  description:
-    'When service IP advertisement is enabled, prevent routing\n                    loops
-    to service IPs that are not in use, by dropping or rejecting\n                    packets
-    that do not get DNAT''d by kube-proxy. Unless set to \"Disabled\",\n                    in
-    which case such routing loops continue to be allowed. [Default:\n                    Drop]'\n
-    \                 type: string\n                sidecarAccelerationEnabled:\n
-    \                 description: 'SidecarAccelerationEnabled enables experimental
-    sidecar\n                  acceleration [Default: false]'\n                  type:
-    boolean\n                usageReportingEnabled:\n                  description:
-    'UsageReportingEnabled reports anonymous Calico version\n                  number
-    and cluster size to projectcalico.org. Logs warnings returned\n                  by
-    the usage server. For example, if a significant security vulnerability\n                  has
-    been discovered in the version of Calico being used. [Default:\n                  true]'\n
-    \                 type: boolean\n                usageReportingInitialDelay:\n
-    \                 description: 'UsageReportingInitialDelay controls the minimum
-    delay\n                  before Felix makes a report. [Default: 300s]'\n                  type:
-    string\n                usageReportingInterval:\n                  description:
-    'UsageReportingInterval controls the interval at which\n                  Felix
-    makes reports. [Default: 86400s]'\n                  type: string\n                useInternalDataplaneDriver:\n
-    \                 type: boolean\n                vxlanEnabled:\n                  type:
-    boolean\n                vxlanMTU:\n                  description: 'VXLANMTU is
-    the MTU to set on the tunnel device. See\n                  Configuring MTU [Default:
-    1440]'\n                  type: integer\n                vxlanPort:\n                  type:
-    integer\n                vxlanVNI:\n                  type: integer\n                wireguardEnabled:\n
-    \                 description: 'WireguardEnabled controls whether Wireguard is
-    enabled.\n                  [Default: false]'\n                  type: boolean\n
-    \               wireguardInterfaceName:\n                  description: 'WireguardInterfaceName
-    specifies the name to use for\n                  the Wireguard interface. [Default:
-    wg.calico]'\n                  type: string\n                wireguardListeningPort:\n
-    \                 description: 'WireguardListeningPort controls the listening
-    port used\n                  by Wireguard. [Default: 51820]'\n                  type:
-    integer\n                wireguardMTU:\n                  description: 'WireguardMTU
-    controls the MTU on the Wireguard interface.\n                  See Configuring
-    MTU [Default: 1420]'\n                  type: integer\n                wireguardRoutingRulePriority:\n
-    \                 description: 'WireguardRoutingRulePriority controls the priority
-    value\n                  to use for the Wireguard routing rule. [Default: 99]'\n
-    \                 type: integer\n                xdpEnabled:\n                  description:
-    'XDPEnabled enables XDP acceleration for suitable untracked\n                  incoming
-    deny rules. [Default: true]'\n                  type: boolean\n                xdpRefreshInterval:\n
-    \                 description: 'XDPRefreshInterval is the period at which Felix
-    re-checks\n                  all XDP state to ensure that no other process has
-    accidentally broken\n                  Calico''s BPF maps or attached programs.
-    Set to 0 to disable XDP\n                  refresh. [Default: 90s]'\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: globalnetworkpolicies.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: GlobalNetworkPolicy\n    listKind:
-    GlobalNetworkPolicyList\n    plural: globalnetworkpolicies\n    singular: globalnetworkpolicy\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                applyOnForward:\n
-    \                 description: ApplyOnForward indicates to apply the rules in
-    this policy\n                    on forward traffic.\n                  type:
-    boolean\n                doNotTrack:\n                  description: DoNotTrack
-    indicates whether packets matched by the rules\n                    in this policy
-    should go through the data plane's connection tracking,\n                    such
-    as Linux conntrack.  If True, the rules in this policy are\n                    applied
-    before any data plane connection tracking, and packets allowed\n                    by
-    this policy are marked as not to be tracked.\n                  type: boolean\n
-    \               egress:\n                  description: The ordered set of egress
-    rules.  Each rule contains\n                    a set of packet match criteria
-    and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                namespaceSelector:\n                  description: NamespaceSelector
-    is an optional field for an expression\n                    used to select a pod
-    based on namespaces.\n                  type: string\n                order:\n
-    \                 description: Order is an optional field that specifies the order
-    in\n                    which the policy is applied. Policies with higher \"order\"
-    are applied\n                    after those with lower order.  If the order is
-    omitted, it may be\n                    considered to be \"infinite\" - i.e. the
-    policy will be applied last.  Policies\n                    with identical order
-    will be applied in alphanumerical order based\n                    on the Policy
-    \"Name\".\n                  type: number\n                preDNAT:\n                  description:
-    PreDNAT indicates to apply the rules in this policy before\n                    any
-    DNAT.\n                  type: boolean\n                selector:\n                  description:
-    \"The selector is an expression used to pick pick out\n                  the endpoints
-    that the policy should be applied to. \\n Selector\n                  expressions
-    follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n                  \\
-    ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel != \\\"string_literal\\\"\n
-    \                 \\  ->  not equal; also matches if label is not present \\tlabel
-    in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\", ... }  ->  true if the
-    value of label X is\n                  one of \\\"a\\\", \\\"b\\\", \\\"c\\\"
-    \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ... }  ->
-    \ true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress rules are present
-    in the policy.  The\n                  default is: \\n - [ PolicyTypeIngress ],
-    if there are no Egress rules\n                  (including the case where there
-    are   also no Ingress rules) \\n\n                  - [ PolicyTypeEgress ], if
-    there are Egress rules but no Ingress\n                  rules \\n - [ PolicyTypeIngress,
-    PolicyTypeEgress ], if there are\n                  both Ingress and Egress rules.
-    \\n When the policy is read back again,\n                  Types will always be
-    one of these values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: globalnetworksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: GlobalNetworkSet\n    listKind: GlobalNetworkSetList\n    plural:
-    globalnetworksets\n    singular: globalnetworkset\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs\n            that
-    share labels to allow rules to refer to them via selectors.  The labels\n            of
-    GlobalNetworkSet are not namespaced.\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: GlobalNetworkSetSpec contains the
-    specification for a NetworkSet\n                resource.\n              properties:\n
-    \               nets:\n                  description: The list of IP networks
-    that belong to this set.\n                  items:\n                    type:
-    string\n                  type: array\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: hostendpoints.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: HostEndpoint\n    listKind: HostEndpointList\n    plural:
-    hostendpoints\n    singular: hostendpoint\n  scope: Cluster\n  versions:\n    -
-    name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: HostEndpointSpec contains the specification
-    for a HostEndpoint\n                resource.\n              properties:\n                expectedIPs:\n
-    \                 description: \"The expected IP addresses (IPv4 and IPv6) of
-    the endpoint.\n                  If \\\"InterfaceName\\\" is not present, Calico
-    will look for an interface\n                  matching any of the IPs in the list
-    and apply policy to that. Note:\n                  \\tWhen using the selector
-    match criteria in an ingress or egress\n                  security Policy \\tor
-    Profile, Calico converts the selector into\n                  a set of IP addresses.
-    For host \\tendpoints, the ExpectedIPs field\n                  is used for that
-    purpose. (If only the interface \\tname is specified,\n                  Calico
-    does not learn the IPs of the interface for use in match\n                  \\tcriteria.)\"\n
-    \                 items:\n                    type: string\n                  type:
-    array\n                interfaceName:\n                  description: \"Either
-    \\\"*\\\", or the name of a specific Linux interface\n                  to apply
-    policy to; or empty.  \\\"*\\\" indicates that this HostEndpoint\n                  governs
-    all traffic to, from or through the default network namespace\n                  of
-    the host named by the \\\"Node\\\" field; entering and leaving that\n                  namespace
-    via any interface, including those from/to non-host-networked\n                  local
-    workloads. \\n If InterfaceName is not \\\"*\\\", this HostEndpoint\n                  only
-    governs traffic that enters or leaves the host through the\n                  specific
-    interface named by InterfaceName, or - when InterfaceName\n                  is
-    empty - through the specific interface that has one of the IPs\n                  in
-    ExpectedIPs. Therefore, when InterfaceName is empty, at least\n                  one
-    expected IP must be specified.  Only external interfaces (such\n                  as
-    “eth0”) are supported here; it isn't possible for a HostEndpoint\n                  to
-    protect traffic through a specific local workload interface.\n                  \\n
-    Note: Only some kinds of policy are implemented for \\\"*\\\" HostEndpoints;\n
-    \                 initially just pre-DNAT policy.  Please check Calico documentation\n
-    \                 for the latest position.\"\n                  type: string\n
-    \               node:\n                  description: The node name identifying
-    the Calico node instance.\n                  type: string\n                ports:\n
-    \                 description: Ports contains the endpoint's named ports, which
-    may\n                    be referenced in security policy rules.\n                  items:\n
-    \                   properties:\n                      name:\n                        type:
-    string\n                      port:\n                        type: integer\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                    required:\n                      - name\n                      -
-    port\n                      - protocol\n                    type: object\n                  type:
-    array\n                profiles:\n                  description: A list of identifiers
-    of security Profile objects that\n                    apply to this endpoint.
-    Each profile is applied in the order that\n                    they appear in
-    this list.  Profile rules are applied after the selector-based\n                    security
-    policy.\n                  items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: ipamblocks.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMBlock\n    listKind: IPAMBlockList\n
-    \   plural: ipamblocks\n    singular: ipamblock\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMBlockSpec contains the specification
-    for an IPAMBlock\n                resource.\n              properties:\n                affinity:\n
-    \                 type: string\n                allocations:\n                  items:\n
-    \                   type: integer\n                    # TODO: This nullable is
-    manually added in. We should update controller-gen\n                    # to handle
-    []*int properly itself.\n                    nullable: true\n                  type:
-    array\n                attributes:\n                  items:\n                    properties:\n
-    \                     handle_id:\n                        type: string\n                      secondary:\n
-    \                       additionalProperties:\n                          type:
-    string\n                        type: object\n                    type: object\n
-    \                 type: array\n                cidr:\n                  type:
-    string\n                deleted:\n                  type: boolean\n                strictAffinity:\n
-    \                 type: boolean\n                unallocated:\n                  items:\n
-    \                   type: integer\n                  type: array\n              required:\n
-    \               - allocations\n                - attributes\n                -
-    cidr\n                - strictAffinity\n                - unallocated\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMConfig\n    listKind: IPAMConfigList\n    plural: ipamconfigs\n
-    \   singular: ipamconfig\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMConfigSpec contains the specification
-    for an IPAMConfig\n                resource.\n              properties:\n                autoAllocateBlocks:\n
-    \                 type: boolean\n                maxBlocksPerHost:\n                  description:
-    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                    that
-    can be affine to each host.\n                  type: integer\n                strictAffinity:\n
-    \                 type: boolean\n              required:\n                - autoAllocateBlocks\n
-    \               - strictAffinity\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ipamhandles.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMHandle\n    listKind: IPAMHandleList\n    plural: ipamhandles\n
-    \   singular: ipamhandle\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMHandleSpec contains the specification
-    for an IPAMHandle\n                resource.\n              properties:\n                block:\n
-    \                 additionalProperties:\n                    type: integer\n                  type:
-    object\n                deleted:\n                  type: boolean\n                handleID:\n
-    \                 type: string\n              required:\n                - block\n
-    \               - handleID\n              type: object\n          type: object\n
-    \     served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ippools.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPPool\n    listKind: IPPoolList\n    plural: ippools\n    singular:
-    ippool\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPPoolSpec contains the specification
-    for an IPPool resource.\n              properties:\n                blockSize:\n
-    \                 description: The block size to use for IP address assignments
-    from\n                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.\n
-    \                 type: integer\n                cidr:\n                  description:
-    The pool CIDR.\n                  type: string\n                disabled:\n                  description:
-    When disabled is true, Calico IPAM will not assign addresses\n                    from
-    this pool.\n                  type: boolean\n                ipip:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  properties:\n                    enabled:\n                      description:
-    When enabled is true, ipip tunneling will be used\n                        to
-    deliver packets to destinations within this pool.\n                      type:
-    boolean\n                    mode:\n                      description: The IPIP
-    mode.  This can be one of \"always\" or \"cross-subnet\".  A\n                        mode
-    of \"always\" will also use IPIP tunneling for routing to\n                        destination
-    IP addresses within this pool.  A mode of \"cross-subnet\"\n                        will
-    only use IPIP tunneling when the destination node is on\n                        a
-    different subnet to the originating node.  The default value\n                        (if
-    not specified) is \"always\".\n                      type: string\n                  type:
-    object\n                ipipMode:\n                  description: Contains configuration
-    for IPIP tunneling for this pool.\n                    If not specified, then
-    this is defaulted to \"Never\" (i.e. IPIP tunneling\n                    is disabled).\n
-    \                 type: string\n                nat-outgoing:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  type: boolean\n                natOutgoing:\n                  description:
-    When nat-outgoing is true, packets sent from Calico networked\n                    containers
-    in this pool to destinations outside of this pool will\n                    be
-    masqueraded.\n                  type: boolean\n                nodeSelector:\n
-    \                 description: Allows IPPool to allocate for a specific node by
-    label\n                    selector.\n                  type: string\n                vxlanMode:\n
-    \                 description: Contains configuration for VXLAN tunneling for
-    this pool.\n                    If not specified, then this is defaulted to \"Never\"
-    (i.e. VXLAN\n                    tunneling is disabled).\n                  type:
-    string\n              required:\n                - cidr\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: kubecontrollersconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: KubeControllersConfiguration\n    listKind: KubeControllersConfigurationList\n
-    \   plural: kubecontrollersconfigurations\n    singular: kubecontrollersconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: KubeControllersConfigurationSpec
-    contains the values of the\n                Kubernetes controllers configuration.\n
-    \             properties:\n                controllers:\n                  description:
-    Controllers enables and configures individual Kubernetes\n                    controllers\n
-    \                 properties:\n                    namespace:\n                      description:
-    Namespace enables and configures the namespace controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   node:\n                      description: Node enables and
-    configures the node controller.\n                        Enabled by default, set
-    to nil to disable.\n                      properties:\n                        hostEndpoint:\n
-    \                         description: HostEndpoint controls syncing nodes to
-    host endpoints.\n                            Disabled by default, set to nil to
-    disable.\n                          properties:\n                            autoCreate:\n
-    \                             description: 'AutoCreate enables automatic creation
-    of\n                              host endpoints for every node. [Default: Disabled]'\n
-    \                             type: string\n                          type: object\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                       syncLabels:\n                          description: 'SyncLabels
-    controls whether to copy Kubernetes\n                          node labels to
-    Calico nodes. [Default: Enabled]'\n                          type: string\n                      type:
-    object\n                    policy:\n                      description: Policy
-    enables and configures the policy controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   serviceAccount:\n                      description: ServiceAccount
-    enables and configures the service\n                        account controller.
-    Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                    workloadEndpoint:\n                      description:
-    WorkloadEndpoint enables and configures the workload\n                        endpoint
-    controller. Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                  type: object\n                etcdV3CompactionPeriod:\n
-    \                 description: 'EtcdV3CompactionPeriod is the period between etcdv3\n
-    \                 compaction requests. Set to 0 to disable. [Default: 10m]'\n
-    \                 type: string\n                healthChecks:\n                  description:
-    'HealthChecks enables or disables support for health\n                  checks
-    [Default: Enabled]'\n                  type: string\n                logSeverityScreen:\n
-    \                 description: 'LogSeverityScreen is the log severity above which
-    logs\n                  are sent to the stdout. [Default: Info]'\n                  type:
-    string\n                prometheusMetricsPort:\n                  description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                    metrics
-    server should bind to. Set to 0 to disable. [Default: 9094]'\n                  type:
-    integer\n              required:\n                - controllers\n              type:
-    object\n            status:\n              description: KubeControllersConfigurationStatus
-    represents the status\n                of the configuration. It's useful for admins
-    to be able to see the actual\n                config that was applied, which can
-    be modified by environment variables\n                on the kube-controllers
-    process.\n              properties:\n                environmentVars:\n                  additionalProperties:\n
-    \                   type: string\n                  description: EnvironmentVars
-    contains the environment variables on\n                    the kube-controllers
-    that influenced the RunningConfig.\n                  type: object\n                runningConfig:\n
-    \                 description: RunningConfig contains the effective config that
-    is running\n                    in the kube-controllers pod, after merging the
-    API resource with\n                    any environment variables.\n                  properties:\n
-    \                   controllers:\n                      description: Controllers
-    enables and configures individual Kubernetes\n                        controllers\n
-    \                     properties:\n                        namespace:\n                          description:
-    Namespace enables and configures the namespace\n                            controller.
-    Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        node:\n
-    \                         description: Node enables and configures the node controller.\n
-    \                           Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           hostEndpoint:\n                              description:
-    HostEndpoint controls syncing nodes to host\n                                endpoints.
-    Disabled by default, set to nil to disable.\n                              properties:\n
-    \                               autoCreate:\n                                  description:
-    'AutoCreate enables automatic creation\n                                  of host
-    endpoints for every node. [Default: Disabled]'\n                                  type:
-    string\n                              type: object\n                            leakGracePeriod:\n
-    \                             description: 'LeakGracePeriod is the period used
-    by the\n                                controller to determine if an IP address
-    has been leaked.\n                                Set to 0 to disable IP garbage
-    collection. [Default:\n                                15m]'\n                              type:
-    string\n                            reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                            syncLabels:\n                              description:
-    'SyncLabels controls whether to copy Kubernetes\n                              node
-    labels to Calico nodes. [Default: Enabled]'\n                              type:
-    string\n                          type: object\n                        policy:\n
-    \                         description: Policy enables and configures the policy
-    controller.\n                            Enabled by default, set to nil to disable.\n
-    \                         properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        serviceAccount:\n
-    \                         description: ServiceAccount enables and configures the
-    service\n                            account controller. Enabled by default, set
-    to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        workloadEndpoint:\n
-    \                         description: WorkloadEndpoint enables and configures
-    the workload\n                            endpoint controller. Enabled by default,
-    set to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                      type: object\n
-    \                   etcdV3CompactionPeriod:\n                      description:
-    'EtcdV3CompactionPeriod is the period between etcdv3\n                      compaction
-    requests. Set to 0 to disable. [Default: 10m]'\n                      type: string\n
-    \                   healthChecks:\n                      description: 'HealthChecks
-    enables or disables support for health\n                      checks [Default:
-    Enabled]'\n                      type: string\n                    logSeverityScreen:\n
-    \                     description: 'LogSeverityScreen is the log severity above
-    which\n                      logs are sent to the stdout. [Default: Info]'\n                      type:
-    string\n                    prometheusMetricsPort:\n                      description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                        metrics
-    server should bind to. Set to 0 to disable. [Default:\n                        9094]'\n
-    \                     type: integer\n                  required:\n                    -
-    controllers\n                  type: object\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: networkpolicies.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkPolicy\n    listKind: NetworkPolicyList\n    plural:
-    networkpolicies\n    singular: networkpolicy\n  scope: Namespaced\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                egress:\n                  description:
-    The ordered set of egress rules.  Each rule contains\n                    a set
-    of packet match criteria and a corresponding action to apply.\n                  items:\n
-    \                   description: \"A Rule encapsulates a set of match criteria
-    and an\n                    action.  Both selector-based security Policy and security
-    Profiles\n                    reference rules - separated out as a list of rules
-    for both ingress\n                    and egress packet matching. \\n Each positive
-    match criteria has\n                    a negated version, prefixed with ”Not”.
-    All the match criteria\n                    within a rule must be satisfied for
-    a packet to match. A single\n                    rule can contain the positive
-    and negative version of a match\n                    and both must be satisfied
-    for the rule to match.\"\n                    properties:\n                      action:\n
-    \                       type: string\n                      destination:\n                        description:
-    Destination contains the match criteria that apply\n                          to
-    destination entity.\n                        properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                order:\n                  description: Order is an optional
-    field that specifies the order in\n                    which the policy is applied.
-    Policies with higher \"order\" are applied\n                    after those with
-    lower order.  If the order is omitted, it may be\n                    considered
-    to be \"infinite\" - i.e. the policy will be applied last.  Policies\n                    with
-    identical order will be applied in alphanumerical order based\n                    on
-    the Policy \"Name\".\n                  type: number\n                selector:\n
-    \                 description: \"The selector is an expression used to pick pick
-    out\n                  the endpoints that the policy should be applied to. \\n
-    Selector\n                  expressions follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n
-    \                 \\ ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel
-    != \\\"string_literal\\\"\n                  \\  ->  not equal; also matches if
-    label is not present \\tlabel in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\",
-    ... }  ->  true if the value of label X is\n                  one of \\\"a\\\",
-    \\\"b\\\", \\\"c\\\" \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ...
-    }  ->  true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress are present in the
-    policy.  The default\n                  is: \\n - [ PolicyTypeIngress ], if there
-    are no Egress rules (including\n                  the case where there are   also
-    no Ingress rules) \\n - [ PolicyTypeEgress\n                  ], if there are
-    Egress rules but no Ingress rules \\n - [ PolicyTypeIngress,\n                  PolicyTypeEgress
-    ], if there are both Ingress and Egress rules.\n                  \\n When the
-    policy is read back again, Types will always be one\n                  of these
-    values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: networksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkSet\n    listKind: NetworkSetList\n    plural: networksets\n
-    \   singular: networkset\n  scope: Namespaced\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          description: NetworkSet is the Namespaced-equivalent
-    of the GlobalNetworkSet.\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: NetworkSetSpec contains the specification
-    for a NetworkSet\n                resource.\n              properties:\n                nets:\n
-    \                 description: The list of IP networks that belong to this set.\n
-    \                 items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n---\n# Source: calico/templates/calico-kube-controllers-rbac.yaml\n\n#
-    Include a clusterrole for the kube-controllers component,\n# and bind it to the
-    calico-kube-controllers serviceaccount.\nkind: ClusterRole\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nrules:\n  # Nodes are watched to monitor for
-    deletions.\n  - apiGroups: [\"\"]\n    resources:\n      - nodes\n    verbs:\n
-    \     - watch\n      - list\n      - get\n  # Pods are watched to check for existence
-    as part of IPAM controller.\n  - apiGroups: [\"\"]\n    resources:\n      - pods\n
-    \   verbs:\n      - get\n      - list\n      - watch\n  # IPAM resources are manipulated
-    when nodes are deleted.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - ippools\n    verbs:\n      - list\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - blockaffinities\n      - ipamblocks\n      - ipamhandles\n
-    \   verbs:\n      - get\n      - list\n      - create\n      - update\n      -
-    delete\n      - watch\n  # kube-controllers manages hostendpoints.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - hostendpoints\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  #
-    Needs access to update clusterinformations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - clusterinformations\n    verbs:\n      - get\n      -
-    create\n      - update\n  # KubeControllersConfiguration is where it gets its
-    config\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - kubecontrollersconfigurations\n
-    \   verbs:\n      # read its own config\n      - get\n      # create a default
-    if none exists\n      - create\n      # update status\n      - update\n      #
-    watch for changes\n      - watch\n---\nkind: ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-kube-controllers\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-kube-controllers\n    namespace: kube-system\n---\n\n---\n# Source:
-    calico/templates/calico-node-rbac.yaml\n# Include a clusterrole for the calico-node
-    DaemonSet,\n# and bind it to the calico-node serviceaccount.\nkind: ClusterRole\napiVersion:
-    rbac.authorization.k8s.io/v1\nmetadata:\n  name: calico-node\nrules:\n  # The
-    CNI plugin needs to get pods, nodes, and namespaces.\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - pods\n      - nodes\n      - namespaces\n    verbs:\n
-    \     - get\n  # EndpointSlices are used for Service-based network policy rule\n
-    \ # enforcement.\n  - apiGroups: [\"discovery.k8s.io\"]\n    resources:\n      -
-    endpointslices\n    verbs:\n      - watch\n      - list\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - endpoints\n      - services\n    verbs:\n      # Used
-    to discover service IPs for advertisement.\n      - watch\n      - list\n      #
-    Used to discover Typhas.\n      - get\n  # Pod CIDR auto-detection on kubeadm
-    needs access to config maps.\n  - apiGroups: [\"\"]\n    resources:\n      - configmaps\n
-    \   verbs:\n      - get\n  - apiGroups: [\"\"]\n    resources:\n      - nodes/status\n
-    \   verbs:\n      # Needed for clearing NodeNetworkUnavailable flag.\n      -
-    patch\n      # Calico stores some configuration information in node annotations.\n
-    \     - update\n  # Watch for changes to Kubernetes NetworkPolicies.\n  - apiGroups:
-    [\"networking.k8s.io\"]\n    resources:\n      - networkpolicies\n    verbs:\n
-    \     - watch\n      - list\n  # Used by Calico for policy information.\n  - apiGroups:
-    [\"\"]\n    resources:\n      - pods\n      - namespaces\n      - serviceaccounts\n
-    \   verbs:\n      - list\n      - watch\n  # The CNI plugin patches pods/status.\n
-    \ - apiGroups: [\"\"]\n    resources:\n      - pods/status\n    verbs:\n      -
-    patch\n  # Calico monitors various CRDs for config.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - globalfelixconfigs\n      - felixconfigurations\n      -
-    bgppeers\n      - globalbgpconfigs\n      - bgpconfigurations\n      - ippools\n
-    \     - ipamblocks\n      - globalnetworkpolicies\n      - globalnetworksets\n
-    \     - networkpolicies\n      - networksets\n      - clusterinformations\n      -
-    hostendpoints\n      - blockaffinities\n    verbs:\n      - get\n      - list\n
-    \     - watch\n  # Calico must create and update some CRDs on startup.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - ippools\n      - felixconfigurations\n
-    \     - clusterinformations\n    verbs:\n      - create\n      - update\n  # Calico
-    stores some configuration information on the node.\n  - apiGroups: [\"\"]\n    resources:\n
-    \     - nodes\n    verbs:\n      - get\n      - list\n      - watch\n  # These
-    permissions are only required for upgrade from v2.6, and can\n  # be removed after
-    upgrade or on fresh installations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - bgpconfigurations\n      - bgppeers\n    verbs:\n      -
-    create\n      - update\n  # These permissions are required for Calico CNI to perform
-    IPAM allocations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n      - ipamblocks\n      - ipamhandles\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  -
-    apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - ipamconfigs\n
-    \   verbs:\n      - get\n  # Block affinities must also be watchable by confd
-    for route aggregation.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n    verbs:\n      - watch\n  # The Calico IPAM migration
-    needs to get daemonsets. These permissions can be\n  # removed if not upgrading
-    from an installation using host-local IPAM.\n  - apiGroups: [\"apps\"]\n    resources:\n
-    \     - daemonsets\n    verbs:\n      - get\n\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:
-    ClusterRoleBinding\nmetadata:\n  name: calico-node\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-node\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-node\n    namespace: kube-system\n\n---\n# Source: calico/templates/calico-node.yaml\n#
-    This manifest installs the calico-node container, as well\n# as the CNI plugins
-    and network config on\n# each master and worker node in a Kubernetes cluster.\nkind:
-    DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: calico-node\n  namespace: kube-system\n
-    \ labels:\n    k8s-app: calico-node\nspec:\n  selector:\n    matchLabels:\n      k8s-app:
-    calico-node\n  updateStrategy:\n    type: RollingUpdate\n    rollingUpdate:\n
-    \     maxUnavailable: 1\n  template:\n    metadata:\n      labels:\n        k8s-app:
-    calico-node\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n
-    \     hostNetwork: true\n      tolerations:\n        # Make sure calico-node gets
-    scheduled on all nodes.\n        - effect: NoSchedule\n          operator: Exists\n
-    \       # Mark the pod as a critical add-on for rescheduling.\n        - key:
-    CriticalAddonsOnly\n          operator: Exists\n        - effect: NoExecute\n
-    \         operator: Exists\n      serviceAccountName: calico-node\n      # Minimize
-    downtime during a rolling upgrade or deletion; tell Kubernetes to do a \"force\n
-    \     # deletion\": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.\n
-    \     terminationGracePeriodSeconds: 0\n      priorityClassName: system-node-critical\n
-    \     initContainers:\n        # This container performs upgrade from host-local
-    IPAM to calico-ipam.\n        # It can be deleted if this is a fresh installation,
-    or if you have already\n        # upgraded to use calico-ipam.\n        - name:
-    upgrade-ipam\n          image: calico/cni:v3.20.0\n          command: [\"/opt/cni/bin/calico-ipam\",
-    \"-upgrade\"]\n          envFrom:\n            - configMapRef:\n                #
-    Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for
-    eBPF mode.\n                name: kubernetes-services-endpoint\n                optional:
-    true\n          env:\n            - name: KUBERNETES_NODE_NAME\n              valueFrom:\n
-    \               fieldRef:\n                  fieldPath: spec.nodeName\n            -
-    name: CALICO_NETWORKING_BACKEND\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: calico_backend\n
-    \         volumeMounts:\n            - mountPath: /var/lib/cni/networks\n              name:
-    host-local-net-dir\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n          securityContext:\n            privileged: true\n        #
-    This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: calico/cni:v3.20.0\n
-    \         command: [\"/opt/cni/bin/install\"]\n          envFrom:\n            -
-    configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
-    to be overridden for eBPF mode.\n                name: kubernetes-services-endpoint\n
-    \               optional: true\n          env:\n            # Name of the CNI
-    config file to create.\n            - name: CNI_CONF_NAME\n              value:
-    \"10-calico.conflist\"\n            # The CNI network config to install on each
-    node.\n            - name: CNI_NETWORK_CONFIG\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: cni_network_config\n
-    \           # Set the hostname based on the k8s node name.\n            - name:
-    KUBERNETES_NODE_NAME\n              valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # CNI MTU Config variable\n            - name: CNI_MTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Prevents the container
-    from sleeping forever.\n            - name: SLEEP\n              value: \"false\"\n
-    \         volumeMounts:\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n            - mountPath: /host/etc/cni/net.d\n              name:
-    cni-net-dir\n          securityContext:\n            privileged: true\n        #
-    Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes\n
-    \       # to communicate with Felix over the Policy Sync API.\n        - name:
-    flexvol-driver\n          image: calico/pod2daemon-flexvol:v3.20.0\n          volumeMounts:\n
-    \           - name: flexvol-driver-host\n              mountPath: /host/driver\n
-    \         securityContext:\n            privileged: true\n      containers:\n
-    \       # Runs calico-node container on each Kubernetes node. This\n        #
-    container programs network policy and routes on each\n        # host.\n        -
-    name: calico-node\n          image: calico/node:v3.20.0\n          envFrom:\n
-    \           - configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and
-    KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.\n                name:
-    kubernetes-services-endpoint\n                optional: true\n          env:\n
-    \           # Use Kubernetes API as the backing datastore.\n            - name:
-    DATASTORE_TYPE\n              value: \"kubernetes\"\n            # Wait for the
-    datastore.\n            - name: WAIT_FOR_DATASTORE\n              value: \"true\"\n
-    \           # Set based on the k8s node name.\n            - name: NODENAME\n
-    \             valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # Choose the backend to use.\n            - name: CALICO_NETWORKING_BACKEND\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: calico_backend\n            # Cluster type
-    to identify the deployment type\n            - name: CLUSTER_TYPE\n              value:
-    \"k8s,bgp\"\n            # Auto-detect the BGP IP address.\n            - name:
-    IP\n              value: \"autodetect\"\n            # Enable VXLAN\n            -
-    name: CALICO_IPV4POOL_VXLAN\n              value: \"Always\"\n            # Set
-    MTU for tunnel device used if ipip is enabled\n            - name: FELIX_IPINIPMTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Set MTU for the
-    VXLAN tunnel device.\n            - name: FELIX_VXLANMTU\n              valueFrom:\n
-    \               configMapKeyRef:\n                  name: calico-config\n                  key:
-    veth_mtu\n            # Set MTU for the Wireguard tunnel device.\n            -
-    name: FELIX_WIREGUARDMTU\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: veth_mtu\n            #
-    The default IPv4 pool to create on startup if none exists. Pod IPs will be\n            #
-    chosen from this range. Changing this value after installation will have\n            #
-    no effect. This should fall within `--cluster-cidr`.\n            # - name: CALICO_IPV4POOL_CIDR\n
-    \           #   value: \"192.168.0.0/16\"\n            # Disable file logging
-    so `kubectl logs` works.\n            - name: CALICO_DISABLE_FILE_LOGGING\n              value:
-    \"true\"\n            # Set Felix endpoint to host default action to ACCEPT.\n
-    \           - name: FELIX_DEFAULTENDPOINTTOHOSTACTION\n              value: \"ACCEPT\"\n
-    \           # Disable IPv6 on Kubernetes.\n            - name: FELIX_IPV6SUPPORT\n
-    \             value: \"false\"\n            - name: FELIX_FEATUREDETECTOVERRIDE\n
-    \             value: \"ChecksumOffloadBroken=true\"\n            - name: FELIX_HEALTHENABLED\n
-    \             value: \"true\"\n          securityContext:\n            privileged:
-    true\n          resources:\n            requests:\n              cpu: 250m\n          livenessProbe:\n
-    \           exec:\n              command:\n                - /bin/calico-node\n
-    \               - -felix-live\n            periodSeconds: 10\n            initialDelaySeconds:
-    10\n            failureThreshold: 6\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /bin/calico-node\n                -
-    -felix-ready\n            periodSeconds: 10\n          volumeMounts:\n            -
-    mountPath: /host/etc/cni/net.d\n              name: cni-net-dir\n              readOnly:
-    false\n            - mountPath: /lib/modules\n              name: lib-modules\n
-    \             readOnly: true\n            - mountPath: /run/xtables.lock\n              name:
-    xtables-lock\n              readOnly: false\n            - mountPath: /var/run/calico\n
-    \             name: var-run-calico\n              readOnly: false\n            -
-    mountPath: /var/lib/calico\n              name: var-lib-calico\n              readOnly:
-    false\n            - name: policysync\n              mountPath: /var/run/nodeagent\n
-    \           # For eBPF mode, we need to be able to mount the BPF filesystem at
-    /sys/fs/bpf so we mount in the\n            # parent directory.\n            -
-    name: sysfs\n              mountPath: /sys/fs/\n              # Bidirectional
-    means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to
-    the host.\n              # If the host is known to mount that filesystem already
-    then Bidirectional can be omitted.\n              mountPropagation: Bidirectional\n
-    \           - name: cni-log-dir\n              mountPath: /var/log/calico/cni\n
-    \             readOnly: true\n      volumes:\n        # Used by calico-node.\n
-    \       - name: lib-modules\n          hostPath:\n            path: /lib/modules\n
-    \       - name: var-run-calico\n          hostPath:\n            path: /var/run/calico\n
-    \       - name: var-lib-calico\n          hostPath:\n            path: /var/lib/calico\n
-    \       - name: xtables-lock\n          hostPath:\n            path: /run/xtables.lock\n
-    \           type: FileOrCreate\n        - name: sysfs\n          hostPath:\n            path:
-    /sys/fs/\n            type: DirectoryOrCreate\n        # Used to install CNI.\n
-    \       - name: cni-bin-dir\n          hostPath:\n            path: /opt/cni/bin\n
-    \       - name: cni-net-dir\n          hostPath:\n            path: /etc/cni/net.d\n
-    \       # Used to access CNI logs.\n        - name: cni-log-dir\n          hostPath:\n
-    \           path: /var/log/calico/cni\n        # Mount in the directory for host-local
-    IPAM allocations. This is\n        # used when upgrading from host-local to calico-ipam,
-    and can be removed\n        # if not using the upgrade-ipam init container.\n
-    \       - name: host-local-net-dir\n          hostPath:\n            path: /var/lib/cni/networks\n
-    \       # Used to create per-pod Unix Domain Sockets\n        - name: policysync\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /var/run/nodeagent\n
-    \       # Used to install Flex Volume Driver\n        - name: flexvol-driver-host\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds\n---\n\napiVersion:
-    v1\nkind: ServiceAccount\nmetadata:\n  name: calico-node\n  namespace: kube-system\n\n---\n#
-    Source: calico/templates/calico-kube-controllers.yaml\n# See https://github.com/projectcalico/kube-controllers\napiVersion:
-    apps/v1\nkind: Deployment\nmetadata:\n  name: calico-kube-controllers\n  namespace:
-    kube-system\n  labels:\n    k8s-app: calico-kube-controllers\nspec:\n  # The controllers
-    can only have a single active instance.\n  replicas: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n  strategy:\n    type: Recreate\n  template:\n
-    \   metadata:\n      name: calico-kube-controllers\n      namespace: kube-system\n
-    \     labels:\n        k8s-app: calico-kube-controllers\n    spec:\n      nodeSelector:\n
-    \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
-    a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
-    Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
-    \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
-    \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
-    \         env:\n            # Choose which controllers to run.\n            -
-    name: ENABLED_CONTROLLERS\n              value: node\n            - name: DATASTORE_TYPE\n
-    \             value: kubernetes\n          livenessProbe:\n            exec:\n
-    \             command:\n              - /usr/bin/check-status\n              -
-    -l\n            periodSeconds: 10\n            initialDelaySeconds: 10\n            failureThreshold:
-    6\n            timeoutSeconds: 10\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /usr/bin/check-status\n                -
-    -r\n            periodSeconds: 10\n\n---\n\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n\n---\n\n# This manifest
-    creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler
-    to evict\n\napiVersion: policy/v1beta1\nkind: PodDisruptionBudget\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n  labels:\n    k8s-app:
-    calico-kube-controllers\nspec:\n  maxUnavailable: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n---\n# Source: calico/templates/calico-etcd-secrets.yaml\n\n---\n#
-    Source: calico/templates/calico-typha.yaml\n\n---\n# Source: calico/templates/configure-canal.yaml\n"
+  resources: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgpconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPConfiguration
+        listKind: BGPConfigurationList
+        plural: bgpconfigurations
+        singular: bgpconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: BGPConfiguration contains the configuration for any BGP routing.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPConfigurationSpec contains the values of the BGP configuration.
+                properties:
+                  asNumber:
+                    description: 'ASNumber is the default AS number used by a node. [Default:
+                      64512]'
+                    format: int32
+                    type: integer
+                  communities:
+                    description: Communities is a list of BGP community values and their
+                      arbitrary names for tagging routes.
+                    items:
+                      description: Community contains standard or large community value
+                        and its name.
+                      properties:
+                        name:
+                          description: Name given to community value.
+                          type: string
+                        value:
+                          description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                            For standard community use `aa:nn` format, where `aa` and
+                            `nn` are 16 bit number. For large community use `aa:nn:mm`
+                            format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                            `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                          pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                          type: string
+                      type: object
+                    type: array
+                  listenPort:
+                    description: ListenPort is the port where BGP protocol should listen.
+                      Defaults to 179
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: INFO]'
+                    type: string
+                  nodeToNodeMeshEnabled:
+                    description: 'NodeToNodeMeshEnabled sets whether full node to node
+                      BGP mesh is enabled. [Default: true]'
+                    type: boolean
+                  prefixAdvertisements:
+                    description: PrefixAdvertisements contains per-prefix advertisement
+                      configuration.
+                    items:
+                      description: PrefixAdvertisement configures advertisement properties
+                        for the specified CIDR.
+                      properties:
+                        cidr:
+                          description: CIDR for which properties should be advertised.
+                          type: string
+                        communities:
+                          description: Communities can be list of either community names
+                            already defined in `Specs.Communities` or community value
+                            of format `aa:nn` or `aa:nn:mm`. For standard community use
+                            `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                            large community use `aa:nn:mm` format, where `aa`, `nn` and
+                            `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                            `mm` are per-AS identifier.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  serviceClusterIPs:
+                    description: ServiceClusterIPs are the CIDR blocks from which service
+                      cluster IPs are allocated. If specified, Calico will advertise these
+                      blocks, as well as any cluster IPs within them.
+                    items:
+                      description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                        CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceExternalIPs:
+                    description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                      Service External IPs. Kubernetes Service ExternalIPs will only be
+                      advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceExternalIPBlock represents a single allowed
+                        External IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceLoadBalancerIPs:
+                    description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                      Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                      IPs will only be advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceLoadBalancerIPBlock represents a single allowed
+                        LoadBalancer IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgppeers.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPPeer
+        listKind: BGPPeerList
+        plural: bgppeers
+        singular: bgppeer
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPPeerSpec contains the specification for a BGPPeer resource.
+                properties:
+                  asNumber:
+                    description: The AS Number of the peer.
+                    format: int32
+                    type: integer
+                  keepOriginalNextHop:
+                    description: Option to keep the original nexthop field when routes
+                      are sent to a BGP Peer. Setting "true" configures the selected BGP
+                      Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                      in the specific branch of the Node on "bird.cfg".
+                    type: boolean
+                  maxRestartTime:
+                    description: Time to allow for software restart.  When specified,
+                      this is configured as the graceful restart timeout.  When not specified,
+                      the BIRD default of 120s is used.
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance that
+                      is targeted by this peer. If this is not set, and no nodeSelector
+                      is specified, then this BGP peer selects all nodes in the cluster.
+                    type: string
+                  nodeSelector:
+                    description: Selector for the nodes that should have this peering.  When
+                      this is set, the Node field must be empty.
+                    type: string
+                  password:
+                    description: Optional BGP password for the peerings generated by this
+                      BGPPeer resource.
+                    properties:
+                      secretKeyRef:
+                        description: Selects a key of a secret in the node pod's namespace.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be
+                              a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be
+                              defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  peerIP:
+                    description: The IP address of the peer followed by an optional port
+                      number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                      or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                      and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                      set in BGPConfiguration, then we use that port to peer.
+                    type: string
+                  peerSelector:
+                    description: Selector for the remote nodes to peer with.  When this
+                      is set, the PeerIP and ASNumber fields must be empty.  For each
+                      peering between the local node and selected remote nodes, we configure
+                      an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                      and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                      remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                      or the global default if that is not set.
+                    type: string
+                  sourceAddress:
+                    description: Specifies whether and how to configure a source address
+                      for the peerings generated by this BGPPeer resource.  Default value
+                      "UseNodeIP" means to configure the node IP as the source address.  "None"
+                      means not to configure a source address.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: blockaffinities.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BlockAffinity
+        listKind: BlockAffinityList
+        plural: blockaffinities
+        singular: blockaffinity
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BlockAffinitySpec contains the specification for a BlockAffinity
+                  resource.
+                properties:
+                  cidr:
+                    type: string
+                  deleted:
+                    description: Deleted indicates that this block affinity is being deleted.
+                      This field is a string for compatibility with older releases that
+                      mistakenly treat this field as a string.
+                    type: string
+                  node:
+                    type: string
+                  state:
+                    type: string
+                required:
+                - cidr
+                - deleted
+                - node
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: clusterinformations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: ClusterInformation
+        listKind: ClusterInformationList
+        plural: clusterinformations
+        singular: clusterinformation
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterInformation contains the cluster specific information.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterInformationSpec contains the values of describing
+                  the cluster.
+                properties:
+                  calicoVersion:
+                    description: CalicoVersion is the version of Calico that the cluster
+                      is running
+                    type: string
+                  clusterGUID:
+                    description: ClusterGUID is the GUID of the cluster
+                    type: string
+                  clusterType:
+                    description: ClusterType describes the type of the cluster
+                    type: string
+                  datastoreReady:
+                    description: DatastoreReady is used during significant datastore migrations
+                      to signal to components such as Felix that it should wait before
+                      accessing the datastore.
+                    type: boolean
+                  variant:
+                    description: Variant declares which variant of Calico should be active.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: felixconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: FelixConfiguration
+        listKind: FelixConfigurationList
+        plural: felixconfigurations
+        singular: felixconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: Felix Configuration contains the configuration for Felix.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: FelixConfigurationSpec contains the values of the Felix configuration.
+                properties:
+                  allowIPIPPacketsFromWorkloads:
+                    description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop IPIP encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  allowVXLANPacketsFromWorkloads:
+                    description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop VXLAN encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  awsSrcDstCheck:
+                    description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                      value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                      DoNothing]'
+                    enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                    type: string
+                  bpfConnectTimeLoadBalancingEnabled:
+                    description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                      controls whether Felix installs the connection-time load balancer.  The
+                      connect-time load balancer is required for the host to be able to
+                      reach Kubernetes services and it improves the performance of pod-to-service
+                      connections.  The only reason to disable it is for debugging purposes.  [Default:
+                      true]'
+                    type: boolean
+                  bpfDataIfacePattern:
+                    description: BPFDataIfacePattern is a regular expression that controls
+                      which interfaces Felix should attach BPF programs to in order to
+                      catch traffic to/from the network.  This needs to match the interfaces
+                      that Calico workload traffic flows over as well as any interfaces
+                      that handle incoming traffic to nodeports and services from outside
+                      the cluster.  It should not match the workload interfaces (usually
+                      named cali...).
+                    type: string
+                  bpfDisableUnprivileged:
+                    description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                      sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                      users cannot access Calico''s BPF maps and cannot insert their own
+                      BPF programs to interfere with Calico''s. [Default: true]'
+                    type: boolean
+                  bpfEnabled:
+                    description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                      [Default: false]'
+                    type: boolean
+                  bpfExtToServiceConnmark:
+                    description: 'BPFExtToServiceConnmark in BPF mode, controls a 32bit
+                      mark that is set on connections from an external client to a local
+                      service. This mark allows us to control how packets of that connection
+                      are routed within the host and how is routing intepreted by RPF
+                      check. [Default: 0]'
+                    type: integer
+                  bpfExternalServiceMode:
+                    description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                      from outside the cluster to services (node ports and cluster IPs)
+                      are forwarded to remote workloads.  If set to "Tunnel" then both
+                      request and response traffic is tunneled to the remote node.  If
+                      set to "DSR", the request traffic is tunneled but the response traffic
+                      is sent directly from the remote node.  In "DSR" mode, the remote
+                      node appears to use the IP of the ingress node; this requires a
+                      permissive L2 network.  [Default: Tunnel]'
+                    type: string
+                  bpfKubeProxyEndpointSlicesEnabled:
+                    description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                      whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                    type: boolean
+                  bpfKubeProxyIptablesCleanupEnabled:
+                    description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                      mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                      iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                      true]'
+                    type: boolean
+                  bpfKubeProxyMinSyncPeriod:
+                    description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                      minimum time between updates to the dataplane for Felix''s embedded
+                      kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                      reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                    type: string
+                  bpfLogLevel:
+                    description: 'BPFLogLevel controls the log level of the BPF programs
+                      when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                      logs are emitted to the BPF trace pipe, accessible with the command
+                      `tc exec bpf debug`. [Default: Off].'
+                    type: string
+                  chainInsertMode:
+                    description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                      top-level iptables chains by inserting a rule at the top of the
+                      chain or by appending a rule at the bottom. insert is the safe default
+                      since it prevents Calico''s rules from being bypassed. If you switch
+                      to append mode, be sure that the other rules in the chains signal
+                      acceptance by falling through to the Calico rules, otherwise the
+                      Calico policy will be bypassed. [Default: insert]'
+                    type: string
+                  dataplaneDriver:
+                    type: string
+                  debugDisableLogDropping:
+                    type: boolean
+                  debugMemoryProfilePath:
+                    type: string
+                  debugSimulateCalcGraphHangAfter:
+                    type: string
+                  debugSimulateDataplaneHangAfter:
+                    type: string
+                  defaultEndpointToHostAction:
+                    description: 'DefaultEndpointToHostAction controls what happens to
+                      traffic that goes from a workload endpoint to the host itself (after
+                      the traffic hits the endpoint egress policy). By default Calico
+                      blocks traffic from workload endpoints to the host itself with an
+                      iptables "DROP" action. If you want to allow some or all traffic
+                      from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                      RETURN if you have your own rules in the iptables "INPUT" chain;
+                      Calico will insert its rules at the top of that chain, then "RETURN"
+                      packets to the "INPUT" chain once it has completed processing workload
+                      endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                      from workloads after processing workload endpoint egress policy.
+                      [Default: Drop]'
+                    type: string
+                  deviceRouteProtocol:
+                    description: This defines the route protocol added to programmed device
+                      routes, by default this will be RTPROT_BOOT when left blank.
+                    type: integer
+                  deviceRouteSourceAddress:
+                    description: This is the source address to use on programmed device
+                      routes. By default the source address is left blank, leaving the
+                      kernel to choose the source address used.
+                    type: string
+                  disableConntrackInvalidCheck:
+                    type: boolean
+                  endpointReportingDelay:
+                    type: string
+                  endpointReportingEnabled:
+                    type: boolean
+                  externalNodesList:
+                    description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                      which may source tunnel traffic and have the tunneled traffic be
+                      accepted at calico nodes.
+                    items:
+                      type: string
+                    type: array
+                  failsafeInboundHostPorts:
+                    description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow incoming traffic to host endpoints
+                      on irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all inbound host ports, use the value
+                      none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                      udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  failsafeOutboundHostPorts:
+                    description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow outgoing traffic from host endpoints
+                      to irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all outbound host ports, use the value
+                      none. The default value opens etcd''s standard ports to ensure that
+                      Felix does not get cut off from etcd as well as allowing DHCP and
+                      DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                      tcp:6667, udp:53, udp:67]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  featureDetectOverride:
+                    description: FeatureDetectOverride is used to override the feature
+                      detection. Values are specified in a comma separated list with no
+                      spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                      "true" or "false" will force the feature, empty or omitted values
+                      are auto-detected.
+                    type: string
+                  genericXDPEnabled:
+                    description: 'GenericXDPEnabled enables Generic XDP so network cards
+                      that don''t support XDP offload or driver modes can use XDP. This
+                      is not recommended since it doesn''t provide better performance
+                      than iptables. [Default: false]'
+                    type: boolean
+                  healthEnabled:
+                    type: boolean
+                  healthHost:
+                    type: string
+                  healthPort:
+                    type: integer
+                  interfaceExclude:
+                    description: 'InterfaceExclude is a comma-separated list of interfaces
+                      that Felix should exclude when monitoring for host endpoints. The
+                      default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                      interface, which is used internally by kube-proxy. If you want to
+                      exclude multiple interface names using a single value, the list
+                      supports regular expressions. For regular expressions you must wrap
+                      the value with ''/''. For example having values ''/^kube/,veth1''
+                      will exclude all interfaces that begin with ''kube'' and also the
+                      interface ''veth1''. [Default: kube-ipvs0]'
+                    type: string
+                  interfacePrefix:
+                    description: 'InterfacePrefix is the interface name prefix that identifies
+                      workload endpoints and so distinguishes them from host endpoint
+                      interfaces. Note: in environments other than bare metal, the orchestrators
+                      configure this appropriately. For example our Kubernetes and Docker
+                      integrations set the ''cali'' value, and our OpenStack integration
+                      sets the ''tap'' value. [Default: cali]'
+                    type: string
+                  interfaceRefreshInterval:
+                    description: InterfaceRefreshInterval is the period at which Felix
+                      rescans local interfaces to verify their state. The rescan can be
+                      disabled by setting the interval to 0.
+                    type: string
+                  ipipEnabled:
+                    type: boolean
+                  ipipMTU:
+                    description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  ipsetsRefreshInterval:
+                    description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                      all iptables state to ensure that no other process has accidentally
+                      broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                      90s]'
+                    type: string
+                  iptablesBackend:
+                    description: IptablesBackend specifies which backend of iptables will
+                      be used. The default is legacy.
+                    type: string
+                  iptablesFilterAllowAction:
+                    type: string
+                  iptablesLockFilePath:
+                    description: 'IptablesLockFilePath is the location of the iptables
+                      lock file. You may need to change this if the lock file is not in
+                      its standard location (for example if you have mapped it into Felix''s
+                      container at a different path). [Default: /run/xtables.lock]'
+                    type: string
+                  iptablesLockProbeInterval:
+                    description: 'IptablesLockProbeInterval is the time that Felix will
+                      wait between attempts to acquire the iptables lock if it is not
+                      available. Lower values make Felix more responsive when the lock
+                      is contended, but use more CPU. [Default: 50ms]'
+                    type: string
+                  iptablesLockTimeout:
+                    description: 'IptablesLockTimeout is the time that Felix will wait
+                      for the iptables lock, or 0, to disable. To use this feature, Felix
+                      must share the iptables lock file with all other processes that
+                      also take the lock. When running Felix inside a container, this
+                      requires the /run directory of the host to be mounted into the calico/node
+                      or calico/felix container. [Default: 0s disabled]'
+                    type: string
+                  iptablesMangleAllowAction:
+                    type: string
+                  iptablesMarkMask:
+                    description: 'IptablesMarkMask is the mask that Felix selects its
+                      IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                      at least 8 bits set, none of which clash with any other mark bits
+                      in use on the system. [Default: 0xff000000]'
+                    format: int32
+                    type: integer
+                  iptablesNATOutgoingInterfaceFilter:
+                    type: string
+                  iptablesPostWriteCheckInterval:
+                    description: 'IptablesPostWriteCheckInterval is the period after Felix
+                      has done a write to the dataplane that it schedules an extra read
+                      back in order to check the write was not clobbered by another process.
+                      This should only occur if another application on the system doesn''t
+                      respect the iptables lock. [Default: 1s]'
+                    type: string
+                  iptablesRefreshInterval:
+                    description: 'IptablesRefreshInterval is the period at which Felix
+                      re-checks the IP sets in the dataplane to ensure that no other process
+                      has accidentally broken Calico''s rules. Set to 0 to disable IP
+                      sets refresh. Note: the default for this value is lower than the
+                      other refresh intervals as a workaround for a Linux kernel bug that
+                      was fixed in kernel version 4.11. If you are using v4.11 or greater
+                      you may want to set this to, a higher value to reduce Felix CPU
+                      usage. [Default: 10s]'
+                    type: string
+                  ipv6Support:
+                    type: boolean
+                  kubeNodePortRanges:
+                    description: 'KubeNodePortRanges holds list of port ranges used for
+                      service node ports. Only used if felix detects kube-proxy running
+                      in ipvs mode. Felix uses these ranges to separate host and workload
+                      traffic. [Default: 30000:32767].'
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  logFilePath:
+                    description: 'LogFilePath is the full path to the Felix log. Set to
+                      none to disable file logging. [Default: /var/log/calico/felix.log]'
+                    type: string
+                  logPrefix:
+                    description: 'LogPrefix is the log prefix that Felix uses when rendering
+                      LOG rules. [Default: calico-packet]'
+                    type: string
+                  logSeverityFile:
+                    description: 'LogSeverityFile is the log severity above which logs
+                      are sent to the log file. [Default: Info]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  logSeveritySys:
+                    description: 'LogSeveritySys is the log severity above which logs
+                      are sent to the syslog. Set to None for no logging to syslog. [Default:
+                      Info]'
+                    type: string
+                  maxIpsetSize:
+                    type: integer
+                  metadataAddr:
+                    description: 'MetadataAddr is the IP address or domain name of the
+                      server that can answer VM queries for cloud-init metadata. In OpenStack,
+                      this corresponds to the machine running nova-api (or in Ubuntu,
+                      nova-api-metadata). A value of none (case insensitive) means that
+                      Felix should not set up any NAT rule for the metadata path. [Default:
+                      127.0.0.1]'
+                    type: string
+                  metadataPort:
+                    description: 'MetadataPort is the port of the metadata server. This,
+                      combined with global.MetadataAddr (if not ''None''), is used to
+                      set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                      In most cases this should not need to be changed [Default: 8775].'
+                    type: integer
+                  mtuIfacePattern:
+                    description: MTUIfacePattern is a regular expression that controls
+                      which interfaces Felix should scan in order to calculate the host's
+                      MTU. This should not match workload interfaces (usually named cali...).
+                    type: string
+                  natOutgoingAddress:
+                    description: NATOutgoingAddress specifies an address to use when performing
+                      source NAT for traffic in a natOutgoing pool that is leaving the
+                      network. By default the address used is an address on the interface
+                      the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                    type: string
+                  natPortRange:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NATPortRange specifies the range of ports that is used
+                      for port mapping when doing outgoing NAT. When unset the default
+                      behavior of the network stack is used.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  netlinkTimeout:
+                    type: string
+                  openstackRegion:
+                    description: 'OpenstackRegion is the name of the region that a particular
+                      Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                      this must be configured somehow for each Felix (here in the datamodel,
+                      or in felix.cfg or the environment on each compute node), and must
+                      match the [calico] openstack_region value configured in neutron.conf
+                      on each node. [Default: Empty]'
+                    type: string
+                  policySyncPathPrefix:
+                    description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                      policy changes to external services, like Application layer policy.
+                      [Default: Empty]'
+                    type: string
+                  prometheusGoMetricsEnabled:
+                    description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusMetricsEnabled:
+                    description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                      server in Felix if set to true. [Default: false]'
+                    type: boolean
+                  prometheusMetricsHost:
+                    description: 'PrometheusMetricsHost is the host that the Prometheus
+                      metrics server should bind to. [Default: empty]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. [Default: 9091]'
+                    type: integer
+                  prometheusProcessMetricsEnabled:
+                    description: 'PrometheusProcessMetricsEnabled disables process metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusWireGuardMetricsEnabled:
+                    description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                      metrics collection, which the Prometheus client does by default,
+                      when set to false. This reduces the number of metrics reported,
+                      reducing Prometheus load. [Default: true]'
+                    type: boolean
+                  removeExternalRoutes:
+                    description: Whether or not to remove device routes that have not
+                      been programmed by Felix. Disabling this will allow external applications
+                      to also add device routes. This is enabled by default which means
+                      we will remove externally added routes.
+                    type: boolean
+                  reportingInterval:
+                    description: 'ReportingInterval is the interval at which Felix reports
+                      its status into the datastore or 0 to disable. Must be non-zero
+                      in OpenStack deployments. [Default: 30s]'
+                    type: string
+                  reportingTTL:
+                    description: 'ReportingTTL is the time-to-live setting for process-wide
+                      status reports. [Default: 90s]'
+                    type: string
+                  routeRefreshInterval:
+                    description: 'RouteRefreshInterval is the period at which Felix re-checks
+                      the routes in the dataplane to ensure that no other process has
+                      accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                      [Default: 90s]'
+                    type: string
+                  routeSource:
+                    description: 'RouteSource configures where Felix gets its routing
+                      information. - WorkloadIPs: use workload endpoints to construct
+                      routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                    type: string
+                  routeTableRange:
+                    description: Calico programs additional Linux route tables for various
+                      purposes.  RouteTableRange specifies the indices of the route tables
+                      that Calico should use.
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                    - max
+                    - min
+                    type: object
+                  serviceLoopPrevention:
+                    description: 'When service IP advertisement is enabled, prevent routing
+                      loops to service IPs that are not in use, by dropping or rejecting
+                      packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                      in which case such routing loops continue to be allowed. [Default:
+                      Drop]'
+                    type: string
+                  sidecarAccelerationEnabled:
+                    description: 'SidecarAccelerationEnabled enables experimental sidecar
+                      acceleration [Default: false]'
+                    type: boolean
+                  usageReportingEnabled:
+                    description: 'UsageReportingEnabled reports anonymous Calico version
+                      number and cluster size to projectcalico.org. Logs warnings returned
+                      by the usage server. For example, if a significant security vulnerability
+                      has been discovered in the version of Calico being used. [Default:
+                      true]'
+                    type: boolean
+                  usageReportingInitialDelay:
+                    description: 'UsageReportingInitialDelay controls the minimum delay
+                      before Felix makes a report. [Default: 300s]'
+                    type: string
+                  usageReportingInterval:
+                    description: 'UsageReportingInterval controls the interval at which
+                      Felix makes reports. [Default: 86400s]'
+                    type: string
+                  useInternalDataplaneDriver:
+                    type: boolean
+                  vxlanEnabled:
+                    type: boolean
+                  vxlanMTU:
+                    description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  vxlanPort:
+                    type: integer
+                  vxlanVNI:
+                    type: integer
+                  wireguardEnabled:
+                    description: 'WireguardEnabled controls whether Wireguard is enabled.
+                      [Default: false]'
+                    type: boolean
+                  wireguardHostEncryptionEnabled:
+                    description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                      host-to-host encryption is enabled. [Default: false]'
+                    type: boolean
+                  wireguardInterfaceName:
+                    description: 'WireguardInterfaceName specifies the name to use for
+                      the Wireguard interface. [Default: wg.calico]'
+                    type: string
+                  wireguardListeningPort:
+                    description: 'WireguardListeningPort controls the listening port used
+                      by Wireguard. [Default: 51820]'
+                    type: integer
+                  wireguardMTU:
+                    description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                      See Configuring MTU [Default: 1420]'
+                    type: integer
+                  wireguardRoutingRulePriority:
+                    description: 'WireguardRoutingRulePriority controls the priority value
+                      to use for the Wireguard routing rule. [Default: 99]'
+                    type: integer
+                  xdpEnabled:
+                    description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                      incoming deny rules. [Default: true]'
+                    type: boolean
+                  xdpRefreshInterval:
+                    description: 'XDPRefreshInterval is the period at which Felix re-checks
+                      all XDP state to ensure that no other process has accidentally broken
+                      Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                      refresh. [Default: 90s]'
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkPolicy
+        listKind: GlobalNetworkPolicyList
+        plural: globalnetworkpolicies
+        singular: globalnetworkpolicy
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  applyOnForward:
+                    description: ApplyOnForward indicates to apply the rules in this policy
+                      on forward traffic.
+                    type: boolean
+                  doNotTrack:
+                    description: DoNotTrack indicates whether packets matched by the rules
+                      in this policy should go through the data plane's connection tracking,
+                      such as Linux conntrack.  If True, the rules in this policy are
+                      applied before any data plane connection tracking, and packets allowed
+                      by this policy are marked as not to be tracked.
+                    type: boolean
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    description: NamespaceSelector is an optional field for an expression
+                      used to select a pod based on namespaces.
+                    type: string
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  preDNAT:
+                    description: PreDNAT indicates to apply the rules in this policy before
+                      any DNAT.
+                    type: boolean
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress rules are present in the policy.  The
+                      default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                      (including the case where there are   also no Ingress rules) \n
+                      - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                      rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                      both Ingress and Egress rules. \n When the policy is read back again,
+                      Types will always be one of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkSet
+        listKind: GlobalNetworkSetList
+        plural: globalnetworksets
+        singular: globalnetworkset
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+              that share labels to allow rules to refer to them via selectors.  The labels
+              of GlobalNetworkSet are not namespaced.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: hostendpoints.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: HostEndpoint
+        listKind: HostEndpointList
+        plural: hostendpoints
+        singular: hostendpoint
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: HostEndpointSpec contains the specification for a HostEndpoint
+                  resource.
+                properties:
+                  expectedIPs:
+                    description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                      If \"InterfaceName\" is not present, Calico will look for an interface
+                      matching any of the IPs in the list and apply policy to that. Note:
+                      \tWhen using the selector match criteria in an ingress or egress
+                      security Policy \tor Profile, Calico converts the selector into
+                      a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                      is used for that purpose. (If only the interface \tname is specified,
+                      Calico does not learn the IPs of the interface for use in match
+                      \tcriteria.)"
+                    items:
+                      type: string
+                    type: array
+                  interfaceName:
+                    description: "Either \"*\", or the name of a specific Linux interface
+                      to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                      governs all traffic to, from or through the default network namespace
+                      of the host named by the \"Node\" field; entering and leaving that
+                      namespace via any interface, including those from/to non-host-networked
+                      local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                      only governs traffic that enters or leaves the host through the
+                      specific interface named by InterfaceName, or - when InterfaceName
+                      is empty - through the specific interface that has one of the IPs
+                      in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                      one expected IP must be specified.  Only external interfaces (such
+                      as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                      to protect traffic through a specific local workload interface.
+                      \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                      initially just pre-DNAT policy.  Please check Calico documentation
+                      for the latest position."
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance.
+                    type: string
+                  ports:
+                    description: Ports contains the endpoint's named ports, which may
+                      be referenced in security policy rules.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  profiles:
+                    description: A list of identifiers of security Profile objects that
+                      apply to this endpoint. Each profile is applied in the order that
+                      they appear in this list.  Profile rules are applied after the selector-based
+                      security policy.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamblocks.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMBlock
+        listKind: IPAMBlockList
+        plural: ipamblocks
+        singular: ipamblock
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMBlockSpec contains the specification for an IPAMBlock
+                  resource.
+                properties:
+                  affinity:
+                    type: string
+                  allocations:
+                    items:
+                      nullable: true
+                      type: integer
+                    type: array
+                  attributes:
+                    items:
+                      properties:
+                        handle_id:
+                          type: string
+                        secondary:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    type: array
+                  cidr:
+                    type: string
+                  deleted:
+                    type: boolean
+                  strictAffinity:
+                    type: boolean
+                  unallocated:
+                    items:
+                      type: integer
+                    type: array
+                required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamconfigs.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMConfig
+        listKind: IPAMConfigList
+        plural: ipamconfigs
+        singular: ipamconfig
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMConfigSpec contains the specification for an IPAMConfig
+                  resource.
+                properties:
+                  autoAllocateBlocks:
+                    type: boolean
+                  maxBlocksPerHost:
+                    description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                      that can be affine to each host.
+                    type: integer
+                  strictAffinity:
+                    type: boolean
+                required:
+                - autoAllocateBlocks
+                - strictAffinity
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamhandles.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMHandle
+        listKind: IPAMHandleList
+        plural: ipamhandles
+        singular: ipamhandle
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMHandleSpec contains the specification for an IPAMHandle
+                  resource.
+                properties:
+                  block:
+                    additionalProperties:
+                      type: integer
+                    type: object
+                  deleted:
+                    type: boolean
+                  handleID:
+                    type: string
+                required:
+                - block
+                - handleID
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ippools.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPPool
+        listKind: IPPoolList
+        plural: ippools
+        singular: ippool
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPPoolSpec contains the specification for an IPPool resource.
+                properties:
+                  blockSize:
+                    description: The block size to use for IP address assignments from
+                      this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                    type: integer
+                  cidr:
+                    description: The pool CIDR.
+                    type: string
+                  disabled:
+                    description: When disabled is true, Calico IPAM will not assign addresses
+                      from this pool.
+                    type: boolean
+                  ipip:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    properties:
+                      enabled:
+                        description: When enabled is true, ipip tunneling will be used
+                          to deliver packets to destinations within this pool.
+                        type: boolean
+                      mode:
+                        description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                          mode of "always" will also use IPIP tunneling for routing to
+                          destination IP addresses within this pool.  A mode of "cross-subnet"
+                          will only use IPIP tunneling when the destination node is on
+                          a different subnet to the originating node.  The default value
+                          (if not specified) is "always".
+                        type: string
+                    type: object
+                  ipipMode:
+                    description: Contains configuration for IPIP tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                      is disabled).
+                    type: string
+                  nat-outgoing:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    type: boolean
+                  natOutgoing:
+                    description: When nat-outgoing is true, packets sent from Calico networked
+                      containers in this pool to destinations outside of this pool will
+                      be masqueraded.
+                    type: boolean
+                  nodeSelector:
+                    description: Allows IPPool to allocate for a specific node by label
+                      selector.
+                    type: string
+                  vxlanMode:
+                    description: Contains configuration for VXLAN tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                      tunneling is disabled).
+                    type: string
+                required:
+                - cidr
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubecontrollersconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: KubeControllersConfiguration
+        listKind: KubeControllersConfigurationList
+        plural: kubecontrollersconfigurations
+        singular: kubecontrollersconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeControllersConfigurationSpec contains the values of the
+                  Kubernetes controllers configuration.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host endpoints.
+                              Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation of
+                                  host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the controller
+                              to determine if an IP address has been leaked. Set to 0
+                              to disable IP garbage collection. [Default: 15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+              status:
+                description: KubeControllersConfigurationStatus represents the status
+                  of the configuration. It's useful for admins to be able to see the actual
+                  config that was applied, which can be modified by environment variables
+                  on the kube-controllers process.
+                properties:
+                  environmentVars:
+                    additionalProperties:
+                      type: string
+                    description: EnvironmentVars contains the environment variables on
+                      the kube-controllers that influenced the RunningConfig.
+                    type: object
+                  runningConfig:
+                    description: RunningConfig contains the effective config that is running
+                      in the kube-controllers pod, after merging the API resource with
+                      any environment variables.
+                    properties:
+                      controllers:
+                        description: Controllers enables and configures individual Kubernetes
+                          controllers
+                        properties:
+                          namespace:
+                            description: Namespace enables and configures the namespace
+                              controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          node:
+                            description: Node enables and configures the node controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              hostEndpoint:
+                                description: HostEndpoint controls syncing nodes to host
+                                  endpoints. Disabled by default, set to nil to disable.
+                                properties:
+                                  autoCreate:
+                                    description: 'AutoCreate enables automatic creation
+                                      of host endpoints for every node. [Default: Disabled]'
+                                    type: string
+                                type: object
+                              leakGracePeriod:
+                                description: 'LeakGracePeriod is the period used by the
+                                  controller to determine if an IP address has been leaked.
+                                  Set to 0 to disable IP garbage collection. [Default:
+                                  15m]'
+                                type: string
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                              syncLabels:
+                                description: 'SyncLabels controls whether to copy Kubernetes
+                                  node labels to Calico nodes. [Default: Enabled]'
+                                type: string
+                            type: object
+                          policy:
+                            description: Policy enables and configures the policy controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          serviceAccount:
+                            description: ServiceAccount enables and configures the service
+                              account controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          workloadEndpoint:
+                            description: WorkloadEndpoint enables and configures the workload
+                              endpoint controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                        type: object
+                      etcdV3CompactionPeriod:
+                        description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                          compaction requests. Set to 0 to disable. [Default: 10m]'
+                        type: string
+                      healthChecks:
+                        description: 'HealthChecks enables or disables support for health
+                          checks [Default: Enabled]'
+                        type: string
+                      logSeverityScreen:
+                        description: 'LogSeverityScreen is the log severity above which
+                          logs are sent to the stdout. [Default: Info]'
+                        type: string
+                      prometheusMetricsPort:
+                        description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                          metrics server should bind to. Set to 0 to disable. [Default:
+                          9094]'
+                        type: integer
+                    required:
+                    - controllers
+                    type: object
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkPolicy
+        listKind: NetworkPolicyList
+        plural: networkpolicies
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress are present in the policy.  The default
+                      is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                      the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                      ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                      PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                      \n When the policy is read back again, Types will always be one
+                      of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkSet
+        listKind: NetworkSetList
+        plural: networksets
+        singular: networkset
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: NetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-kube-controllers
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      verbs:
+      - list
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - hostendpoints
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - clusterinformations
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - kubecontrollersconfigurations
+      verbs:
+      - get
+      - create
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-node
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - namespaces
+      verbs:
+      - get
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - patch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - bgpconfigurations
+      - bgppeers
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ipamconfigs
+      verbs:
+      - get
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      verbs:
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - daemonsets
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-kube-controllers
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      calico_backend: vxlan
+      cni_network_config: |-
+        {
+          "name": "k8s-pod-network",
+          "cniVersion": "0.3.1",
+          "plugins": [
+            {
+              "type": "calico",
+              "log_level": "info",
+              "log_file_path": "/var/log/calico/cni/cni.log",
+              "datastore_type": "kubernetes",
+              "nodename": "__KUBERNETES_NODE_NAME__",
+              "mtu": __CNI_MTU__,
+              "ipam": {
+                  "type": "calico-ipam"
+              },
+              "policy": {
+                  "type": "k8s"
+              },
+              "kubernetes": {
+                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              }
+            },
+            {
+              "type": "portmap",
+              "snat": true,
+              "capabilities": {"portMappings": true}
+            },
+            {
+              "type": "bandwidth",
+              "capabilities": {"bandwidth": true}
+            }
+          ]
+        }
+      typha_service_name: none
+      veth_mtu: "1350"
+    kind: ConfigMap
+    metadata:
+      name: calico-config
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-kube-controllers
+          name: calico-kube-controllers
+          namespace: kube-system
+        spec:
+          containers:
+          - env:
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            image: docker.io/calico/kube-controllers:v3.20.3
+            livenessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -l
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-kube-controllers
+            readinessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -r
+              periodSeconds: 10
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: calico-kube-controllers
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: calico-node
+      name: calico-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+        spec:
+          containers:
+          - env:
+            - name: FELIX_FEATUREDETECTOVERRIDE
+              value: ChecksumOffloadBroken=true
+            - name: CALICO_IPV4POOL_VXLAN
+              value: Always
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            - name: CLUSTER_TYPE
+              value: k8s,bgp
+            - name: IP
+              value: autodetect
+            - name: CALICO_IPV4POOL_IPIP
+              value: Never
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_WIREGUARDMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_AWSSRCDSTCHECK
+              value: Disable
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: ACCEPT
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/node:v3.20.3
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -shutdown
+            livenessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-live
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-node
+            readinessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-ready
+              periodSeconds: 10
+              timeoutSeconds: 10
+            resources:
+              requests:
+                cpu: 250m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /var/run/nodeagent
+              name: policysync
+            - mountPath: /sys/fs/
+              mountPropagation: Bidirectional
+              name: sysfs
+            - mountPath: /var/log/calico/cni
+              name: cni-log-dir
+              readOnly: true
+          hostNetwork: true
+          initContainers:
+          - command:
+            - /opt/cni/bin/calico-ipam
+            - -upgrade
+            env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: upgrade-ipam
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          - command:
+            - /opt/cni/bin/install
+            env:
+            - name: CNI_CONF_NAME
+              value: 10-calico.conflist
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  key: cni_network_config
+                  name: calico-config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: SLEEP
+              value: "false"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: install-cni
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+            name: flexvol-driver
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/driver
+              name: flexvol-driver-host
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: calico-node
+          terminationGracePeriodSeconds: 0
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /lib/modules
+            name: lib-modules
+          - hostPath:
+              path: /var/run/calico
+            name: var-run-calico
+          - hostPath:
+              path: /var/lib/calico
+            name: var-lib-calico
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+          - hostPath:
+              path: /sys/fs/
+              type: DirectoryOrCreate
+            name: sysfs
+          - hostPath:
+              path: /opt/cni/bin
+            name: cni-bin-dir
+          - hostPath:
+              path: /etc/cni/net.d
+            name: cni-net-dir
+          - hostPath:
+              path: /var/log/calico/cni
+            name: cni-log-dir
+          - hostPath:
+              path: /var/lib/cni/networks
+            name: host-local-net-dir
+          - hostPath:
+              path: /var/run/nodeagent
+              type: DirectoryOrCreate
+            name: policysync
+          - hostPath:
+              path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+              type: DirectoryOrCreate
+            name: flexvol-driver-host
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -4068,7 +4068,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.20.3
+            image: docker.io/calico/kube-controllers:v3.20.4
             livenessProbe:
               exec:
                 command:
@@ -4178,7 +4178,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.20.3
+            image: docker.io/calico/node:v3.20.4
             lifecycle:
               preStop:
                 exec:
@@ -4250,7 +4250,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: upgrade-ipam
             securityContext:
               privileged: true
@@ -4284,7 +4284,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: install-cni
             securityContext:
               privileged: true
@@ -4293,7 +4293,7 @@ data:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.4
             name: flexvol-driver
             securityContext:
               privileged: true
@@ -4401,7 +4401,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.20.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.20.4-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -4420,7 +4420,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.20.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.20.4-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -4431,7 +4431,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.20.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.20.4-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -375,2440 +375,3985 @@ data:
     \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
     kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
     \   type: RollingUpdate\n"
-  resources: "---\n# Source: calico/templates/calico-config.yaml\n# This ConfigMap
-    is used to configure a self-hosted Calico installation.\nkind: ConfigMap\napiVersion:
-    v1\nmetadata:\n  name: calico-config\n  namespace: kube-system\ndata:\n  # Typha
-    is disabled.\n  typha_service_name: \"none\"\n  # Configure the backend to use.\n
-    \ calico_backend: \"vxlan\"\n  # On Azure, the underlying network has an MTU of
-    1400, even though the network interface will have an MTU of 1500.\n  # We set
-    this value to 1350 for “physical network MTU size minus 50” since we use VXLAN,
-    which uses a 50-byte header.\n  # If enabling Wireguard, this value should be
-    changed to 1340 (Wireguard uses a 60-byte header).\n  # https://docs.projectcalico.org/networking/mtu#determine-mtu-size\n
-    \ veth_mtu: \"1350\"\n  \n  # The CNI network configuration to install on each
-    node. The special\n  # values in this config will be automatically populated.\n
-    \ cni_network_config: |-\n    {\n      \"name\": \"k8s-pod-network\",\n      \"cniVersion\":
-    \"0.3.1\",\n      \"plugins\": [\n        {\n          \"type\": \"calico\",\n
-    \         \"log_level\": \"info\",\n          \"log_file_path\": \"/var/log/calico/cni/cni.log\",\n
-    \         \"datastore_type\": \"kubernetes\",\n          \"nodename\": \"__KUBERNETES_NODE_NAME__\",\n
-    \         \"mtu\": __CNI_MTU__,\n          \"ipam\": {\n              \"type\":
-    \"calico-ipam\"\n          },\n          \"policy\": {\n              \"type\":
-    \"k8s\"\n          },\n          \"kubernetes\": {\n              \"kubeconfig\":
-    \"__KUBECONFIG_FILEPATH__\"\n          }\n        },\n        {\n          \"type\":
-    \"portmap\",\n          \"snat\": true,\n          \"capabilities\": {\"portMappings\":
-    true}\n        },\n        {\n          \"type\": \"bandwidth\",\n          \"capabilities\":
-    {\"bandwidth\": true}\n        }\n      ]\n    }\n\n---\n# Source: calico/templates/kdd-crds.yaml\n\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: bgpconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPConfiguration\n    listKind: BGPConfigurationList\n    plural:
-    bgpconfigurations\n    singular: bgpconfiguration\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    BGPConfiguration contains the configuration for any BGP routing.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPConfigurationSpec contains the
-    values of the BGP configuration.\n              properties:\n                asNumber:\n
-    \                 description: 'ASNumber is the default AS number used by a node.
-    [Default:\n                  64512]'\n                  format: int32\n                  type:
-    integer\n                communities:\n                  description: Communities
-    is a list of BGP community values and their\n                    arbitrary names
-    for tagging routes.\n                  items:\n                    description:
-    Community contains standard or large community value\n                      and
-    its name.\n                    properties:\n                      name:\n                        description:
-    Name given to community value.\n                        type: string\n                      value:\n
-    \                       description: Value must be of format `aa:nn` or `aa:nn:mm`.\n
-    \                         For standard community use `aa:nn` format, where `aa`
-    and\n                          `nn` are 16 bit number. For large community use
-    `aa:nn:mm`\n                          format, where `aa`, `nn` and `mm` are 32
-    bit number. Where,\n                          `aa` is an AS Number, `nn` and `mm`
-    are per-AS identifier.\n                        pattern: ^(\\d+):(\\d+)$|^(\\d+):(\\d+):(\\d+)$\n
-    \                       type: string\n                    type: object\n                  type:
-    array\n                listenPort:\n                  description: ListenPort
-    is the port where BGP protocol should listen.\n                    Defaults to
-    179\n                  maximum: 65535\n                  minimum: 1\n                  type:
-    integer\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: INFO]'\n                  type: string\n                nodeToNodeMeshEnabled:\n
-    \                 description: 'NodeToNodeMeshEnabled sets whether full node to
-    node\n                  BGP mesh is enabled. [Default: true]'\n                  type:
-    boolean\n                prefixAdvertisements:\n                  description:
-    PrefixAdvertisements contains per-prefix advertisement\n                    configuration.\n
-    \                 items:\n                    description: PrefixAdvertisement
-    configures advertisement properties\n                      for the specified CIDR.\n
-    \                   properties:\n                      cidr:\n                        description:
-    CIDR for which properties should be advertised.\n                        type:
-    string\n                      communities:\n                        description:
-    Communities can be list of either community names\n                          already
-    defined in `Specs.Communities` or community value\n                          of
-    format `aa:nn` or `aa:nn:mm`. For standard community use\n                          `aa:nn`
-    format, where `aa` and `nn` are 16 bit number. For\n                          large
-    community use `aa:nn:mm` format, where `aa`, `nn` and\n                          `mm`
-    are 32 bit number. Where,`aa` is an AS Number, `nn` and\n                          `mm`
-    are per-AS identifier.\n                        items:\n                          type:
-    string\n                        type: array\n                    type: object\n
-    \                 type: array\n                serviceClusterIPs:\n                  description:
-    ServiceClusterIPs are the CIDR blocks from which service\n                    cluster
-    IPs are allocated. If specified, Calico will advertise these\n                    blocks,
-    as well as any cluster IPs within them.\n                  items:\n                    description:
-    ServiceClusterIPBlock represents a single allowed ClusterIP\n                      CIDR
-    block.\n                    properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n                serviceExternalIPs:\n
-    \                 description: ServiceExternalIPs are the CIDR blocks for Kubernetes\n
-    \                   Service External IPs. Kubernetes Service ExternalIPs will
-    only be\n                    advertised if they are within one of these blocks.\n
-    \                 items:\n                    description: ServiceExternalIPBlock
-    represents a single allowed\n                      External IP CIDR block.\n                    properties:\n
-    \                     cidr:\n                        type: string\n                    type:
-    object\n                  type: array\n                serviceLoadBalancerIPs:\n
-    \                 description: ServiceLoadBalancerIPs are the CIDR blocks for
-    Kubernetes\n                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress\n
-    \                   IPs will only be advertised if they are within one of these
-    blocks.\n                  items:\n                    description: ServiceLoadBalancerIPBlock
-    represents a single allowed\n                      LoadBalancer IP CIDR block.\n
-    \                   properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: bgppeers.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPPeer\n    listKind: BGPPeerList\n    plural: bgppeers\n
-    \   singular: bgppeer\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPPeerSpec contains the specification
-    for a BGPPeer resource.\n              properties:\n                asNumber:\n
-    \                 description: The AS Number of the peer.\n                  format:
-    int32\n                  type: integer\n                keepOriginalNextHop:\n
-    \                 description: Option to keep the original nexthop field when
-    routes\n                    are sent to a BGP Peer. Setting \"true\" configures
-    the selected BGP\n                    Peers node to use the \"next hop keep;\"
-    instead of \"next hop self;\"(default)\n                    in the specific branch
-    of the Node on \"bird.cfg\".\n                  type: boolean\n                maxRestartTime:\n
-    \                 description: Time to allow for software restart.  When specified,
-    this\n                    is configured as the graceful restart timeout.  When
-    not specified,\n                    the BIRD default of 120s is used.\n                  type:
-    string\n                node:\n                  description: The node name identifying
-    the Calico node instance that\n                    is targeted by this peer. If
-    this is not set, and no nodeSelector\n                    is specified, then this
-    BGP peer selects all nodes in the cluster.\n                  type: string\n                nodeSelector:\n
-    \                 description: Selector for the nodes that should have this peering.
-    \ When\n                    this is set, the Node field must be empty.\n                  type:
-    string\n                password:\n                  description: Optional BGP
-    password for the peerings generated by this\n                    BGPPeer resource.\n
-    \                 properties:\n                    secretKeyRef:\n                      description:
-    Selects a key of a secret in the node pod's namespace.\n                      properties:\n
-    \                       key:\n                          description: The key of
-    the secret to select from.  Must be\n                            a valid secret
-    key.\n                          type: string\n                        name:\n
-    \                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n
-    \                         TODO: Add other useful fields. apiVersion, kind, uid?'\n
-    \                         type: string\n                        optional:\n                          description:
-    Specify whether the Secret or its key must be\n                            defined\n
-    \                         type: boolean\n                      required:\n                        -
-    key\n                      type: object\n                  type: object\n                peerIP:\n
-    \                 description: The IP address of the peer followed by an optional
-    port\n                    number to peer with. If port number is given, format
-    should be `[<IPv6>]:port`\n                    or `<IPv4>:<port>` for IPv4. If
-    optional port number is not set,\n                    and this peer IP and ASNumber
-    belongs to a calico/node with ListenPort\n                    set in BGPConfiguration,
-    then we use that port to peer.\n                  type: string\n                peerSelector:\n
-    \                 description: Selector for the remote nodes to peer with.  When
-    this\n                    is set, the PeerIP and ASNumber fields must be empty.
-    \ For each\n                    peering between the local node and selected remote
-    nodes, we configure\n                    an IPv4 peering if both ends have NodeBGPSpec.IPv4Address
-    specified,\n                    and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address
-    specified.  The\n                    remote AS number comes from the remote node’s
-    NodeBGPSpec.ASNumber,\n                    or the global default if that is not
-    set.\n                  type: string\n                sourceAddress:\n                  description:
-    Specifies whether and how to configure a source address\n                    for
-    the peerings generated by this BGPPeer resource.  Default value\n                    \"UseNodeIP\"
-    means to configure the node IP as the source address.  \"None\"\n                    means
-    not to configure a source address.\n                  type: string\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: blockaffinities.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BlockAffinity\n    listKind: BlockAffinityList\n    plural:
-    blockaffinities\n    singular: blockaffinity\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BlockAffinitySpec contains the specification
-    for a BlockAffinity\n                resource.\n              properties:\n                cidr:\n
-    \                 type: string\n                deleted:\n                  description:
-    Deleted indicates that this block affinity is being deleted.\n                    This
-    field is a string for compatibility with older releases that\n                    mistakenly
-    treat this field as a string.\n                  type: string\n                node:\n
-    \                 type: string\n                state:\n                  type:
-    string\n              required:\n                - cidr\n                - deleted\n
-    \               - node\n                - state\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: clusterinformations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: ClusterInformation\n    listKind: ClusterInformationList\n
-    \   plural: clusterinformations\n    singular: clusterinformation\n  scope: Cluster\n
-    \ versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    ClusterInformation contains the cluster specific information.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: ClusterInformationSpec contains
-    the values of describing\n                the cluster.\n              properties:\n
-    \               calicoVersion:\n                  description: CalicoVersion is
-    the version of Calico that the cluster\n                    is running\n                  type:
-    string\n                clusterGUID:\n                  description: ClusterGUID
-    is the GUID of the cluster\n                  type: string\n                clusterType:\n
-    \                 description: ClusterType describes the type of the cluster\n
-    \                 type: string\n                datastoreReady:\n                  description:
-    DatastoreReady is used during significant datastore migrations\n                    to
-    signal to components such as Felix that it should wait before\n                    accessing
-    the datastore.\n                  type: boolean\n                variant:\n                  description:
-    Variant declares which variant of Calico should be active.\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: felixconfigurations.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: FelixConfiguration\n    listKind:
-    FelixConfigurationList\n    plural: felixconfigurations\n    singular: felixconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         description: Felix Configuration contains the configuration for Felix.\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: FelixConfigurationSpec contains
-    the values of the Felix configuration.\n              properties:\n                allowIPIPPacketsFromWorkloads:\n
-    \                 description: 'AllowIPIPPacketsFromWorkloads controls whether
-    Felix\n                  will add a rule to drop IPIP encapsulated traffic from
-    workloads\n                  [Default: false]'\n                  type: boolean\n
-    \               allowVXLANPacketsFromWorkloads:\n                  description:
-    'AllowVXLANPacketsFromWorkloads controls whether Felix\n                  will
-    add a rule to drop VXLAN encapsulated traffic from workloads\n                  [Default:
-    false]'\n                  type: boolean\n                awsSrcDstCheck:\n                  description:
-    'Set source-destination-check on AWS EC2 instances. Accepted\n                  value
-    must be one of \"DoNothing\", \"Enabled\" or \"Disabled\". [Default:\n                  DoNothing]'\n
-    \                 enum:\n                    - DoNothing\n                    -
-    Enable\n                    - Disable\n                  type: string\n                bpfConnectTimeLoadBalancingEnabled:\n
-    \                 description: 'BPFConnectTimeLoadBalancingEnabled when in BPF
-    mode,\n                  controls whether Felix installs the connection-time load
-    balancer.  The\n                  connect-time load balancer is required for the
-    host to be able to\n                  reach Kubernetes services and it improves
-    the performance of pod-to-service\n                  connections.  The only reason
-    to disable it is for debugging purposes.  [Default:\n                  true]'\n
-    \                 type: boolean\n                bpfDataIfacePattern:\n                  description:
-    'BPFDataIfacePattern is a regular expression that controls\n                  which
-    interfaces Felix should attach BPF programs to in order to\n                  catch
-    traffic to/from the network.  This needs to match the interfaces\n                  that
-    Calico workload traffic flows over as well as any interfaces\n                  that
-    handle incoming traffic to nodeports and services from outside\n                  the
-    cluster.  It should not match the workload interfaces (usually\n                  named
-    cali...). [Default: ^(en.*|eth.*|tunl0$)]'\n                  type: string\n                bpfDisableUnprivileged:\n
-    \                 description: 'BPFDisableUnprivileged, if enabled, Felix sets
-    the kernel.unprivileged_bpf_disabled\n                  sysctl to disable unprivileged
-    use of BPF.  This ensures that unprivileged\n                  users cannot access
-    Calico''s BPF maps and cannot insert their own\n                  BPF programs
-    to interfere with Calico''s. [Default: true]'\n                  type: boolean\n
-    \               bpfEnabled:\n                  description: 'BPFEnabled, if enabled
-    Felix will use the BPF dataplane.\n                  [Default: false]'\n                  type:
-    boolean\n                bpfExtToServiceConnmark:\n                  description:
-    'BPFExtToServiceConnmark in BPF mode, control a 32bit\n                    mark
-    that is set on connections from an external client to a local\n                    service.
-    This mark allows us to control how packets of that connection\n                    are
-    routed within the host and how is routing intepreted by RPF\n                    check.
-    [Default: 0]'\n                  type: integer\n                bpfExternalServiceMode:\n
-    \                 description: 'BPFExternalServiceMode in BPF mode, controls how
-    connections\n                  from outside the cluster to services (node ports
-    and cluster IPs)\n                  are forwarded to remote workloads.  If set
-    to \"Tunnel\" then both\n                  request and response traffic is tunneled
-    to the remote node.  If\n                  set to \"DSR\", the request traffic
-    is tunneled but the response traffic\n                  is sent directly from
-    the remote node.  In \"DSR\" mode, the remote\n                  node appears
-    to use the IP of the ingress node; this requires a\n                  permissive
-    L2 network.  [Default: Tunnel]'\n                  type: string\n                bpfKubeProxyEndpointSlicesEnabled:\n
-    \                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode,
-    controls\n                    whether Felix's embedded kube-proxy accepts EndpointSlices
-    or not.\n                  type: boolean\n                bpfKubeProxyIptablesCleanupEnabled:\n
-    \                 description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled
-    in BPF\n                  mode, Felix will proactively clean up the upstream Kubernetes
-    kube-proxy''s\n                  iptables chains.  Should only be enabled if kube-proxy
-    is not running.  [Default:\n                  true]'\n                  type:
-    boolean\n                bpfKubeProxyMinSyncPeriod:\n                  description:
-    'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the\n                  minimum
-    time between updates to the dataplane for Felix''s embedded\n                  kube-proxy.
-    \ Lower values give reduced set-up latency.  Higher values\n                  reduce
-    Felix CPU usage by batching up more work.  [Default: 1s]'\n                  type:
-    string\n                bpfLogLevel:\n                  description: 'BPFLogLevel
-    controls the log level of the BPF programs\n                  when in BPF dataplane
-    mode.  One of \"Off\", \"Info\", or \"Debug\".  The\n                  logs are
-    emitted to the BPF trace pipe, accessible with the command\n                  `tc
-    exec bpf debug`. [Default: Off].'\n                  type: string\n                chainInsertMode:\n
-    \                 description: 'ChainInsertMode controls whether Felix hooks the
-    kernel’s\n                  top-level iptables chains by inserting a rule at the
-    top of the\n                  chain or by appending a rule at the bottom. insert
-    is the safe default\n                  since it prevents Calico’s rules from being
-    bypassed. If you switch\n                  to append mode, be sure that the other
-    rules in the chains signal\n                  acceptance by falling through to
-    the Calico rules, otherwise the\n                  Calico policy will be bypassed.
-    [Default: insert]'\n                  type: string\n                dataplaneDriver:\n
-    \                 type: string\n                debugDisableLogDropping:\n                  type:
-    boolean\n                debugMemoryProfilePath:\n                  type: string\n
-    \               debugSimulateCalcGraphHangAfter:\n                  type: string\n
-    \               debugSimulateDataplaneHangAfter:\n                  type: string\n
-    \               defaultEndpointToHostAction:\n                  description: 'DefaultEndpointToHostAction
-    controls what happens to\n                  traffic that goes from a workload
-    endpoint to the host itself (after\n                  the traffic hits the endpoint
-    egress policy). By default Calico\n                  blocks traffic from workload
-    endpoints to the host itself with an\n                  iptables “DROP” action.
-    If you want to allow some or all traffic\n                  from endpoint to host,
-    set this parameter to RETURN or ACCEPT. Use\n                  RETURN if you have
-    your own rules in the iptables “INPUT” chain;\n                  Calico will insert
-    its rules at the top of that chain, then “RETURN”\n                  packets to
-    the “INPUT” chain once it has completed processing workload\n                  endpoint
-    egress policy. Use ACCEPT to unconditionally accept packets\n                  from
-    workloads after processing workload endpoint egress policy.\n                  [Default:
-    Drop]'\n                  type: string\n                deviceRouteProtocol:\n
-    \                 description: This defines the route protocol added to programmed
-    device\n                    routes, by default this will be RTPROT_BOOT when left
-    blank.\n                  type: integer\n                deviceRouteSourceAddress:\n
-    \                 description: This is the source address to use on programmed
-    device\n                    routes. By default the source address is left blank,
-    leaving the\n                    kernel to choose the source address used.\n                  type:
-    string\n                disableConntrackInvalidCheck:\n                  type:
-    boolean\n                endpointReportingDelay:\n                  type: string\n
-    \               endpointReportingEnabled:\n                  type: boolean\n                externalNodesList:\n
-    \                 description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes\n
-    \                   which may source tunnel traffic and have the tunneled traffic
-    be\n                    accepted at calico nodes.\n                  items:\n
-    \                   type: string\n                  type: array\n                failsafeInboundHostPorts:\n
-    \                 description: 'FailsafeInboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow incoming traffic to
-    host endpoints\n                    on irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    inbound host ports, use the value\n                    none. The default value
-    allows ssh access and DHCP. [Default: tcp:22,\n                    udp:68, tcp:179,
-    tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'\n                  items:\n
-    \                   description: ProtoPort is combination of protocol, port, and
-    CIDR.\n                      Protocol and port must be specified.\n                    properties:\n
-    \                     net:\n                        type: string\n                      port:\n
-    \                       type: integer\n                      protocol:\n                        type:
-    string\n                    required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                failsafeOutboundHostPorts:\n
-    \                 description: 'FailsafeOutboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow outgoing traffic from
-    host endpoints\n                    to irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    outbound host ports, use the value\n                    none. The default value
-    opens etcd''s standard ports to ensure that\n                    Felix does not
-    get cut off from etcd as well as allowing DHCP and\n                    DNS. [Default:
-    tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,\n                    tcp:6667,
-    udp:53, udp:67]'\n                  items:\n                    description: ProtoPort
-    is combination of protocol, port, and CIDR.\n                      Protocol and
-    port must be specified.\n                    properties:\n                      net:\n
-    \                       type: string\n                      port:\n                        type:
-    integer\n                      protocol:\n                        type: string\n
-    \                   required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                featureDetectOverride:\n
-    \                 description: FeatureDetectOverride is used to override the feature\n
-    \                   detection. Values are specified in a comma separated list
-    with no\n                    spaces, example; \"SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=\".\n
-    \                   \"true\" or \"false\" will force the feature, empty or omitted
-    values\n                    are auto-detected.\n                  type: string\n
-    \               genericXDPEnabled:\n                  description: 'GenericXDPEnabled
-    enables Generic XDP so network cards\n                  that don''t support XDP
-    offload or driver modes can use XDP. This\n                  is not recommended
-    since it doesn''t provide better performance\n                  than iptables.
-    [Default: false]'\n                  type: boolean\n                healthEnabled:\n
-    \                 type: boolean\n                healthHost:\n                  type:
-    string\n                healthPort:\n                  type: integer\n                interfaceExclude:\n
-    \                 description: 'InterfaceExclude is a comma-separated list of
-    interfaces\n                  that Felix should exclude when monitoring for host
-    endpoints. The\n                  default value ensures that Felix ignores Kubernetes''
-    IPVS dummy\n                  interface, which is used internally by kube-proxy.
-    If you want to\n                  exclude multiple interface names using a single
-    value, the list\n                  supports regular expressions. For regular expressions
-    you must wrap\n                  the value with ''/''. For example having values
-    ''/^kube/,veth1''\n                  will exclude all interfaces that begin with
-    ''kube'' and also the\n                  interface ''veth1''. [Default: kube-ipvs0]'\n
-    \                 type: string\n                interfacePrefix:\n                  description:
-    'InterfacePrefix is the interface name prefix that identifies\n                  workload
-    endpoints and so distinguishes them from host endpoint\n                  interfaces.
-    Note: in environments other than bare metal, the orchestrators\n                  configure
-    this appropriately. For example our Kubernetes and Docker\n                  integrations
-    set the ‘cali’ value, and our OpenStack integration\n                  sets the
-    ‘tap’ value. [Default: cali]'\n                  type: string\n                interfaceRefreshInterval:\n
-    \                 description: InterfaceRefreshInterval is the period at which
-    Felix\n                    rescans local interfaces to verify their state. The
-    rescan can be\n                    disabled by setting the interval to 0.\n                  type:
-    string\n                ipipEnabled:\n                  type: boolean\n                ipipMTU:\n
-    \                 description: 'IPIPMTU is the MTU to set on the tunnel device.
-    See\n                  Configuring MTU [Default: 1440]'\n                  type:
-    integer\n                ipsetsRefreshInterval:\n                  description:
-    'IpsetsRefreshInterval is the period at which Felix re-checks\n                  all
-    iptables state to ensure that no other process has accidentally\n                  broken
-    Calico’s rules. Set to 0 to disable iptables refresh. [Default:\n                  90s]'\n
-    \                 type: string\n                iptablesBackend:\n                  description:
-    IptablesBackend specifies which backend of iptables will\n                    be
-    used. The default is legacy.\n                  type: string\n                iptablesFilterAllowAction:\n
-    \                 type: string\n                iptablesLockFilePath:\n                  description:
-    'IptablesLockFilePath is the location of the iptables\n                  lock
-    file. You may need to change this if the lock file is not in\n                  its
-    standard location (for example if you have mapped it into Felix’s\n                  container
-    at a different path). [Default: /run/xtables.lock]'\n                  type: string\n
-    \               iptablesLockProbeInterval:\n                  description: 'IptablesLockProbeInterval
-    is the time that Felix will\n                  wait between attempts to acquire
-    the iptables lock if it is not\n                  available. Lower values make
-    Felix more responsive when the lock\n                  is contended, but use more
-    CPU. [Default: 50ms]'\n                  type: string\n                iptablesLockTimeout:\n
-    \                 description: 'IptablesLockTimeout is the time that Felix will
-    wait\n                  for the iptables lock, or 0, to disable. To use this feature,
-    Felix\n                  must share the iptables lock file with all other processes
-    that\n                  also take the lock. When running Felix inside a container,
-    this\n                  requires the /run directory of the host to be mounted
-    into the calico/node\n                  or calico/felix container. [Default: 0s
-    disabled]'\n                  type: string\n                iptablesMangleAllowAction:\n
-    \                 type: string\n                iptablesMarkMask:\n                  description:
-    'IptablesMarkMask is the mask that Felix selects its\n                  IPTables
-    Mark bits from. Should be a 32 bit hexadecimal number with\n                  at
-    least 8 bits set, none of which clash with any other mark bits\n                  in
-    use on the system. [Default: 0xff000000]'\n                  format: int32\n                  type:
-    integer\n                iptablesNATOutgoingInterfaceFilter:\n                  type:
-    string\n                iptablesPostWriteCheckInterval:\n                  description:
-    'IptablesPostWriteCheckInterval is the period after Felix\n                  has
-    done a write to the dataplane that it schedules an extra read\n                  back
-    in order to check the write was not clobbered by another process.\n                  This
-    should only occur if another application on the system doesn’t\n                  respect
-    the iptables lock. [Default: 1s]'\n                  type: string\n                iptablesRefreshInterval:\n
-    \                 description: 'IptablesRefreshInterval is the period at which
-    Felix\n                    re-checks the IP sets in the dataplane to ensure that
-    no other process\n                    has accidentally broken Calico''s rules.
-    Set to 0 to disable IP\n                    sets refresh. Note: the default for
-    this value is lower than the\n                    other refresh intervals as a
-    workaround for a Linux kernel bug that\n                    was fixed in kernel
-    version 4.11. If you are using v4.11 or greater\n                    you may want
-    to set this to, a higher value to reduce Felix CPU\n                    usage.
-    [Default: 10s]'\n                  type: string\n                ipv6Support:\n
-    \                 type: boolean\n                kubeNodePortRanges:\n                  description:
-    'KubeNodePortRanges holds list of port ranges used for\n                  service
-    node ports. Only used if felix detects kube-proxy running\n                  in
-    ipvs mode. Felix uses these ranges to separate host and workload\n                  traffic.
-    [Default: 30000:32767].'\n                  items:\n                    anyOf:\n
-    \                     - type: integer\n                      - type: string\n
-    \                   pattern: ^.*\n                    x-kubernetes-int-or-string:
-    true\n                  type: array\n                logFilePath:\n                  description:
-    'LogFilePath is the full path to the Felix log. Set to\n                  none
-    to disable file logging. [Default: /var/log/calico/felix.log]'\n                  type:
-    string\n                logPrefix:\n                  description: 'LogPrefix
-    is the log prefix that Felix uses when rendering\n                  LOG rules.
-    [Default: calico-packet]'\n                  type: string\n                logSeverityFile:\n
-    \                 description: 'LogSeverityFile is the log severity above which
-    logs\n                  are sent to the log file. [Default: Info]'\n                  type:
-    string\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: Info]'\n                  type: string\n                logSeveritySys:\n
-    \                 description: 'LogSeveritySys is the log severity above which
-    logs\n                  are sent to the syslog. Set to None for no logging to
-    syslog. [Default:\n                  Info]'\n                  type: string\n
-    \               maxIpsetSize:\n                  type: integer\n                metadataAddr:\n
-    \                 description: 'MetadataAddr is the IP address or domain name
-    of the\n                  server that can answer VM queries for cloud-init metadata.
-    In OpenStack,\n                  this corresponds to the machine running nova-api
-    (or in Ubuntu,\n                  nova-api-metadata). A value of none (case insensitive)
-    means that\n                  Felix should not set up any NAT rule for the metadata
-    path. [Default:\n                  127.0.0.1]'\n                  type: string\n
-    \               metadataPort:\n                  description: 'MetadataPort is
-    the port of the metadata server. This,\n                  combined with global.MetadataAddr
-    (if not ‘None’), is used to set\n                  up a NAT rule, from 169.254.169.254:80
-    to MetadataAddr:MetadataPort.\n                  In most cases this should not
-    need to be changed [Default: 8775].'\n                  type: integer\n                mtuIfacePattern:\n
-    \                 description: MTUIfacePattern is a regular expression that controls\n
-    \                   which interfaces Felix should scan in order to calculate the
-    host's\n                    MTU. This should not match workload interfaces (usually
-    named cali...).\n                  type: string\n                natOutgoingAddress:\n
-    \                 description: NATOutgoingAddress specifies an address to use
-    when performing\n                    source NAT for traffic in a natOutgoing pool
-    that is leaving the\n                    network. By default the address used
-    is an address on the interface\n                    the traffic is leaving on
-    (ie it uses the iptables MASQUERADE target)\n                  type: string\n
-    \               natPortRange:\n                  anyOf:\n                    -
-    type: integer\n                    - type: string\n                  description:
-    NATPortRange specifies the range of ports that is used\n                    for
-    port mapping when doing outgoing NAT. When unset the default\n                    behavior
-    of the network stack is used.\n                  pattern: ^.*\n                  x-kubernetes-int-or-string:
-    true\n                netlinkTimeout:\n                  type: string\n                openstackRegion:\n
-    \                 description: 'OpenstackRegion is the name of the region that
-    a particular\n                  Felix belongs to. In a multi-region Calico/OpenStack
-    deployment,\n                  this must be configured somehow for each Felix
-    (here in the datamodel,\n                  or in felix.cfg or the environment
-    on each compute node), and must\n                  match the [calico] openstack_region
-    value configured in neutron.conf\n                  on each node. [Default: Empty]'\n
-    \                 type: string\n                policySyncPathPrefix:\n                  description:
-    'PolicySyncPathPrefix is used to by Felix to communicate\n                  policy
-    changes to external services, like Application layer policy.\n                  [Default:
-    Empty]'\n                  type: string\n                prometheusGoMetricsEnabled:\n
-    \                 description: 'PrometheusGoMetricsEnabled disables Go runtime
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                prometheusMetricsEnabled:\n                  description:
-    'PrometheusMetricsEnabled enables the Prometheus metrics\n                  server
-    in Felix if set to true. [Default: false]'\n                  type: boolean\n
-    \               prometheusMetricsHost:\n                  description: 'PrometheusMetricsHost
-    is the host that the Prometheus\n                  metrics server should bind
-    to. [Default: empty]'\n                  type: string\n                prometheusMetricsPort:\n
-    \                 description: 'PrometheusMetricsPort is the TCP port that the
-    Prometheus\n                  metrics server should bind to. [Default: 9091]'\n
-    \                 type: integer\n                prometheusProcessMetricsEnabled:\n
-    \                 description: 'PrometheusProcessMetricsEnabled disables process
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                removeExternalRoutes:\n                  description:
-    Whether or not to remove device routes that have not\n                    been
-    programmed by Felix. Disabling this will allow external applications\n                    to
-    also add device routes. This is enabled by default which means\n                    we
-    will remove externally added routes.\n                  type: boolean\n                reportingInterval:\n
-    \                 description: 'ReportingInterval is the interval at which Felix
-    reports\n                  its status into the datastore or 0 to disable. Must
-    be non-zero\n                  in OpenStack deployments. [Default: 30s]'\n                  type:
-    string\n                reportingTTL:\n                  description: 'ReportingTTL
-    is the time-to-live setting for process-wide\n                  status reports.
-    [Default: 90s]'\n                  type: string\n                routeRefreshInterval:\n
-    \                 description: 'RouterefreshInterval is the period at which Felix
-    re-checks\n                  the routes in the dataplane to ensure that no other
-    process has\n                  accidentally broken Calico’s rules. Set to 0 to
-    disable route refresh.\n                  [Default: 90s]'\n                  type:
-    string\n                routeSource:\n                  description: 'RouteSource
-    configures where Felix gets its routing\n                  information. - WorkloadIPs:
-    use workload endpoints to construct\n                  routes. - CalicoIPAM: the
-    default - use IPAM data to construct routes.'\n                  type: string\n
-    \               routeTableRange:\n                  description: Calico programs
-    additional Linux route tables for various\n                    purposes.  RouteTableRange
-    specifies the indices of the route tables\n                    that Calico should
-    use.\n                  properties:\n                    max:\n                      type:
-    integer\n                    min:\n                      type: integer\n                  required:\n
-    \                   - max\n                    - min\n                  type:
-    object\n                serviceLoopPrevention:\n                  description:
-    'When service IP advertisement is enabled, prevent routing\n                    loops
-    to service IPs that are not in use, by dropping or rejecting\n                    packets
-    that do not get DNAT''d by kube-proxy. Unless set to \"Disabled\",\n                    in
-    which case such routing loops continue to be allowed. [Default:\n                    Drop]'\n
-    \                 type: string\n                sidecarAccelerationEnabled:\n
-    \                 description: 'SidecarAccelerationEnabled enables experimental
-    sidecar\n                  acceleration [Default: false]'\n                  type:
-    boolean\n                usageReportingEnabled:\n                  description:
-    'UsageReportingEnabled reports anonymous Calico version\n                  number
-    and cluster size to projectcalico.org. Logs warnings returned\n                  by
-    the usage server. For example, if a significant security vulnerability\n                  has
-    been discovered in the version of Calico being used. [Default:\n                  true]'\n
-    \                 type: boolean\n                usageReportingInitialDelay:\n
-    \                 description: 'UsageReportingInitialDelay controls the minimum
-    delay\n                  before Felix makes a report. [Default: 300s]'\n                  type:
-    string\n                usageReportingInterval:\n                  description:
-    'UsageReportingInterval controls the interval at which\n                  Felix
-    makes reports. [Default: 86400s]'\n                  type: string\n                useInternalDataplaneDriver:\n
-    \                 type: boolean\n                vxlanEnabled:\n                  type:
-    boolean\n                vxlanMTU:\n                  description: 'VXLANMTU is
-    the MTU to set on the tunnel device. See\n                  Configuring MTU [Default:
-    1440]'\n                  type: integer\n                vxlanPort:\n                  type:
-    integer\n                vxlanVNI:\n                  type: integer\n                wireguardEnabled:\n
-    \                 description: 'WireguardEnabled controls whether Wireguard is
-    enabled.\n                  [Default: false]'\n                  type: boolean\n
-    \               wireguardInterfaceName:\n                  description: 'WireguardInterfaceName
-    specifies the name to use for\n                  the Wireguard interface. [Default:
-    wg.calico]'\n                  type: string\n                wireguardListeningPort:\n
-    \                 description: 'WireguardListeningPort controls the listening
-    port used\n                  by Wireguard. [Default: 51820]'\n                  type:
-    integer\n                wireguardMTU:\n                  description: 'WireguardMTU
-    controls the MTU on the Wireguard interface.\n                  See Configuring
-    MTU [Default: 1420]'\n                  type: integer\n                wireguardRoutingRulePriority:\n
-    \                 description: 'WireguardRoutingRulePriority controls the priority
-    value\n                  to use for the Wireguard routing rule. [Default: 99]'\n
-    \                 type: integer\n                xdpEnabled:\n                  description:
-    'XDPEnabled enables XDP acceleration for suitable untracked\n                  incoming
-    deny rules. [Default: true]'\n                  type: boolean\n                xdpRefreshInterval:\n
-    \                 description: 'XDPRefreshInterval is the period at which Felix
-    re-checks\n                  all XDP state to ensure that no other process has
-    accidentally broken\n                  Calico''s BPF maps or attached programs.
-    Set to 0 to disable XDP\n                  refresh. [Default: 90s]'\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: globalnetworkpolicies.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: GlobalNetworkPolicy\n    listKind:
-    GlobalNetworkPolicyList\n    plural: globalnetworkpolicies\n    singular: globalnetworkpolicy\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                applyOnForward:\n
-    \                 description: ApplyOnForward indicates to apply the rules in
-    this policy\n                    on forward traffic.\n                  type:
-    boolean\n                doNotTrack:\n                  description: DoNotTrack
-    indicates whether packets matched by the rules\n                    in this policy
-    should go through the data plane's connection tracking,\n                    such
-    as Linux conntrack.  If True, the rules in this policy are\n                    applied
-    before any data plane connection tracking, and packets allowed\n                    by
-    this policy are marked as not to be tracked.\n                  type: boolean\n
-    \               egress:\n                  description: The ordered set of egress
-    rules.  Each rule contains\n                    a set of packet match criteria
-    and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                namespaceSelector:\n                  description: NamespaceSelector
-    is an optional field for an expression\n                    used to select a pod
-    based on namespaces.\n                  type: string\n                order:\n
-    \                 description: Order is an optional field that specifies the order
-    in\n                    which the policy is applied. Policies with higher \"order\"
-    are applied\n                    after those with lower order.  If the order is
-    omitted, it may be\n                    considered to be \"infinite\" - i.e. the
-    policy will be applied last.  Policies\n                    with identical order
-    will be applied in alphanumerical order based\n                    on the Policy
-    \"Name\".\n                  type: number\n                preDNAT:\n                  description:
-    PreDNAT indicates to apply the rules in this policy before\n                    any
-    DNAT.\n                  type: boolean\n                selector:\n                  description:
-    \"The selector is an expression used to pick pick out\n                  the endpoints
-    that the policy should be applied to. \\n Selector\n                  expressions
-    follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n                  \\
-    ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel != \\\"string_literal\\\"\n
-    \                 \\  ->  not equal; also matches if label is not present \\tlabel
-    in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\", ... }  ->  true if the
-    value of label X is\n                  one of \\\"a\\\", \\\"b\\\", \\\"c\\\"
-    \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ... }  ->
-    \ true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress rules are present
-    in the policy.  The\n                  default is: \\n - [ PolicyTypeIngress ],
-    if there are no Egress rules\n                  (including the case where there
-    are   also no Ingress rules) \\n\n                  - [ PolicyTypeEgress ], if
-    there are Egress rules but no Ingress\n                  rules \\n - [ PolicyTypeIngress,
-    PolicyTypeEgress ], if there are\n                  both Ingress and Egress rules.
-    \\n When the policy is read back again,\n                  Types will always be
-    one of these values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: globalnetworksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: GlobalNetworkSet\n    listKind: GlobalNetworkSetList\n    plural:
-    globalnetworksets\n    singular: globalnetworkset\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs\n            that
-    share labels to allow rules to refer to them via selectors.  The labels\n            of
-    GlobalNetworkSet are not namespaced.\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: GlobalNetworkSetSpec contains the
-    specification for a NetworkSet\n                resource.\n              properties:\n
-    \               nets:\n                  description: The list of IP networks
-    that belong to this set.\n                  items:\n                    type:
-    string\n                  type: array\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: hostendpoints.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: HostEndpoint\n    listKind: HostEndpointList\n    plural:
-    hostendpoints\n    singular: hostendpoint\n  scope: Cluster\n  versions:\n    -
-    name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: HostEndpointSpec contains the specification
-    for a HostEndpoint\n                resource.\n              properties:\n                expectedIPs:\n
-    \                 description: \"The expected IP addresses (IPv4 and IPv6) of
-    the endpoint.\n                  If \\\"InterfaceName\\\" is not present, Calico
-    will look for an interface\n                  matching any of the IPs in the list
-    and apply policy to that. Note:\n                  \\tWhen using the selector
-    match criteria in an ingress or egress\n                  security Policy \\tor
-    Profile, Calico converts the selector into\n                  a set of IP addresses.
-    For host \\tendpoints, the ExpectedIPs field\n                  is used for that
-    purpose. (If only the interface \\tname is specified,\n                  Calico
-    does not learn the IPs of the interface for use in match\n                  \\tcriteria.)\"\n
-    \                 items:\n                    type: string\n                  type:
-    array\n                interfaceName:\n                  description: \"Either
-    \\\"*\\\", or the name of a specific Linux interface\n                  to apply
-    policy to; or empty.  \\\"*\\\" indicates that this HostEndpoint\n                  governs
-    all traffic to, from or through the default network namespace\n                  of
-    the host named by the \\\"Node\\\" field; entering and leaving that\n                  namespace
-    via any interface, including those from/to non-host-networked\n                  local
-    workloads. \\n If InterfaceName is not \\\"*\\\", this HostEndpoint\n                  only
-    governs traffic that enters or leaves the host through the\n                  specific
-    interface named by InterfaceName, or - when InterfaceName\n                  is
-    empty - through the specific interface that has one of the IPs\n                  in
-    ExpectedIPs. Therefore, when InterfaceName is empty, at least\n                  one
-    expected IP must be specified.  Only external interfaces (such\n                  as
-    “eth0”) are supported here; it isn't possible for a HostEndpoint\n                  to
-    protect traffic through a specific local workload interface.\n                  \\n
-    Note: Only some kinds of policy are implemented for \\\"*\\\" HostEndpoints;\n
-    \                 initially just pre-DNAT policy.  Please check Calico documentation\n
-    \                 for the latest position.\"\n                  type: string\n
-    \               node:\n                  description: The node name identifying
-    the Calico node instance.\n                  type: string\n                ports:\n
-    \                 description: Ports contains the endpoint's named ports, which
-    may\n                    be referenced in security policy rules.\n                  items:\n
-    \                   properties:\n                      name:\n                        type:
-    string\n                      port:\n                        type: integer\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                    required:\n                      - name\n                      -
-    port\n                      - protocol\n                    type: object\n                  type:
-    array\n                profiles:\n                  description: A list of identifiers
-    of security Profile objects that\n                    apply to this endpoint.
-    Each profile is applied in the order that\n                    they appear in
-    this list.  Profile rules are applied after the selector-based\n                    security
-    policy.\n                  items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: ipamblocks.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMBlock\n    listKind: IPAMBlockList\n
-    \   plural: ipamblocks\n    singular: ipamblock\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMBlockSpec contains the specification
-    for an IPAMBlock\n                resource.\n              properties:\n                affinity:\n
-    \                 type: string\n                allocations:\n                  items:\n
-    \                   type: integer\n                    # TODO: This nullable is
-    manually added in. We should update controller-gen\n                    # to handle
-    []*int properly itself.\n                    nullable: true\n                  type:
-    array\n                attributes:\n                  items:\n                    properties:\n
-    \                     handle_id:\n                        type: string\n                      secondary:\n
-    \                       additionalProperties:\n                          type:
-    string\n                        type: object\n                    type: object\n
-    \                 type: array\n                cidr:\n                  type:
-    string\n                deleted:\n                  type: boolean\n                strictAffinity:\n
-    \                 type: boolean\n                unallocated:\n                  items:\n
-    \                   type: integer\n                  type: array\n              required:\n
-    \               - allocations\n                - attributes\n                -
-    cidr\n                - strictAffinity\n                - unallocated\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMConfig\n    listKind: IPAMConfigList\n    plural: ipamconfigs\n
-    \   singular: ipamconfig\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMConfigSpec contains the specification
-    for an IPAMConfig\n                resource.\n              properties:\n                autoAllocateBlocks:\n
-    \                 type: boolean\n                maxBlocksPerHost:\n                  description:
-    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                    that
-    can be affine to each host.\n                  type: integer\n                strictAffinity:\n
-    \                 type: boolean\n              required:\n                - autoAllocateBlocks\n
-    \               - strictAffinity\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ipamhandles.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMHandle\n    listKind: IPAMHandleList\n    plural: ipamhandles\n
-    \   singular: ipamhandle\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMHandleSpec contains the specification
-    for an IPAMHandle\n                resource.\n              properties:\n                block:\n
-    \                 additionalProperties:\n                    type: integer\n                  type:
-    object\n                deleted:\n                  type: boolean\n                handleID:\n
-    \                 type: string\n              required:\n                - block\n
-    \               - handleID\n              type: object\n          type: object\n
-    \     served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ippools.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPPool\n    listKind: IPPoolList\n    plural: ippools\n    singular:
-    ippool\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPPoolSpec contains the specification
-    for an IPPool resource.\n              properties:\n                blockSize:\n
-    \                 description: The block size to use for IP address assignments
-    from\n                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.\n
-    \                 type: integer\n                cidr:\n                  description:
-    The pool CIDR.\n                  type: string\n                disabled:\n                  description:
-    When disabled is true, Calico IPAM will not assign addresses\n                    from
-    this pool.\n                  type: boolean\n                ipip:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  properties:\n                    enabled:\n                      description:
-    When enabled is true, ipip tunneling will be used\n                        to
-    deliver packets to destinations within this pool.\n                      type:
-    boolean\n                    mode:\n                      description: The IPIP
-    mode.  This can be one of \"always\" or \"cross-subnet\".  A\n                        mode
-    of \"always\" will also use IPIP tunneling for routing to\n                        destination
-    IP addresses within this pool.  A mode of \"cross-subnet\"\n                        will
-    only use IPIP tunneling when the destination node is on\n                        a
-    different subnet to the originating node.  The default value\n                        (if
-    not specified) is \"always\".\n                      type: string\n                  type:
-    object\n                ipipMode:\n                  description: Contains configuration
-    for IPIP tunneling for this pool.\n                    If not specified, then
-    this is defaulted to \"Never\" (i.e. IPIP tunneling\n                    is disabled).\n
-    \                 type: string\n                nat-outgoing:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  type: boolean\n                natOutgoing:\n                  description:
-    When nat-outgoing is true, packets sent from Calico networked\n                    containers
-    in this pool to destinations outside of this pool will\n                    be
-    masqueraded.\n                  type: boolean\n                nodeSelector:\n
-    \                 description: Allows IPPool to allocate for a specific node by
-    label\n                    selector.\n                  type: string\n                vxlanMode:\n
-    \                 description: Contains configuration for VXLAN tunneling for
-    this pool.\n                    If not specified, then this is defaulted to \"Never\"
-    (i.e. VXLAN\n                    tunneling is disabled).\n                  type:
-    string\n              required:\n                - cidr\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: kubecontrollersconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: KubeControllersConfiguration\n    listKind: KubeControllersConfigurationList\n
-    \   plural: kubecontrollersconfigurations\n    singular: kubecontrollersconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: KubeControllersConfigurationSpec
-    contains the values of the\n                Kubernetes controllers configuration.\n
-    \             properties:\n                controllers:\n                  description:
-    Controllers enables and configures individual Kubernetes\n                    controllers\n
-    \                 properties:\n                    namespace:\n                      description:
-    Namespace enables and configures the namespace controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   node:\n                      description: Node enables and
-    configures the node controller.\n                        Enabled by default, set
-    to nil to disable.\n                      properties:\n                        hostEndpoint:\n
-    \                         description: HostEndpoint controls syncing nodes to
-    host endpoints.\n                            Disabled by default, set to nil to
-    disable.\n                          properties:\n                            autoCreate:\n
-    \                             description: 'AutoCreate enables automatic creation
-    of\n                              host endpoints for every node. [Default: Disabled]'\n
-    \                             type: string\n                          type: object\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                       syncLabels:\n                          description: 'SyncLabels
-    controls whether to copy Kubernetes\n                          node labels to
-    Calico nodes. [Default: Enabled]'\n                          type: string\n                      type:
-    object\n                    policy:\n                      description: Policy
-    enables and configures the policy controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   serviceAccount:\n                      description: ServiceAccount
-    enables and configures the service\n                        account controller.
-    Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                    workloadEndpoint:\n                      description:
-    WorkloadEndpoint enables and configures the workload\n                        endpoint
-    controller. Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                  type: object\n                etcdV3CompactionPeriod:\n
-    \                 description: 'EtcdV3CompactionPeriod is the period between etcdv3\n
-    \                 compaction requests. Set to 0 to disable. [Default: 10m]'\n
-    \                 type: string\n                healthChecks:\n                  description:
-    'HealthChecks enables or disables support for health\n                  checks
-    [Default: Enabled]'\n                  type: string\n                logSeverityScreen:\n
-    \                 description: 'LogSeverityScreen is the log severity above which
-    logs\n                  are sent to the stdout. [Default: Info]'\n                  type:
-    string\n                prometheusMetricsPort:\n                  description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                    metrics
-    server should bind to. Set to 0 to disable. [Default: 9094]'\n                  type:
-    integer\n              required:\n                - controllers\n              type:
-    object\n            status:\n              description: KubeControllersConfigurationStatus
-    represents the status\n                of the configuration. It's useful for admins
-    to be able to see the actual\n                config that was applied, which can
-    be modified by environment variables\n                on the kube-controllers
-    process.\n              properties:\n                environmentVars:\n                  additionalProperties:\n
-    \                   type: string\n                  description: EnvironmentVars
-    contains the environment variables on\n                    the kube-controllers
-    that influenced the RunningConfig.\n                  type: object\n                runningConfig:\n
-    \                 description: RunningConfig contains the effective config that
-    is running\n                    in the kube-controllers pod, after merging the
-    API resource with\n                    any environment variables.\n                  properties:\n
-    \                   controllers:\n                      description: Controllers
-    enables and configures individual Kubernetes\n                        controllers\n
-    \                     properties:\n                        namespace:\n                          description:
-    Namespace enables and configures the namespace\n                            controller.
-    Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        node:\n
-    \                         description: Node enables and configures the node controller.\n
-    \                           Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           hostEndpoint:\n                              description:
-    HostEndpoint controls syncing nodes to host\n                                endpoints.
-    Disabled by default, set to nil to disable.\n                              properties:\n
-    \                               autoCreate:\n                                  description:
-    'AutoCreate enables automatic creation\n                                  of host
-    endpoints for every node. [Default: Disabled]'\n                                  type:
-    string\n                              type: object\n                            leakGracePeriod:\n
-    \                             description: 'LeakGracePeriod is the period used
-    by the\n                                controller to determine if an IP address
-    has been leaked.\n                                Set to 0 to disable IP garbage
-    collection. [Default:\n                                15m]'\n                              type:
-    string\n                            reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                            syncLabels:\n                              description:
-    'SyncLabels controls whether to copy Kubernetes\n                              node
-    labels to Calico nodes. [Default: Enabled]'\n                              type:
-    string\n                          type: object\n                        policy:\n
-    \                         description: Policy enables and configures the policy
-    controller.\n                            Enabled by default, set to nil to disable.\n
-    \                         properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        serviceAccount:\n
-    \                         description: ServiceAccount enables and configures the
-    service\n                            account controller. Enabled by default, set
-    to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        workloadEndpoint:\n
-    \                         description: WorkloadEndpoint enables and configures
-    the workload\n                            endpoint controller. Enabled by default,
-    set to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                      type: object\n
-    \                   etcdV3CompactionPeriod:\n                      description:
-    'EtcdV3CompactionPeriod is the period between etcdv3\n                      compaction
-    requests. Set to 0 to disable. [Default: 10m]'\n                      type: string\n
-    \                   healthChecks:\n                      description: 'HealthChecks
-    enables or disables support for health\n                      checks [Default:
-    Enabled]'\n                      type: string\n                    logSeverityScreen:\n
-    \                     description: 'LogSeverityScreen is the log severity above
-    which\n                      logs are sent to the stdout. [Default: Info]'\n                      type:
-    string\n                    prometheusMetricsPort:\n                      description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                        metrics
-    server should bind to. Set to 0 to disable. [Default:\n                        9094]'\n
-    \                     type: integer\n                  required:\n                    -
-    controllers\n                  type: object\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: networkpolicies.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkPolicy\n    listKind: NetworkPolicyList\n    plural:
-    networkpolicies\n    singular: networkpolicy\n  scope: Namespaced\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                egress:\n                  description:
-    The ordered set of egress rules.  Each rule contains\n                    a set
-    of packet match criteria and a corresponding action to apply.\n                  items:\n
-    \                   description: \"A Rule encapsulates a set of match criteria
-    and an\n                    action.  Both selector-based security Policy and security
-    Profiles\n                    reference rules - separated out as a list of rules
-    for both ingress\n                    and egress packet matching. \\n Each positive
-    match criteria has\n                    a negated version, prefixed with ”Not”.
-    All the match criteria\n                    within a rule must be satisfied for
-    a packet to match. A single\n                    rule can contain the positive
-    and negative version of a match\n                    and both must be satisfied
-    for the rule to match.\"\n                    properties:\n                      action:\n
-    \                       type: string\n                      destination:\n                        description:
-    Destination contains the match criteria that apply\n                          to
-    destination entity.\n                        properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                order:\n                  description: Order is an optional
-    field that specifies the order in\n                    which the policy is applied.
-    Policies with higher \"order\" are applied\n                    after those with
-    lower order.  If the order is omitted, it may be\n                    considered
-    to be \"infinite\" - i.e. the policy will be applied last.  Policies\n                    with
-    identical order will be applied in alphanumerical order based\n                    on
-    the Policy \"Name\".\n                  type: number\n                selector:\n
-    \                 description: \"The selector is an expression used to pick pick
-    out\n                  the endpoints that the policy should be applied to. \\n
-    Selector\n                  expressions follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n
-    \                 \\ ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel
-    != \\\"string_literal\\\"\n                  \\  ->  not equal; also matches if
-    label is not present \\tlabel in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\",
-    ... }  ->  true if the value of label X is\n                  one of \\\"a\\\",
-    \\\"b\\\", \\\"c\\\" \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ...
-    }  ->  true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress are present in the
-    policy.  The default\n                  is: \\n - [ PolicyTypeIngress ], if there
-    are no Egress rules (including\n                  the case where there are   also
-    no Ingress rules) \\n - [ PolicyTypeEgress\n                  ], if there are
-    Egress rules but no Ingress rules \\n - [ PolicyTypeIngress,\n                  PolicyTypeEgress
-    ], if there are both Ingress and Egress rules.\n                  \\n When the
-    policy is read back again, Types will always be one\n                  of these
-    values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: networksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkSet\n    listKind: NetworkSetList\n    plural: networksets\n
-    \   singular: networkset\n  scope: Namespaced\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          description: NetworkSet is the Namespaced-equivalent
-    of the GlobalNetworkSet.\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: NetworkSetSpec contains the specification
-    for a NetworkSet\n                resource.\n              properties:\n                nets:\n
-    \                 description: The list of IP networks that belong to this set.\n
-    \                 items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n---\n# Source: calico/templates/calico-kube-controllers-rbac.yaml\n\n#
-    Include a clusterrole for the kube-controllers component,\n# and bind it to the
-    calico-kube-controllers serviceaccount.\nkind: ClusterRole\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nrules:\n  # Nodes are watched to monitor for
-    deletions.\n  - apiGroups: [\"\"]\n    resources:\n      - nodes\n    verbs:\n
-    \     - watch\n      - list\n      - get\n  # Pods are watched to check for existence
-    as part of IPAM controller.\n  - apiGroups: [\"\"]\n    resources:\n      - pods\n
-    \   verbs:\n      - get\n      - list\n      - watch\n  # IPAM resources are manipulated
-    when nodes are deleted.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - ippools\n    verbs:\n      - list\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - blockaffinities\n      - ipamblocks\n      - ipamhandles\n
-    \   verbs:\n      - get\n      - list\n      - create\n      - update\n      -
-    delete\n      - watch\n  # kube-controllers manages hostendpoints.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - hostendpoints\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  #
-    Needs access to update clusterinformations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - clusterinformations\n    verbs:\n      - get\n      -
-    create\n      - update\n  # KubeControllersConfiguration is where it gets its
-    config\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - kubecontrollersconfigurations\n
-    \   verbs:\n      # read its own config\n      - get\n      # create a default
-    if none exists\n      - create\n      # update status\n      - update\n      #
-    watch for changes\n      - watch\n---\nkind: ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-kube-controllers\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-kube-controllers\n    namespace: kube-system\n---\n\n---\n# Source:
-    calico/templates/calico-node-rbac.yaml\n# Include a clusterrole for the calico-node
-    DaemonSet,\n# and bind it to the calico-node serviceaccount.\nkind: ClusterRole\napiVersion:
-    rbac.authorization.k8s.io/v1\nmetadata:\n  name: calico-node\nrules:\n  # The
-    CNI plugin needs to get pods, nodes, and namespaces.\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - pods\n      - nodes\n      - namespaces\n    verbs:\n
-    \     - get\n  # EndpointSlices are used for Service-based network policy rule\n
-    \ # enforcement.\n  - apiGroups: [\"discovery.k8s.io\"]\n    resources:\n      -
-    endpointslices\n    verbs:\n      - watch\n      - list\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - endpoints\n      - services\n    verbs:\n      # Used
-    to discover service IPs for advertisement.\n      - watch\n      - list\n      #
-    Used to discover Typhas.\n      - get\n  # Pod CIDR auto-detection on kubeadm
-    needs access to config maps.\n  - apiGroups: [\"\"]\n    resources:\n      - configmaps\n
-    \   verbs:\n      - get\n  - apiGroups: [\"\"]\n    resources:\n      - nodes/status\n
-    \   verbs:\n      # Needed for clearing NodeNetworkUnavailable flag.\n      -
-    patch\n      # Calico stores some configuration information in node annotations.\n
-    \     - update\n  # Watch for changes to Kubernetes NetworkPolicies.\n  - apiGroups:
-    [\"networking.k8s.io\"]\n    resources:\n      - networkpolicies\n    verbs:\n
-    \     - watch\n      - list\n  # Used by Calico for policy information.\n  - apiGroups:
-    [\"\"]\n    resources:\n      - pods\n      - namespaces\n      - serviceaccounts\n
-    \   verbs:\n      - list\n      - watch\n  # The CNI plugin patches pods/status.\n
-    \ - apiGroups: [\"\"]\n    resources:\n      - pods/status\n    verbs:\n      -
-    patch\n  # Calico monitors various CRDs for config.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - globalfelixconfigs\n      - felixconfigurations\n      -
-    bgppeers\n      - globalbgpconfigs\n      - bgpconfigurations\n      - ippools\n
-    \     - ipamblocks\n      - globalnetworkpolicies\n      - globalnetworksets\n
-    \     - networkpolicies\n      - networksets\n      - clusterinformations\n      -
-    hostendpoints\n      - blockaffinities\n    verbs:\n      - get\n      - list\n
-    \     - watch\n  # Calico must create and update some CRDs on startup.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - ippools\n      - felixconfigurations\n
-    \     - clusterinformations\n    verbs:\n      - create\n      - update\n  # Calico
-    stores some configuration information on the node.\n  - apiGroups: [\"\"]\n    resources:\n
-    \     - nodes\n    verbs:\n      - get\n      - list\n      - watch\n  # These
-    permissions are only required for upgrade from v2.6, and can\n  # be removed after
-    upgrade or on fresh installations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - bgpconfigurations\n      - bgppeers\n    verbs:\n      -
-    create\n      - update\n  # These permissions are required for Calico CNI to perform
-    IPAM allocations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n      - ipamblocks\n      - ipamhandles\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  -
-    apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - ipamconfigs\n
-    \   verbs:\n      - get\n  # Block affinities must also be watchable by confd
-    for route aggregation.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n    verbs:\n      - watch\n  # The Calico IPAM migration
-    needs to get daemonsets. These permissions can be\n  # removed if not upgrading
-    from an installation using host-local IPAM.\n  - apiGroups: [\"apps\"]\n    resources:\n
-    \     - daemonsets\n    verbs:\n      - get\n\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:
-    ClusterRoleBinding\nmetadata:\n  name: calico-node\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-node\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-node\n    namespace: kube-system\n\n---\n# Source: calico/templates/calico-node.yaml\n#
-    This manifest installs the calico-node container, as well\n# as the CNI plugins
-    and network config on\n# each master and worker node in a Kubernetes cluster.\nkind:
-    DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: calico-node\n  namespace: kube-system\n
-    \ labels:\n    k8s-app: calico-node\nspec:\n  selector:\n    matchLabels:\n      k8s-app:
-    calico-node\n  updateStrategy:\n    type: RollingUpdate\n    rollingUpdate:\n
-    \     maxUnavailable: 1\n  template:\n    metadata:\n      labels:\n        k8s-app:
-    calico-node\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n
-    \     hostNetwork: true\n      tolerations:\n        # Make sure calico-node gets
-    scheduled on all nodes.\n        - effect: NoSchedule\n          operator: Exists\n
-    \       # Mark the pod as a critical add-on for rescheduling.\n        - key:
-    CriticalAddonsOnly\n          operator: Exists\n        - effect: NoExecute\n
-    \         operator: Exists\n      serviceAccountName: calico-node\n      # Minimize
-    downtime during a rolling upgrade or deletion; tell Kubernetes to do a \"force\n
-    \     # deletion\": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.\n
-    \     terminationGracePeriodSeconds: 0\n      priorityClassName: system-node-critical\n
-    \     initContainers:\n        # This container performs upgrade from host-local
-    IPAM to calico-ipam.\n        # It can be deleted if this is a fresh installation,
-    or if you have already\n        # upgraded to use calico-ipam.\n        - name:
-    upgrade-ipam\n          image: calico/cni:v3.20.0\n          command: [\"/opt/cni/bin/calico-ipam\",
-    \"-upgrade\"]\n          envFrom:\n            - configMapRef:\n                #
-    Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for
-    eBPF mode.\n                name: kubernetes-services-endpoint\n                optional:
-    true\n          env:\n            - name: KUBERNETES_NODE_NAME\n              valueFrom:\n
-    \               fieldRef:\n                  fieldPath: spec.nodeName\n            -
-    name: CALICO_NETWORKING_BACKEND\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: calico_backend\n
-    \         volumeMounts:\n            - mountPath: /var/lib/cni/networks\n              name:
-    host-local-net-dir\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n          securityContext:\n            privileged: true\n        #
-    This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: calico/cni:v3.20.0\n
-    \         command: [\"/opt/cni/bin/install\"]\n          envFrom:\n            -
-    configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
-    to be overridden for eBPF mode.\n                name: kubernetes-services-endpoint\n
-    \               optional: true\n          env:\n            # Name of the CNI
-    config file to create.\n            - name: CNI_CONF_NAME\n              value:
-    \"10-calico.conflist\"\n            # The CNI network config to install on each
-    node.\n            - name: CNI_NETWORK_CONFIG\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: cni_network_config\n
-    \           # Set the hostname based on the k8s node name.\n            - name:
-    KUBERNETES_NODE_NAME\n              valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # CNI MTU Config variable\n            - name: CNI_MTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Prevents the container
-    from sleeping forever.\n            - name: SLEEP\n              value: \"false\"\n
-    \         volumeMounts:\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n            - mountPath: /host/etc/cni/net.d\n              name:
-    cni-net-dir\n          securityContext:\n            privileged: true\n        #
-    Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes\n
-    \       # to communicate with Felix over the Policy Sync API.\n        - name:
-    flexvol-driver\n          image: calico/pod2daemon-flexvol:v3.20.0\n          volumeMounts:\n
-    \           - name: flexvol-driver-host\n              mountPath: /host/driver\n
-    \         securityContext:\n            privileged: true\n      containers:\n
-    \       # Runs calico-node container on each Kubernetes node. This\n        #
-    container programs network policy and routes on each\n        # host.\n        -
-    name: calico-node\n          image: calico/node:v3.20.0\n          envFrom:\n
-    \           - configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and
-    KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.\n                name:
-    kubernetes-services-endpoint\n                optional: true\n          env:\n
-    \           # Use Kubernetes API as the backing datastore.\n            - name:
-    DATASTORE_TYPE\n              value: \"kubernetes\"\n            # Wait for the
-    datastore.\n            - name: WAIT_FOR_DATASTORE\n              value: \"true\"\n
-    \           # Set based on the k8s node name.\n            - name: NODENAME\n
-    \             valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # Choose the backend to use.\n            - name: CALICO_NETWORKING_BACKEND\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: calico_backend\n            # Cluster type
-    to identify the deployment type\n            - name: CLUSTER_TYPE\n              value:
-    \"k8s,bgp\"\n            # Auto-detect the BGP IP address.\n            - name:
-    IP\n              value: \"autodetect\"\n            # Enable VXLAN\n            -
-    name: CALICO_IPV4POOL_VXLAN\n              value: \"Always\"\n            # Set
-    MTU for tunnel device used if ipip is enabled\n            - name: FELIX_IPINIPMTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Set MTU for the
-    VXLAN tunnel device.\n            - name: FELIX_VXLANMTU\n              valueFrom:\n
-    \               configMapKeyRef:\n                  name: calico-config\n                  key:
-    veth_mtu\n            # Set MTU for the Wireguard tunnel device.\n            -
-    name: FELIX_WIREGUARDMTU\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: veth_mtu\n            #
-    The default IPv4 pool to create on startup if none exists. Pod IPs will be\n            #
-    chosen from this range. Changing this value after installation will have\n            #
-    no effect. This should fall within `--cluster-cidr`.\n            # - name: CALICO_IPV4POOL_CIDR\n
-    \           #   value: \"192.168.0.0/16\"\n            # Disable file logging
-    so `kubectl logs` works.\n            - name: CALICO_DISABLE_FILE_LOGGING\n              value:
-    \"true\"\n            # Set Felix endpoint to host default action to ACCEPT.\n
-    \           - name: FELIX_DEFAULTENDPOINTTOHOSTACTION\n              value: \"ACCEPT\"\n
-    \           # Disable IPv6 on Kubernetes.\n            - name: FELIX_IPV6SUPPORT\n
-    \             value: \"false\"\n            - name: FELIX_FEATUREDETECTOVERRIDE\n
-    \             value: \"ChecksumOffloadBroken=true\"\n            - name: FELIX_HEALTHENABLED\n
-    \             value: \"true\"\n          securityContext:\n            privileged:
-    true\n          resources:\n            requests:\n              cpu: 250m\n          livenessProbe:\n
-    \           exec:\n              command:\n                - /bin/calico-node\n
-    \               - -felix-live\n            periodSeconds: 10\n            initialDelaySeconds:
-    10\n            failureThreshold: 6\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /bin/calico-node\n                -
-    -felix-ready\n            periodSeconds: 10\n          volumeMounts:\n            -
-    mountPath: /host/etc/cni/net.d\n              name: cni-net-dir\n              readOnly:
-    false\n            - mountPath: /lib/modules\n              name: lib-modules\n
-    \             readOnly: true\n            - mountPath: /run/xtables.lock\n              name:
-    xtables-lock\n              readOnly: false\n            - mountPath: /var/run/calico\n
-    \             name: var-run-calico\n              readOnly: false\n            -
-    mountPath: /var/lib/calico\n              name: var-lib-calico\n              readOnly:
-    false\n            - name: policysync\n              mountPath: /var/run/nodeagent\n
-    \           # For eBPF mode, we need to be able to mount the BPF filesystem at
-    /sys/fs/bpf so we mount in the\n            # parent directory.\n            -
-    name: sysfs\n              mountPath: /sys/fs/\n              # Bidirectional
-    means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to
-    the host.\n              # If the host is known to mount that filesystem already
-    then Bidirectional can be omitted.\n              mountPropagation: Bidirectional\n
-    \           - name: cni-log-dir\n              mountPath: /var/log/calico/cni\n
-    \             readOnly: true\n      volumes:\n        # Used by calico-node.\n
-    \       - name: lib-modules\n          hostPath:\n            path: /lib/modules\n
-    \       - name: var-run-calico\n          hostPath:\n            path: /var/run/calico\n
-    \       - name: var-lib-calico\n          hostPath:\n            path: /var/lib/calico\n
-    \       - name: xtables-lock\n          hostPath:\n            path: /run/xtables.lock\n
-    \           type: FileOrCreate\n        - name: sysfs\n          hostPath:\n            path:
-    /sys/fs/\n            type: DirectoryOrCreate\n        # Used to install CNI.\n
-    \       - name: cni-bin-dir\n          hostPath:\n            path: /opt/cni/bin\n
-    \       - name: cni-net-dir\n          hostPath:\n            path: /etc/cni/net.d\n
-    \       # Used to access CNI logs.\n        - name: cni-log-dir\n          hostPath:\n
-    \           path: /var/log/calico/cni\n        # Mount in the directory for host-local
-    IPAM allocations. This is\n        # used when upgrading from host-local to calico-ipam,
-    and can be removed\n        # if not using the upgrade-ipam init container.\n
-    \       - name: host-local-net-dir\n          hostPath:\n            path: /var/lib/cni/networks\n
-    \       # Used to create per-pod Unix Domain Sockets\n        - name: policysync\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /var/run/nodeagent\n
-    \       # Used to install Flex Volume Driver\n        - name: flexvol-driver-host\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds\n---\n\napiVersion:
-    v1\nkind: ServiceAccount\nmetadata:\n  name: calico-node\n  namespace: kube-system\n\n---\n#
-    Source: calico/templates/calico-kube-controllers.yaml\n# See https://github.com/projectcalico/kube-controllers\napiVersion:
-    apps/v1\nkind: Deployment\nmetadata:\n  name: calico-kube-controllers\n  namespace:
-    kube-system\n  labels:\n    k8s-app: calico-kube-controllers\nspec:\n  # The controllers
-    can only have a single active instance.\n  replicas: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n  strategy:\n    type: Recreate\n  template:\n
-    \   metadata:\n      name: calico-kube-controllers\n      namespace: kube-system\n
-    \     labels:\n        k8s-app: calico-kube-controllers\n    spec:\n      nodeSelector:\n
-    \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
-    a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
-    Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
-    \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
-    \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
-    \         env:\n            # Choose which controllers to run.\n            -
-    name: ENABLED_CONTROLLERS\n              value: node\n            - name: DATASTORE_TYPE\n
-    \             value: kubernetes\n          livenessProbe:\n            exec:\n
-    \             command:\n              - /usr/bin/check-status\n              -
-    -l\n            periodSeconds: 10\n            initialDelaySeconds: 10\n            failureThreshold:
-    6\n            timeoutSeconds: 10\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /usr/bin/check-status\n                -
-    -r\n            periodSeconds: 10\n\n---\n\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n\n---\n\n# This manifest
-    creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler
-    to evict\n\napiVersion: policy/v1beta1\nkind: PodDisruptionBudget\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n  labels:\n    k8s-app:
-    calico-kube-controllers\nspec:\n  maxUnavailable: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n---\n# Source: calico/templates/calico-etcd-secrets.yaml\n\n---\n#
-    Source: calico/templates/calico-typha.yaml\n\n---\n# Source: calico/templates/configure-canal.yaml\n"
+  resources: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgpconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPConfiguration
+        listKind: BGPConfigurationList
+        plural: bgpconfigurations
+        singular: bgpconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: BGPConfiguration contains the configuration for any BGP routing.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPConfigurationSpec contains the values of the BGP configuration.
+                properties:
+                  asNumber:
+                    description: 'ASNumber is the default AS number used by a node. [Default:
+                      64512]'
+                    format: int32
+                    type: integer
+                  communities:
+                    description: Communities is a list of BGP community values and their
+                      arbitrary names for tagging routes.
+                    items:
+                      description: Community contains standard or large community value
+                        and its name.
+                      properties:
+                        name:
+                          description: Name given to community value.
+                          type: string
+                        value:
+                          description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                            For standard community use `aa:nn` format, where `aa` and
+                            `nn` are 16 bit number. For large community use `aa:nn:mm`
+                            format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                            `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                          pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                          type: string
+                      type: object
+                    type: array
+                  listenPort:
+                    description: ListenPort is the port where BGP protocol should listen.
+                      Defaults to 179
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: INFO]'
+                    type: string
+                  nodeToNodeMeshEnabled:
+                    description: 'NodeToNodeMeshEnabled sets whether full node to node
+                      BGP mesh is enabled. [Default: true]'
+                    type: boolean
+                  prefixAdvertisements:
+                    description: PrefixAdvertisements contains per-prefix advertisement
+                      configuration.
+                    items:
+                      description: PrefixAdvertisement configures advertisement properties
+                        for the specified CIDR.
+                      properties:
+                        cidr:
+                          description: CIDR for which properties should be advertised.
+                          type: string
+                        communities:
+                          description: Communities can be list of either community names
+                            already defined in `Specs.Communities` or community value
+                            of format `aa:nn` or `aa:nn:mm`. For standard community use
+                            `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                            large community use `aa:nn:mm` format, where `aa`, `nn` and
+                            `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                            `mm` are per-AS identifier.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  serviceClusterIPs:
+                    description: ServiceClusterIPs are the CIDR blocks from which service
+                      cluster IPs are allocated. If specified, Calico will advertise these
+                      blocks, as well as any cluster IPs within them.
+                    items:
+                      description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                        CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceExternalIPs:
+                    description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                      Service External IPs. Kubernetes Service ExternalIPs will only be
+                      advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceExternalIPBlock represents a single allowed
+                        External IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceLoadBalancerIPs:
+                    description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                      Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                      IPs will only be advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceLoadBalancerIPBlock represents a single allowed
+                        LoadBalancer IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgppeers.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPPeer
+        listKind: BGPPeerList
+        plural: bgppeers
+        singular: bgppeer
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPPeerSpec contains the specification for a BGPPeer resource.
+                properties:
+                  asNumber:
+                    description: The AS Number of the peer.
+                    format: int32
+                    type: integer
+                  keepOriginalNextHop:
+                    description: Option to keep the original nexthop field when routes
+                      are sent to a BGP Peer. Setting "true" configures the selected BGP
+                      Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                      in the specific branch of the Node on "bird.cfg".
+                    type: boolean
+                  maxRestartTime:
+                    description: Time to allow for software restart.  When specified,
+                      this is configured as the graceful restart timeout.  When not specified,
+                      the BIRD default of 120s is used.
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance that
+                      is targeted by this peer. If this is not set, and no nodeSelector
+                      is specified, then this BGP peer selects all nodes in the cluster.
+                    type: string
+                  nodeSelector:
+                    description: Selector for the nodes that should have this peering.  When
+                      this is set, the Node field must be empty.
+                    type: string
+                  password:
+                    description: Optional BGP password for the peerings generated by this
+                      BGPPeer resource.
+                    properties:
+                      secretKeyRef:
+                        description: Selects a key of a secret in the node pod's namespace.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be
+                              a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be
+                              defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  peerIP:
+                    description: The IP address of the peer followed by an optional port
+                      number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                      or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                      and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                      set in BGPConfiguration, then we use that port to peer.
+                    type: string
+                  peerSelector:
+                    description: Selector for the remote nodes to peer with.  When this
+                      is set, the PeerIP and ASNumber fields must be empty.  For each
+                      peering between the local node and selected remote nodes, we configure
+                      an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                      and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                      remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                      or the global default if that is not set.
+                    type: string
+                  sourceAddress:
+                    description: Specifies whether and how to configure a source address
+                      for the peerings generated by this BGPPeer resource.  Default value
+                      "UseNodeIP" means to configure the node IP as the source address.  "None"
+                      means not to configure a source address.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: blockaffinities.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BlockAffinity
+        listKind: BlockAffinityList
+        plural: blockaffinities
+        singular: blockaffinity
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BlockAffinitySpec contains the specification for a BlockAffinity
+                  resource.
+                properties:
+                  cidr:
+                    type: string
+                  deleted:
+                    description: Deleted indicates that this block affinity is being deleted.
+                      This field is a string for compatibility with older releases that
+                      mistakenly treat this field as a string.
+                    type: string
+                  node:
+                    type: string
+                  state:
+                    type: string
+                required:
+                - cidr
+                - deleted
+                - node
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: clusterinformations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: ClusterInformation
+        listKind: ClusterInformationList
+        plural: clusterinformations
+        singular: clusterinformation
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterInformation contains the cluster specific information.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterInformationSpec contains the values of describing
+                  the cluster.
+                properties:
+                  calicoVersion:
+                    description: CalicoVersion is the version of Calico that the cluster
+                      is running
+                    type: string
+                  clusterGUID:
+                    description: ClusterGUID is the GUID of the cluster
+                    type: string
+                  clusterType:
+                    description: ClusterType describes the type of the cluster
+                    type: string
+                  datastoreReady:
+                    description: DatastoreReady is used during significant datastore migrations
+                      to signal to components such as Felix that it should wait before
+                      accessing the datastore.
+                    type: boolean
+                  variant:
+                    description: Variant declares which variant of Calico should be active.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: felixconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: FelixConfiguration
+        listKind: FelixConfigurationList
+        plural: felixconfigurations
+        singular: felixconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: Felix Configuration contains the configuration for Felix.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: FelixConfigurationSpec contains the values of the Felix configuration.
+                properties:
+                  allowIPIPPacketsFromWorkloads:
+                    description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop IPIP encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  allowVXLANPacketsFromWorkloads:
+                    description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop VXLAN encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  awsSrcDstCheck:
+                    description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                      value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                      DoNothing]'
+                    enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                    type: string
+                  bpfConnectTimeLoadBalancingEnabled:
+                    description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                      controls whether Felix installs the connection-time load balancer.  The
+                      connect-time load balancer is required for the host to be able to
+                      reach Kubernetes services and it improves the performance of pod-to-service
+                      connections.  The only reason to disable it is for debugging purposes.  [Default:
+                      true]'
+                    type: boolean
+                  bpfDataIfacePattern:
+                    description: BPFDataIfacePattern is a regular expression that controls
+                      which interfaces Felix should attach BPF programs to in order to
+                      catch traffic to/from the network.  This needs to match the interfaces
+                      that Calico workload traffic flows over as well as any interfaces
+                      that handle incoming traffic to nodeports and services from outside
+                      the cluster.  It should not match the workload interfaces (usually
+                      named cali...).
+                    type: string
+                  bpfDisableUnprivileged:
+                    description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                      sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                      users cannot access Calico''s BPF maps and cannot insert their own
+                      BPF programs to interfere with Calico''s. [Default: true]'
+                    type: boolean
+                  bpfEnabled:
+                    description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                      [Default: false]'
+                    type: boolean
+                  bpfExtToServiceConnmark:
+                    description: 'BPFExtToServiceConnmark in BPF mode, controls a 32bit
+                      mark that is set on connections from an external client to a local
+                      service. This mark allows us to control how packets of that connection
+                      are routed within the host and how is routing intepreted by RPF
+                      check. [Default: 0]'
+                    type: integer
+                  bpfExternalServiceMode:
+                    description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                      from outside the cluster to services (node ports and cluster IPs)
+                      are forwarded to remote workloads.  If set to "Tunnel" then both
+                      request and response traffic is tunneled to the remote node.  If
+                      set to "DSR", the request traffic is tunneled but the response traffic
+                      is sent directly from the remote node.  In "DSR" mode, the remote
+                      node appears to use the IP of the ingress node; this requires a
+                      permissive L2 network.  [Default: Tunnel]'
+                    type: string
+                  bpfKubeProxyEndpointSlicesEnabled:
+                    description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                      whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                    type: boolean
+                  bpfKubeProxyIptablesCleanupEnabled:
+                    description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                      mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                      iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                      true]'
+                    type: boolean
+                  bpfKubeProxyMinSyncPeriod:
+                    description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                      minimum time between updates to the dataplane for Felix''s embedded
+                      kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                      reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                    type: string
+                  bpfLogLevel:
+                    description: 'BPFLogLevel controls the log level of the BPF programs
+                      when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                      logs are emitted to the BPF trace pipe, accessible with the command
+                      `tc exec bpf debug`. [Default: Off].'
+                    type: string
+                  chainInsertMode:
+                    description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                      top-level iptables chains by inserting a rule at the top of the
+                      chain or by appending a rule at the bottom. insert is the safe default
+                      since it prevents Calico''s rules from being bypassed. If you switch
+                      to append mode, be sure that the other rules in the chains signal
+                      acceptance by falling through to the Calico rules, otherwise the
+                      Calico policy will be bypassed. [Default: insert]'
+                    type: string
+                  dataplaneDriver:
+                    type: string
+                  debugDisableLogDropping:
+                    type: boolean
+                  debugMemoryProfilePath:
+                    type: string
+                  debugSimulateCalcGraphHangAfter:
+                    type: string
+                  debugSimulateDataplaneHangAfter:
+                    type: string
+                  defaultEndpointToHostAction:
+                    description: 'DefaultEndpointToHostAction controls what happens to
+                      traffic that goes from a workload endpoint to the host itself (after
+                      the traffic hits the endpoint egress policy). By default Calico
+                      blocks traffic from workload endpoints to the host itself with an
+                      iptables "DROP" action. If you want to allow some or all traffic
+                      from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                      RETURN if you have your own rules in the iptables "INPUT" chain;
+                      Calico will insert its rules at the top of that chain, then "RETURN"
+                      packets to the "INPUT" chain once it has completed processing workload
+                      endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                      from workloads after processing workload endpoint egress policy.
+                      [Default: Drop]'
+                    type: string
+                  deviceRouteProtocol:
+                    description: This defines the route protocol added to programmed device
+                      routes, by default this will be RTPROT_BOOT when left blank.
+                    type: integer
+                  deviceRouteSourceAddress:
+                    description: This is the source address to use on programmed device
+                      routes. By default the source address is left blank, leaving the
+                      kernel to choose the source address used.
+                    type: string
+                  disableConntrackInvalidCheck:
+                    type: boolean
+                  endpointReportingDelay:
+                    type: string
+                  endpointReportingEnabled:
+                    type: boolean
+                  externalNodesList:
+                    description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                      which may source tunnel traffic and have the tunneled traffic be
+                      accepted at calico nodes.
+                    items:
+                      type: string
+                    type: array
+                  failsafeInboundHostPorts:
+                    description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow incoming traffic to host endpoints
+                      on irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all inbound host ports, use the value
+                      none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                      udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  failsafeOutboundHostPorts:
+                    description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow outgoing traffic from host endpoints
+                      to irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all outbound host ports, use the value
+                      none. The default value opens etcd''s standard ports to ensure that
+                      Felix does not get cut off from etcd as well as allowing DHCP and
+                      DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                      tcp:6667, udp:53, udp:67]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  featureDetectOverride:
+                    description: FeatureDetectOverride is used to override the feature
+                      detection. Values are specified in a comma separated list with no
+                      spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                      "true" or "false" will force the feature, empty or omitted values
+                      are auto-detected.
+                    type: string
+                  genericXDPEnabled:
+                    description: 'GenericXDPEnabled enables Generic XDP so network cards
+                      that don''t support XDP offload or driver modes can use XDP. This
+                      is not recommended since it doesn''t provide better performance
+                      than iptables. [Default: false]'
+                    type: boolean
+                  healthEnabled:
+                    type: boolean
+                  healthHost:
+                    type: string
+                  healthPort:
+                    type: integer
+                  interfaceExclude:
+                    description: 'InterfaceExclude is a comma-separated list of interfaces
+                      that Felix should exclude when monitoring for host endpoints. The
+                      default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                      interface, which is used internally by kube-proxy. If you want to
+                      exclude multiple interface names using a single value, the list
+                      supports regular expressions. For regular expressions you must wrap
+                      the value with ''/''. For example having values ''/^kube/,veth1''
+                      will exclude all interfaces that begin with ''kube'' and also the
+                      interface ''veth1''. [Default: kube-ipvs0]'
+                    type: string
+                  interfacePrefix:
+                    description: 'InterfacePrefix is the interface name prefix that identifies
+                      workload endpoints and so distinguishes them from host endpoint
+                      interfaces. Note: in environments other than bare metal, the orchestrators
+                      configure this appropriately. For example our Kubernetes and Docker
+                      integrations set the ''cali'' value, and our OpenStack integration
+                      sets the ''tap'' value. [Default: cali]'
+                    type: string
+                  interfaceRefreshInterval:
+                    description: InterfaceRefreshInterval is the period at which Felix
+                      rescans local interfaces to verify their state. The rescan can be
+                      disabled by setting the interval to 0.
+                    type: string
+                  ipipEnabled:
+                    type: boolean
+                  ipipMTU:
+                    description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  ipsetsRefreshInterval:
+                    description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                      all iptables state to ensure that no other process has accidentally
+                      broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                      90s]'
+                    type: string
+                  iptablesBackend:
+                    description: IptablesBackend specifies which backend of iptables will
+                      be used. The default is legacy.
+                    type: string
+                  iptablesFilterAllowAction:
+                    type: string
+                  iptablesLockFilePath:
+                    description: 'IptablesLockFilePath is the location of the iptables
+                      lock file. You may need to change this if the lock file is not in
+                      its standard location (for example if you have mapped it into Felix''s
+                      container at a different path). [Default: /run/xtables.lock]'
+                    type: string
+                  iptablesLockProbeInterval:
+                    description: 'IptablesLockProbeInterval is the time that Felix will
+                      wait between attempts to acquire the iptables lock if it is not
+                      available. Lower values make Felix more responsive when the lock
+                      is contended, but use more CPU. [Default: 50ms]'
+                    type: string
+                  iptablesLockTimeout:
+                    description: 'IptablesLockTimeout is the time that Felix will wait
+                      for the iptables lock, or 0, to disable. To use this feature, Felix
+                      must share the iptables lock file with all other processes that
+                      also take the lock. When running Felix inside a container, this
+                      requires the /run directory of the host to be mounted into the calico/node
+                      or calico/felix container. [Default: 0s disabled]'
+                    type: string
+                  iptablesMangleAllowAction:
+                    type: string
+                  iptablesMarkMask:
+                    description: 'IptablesMarkMask is the mask that Felix selects its
+                      IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                      at least 8 bits set, none of which clash with any other mark bits
+                      in use on the system. [Default: 0xff000000]'
+                    format: int32
+                    type: integer
+                  iptablesNATOutgoingInterfaceFilter:
+                    type: string
+                  iptablesPostWriteCheckInterval:
+                    description: 'IptablesPostWriteCheckInterval is the period after Felix
+                      has done a write to the dataplane that it schedules an extra read
+                      back in order to check the write was not clobbered by another process.
+                      This should only occur if another application on the system doesn''t
+                      respect the iptables lock. [Default: 1s]'
+                    type: string
+                  iptablesRefreshInterval:
+                    description: 'IptablesRefreshInterval is the period at which Felix
+                      re-checks the IP sets in the dataplane to ensure that no other process
+                      has accidentally broken Calico''s rules. Set to 0 to disable IP
+                      sets refresh. Note: the default for this value is lower than the
+                      other refresh intervals as a workaround for a Linux kernel bug that
+                      was fixed in kernel version 4.11. If you are using v4.11 or greater
+                      you may want to set this to, a higher value to reduce Felix CPU
+                      usage. [Default: 10s]'
+                    type: string
+                  ipv6Support:
+                    type: boolean
+                  kubeNodePortRanges:
+                    description: 'KubeNodePortRanges holds list of port ranges used for
+                      service node ports. Only used if felix detects kube-proxy running
+                      in ipvs mode. Felix uses these ranges to separate host and workload
+                      traffic. [Default: 30000:32767].'
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  logFilePath:
+                    description: 'LogFilePath is the full path to the Felix log. Set to
+                      none to disable file logging. [Default: /var/log/calico/felix.log]'
+                    type: string
+                  logPrefix:
+                    description: 'LogPrefix is the log prefix that Felix uses when rendering
+                      LOG rules. [Default: calico-packet]'
+                    type: string
+                  logSeverityFile:
+                    description: 'LogSeverityFile is the log severity above which logs
+                      are sent to the log file. [Default: Info]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  logSeveritySys:
+                    description: 'LogSeveritySys is the log severity above which logs
+                      are sent to the syslog. Set to None for no logging to syslog. [Default:
+                      Info]'
+                    type: string
+                  maxIpsetSize:
+                    type: integer
+                  metadataAddr:
+                    description: 'MetadataAddr is the IP address or domain name of the
+                      server that can answer VM queries for cloud-init metadata. In OpenStack,
+                      this corresponds to the machine running nova-api (or in Ubuntu,
+                      nova-api-metadata). A value of none (case insensitive) means that
+                      Felix should not set up any NAT rule for the metadata path. [Default:
+                      127.0.0.1]'
+                    type: string
+                  metadataPort:
+                    description: 'MetadataPort is the port of the metadata server. This,
+                      combined with global.MetadataAddr (if not ''None''), is used to
+                      set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                      In most cases this should not need to be changed [Default: 8775].'
+                    type: integer
+                  mtuIfacePattern:
+                    description: MTUIfacePattern is a regular expression that controls
+                      which interfaces Felix should scan in order to calculate the host's
+                      MTU. This should not match workload interfaces (usually named cali...).
+                    type: string
+                  natOutgoingAddress:
+                    description: NATOutgoingAddress specifies an address to use when performing
+                      source NAT for traffic in a natOutgoing pool that is leaving the
+                      network. By default the address used is an address on the interface
+                      the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                    type: string
+                  natPortRange:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NATPortRange specifies the range of ports that is used
+                      for port mapping when doing outgoing NAT. When unset the default
+                      behavior of the network stack is used.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  netlinkTimeout:
+                    type: string
+                  openstackRegion:
+                    description: 'OpenstackRegion is the name of the region that a particular
+                      Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                      this must be configured somehow for each Felix (here in the datamodel,
+                      or in felix.cfg or the environment on each compute node), and must
+                      match the [calico] openstack_region value configured in neutron.conf
+                      on each node. [Default: Empty]'
+                    type: string
+                  policySyncPathPrefix:
+                    description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                      policy changes to external services, like Application layer policy.
+                      [Default: Empty]'
+                    type: string
+                  prometheusGoMetricsEnabled:
+                    description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusMetricsEnabled:
+                    description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                      server in Felix if set to true. [Default: false]'
+                    type: boolean
+                  prometheusMetricsHost:
+                    description: 'PrometheusMetricsHost is the host that the Prometheus
+                      metrics server should bind to. [Default: empty]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. [Default: 9091]'
+                    type: integer
+                  prometheusProcessMetricsEnabled:
+                    description: 'PrometheusProcessMetricsEnabled disables process metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusWireGuardMetricsEnabled:
+                    description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                      metrics collection, which the Prometheus client does by default,
+                      when set to false. This reduces the number of metrics reported,
+                      reducing Prometheus load. [Default: true]'
+                    type: boolean
+                  removeExternalRoutes:
+                    description: Whether or not to remove device routes that have not
+                      been programmed by Felix. Disabling this will allow external applications
+                      to also add device routes. This is enabled by default which means
+                      we will remove externally added routes.
+                    type: boolean
+                  reportingInterval:
+                    description: 'ReportingInterval is the interval at which Felix reports
+                      its status into the datastore or 0 to disable. Must be non-zero
+                      in OpenStack deployments. [Default: 30s]'
+                    type: string
+                  reportingTTL:
+                    description: 'ReportingTTL is the time-to-live setting for process-wide
+                      status reports. [Default: 90s]'
+                    type: string
+                  routeRefreshInterval:
+                    description: 'RouteRefreshInterval is the period at which Felix re-checks
+                      the routes in the dataplane to ensure that no other process has
+                      accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                      [Default: 90s]'
+                    type: string
+                  routeSource:
+                    description: 'RouteSource configures where Felix gets its routing
+                      information. - WorkloadIPs: use workload endpoints to construct
+                      routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                    type: string
+                  routeTableRange:
+                    description: Calico programs additional Linux route tables for various
+                      purposes.  RouteTableRange specifies the indices of the route tables
+                      that Calico should use.
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                    - max
+                    - min
+                    type: object
+                  serviceLoopPrevention:
+                    description: 'When service IP advertisement is enabled, prevent routing
+                      loops to service IPs that are not in use, by dropping or rejecting
+                      packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                      in which case such routing loops continue to be allowed. [Default:
+                      Drop]'
+                    type: string
+                  sidecarAccelerationEnabled:
+                    description: 'SidecarAccelerationEnabled enables experimental sidecar
+                      acceleration [Default: false]'
+                    type: boolean
+                  usageReportingEnabled:
+                    description: 'UsageReportingEnabled reports anonymous Calico version
+                      number and cluster size to projectcalico.org. Logs warnings returned
+                      by the usage server. For example, if a significant security vulnerability
+                      has been discovered in the version of Calico being used. [Default:
+                      true]'
+                    type: boolean
+                  usageReportingInitialDelay:
+                    description: 'UsageReportingInitialDelay controls the minimum delay
+                      before Felix makes a report. [Default: 300s]'
+                    type: string
+                  usageReportingInterval:
+                    description: 'UsageReportingInterval controls the interval at which
+                      Felix makes reports. [Default: 86400s]'
+                    type: string
+                  useInternalDataplaneDriver:
+                    type: boolean
+                  vxlanEnabled:
+                    type: boolean
+                  vxlanMTU:
+                    description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  vxlanPort:
+                    type: integer
+                  vxlanVNI:
+                    type: integer
+                  wireguardEnabled:
+                    description: 'WireguardEnabled controls whether Wireguard is enabled.
+                      [Default: false]'
+                    type: boolean
+                  wireguardHostEncryptionEnabled:
+                    description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                      host-to-host encryption is enabled. [Default: false]'
+                    type: boolean
+                  wireguardInterfaceName:
+                    description: 'WireguardInterfaceName specifies the name to use for
+                      the Wireguard interface. [Default: wg.calico]'
+                    type: string
+                  wireguardListeningPort:
+                    description: 'WireguardListeningPort controls the listening port used
+                      by Wireguard. [Default: 51820]'
+                    type: integer
+                  wireguardMTU:
+                    description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                      See Configuring MTU [Default: 1420]'
+                    type: integer
+                  wireguardRoutingRulePriority:
+                    description: 'WireguardRoutingRulePriority controls the priority value
+                      to use for the Wireguard routing rule. [Default: 99]'
+                    type: integer
+                  xdpEnabled:
+                    description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                      incoming deny rules. [Default: true]'
+                    type: boolean
+                  xdpRefreshInterval:
+                    description: 'XDPRefreshInterval is the period at which Felix re-checks
+                      all XDP state to ensure that no other process has accidentally broken
+                      Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                      refresh. [Default: 90s]'
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkPolicy
+        listKind: GlobalNetworkPolicyList
+        plural: globalnetworkpolicies
+        singular: globalnetworkpolicy
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  applyOnForward:
+                    description: ApplyOnForward indicates to apply the rules in this policy
+                      on forward traffic.
+                    type: boolean
+                  doNotTrack:
+                    description: DoNotTrack indicates whether packets matched by the rules
+                      in this policy should go through the data plane's connection tracking,
+                      such as Linux conntrack.  If True, the rules in this policy are
+                      applied before any data plane connection tracking, and packets allowed
+                      by this policy are marked as not to be tracked.
+                    type: boolean
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    description: NamespaceSelector is an optional field for an expression
+                      used to select a pod based on namespaces.
+                    type: string
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  preDNAT:
+                    description: PreDNAT indicates to apply the rules in this policy before
+                      any DNAT.
+                    type: boolean
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress rules are present in the policy.  The
+                      default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                      (including the case where there are   also no Ingress rules) \n
+                      - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                      rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                      both Ingress and Egress rules. \n When the policy is read back again,
+                      Types will always be one of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkSet
+        listKind: GlobalNetworkSetList
+        plural: globalnetworksets
+        singular: globalnetworkset
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+              that share labels to allow rules to refer to them via selectors.  The labels
+              of GlobalNetworkSet are not namespaced.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: hostendpoints.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: HostEndpoint
+        listKind: HostEndpointList
+        plural: hostendpoints
+        singular: hostendpoint
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: HostEndpointSpec contains the specification for a HostEndpoint
+                  resource.
+                properties:
+                  expectedIPs:
+                    description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                      If \"InterfaceName\" is not present, Calico will look for an interface
+                      matching any of the IPs in the list and apply policy to that. Note:
+                      \tWhen using the selector match criteria in an ingress or egress
+                      security Policy \tor Profile, Calico converts the selector into
+                      a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                      is used for that purpose. (If only the interface \tname is specified,
+                      Calico does not learn the IPs of the interface for use in match
+                      \tcriteria.)"
+                    items:
+                      type: string
+                    type: array
+                  interfaceName:
+                    description: "Either \"*\", or the name of a specific Linux interface
+                      to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                      governs all traffic to, from or through the default network namespace
+                      of the host named by the \"Node\" field; entering and leaving that
+                      namespace via any interface, including those from/to non-host-networked
+                      local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                      only governs traffic that enters or leaves the host through the
+                      specific interface named by InterfaceName, or - when InterfaceName
+                      is empty - through the specific interface that has one of the IPs
+                      in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                      one expected IP must be specified.  Only external interfaces (such
+                      as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                      to protect traffic through a specific local workload interface.
+                      \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                      initially just pre-DNAT policy.  Please check Calico documentation
+                      for the latest position."
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance.
+                    type: string
+                  ports:
+                    description: Ports contains the endpoint's named ports, which may
+                      be referenced in security policy rules.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  profiles:
+                    description: A list of identifiers of security Profile objects that
+                      apply to this endpoint. Each profile is applied in the order that
+                      they appear in this list.  Profile rules are applied after the selector-based
+                      security policy.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamblocks.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMBlock
+        listKind: IPAMBlockList
+        plural: ipamblocks
+        singular: ipamblock
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMBlockSpec contains the specification for an IPAMBlock
+                  resource.
+                properties:
+                  affinity:
+                    type: string
+                  allocations:
+                    items:
+                      nullable: true
+                      type: integer
+                    type: array
+                  attributes:
+                    items:
+                      properties:
+                        handle_id:
+                          type: string
+                        secondary:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    type: array
+                  cidr:
+                    type: string
+                  deleted:
+                    type: boolean
+                  strictAffinity:
+                    type: boolean
+                  unallocated:
+                    items:
+                      type: integer
+                    type: array
+                required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamconfigs.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMConfig
+        listKind: IPAMConfigList
+        plural: ipamconfigs
+        singular: ipamconfig
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMConfigSpec contains the specification for an IPAMConfig
+                  resource.
+                properties:
+                  autoAllocateBlocks:
+                    type: boolean
+                  maxBlocksPerHost:
+                    description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                      that can be affine to each host.
+                    type: integer
+                  strictAffinity:
+                    type: boolean
+                required:
+                - autoAllocateBlocks
+                - strictAffinity
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamhandles.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMHandle
+        listKind: IPAMHandleList
+        plural: ipamhandles
+        singular: ipamhandle
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMHandleSpec contains the specification for an IPAMHandle
+                  resource.
+                properties:
+                  block:
+                    additionalProperties:
+                      type: integer
+                    type: object
+                  deleted:
+                    type: boolean
+                  handleID:
+                    type: string
+                required:
+                - block
+                - handleID
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ippools.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPPool
+        listKind: IPPoolList
+        plural: ippools
+        singular: ippool
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPPoolSpec contains the specification for an IPPool resource.
+                properties:
+                  blockSize:
+                    description: The block size to use for IP address assignments from
+                      this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                    type: integer
+                  cidr:
+                    description: The pool CIDR.
+                    type: string
+                  disabled:
+                    description: When disabled is true, Calico IPAM will not assign addresses
+                      from this pool.
+                    type: boolean
+                  ipip:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    properties:
+                      enabled:
+                        description: When enabled is true, ipip tunneling will be used
+                          to deliver packets to destinations within this pool.
+                        type: boolean
+                      mode:
+                        description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                          mode of "always" will also use IPIP tunneling for routing to
+                          destination IP addresses within this pool.  A mode of "cross-subnet"
+                          will only use IPIP tunneling when the destination node is on
+                          a different subnet to the originating node.  The default value
+                          (if not specified) is "always".
+                        type: string
+                    type: object
+                  ipipMode:
+                    description: Contains configuration for IPIP tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                      is disabled).
+                    type: string
+                  nat-outgoing:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    type: boolean
+                  natOutgoing:
+                    description: When nat-outgoing is true, packets sent from Calico networked
+                      containers in this pool to destinations outside of this pool will
+                      be masqueraded.
+                    type: boolean
+                  nodeSelector:
+                    description: Allows IPPool to allocate for a specific node by label
+                      selector.
+                    type: string
+                  vxlanMode:
+                    description: Contains configuration for VXLAN tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                      tunneling is disabled).
+                    type: string
+                required:
+                - cidr
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubecontrollersconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: KubeControllersConfiguration
+        listKind: KubeControllersConfigurationList
+        plural: kubecontrollersconfigurations
+        singular: kubecontrollersconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeControllersConfigurationSpec contains the values of the
+                  Kubernetes controllers configuration.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host endpoints.
+                              Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation of
+                                  host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the controller
+                              to determine if an IP address has been leaked. Set to 0
+                              to disable IP garbage collection. [Default: 15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+              status:
+                description: KubeControllersConfigurationStatus represents the status
+                  of the configuration. It's useful for admins to be able to see the actual
+                  config that was applied, which can be modified by environment variables
+                  on the kube-controllers process.
+                properties:
+                  environmentVars:
+                    additionalProperties:
+                      type: string
+                    description: EnvironmentVars contains the environment variables on
+                      the kube-controllers that influenced the RunningConfig.
+                    type: object
+                  runningConfig:
+                    description: RunningConfig contains the effective config that is running
+                      in the kube-controllers pod, after merging the API resource with
+                      any environment variables.
+                    properties:
+                      controllers:
+                        description: Controllers enables and configures individual Kubernetes
+                          controllers
+                        properties:
+                          namespace:
+                            description: Namespace enables and configures the namespace
+                              controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          node:
+                            description: Node enables and configures the node controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              hostEndpoint:
+                                description: HostEndpoint controls syncing nodes to host
+                                  endpoints. Disabled by default, set to nil to disable.
+                                properties:
+                                  autoCreate:
+                                    description: 'AutoCreate enables automatic creation
+                                      of host endpoints for every node. [Default: Disabled]'
+                                    type: string
+                                type: object
+                              leakGracePeriod:
+                                description: 'LeakGracePeriod is the period used by the
+                                  controller to determine if an IP address has been leaked.
+                                  Set to 0 to disable IP garbage collection. [Default:
+                                  15m]'
+                                type: string
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                              syncLabels:
+                                description: 'SyncLabels controls whether to copy Kubernetes
+                                  node labels to Calico nodes. [Default: Enabled]'
+                                type: string
+                            type: object
+                          policy:
+                            description: Policy enables and configures the policy controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          serviceAccount:
+                            description: ServiceAccount enables and configures the service
+                              account controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          workloadEndpoint:
+                            description: WorkloadEndpoint enables and configures the workload
+                              endpoint controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                        type: object
+                      etcdV3CompactionPeriod:
+                        description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                          compaction requests. Set to 0 to disable. [Default: 10m]'
+                        type: string
+                      healthChecks:
+                        description: 'HealthChecks enables or disables support for health
+                          checks [Default: Enabled]'
+                        type: string
+                      logSeverityScreen:
+                        description: 'LogSeverityScreen is the log severity above which
+                          logs are sent to the stdout. [Default: Info]'
+                        type: string
+                      prometheusMetricsPort:
+                        description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                          metrics server should bind to. Set to 0 to disable. [Default:
+                          9094]'
+                        type: integer
+                    required:
+                    - controllers
+                    type: object
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkPolicy
+        listKind: NetworkPolicyList
+        plural: networkpolicies
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress are present in the policy.  The default
+                      is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                      the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                      ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                      PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                      \n When the policy is read back again, Types will always be one
+                      of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkSet
+        listKind: NetworkSetList
+        plural: networksets
+        singular: networkset
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: NetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-kube-controllers
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      verbs:
+      - list
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - hostendpoints
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - clusterinformations
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - kubecontrollersconfigurations
+      verbs:
+      - get
+      - create
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-node
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - namespaces
+      verbs:
+      - get
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - patch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - bgpconfigurations
+      - bgppeers
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ipamconfigs
+      verbs:
+      - get
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      verbs:
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - daemonsets
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-kube-controllers
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      calico_backend: vxlan
+      cni_network_config: |-
+        {
+          "name": "k8s-pod-network",
+          "cniVersion": "0.3.1",
+          "plugins": [
+            {
+              "type": "calico",
+              "log_level": "info",
+              "log_file_path": "/var/log/calico/cni/cni.log",
+              "datastore_type": "kubernetes",
+              "nodename": "__KUBERNETES_NODE_NAME__",
+              "mtu": __CNI_MTU__,
+              "ipam": {
+                  "type": "calico-ipam"
+              },
+              "policy": {
+                  "type": "k8s"
+              },
+              "kubernetes": {
+                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              }
+            },
+            {
+              "type": "portmap",
+              "snat": true,
+              "capabilities": {"portMappings": true}
+            },
+            {
+              "type": "bandwidth",
+              "capabilities": {"bandwidth": true}
+            }
+          ]
+        }
+      typha_service_name: none
+      veth_mtu: "1350"
+    kind: ConfigMap
+    metadata:
+      name: calico-config
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-kube-controllers
+          name: calico-kube-controllers
+          namespace: kube-system
+        spec:
+          containers:
+          - env:
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            image: docker.io/calico/kube-controllers:v3.20.3
+            livenessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -l
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-kube-controllers
+            readinessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -r
+              periodSeconds: 10
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: calico-kube-controllers
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: calico-node
+      name: calico-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+        spec:
+          containers:
+          - env:
+            - name: FELIX_FEATUREDETECTOVERRIDE
+              value: ChecksumOffloadBroken=true
+            - name: CALICO_IPV4POOL_VXLAN
+              value: Always
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            - name: CLUSTER_TYPE
+              value: k8s,bgp
+            - name: IP
+              value: autodetect
+            - name: CALICO_IPV4POOL_IPIP
+              value: Never
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_WIREGUARDMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_AWSSRCDSTCHECK
+              value: Disable
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: ACCEPT
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/node:v3.20.3
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -shutdown
+            livenessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-live
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-node
+            readinessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-ready
+              periodSeconds: 10
+              timeoutSeconds: 10
+            resources:
+              requests:
+                cpu: 250m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /var/run/nodeagent
+              name: policysync
+            - mountPath: /sys/fs/
+              mountPropagation: Bidirectional
+              name: sysfs
+            - mountPath: /var/log/calico/cni
+              name: cni-log-dir
+              readOnly: true
+          hostNetwork: true
+          initContainers:
+          - command:
+            - /opt/cni/bin/calico-ipam
+            - -upgrade
+            env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: upgrade-ipam
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          - command:
+            - /opt/cni/bin/install
+            env:
+            - name: CNI_CONF_NAME
+              value: 10-calico.conflist
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  key: cni_network_config
+                  name: calico-config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: SLEEP
+              value: "false"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: install-cni
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+            name: flexvol-driver
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/driver
+              name: flexvol-driver-host
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: calico-node
+          terminationGracePeriodSeconds: 0
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /lib/modules
+            name: lib-modules
+          - hostPath:
+              path: /var/run/calico
+            name: var-run-calico
+          - hostPath:
+              path: /var/lib/calico
+            name: var-lib-calico
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+          - hostPath:
+              path: /sys/fs/
+              type: DirectoryOrCreate
+            name: sysfs
+          - hostPath:
+              path: /opt/cni/bin
+            name: cni-bin-dir
+          - hostPath:
+              path: /etc/cni/net.d
+            name: cni-net-dir
+          - hostPath:
+              path: /var/log/calico/cni
+            name: cni-log-dir
+          - hostPath:
+              path: /var/lib/cni/networks
+            name: host-local-net-dir
+          - hostPath:
+              path: /var/run/nodeagent
+              type: DirectoryOrCreate
+            name: policysync
+          - hostPath:
+              path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+              type: DirectoryOrCreate
+            name: flexvol-driver-host
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
   windows-cni: "# strictAffinity required for windows\napiVersion: crd.projectcalico.org/v1\nkind:
     IPAMConfig\nmetadata:\n  name: default\nspec:\n  autoAllocateBlocks: true\n  strictAffinity:
     true\n---\nkind: ConfigMap\napiVersion: v1\nmetadata:\n  name: calico-static-rules\n

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -4133,7 +4133,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.20.3
+            image: docker.io/calico/kube-controllers:v3.20.4
             livenessProbe:
               exec:
                 command:
@@ -4243,7 +4243,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.20.3
+            image: docker.io/calico/node:v3.20.4
             lifecycle:
               preStop:
                 exec:
@@ -4315,7 +4315,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: upgrade-ipam
             securityContext:
               privileged: true
@@ -4349,7 +4349,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: install-cni
             securityContext:
               privileged: true
@@ -4358,7 +4358,7 @@ data:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.4
             name: flexvol-driver
             securityContext:
               privileged: true
@@ -4466,7 +4466,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.20.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.20.4-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -4485,7 +4485,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.20.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.20.4-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -4496,7 +4496,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.20.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.20.4-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -440,2440 +440,3985 @@ data:
     \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
     kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
     \   type: RollingUpdate\n"
-  resources: "---\n# Source: calico/templates/calico-config.yaml\n# This ConfigMap
-    is used to configure a self-hosted Calico installation.\nkind: ConfigMap\napiVersion:
-    v1\nmetadata:\n  name: calico-config\n  namespace: kube-system\ndata:\n  # Typha
-    is disabled.\n  typha_service_name: \"none\"\n  # Configure the backend to use.\n
-    \ calico_backend: \"vxlan\"\n  # On Azure, the underlying network has an MTU of
-    1400, even though the network interface will have an MTU of 1500.\n  # We set
-    this value to 1350 for “physical network MTU size minus 50” since we use VXLAN,
-    which uses a 50-byte header.\n  # If enabling Wireguard, this value should be
-    changed to 1340 (Wireguard uses a 60-byte header).\n  # https://docs.projectcalico.org/networking/mtu#determine-mtu-size\n
-    \ veth_mtu: \"1350\"\n  \n  # The CNI network configuration to install on each
-    node. The special\n  # values in this config will be automatically populated.\n
-    \ cni_network_config: |-\n    {\n      \"name\": \"k8s-pod-network\",\n      \"cniVersion\":
-    \"0.3.1\",\n      \"plugins\": [\n        {\n          \"type\": \"calico\",\n
-    \         \"log_level\": \"info\",\n          \"log_file_path\": \"/var/log/calico/cni/cni.log\",\n
-    \         \"datastore_type\": \"kubernetes\",\n          \"nodename\": \"__KUBERNETES_NODE_NAME__\",\n
-    \         \"mtu\": __CNI_MTU__,\n          \"ipam\": {\n              \"type\":
-    \"calico-ipam\"\n          },\n          \"policy\": {\n              \"type\":
-    \"k8s\"\n          },\n          \"kubernetes\": {\n              \"kubeconfig\":
-    \"__KUBECONFIG_FILEPATH__\"\n          }\n        },\n        {\n          \"type\":
-    \"portmap\",\n          \"snat\": true,\n          \"capabilities\": {\"portMappings\":
-    true}\n        },\n        {\n          \"type\": \"bandwidth\",\n          \"capabilities\":
-    {\"bandwidth\": true}\n        }\n      ]\n    }\n\n---\n# Source: calico/templates/kdd-crds.yaml\n\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: bgpconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPConfiguration\n    listKind: BGPConfigurationList\n    plural:
-    bgpconfigurations\n    singular: bgpconfiguration\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    BGPConfiguration contains the configuration for any BGP routing.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPConfigurationSpec contains the
-    values of the BGP configuration.\n              properties:\n                asNumber:\n
-    \                 description: 'ASNumber is the default AS number used by a node.
-    [Default:\n                  64512]'\n                  format: int32\n                  type:
-    integer\n                communities:\n                  description: Communities
-    is a list of BGP community values and their\n                    arbitrary names
-    for tagging routes.\n                  items:\n                    description:
-    Community contains standard or large community value\n                      and
-    its name.\n                    properties:\n                      name:\n                        description:
-    Name given to community value.\n                        type: string\n                      value:\n
-    \                       description: Value must be of format `aa:nn` or `aa:nn:mm`.\n
-    \                         For standard community use `aa:nn` format, where `aa`
-    and\n                          `nn` are 16 bit number. For large community use
-    `aa:nn:mm`\n                          format, where `aa`, `nn` and `mm` are 32
-    bit number. Where,\n                          `aa` is an AS Number, `nn` and `mm`
-    are per-AS identifier.\n                        pattern: ^(\\d+):(\\d+)$|^(\\d+):(\\d+):(\\d+)$\n
-    \                       type: string\n                    type: object\n                  type:
-    array\n                listenPort:\n                  description: ListenPort
-    is the port where BGP protocol should listen.\n                    Defaults to
-    179\n                  maximum: 65535\n                  minimum: 1\n                  type:
-    integer\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: INFO]'\n                  type: string\n                nodeToNodeMeshEnabled:\n
-    \                 description: 'NodeToNodeMeshEnabled sets whether full node to
-    node\n                  BGP mesh is enabled. [Default: true]'\n                  type:
-    boolean\n                prefixAdvertisements:\n                  description:
-    PrefixAdvertisements contains per-prefix advertisement\n                    configuration.\n
-    \                 items:\n                    description: PrefixAdvertisement
-    configures advertisement properties\n                      for the specified CIDR.\n
-    \                   properties:\n                      cidr:\n                        description:
-    CIDR for which properties should be advertised.\n                        type:
-    string\n                      communities:\n                        description:
-    Communities can be list of either community names\n                          already
-    defined in `Specs.Communities` or community value\n                          of
-    format `aa:nn` or `aa:nn:mm`. For standard community use\n                          `aa:nn`
-    format, where `aa` and `nn` are 16 bit number. For\n                          large
-    community use `aa:nn:mm` format, where `aa`, `nn` and\n                          `mm`
-    are 32 bit number. Where,`aa` is an AS Number, `nn` and\n                          `mm`
-    are per-AS identifier.\n                        items:\n                          type:
-    string\n                        type: array\n                    type: object\n
-    \                 type: array\n                serviceClusterIPs:\n                  description:
-    ServiceClusterIPs are the CIDR blocks from which service\n                    cluster
-    IPs are allocated. If specified, Calico will advertise these\n                    blocks,
-    as well as any cluster IPs within them.\n                  items:\n                    description:
-    ServiceClusterIPBlock represents a single allowed ClusterIP\n                      CIDR
-    block.\n                    properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n                serviceExternalIPs:\n
-    \                 description: ServiceExternalIPs are the CIDR blocks for Kubernetes\n
-    \                   Service External IPs. Kubernetes Service ExternalIPs will
-    only be\n                    advertised if they are within one of these blocks.\n
-    \                 items:\n                    description: ServiceExternalIPBlock
-    represents a single allowed\n                      External IP CIDR block.\n                    properties:\n
-    \                     cidr:\n                        type: string\n                    type:
-    object\n                  type: array\n                serviceLoadBalancerIPs:\n
-    \                 description: ServiceLoadBalancerIPs are the CIDR blocks for
-    Kubernetes\n                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress\n
-    \                   IPs will only be advertised if they are within one of these
-    blocks.\n                  items:\n                    description: ServiceLoadBalancerIPBlock
-    represents a single allowed\n                      LoadBalancer IP CIDR block.\n
-    \                   properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: bgppeers.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPPeer\n    listKind: BGPPeerList\n    plural: bgppeers\n
-    \   singular: bgppeer\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPPeerSpec contains the specification
-    for a BGPPeer resource.\n              properties:\n                asNumber:\n
-    \                 description: The AS Number of the peer.\n                  format:
-    int32\n                  type: integer\n                keepOriginalNextHop:\n
-    \                 description: Option to keep the original nexthop field when
-    routes\n                    are sent to a BGP Peer. Setting \"true\" configures
-    the selected BGP\n                    Peers node to use the \"next hop keep;\"
-    instead of \"next hop self;\"(default)\n                    in the specific branch
-    of the Node on \"bird.cfg\".\n                  type: boolean\n                maxRestartTime:\n
-    \                 description: Time to allow for software restart.  When specified,
-    this\n                    is configured as the graceful restart timeout.  When
-    not specified,\n                    the BIRD default of 120s is used.\n                  type:
-    string\n                node:\n                  description: The node name identifying
-    the Calico node instance that\n                    is targeted by this peer. If
-    this is not set, and no nodeSelector\n                    is specified, then this
-    BGP peer selects all nodes in the cluster.\n                  type: string\n                nodeSelector:\n
-    \                 description: Selector for the nodes that should have this peering.
-    \ When\n                    this is set, the Node field must be empty.\n                  type:
-    string\n                password:\n                  description: Optional BGP
-    password for the peerings generated by this\n                    BGPPeer resource.\n
-    \                 properties:\n                    secretKeyRef:\n                      description:
-    Selects a key of a secret in the node pod's namespace.\n                      properties:\n
-    \                       key:\n                          description: The key of
-    the secret to select from.  Must be\n                            a valid secret
-    key.\n                          type: string\n                        name:\n
-    \                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n
-    \                         TODO: Add other useful fields. apiVersion, kind, uid?'\n
-    \                         type: string\n                        optional:\n                          description:
-    Specify whether the Secret or its key must be\n                            defined\n
-    \                         type: boolean\n                      required:\n                        -
-    key\n                      type: object\n                  type: object\n                peerIP:\n
-    \                 description: The IP address of the peer followed by an optional
-    port\n                    number to peer with. If port number is given, format
-    should be `[<IPv6>]:port`\n                    or `<IPv4>:<port>` for IPv4. If
-    optional port number is not set,\n                    and this peer IP and ASNumber
-    belongs to a calico/node with ListenPort\n                    set in BGPConfiguration,
-    then we use that port to peer.\n                  type: string\n                peerSelector:\n
-    \                 description: Selector for the remote nodes to peer with.  When
-    this\n                    is set, the PeerIP and ASNumber fields must be empty.
-    \ For each\n                    peering between the local node and selected remote
-    nodes, we configure\n                    an IPv4 peering if both ends have NodeBGPSpec.IPv4Address
-    specified,\n                    and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address
-    specified.  The\n                    remote AS number comes from the remote node’s
-    NodeBGPSpec.ASNumber,\n                    or the global default if that is not
-    set.\n                  type: string\n                sourceAddress:\n                  description:
-    Specifies whether and how to configure a source address\n                    for
-    the peerings generated by this BGPPeer resource.  Default value\n                    \"UseNodeIP\"
-    means to configure the node IP as the source address.  \"None\"\n                    means
-    not to configure a source address.\n                  type: string\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: blockaffinities.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BlockAffinity\n    listKind: BlockAffinityList\n    plural:
-    blockaffinities\n    singular: blockaffinity\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BlockAffinitySpec contains the specification
-    for a BlockAffinity\n                resource.\n              properties:\n                cidr:\n
-    \                 type: string\n                deleted:\n                  description:
-    Deleted indicates that this block affinity is being deleted.\n                    This
-    field is a string for compatibility with older releases that\n                    mistakenly
-    treat this field as a string.\n                  type: string\n                node:\n
-    \                 type: string\n                state:\n                  type:
-    string\n              required:\n                - cidr\n                - deleted\n
-    \               - node\n                - state\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: clusterinformations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: ClusterInformation\n    listKind: ClusterInformationList\n
-    \   plural: clusterinformations\n    singular: clusterinformation\n  scope: Cluster\n
-    \ versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    ClusterInformation contains the cluster specific information.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: ClusterInformationSpec contains
-    the values of describing\n                the cluster.\n              properties:\n
-    \               calicoVersion:\n                  description: CalicoVersion is
-    the version of Calico that the cluster\n                    is running\n                  type:
-    string\n                clusterGUID:\n                  description: ClusterGUID
-    is the GUID of the cluster\n                  type: string\n                clusterType:\n
-    \                 description: ClusterType describes the type of the cluster\n
-    \                 type: string\n                datastoreReady:\n                  description:
-    DatastoreReady is used during significant datastore migrations\n                    to
-    signal to components such as Felix that it should wait before\n                    accessing
-    the datastore.\n                  type: boolean\n                variant:\n                  description:
-    Variant declares which variant of Calico should be active.\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: felixconfigurations.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: FelixConfiguration\n    listKind:
-    FelixConfigurationList\n    plural: felixconfigurations\n    singular: felixconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         description: Felix Configuration contains the configuration for Felix.\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: FelixConfigurationSpec contains
-    the values of the Felix configuration.\n              properties:\n                allowIPIPPacketsFromWorkloads:\n
-    \                 description: 'AllowIPIPPacketsFromWorkloads controls whether
-    Felix\n                  will add a rule to drop IPIP encapsulated traffic from
-    workloads\n                  [Default: false]'\n                  type: boolean\n
-    \               allowVXLANPacketsFromWorkloads:\n                  description:
-    'AllowVXLANPacketsFromWorkloads controls whether Felix\n                  will
-    add a rule to drop VXLAN encapsulated traffic from workloads\n                  [Default:
-    false]'\n                  type: boolean\n                awsSrcDstCheck:\n                  description:
-    'Set source-destination-check on AWS EC2 instances. Accepted\n                  value
-    must be one of \"DoNothing\", \"Enabled\" or \"Disabled\". [Default:\n                  DoNothing]'\n
-    \                 enum:\n                    - DoNothing\n                    -
-    Enable\n                    - Disable\n                  type: string\n                bpfConnectTimeLoadBalancingEnabled:\n
-    \                 description: 'BPFConnectTimeLoadBalancingEnabled when in BPF
-    mode,\n                  controls whether Felix installs the connection-time load
-    balancer.  The\n                  connect-time load balancer is required for the
-    host to be able to\n                  reach Kubernetes services and it improves
-    the performance of pod-to-service\n                  connections.  The only reason
-    to disable it is for debugging purposes.  [Default:\n                  true]'\n
-    \                 type: boolean\n                bpfDataIfacePattern:\n                  description:
-    'BPFDataIfacePattern is a regular expression that controls\n                  which
-    interfaces Felix should attach BPF programs to in order to\n                  catch
-    traffic to/from the network.  This needs to match the interfaces\n                  that
-    Calico workload traffic flows over as well as any interfaces\n                  that
-    handle incoming traffic to nodeports and services from outside\n                  the
-    cluster.  It should not match the workload interfaces (usually\n                  named
-    cali...). [Default: ^(en.*|eth.*|tunl0$)]'\n                  type: string\n                bpfDisableUnprivileged:\n
-    \                 description: 'BPFDisableUnprivileged, if enabled, Felix sets
-    the kernel.unprivileged_bpf_disabled\n                  sysctl to disable unprivileged
-    use of BPF.  This ensures that unprivileged\n                  users cannot access
-    Calico''s BPF maps and cannot insert their own\n                  BPF programs
-    to interfere with Calico''s. [Default: true]'\n                  type: boolean\n
-    \               bpfEnabled:\n                  description: 'BPFEnabled, if enabled
-    Felix will use the BPF dataplane.\n                  [Default: false]'\n                  type:
-    boolean\n                bpfExtToServiceConnmark:\n                  description:
-    'BPFExtToServiceConnmark in BPF mode, control a 32bit\n                    mark
-    that is set on connections from an external client to a local\n                    service.
-    This mark allows us to control how packets of that connection\n                    are
-    routed within the host and how is routing intepreted by RPF\n                    check.
-    [Default: 0]'\n                  type: integer\n                bpfExternalServiceMode:\n
-    \                 description: 'BPFExternalServiceMode in BPF mode, controls how
-    connections\n                  from outside the cluster to services (node ports
-    and cluster IPs)\n                  are forwarded to remote workloads.  If set
-    to \"Tunnel\" then both\n                  request and response traffic is tunneled
-    to the remote node.  If\n                  set to \"DSR\", the request traffic
-    is tunneled but the response traffic\n                  is sent directly from
-    the remote node.  In \"DSR\" mode, the remote\n                  node appears
-    to use the IP of the ingress node; this requires a\n                  permissive
-    L2 network.  [Default: Tunnel]'\n                  type: string\n                bpfKubeProxyEndpointSlicesEnabled:\n
-    \                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode,
-    controls\n                    whether Felix's embedded kube-proxy accepts EndpointSlices
-    or not.\n                  type: boolean\n                bpfKubeProxyIptablesCleanupEnabled:\n
-    \                 description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled
-    in BPF\n                  mode, Felix will proactively clean up the upstream Kubernetes
-    kube-proxy''s\n                  iptables chains.  Should only be enabled if kube-proxy
-    is not running.  [Default:\n                  true]'\n                  type:
-    boolean\n                bpfKubeProxyMinSyncPeriod:\n                  description:
-    'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the\n                  minimum
-    time between updates to the dataplane for Felix''s embedded\n                  kube-proxy.
-    \ Lower values give reduced set-up latency.  Higher values\n                  reduce
-    Felix CPU usage by batching up more work.  [Default: 1s]'\n                  type:
-    string\n                bpfLogLevel:\n                  description: 'BPFLogLevel
-    controls the log level of the BPF programs\n                  when in BPF dataplane
-    mode.  One of \"Off\", \"Info\", or \"Debug\".  The\n                  logs are
-    emitted to the BPF trace pipe, accessible with the command\n                  `tc
-    exec bpf debug`. [Default: Off].'\n                  type: string\n                chainInsertMode:\n
-    \                 description: 'ChainInsertMode controls whether Felix hooks the
-    kernel’s\n                  top-level iptables chains by inserting a rule at the
-    top of the\n                  chain or by appending a rule at the bottom. insert
-    is the safe default\n                  since it prevents Calico’s rules from being
-    bypassed. If you switch\n                  to append mode, be sure that the other
-    rules in the chains signal\n                  acceptance by falling through to
-    the Calico rules, otherwise the\n                  Calico policy will be bypassed.
-    [Default: insert]'\n                  type: string\n                dataplaneDriver:\n
-    \                 type: string\n                debugDisableLogDropping:\n                  type:
-    boolean\n                debugMemoryProfilePath:\n                  type: string\n
-    \               debugSimulateCalcGraphHangAfter:\n                  type: string\n
-    \               debugSimulateDataplaneHangAfter:\n                  type: string\n
-    \               defaultEndpointToHostAction:\n                  description: 'DefaultEndpointToHostAction
-    controls what happens to\n                  traffic that goes from a workload
-    endpoint to the host itself (after\n                  the traffic hits the endpoint
-    egress policy). By default Calico\n                  blocks traffic from workload
-    endpoints to the host itself with an\n                  iptables “DROP” action.
-    If you want to allow some or all traffic\n                  from endpoint to host,
-    set this parameter to RETURN or ACCEPT. Use\n                  RETURN if you have
-    your own rules in the iptables “INPUT” chain;\n                  Calico will insert
-    its rules at the top of that chain, then “RETURN”\n                  packets to
-    the “INPUT” chain once it has completed processing workload\n                  endpoint
-    egress policy. Use ACCEPT to unconditionally accept packets\n                  from
-    workloads after processing workload endpoint egress policy.\n                  [Default:
-    Drop]'\n                  type: string\n                deviceRouteProtocol:\n
-    \                 description: This defines the route protocol added to programmed
-    device\n                    routes, by default this will be RTPROT_BOOT when left
-    blank.\n                  type: integer\n                deviceRouteSourceAddress:\n
-    \                 description: This is the source address to use on programmed
-    device\n                    routes. By default the source address is left blank,
-    leaving the\n                    kernel to choose the source address used.\n                  type:
-    string\n                disableConntrackInvalidCheck:\n                  type:
-    boolean\n                endpointReportingDelay:\n                  type: string\n
-    \               endpointReportingEnabled:\n                  type: boolean\n                externalNodesList:\n
-    \                 description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes\n
-    \                   which may source tunnel traffic and have the tunneled traffic
-    be\n                    accepted at calico nodes.\n                  items:\n
-    \                   type: string\n                  type: array\n                failsafeInboundHostPorts:\n
-    \                 description: 'FailsafeInboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow incoming traffic to
-    host endpoints\n                    on irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    inbound host ports, use the value\n                    none. The default value
-    allows ssh access and DHCP. [Default: tcp:22,\n                    udp:68, tcp:179,
-    tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'\n                  items:\n
-    \                   description: ProtoPort is combination of protocol, port, and
-    CIDR.\n                      Protocol and port must be specified.\n                    properties:\n
-    \                     net:\n                        type: string\n                      port:\n
-    \                       type: integer\n                      protocol:\n                        type:
-    string\n                    required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                failsafeOutboundHostPorts:\n
-    \                 description: 'FailsafeOutboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow outgoing traffic from
-    host endpoints\n                    to irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    outbound host ports, use the value\n                    none. The default value
-    opens etcd''s standard ports to ensure that\n                    Felix does not
-    get cut off from etcd as well as allowing DHCP and\n                    DNS. [Default:
-    tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,\n                    tcp:6667,
-    udp:53, udp:67]'\n                  items:\n                    description: ProtoPort
-    is combination of protocol, port, and CIDR.\n                      Protocol and
-    port must be specified.\n                    properties:\n                      net:\n
-    \                       type: string\n                      port:\n                        type:
-    integer\n                      protocol:\n                        type: string\n
-    \                   required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                featureDetectOverride:\n
-    \                 description: FeatureDetectOverride is used to override the feature\n
-    \                   detection. Values are specified in a comma separated list
-    with no\n                    spaces, example; \"SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=\".\n
-    \                   \"true\" or \"false\" will force the feature, empty or omitted
-    values\n                    are auto-detected.\n                  type: string\n
-    \               genericXDPEnabled:\n                  description: 'GenericXDPEnabled
-    enables Generic XDP so network cards\n                  that don''t support XDP
-    offload or driver modes can use XDP. This\n                  is not recommended
-    since it doesn''t provide better performance\n                  than iptables.
-    [Default: false]'\n                  type: boolean\n                healthEnabled:\n
-    \                 type: boolean\n                healthHost:\n                  type:
-    string\n                healthPort:\n                  type: integer\n                interfaceExclude:\n
-    \                 description: 'InterfaceExclude is a comma-separated list of
-    interfaces\n                  that Felix should exclude when monitoring for host
-    endpoints. The\n                  default value ensures that Felix ignores Kubernetes''
-    IPVS dummy\n                  interface, which is used internally by kube-proxy.
-    If you want to\n                  exclude multiple interface names using a single
-    value, the list\n                  supports regular expressions. For regular expressions
-    you must wrap\n                  the value with ''/''. For example having values
-    ''/^kube/,veth1''\n                  will exclude all interfaces that begin with
-    ''kube'' and also the\n                  interface ''veth1''. [Default: kube-ipvs0]'\n
-    \                 type: string\n                interfacePrefix:\n                  description:
-    'InterfacePrefix is the interface name prefix that identifies\n                  workload
-    endpoints and so distinguishes them from host endpoint\n                  interfaces.
-    Note: in environments other than bare metal, the orchestrators\n                  configure
-    this appropriately. For example our Kubernetes and Docker\n                  integrations
-    set the ‘cali’ value, and our OpenStack integration\n                  sets the
-    ‘tap’ value. [Default: cali]'\n                  type: string\n                interfaceRefreshInterval:\n
-    \                 description: InterfaceRefreshInterval is the period at which
-    Felix\n                    rescans local interfaces to verify their state. The
-    rescan can be\n                    disabled by setting the interval to 0.\n                  type:
-    string\n                ipipEnabled:\n                  type: boolean\n                ipipMTU:\n
-    \                 description: 'IPIPMTU is the MTU to set on the tunnel device.
-    See\n                  Configuring MTU [Default: 1440]'\n                  type:
-    integer\n                ipsetsRefreshInterval:\n                  description:
-    'IpsetsRefreshInterval is the period at which Felix re-checks\n                  all
-    iptables state to ensure that no other process has accidentally\n                  broken
-    Calico’s rules. Set to 0 to disable iptables refresh. [Default:\n                  90s]'\n
-    \                 type: string\n                iptablesBackend:\n                  description:
-    IptablesBackend specifies which backend of iptables will\n                    be
-    used. The default is legacy.\n                  type: string\n                iptablesFilterAllowAction:\n
-    \                 type: string\n                iptablesLockFilePath:\n                  description:
-    'IptablesLockFilePath is the location of the iptables\n                  lock
-    file. You may need to change this if the lock file is not in\n                  its
-    standard location (for example if you have mapped it into Felix’s\n                  container
-    at a different path). [Default: /run/xtables.lock]'\n                  type: string\n
-    \               iptablesLockProbeInterval:\n                  description: 'IptablesLockProbeInterval
-    is the time that Felix will\n                  wait between attempts to acquire
-    the iptables lock if it is not\n                  available. Lower values make
-    Felix more responsive when the lock\n                  is contended, but use more
-    CPU. [Default: 50ms]'\n                  type: string\n                iptablesLockTimeout:\n
-    \                 description: 'IptablesLockTimeout is the time that Felix will
-    wait\n                  for the iptables lock, or 0, to disable. To use this feature,
-    Felix\n                  must share the iptables lock file with all other processes
-    that\n                  also take the lock. When running Felix inside a container,
-    this\n                  requires the /run directory of the host to be mounted
-    into the calico/node\n                  or calico/felix container. [Default: 0s
-    disabled]'\n                  type: string\n                iptablesMangleAllowAction:\n
-    \                 type: string\n                iptablesMarkMask:\n                  description:
-    'IptablesMarkMask is the mask that Felix selects its\n                  IPTables
-    Mark bits from. Should be a 32 bit hexadecimal number with\n                  at
-    least 8 bits set, none of which clash with any other mark bits\n                  in
-    use on the system. [Default: 0xff000000]'\n                  format: int32\n                  type:
-    integer\n                iptablesNATOutgoingInterfaceFilter:\n                  type:
-    string\n                iptablesPostWriteCheckInterval:\n                  description:
-    'IptablesPostWriteCheckInterval is the period after Felix\n                  has
-    done a write to the dataplane that it schedules an extra read\n                  back
-    in order to check the write was not clobbered by another process.\n                  This
-    should only occur if another application on the system doesn’t\n                  respect
-    the iptables lock. [Default: 1s]'\n                  type: string\n                iptablesRefreshInterval:\n
-    \                 description: 'IptablesRefreshInterval is the period at which
-    Felix\n                    re-checks the IP sets in the dataplane to ensure that
-    no other process\n                    has accidentally broken Calico''s rules.
-    Set to 0 to disable IP\n                    sets refresh. Note: the default for
-    this value is lower than the\n                    other refresh intervals as a
-    workaround for a Linux kernel bug that\n                    was fixed in kernel
-    version 4.11. If you are using v4.11 or greater\n                    you may want
-    to set this to, a higher value to reduce Felix CPU\n                    usage.
-    [Default: 10s]'\n                  type: string\n                ipv6Support:\n
-    \                 type: boolean\n                kubeNodePortRanges:\n                  description:
-    'KubeNodePortRanges holds list of port ranges used for\n                  service
-    node ports. Only used if felix detects kube-proxy running\n                  in
-    ipvs mode. Felix uses these ranges to separate host and workload\n                  traffic.
-    [Default: 30000:32767].'\n                  items:\n                    anyOf:\n
-    \                     - type: integer\n                      - type: string\n
-    \                   pattern: ^.*\n                    x-kubernetes-int-or-string:
-    true\n                  type: array\n                logFilePath:\n                  description:
-    'LogFilePath is the full path to the Felix log. Set to\n                  none
-    to disable file logging. [Default: /var/log/calico/felix.log]'\n                  type:
-    string\n                logPrefix:\n                  description: 'LogPrefix
-    is the log prefix that Felix uses when rendering\n                  LOG rules.
-    [Default: calico-packet]'\n                  type: string\n                logSeverityFile:\n
-    \                 description: 'LogSeverityFile is the log severity above which
-    logs\n                  are sent to the log file. [Default: Info]'\n                  type:
-    string\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: Info]'\n                  type: string\n                logSeveritySys:\n
-    \                 description: 'LogSeveritySys is the log severity above which
-    logs\n                  are sent to the syslog. Set to None for no logging to
-    syslog. [Default:\n                  Info]'\n                  type: string\n
-    \               maxIpsetSize:\n                  type: integer\n                metadataAddr:\n
-    \                 description: 'MetadataAddr is the IP address or domain name
-    of the\n                  server that can answer VM queries for cloud-init metadata.
-    In OpenStack,\n                  this corresponds to the machine running nova-api
-    (or in Ubuntu,\n                  nova-api-metadata). A value of none (case insensitive)
-    means that\n                  Felix should not set up any NAT rule for the metadata
-    path. [Default:\n                  127.0.0.1]'\n                  type: string\n
-    \               metadataPort:\n                  description: 'MetadataPort is
-    the port of the metadata server. This,\n                  combined with global.MetadataAddr
-    (if not ‘None’), is used to set\n                  up a NAT rule, from 169.254.169.254:80
-    to MetadataAddr:MetadataPort.\n                  In most cases this should not
-    need to be changed [Default: 8775].'\n                  type: integer\n                mtuIfacePattern:\n
-    \                 description: MTUIfacePattern is a regular expression that controls\n
-    \                   which interfaces Felix should scan in order to calculate the
-    host's\n                    MTU. This should not match workload interfaces (usually
-    named cali...).\n                  type: string\n                natOutgoingAddress:\n
-    \                 description: NATOutgoingAddress specifies an address to use
-    when performing\n                    source NAT for traffic in a natOutgoing pool
-    that is leaving the\n                    network. By default the address used
-    is an address on the interface\n                    the traffic is leaving on
-    (ie it uses the iptables MASQUERADE target)\n                  type: string\n
-    \               natPortRange:\n                  anyOf:\n                    -
-    type: integer\n                    - type: string\n                  description:
-    NATPortRange specifies the range of ports that is used\n                    for
-    port mapping when doing outgoing NAT. When unset the default\n                    behavior
-    of the network stack is used.\n                  pattern: ^.*\n                  x-kubernetes-int-or-string:
-    true\n                netlinkTimeout:\n                  type: string\n                openstackRegion:\n
-    \                 description: 'OpenstackRegion is the name of the region that
-    a particular\n                  Felix belongs to. In a multi-region Calico/OpenStack
-    deployment,\n                  this must be configured somehow for each Felix
-    (here in the datamodel,\n                  or in felix.cfg or the environment
-    on each compute node), and must\n                  match the [calico] openstack_region
-    value configured in neutron.conf\n                  on each node. [Default: Empty]'\n
-    \                 type: string\n                policySyncPathPrefix:\n                  description:
-    'PolicySyncPathPrefix is used to by Felix to communicate\n                  policy
-    changes to external services, like Application layer policy.\n                  [Default:
-    Empty]'\n                  type: string\n                prometheusGoMetricsEnabled:\n
-    \                 description: 'PrometheusGoMetricsEnabled disables Go runtime
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                prometheusMetricsEnabled:\n                  description:
-    'PrometheusMetricsEnabled enables the Prometheus metrics\n                  server
-    in Felix if set to true. [Default: false]'\n                  type: boolean\n
-    \               prometheusMetricsHost:\n                  description: 'PrometheusMetricsHost
-    is the host that the Prometheus\n                  metrics server should bind
-    to. [Default: empty]'\n                  type: string\n                prometheusMetricsPort:\n
-    \                 description: 'PrometheusMetricsPort is the TCP port that the
-    Prometheus\n                  metrics server should bind to. [Default: 9091]'\n
-    \                 type: integer\n                prometheusProcessMetricsEnabled:\n
-    \                 description: 'PrometheusProcessMetricsEnabled disables process
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                removeExternalRoutes:\n                  description:
-    Whether or not to remove device routes that have not\n                    been
-    programmed by Felix. Disabling this will allow external applications\n                    to
-    also add device routes. This is enabled by default which means\n                    we
-    will remove externally added routes.\n                  type: boolean\n                reportingInterval:\n
-    \                 description: 'ReportingInterval is the interval at which Felix
-    reports\n                  its status into the datastore or 0 to disable. Must
-    be non-zero\n                  in OpenStack deployments. [Default: 30s]'\n                  type:
-    string\n                reportingTTL:\n                  description: 'ReportingTTL
-    is the time-to-live setting for process-wide\n                  status reports.
-    [Default: 90s]'\n                  type: string\n                routeRefreshInterval:\n
-    \                 description: 'RouterefreshInterval is the period at which Felix
-    re-checks\n                  the routes in the dataplane to ensure that no other
-    process has\n                  accidentally broken Calico’s rules. Set to 0 to
-    disable route refresh.\n                  [Default: 90s]'\n                  type:
-    string\n                routeSource:\n                  description: 'RouteSource
-    configures where Felix gets its routing\n                  information. - WorkloadIPs:
-    use workload endpoints to construct\n                  routes. - CalicoIPAM: the
-    default - use IPAM data to construct routes.'\n                  type: string\n
-    \               routeTableRange:\n                  description: Calico programs
-    additional Linux route tables for various\n                    purposes.  RouteTableRange
-    specifies the indices of the route tables\n                    that Calico should
-    use.\n                  properties:\n                    max:\n                      type:
-    integer\n                    min:\n                      type: integer\n                  required:\n
-    \                   - max\n                    - min\n                  type:
-    object\n                serviceLoopPrevention:\n                  description:
-    'When service IP advertisement is enabled, prevent routing\n                    loops
-    to service IPs that are not in use, by dropping or rejecting\n                    packets
-    that do not get DNAT''d by kube-proxy. Unless set to \"Disabled\",\n                    in
-    which case such routing loops continue to be allowed. [Default:\n                    Drop]'\n
-    \                 type: string\n                sidecarAccelerationEnabled:\n
-    \                 description: 'SidecarAccelerationEnabled enables experimental
-    sidecar\n                  acceleration [Default: false]'\n                  type:
-    boolean\n                usageReportingEnabled:\n                  description:
-    'UsageReportingEnabled reports anonymous Calico version\n                  number
-    and cluster size to projectcalico.org. Logs warnings returned\n                  by
-    the usage server. For example, if a significant security vulnerability\n                  has
-    been discovered in the version of Calico being used. [Default:\n                  true]'\n
-    \                 type: boolean\n                usageReportingInitialDelay:\n
-    \                 description: 'UsageReportingInitialDelay controls the minimum
-    delay\n                  before Felix makes a report. [Default: 300s]'\n                  type:
-    string\n                usageReportingInterval:\n                  description:
-    'UsageReportingInterval controls the interval at which\n                  Felix
-    makes reports. [Default: 86400s]'\n                  type: string\n                useInternalDataplaneDriver:\n
-    \                 type: boolean\n                vxlanEnabled:\n                  type:
-    boolean\n                vxlanMTU:\n                  description: 'VXLANMTU is
-    the MTU to set on the tunnel device. See\n                  Configuring MTU [Default:
-    1440]'\n                  type: integer\n                vxlanPort:\n                  type:
-    integer\n                vxlanVNI:\n                  type: integer\n                wireguardEnabled:\n
-    \                 description: 'WireguardEnabled controls whether Wireguard is
-    enabled.\n                  [Default: false]'\n                  type: boolean\n
-    \               wireguardInterfaceName:\n                  description: 'WireguardInterfaceName
-    specifies the name to use for\n                  the Wireguard interface. [Default:
-    wg.calico]'\n                  type: string\n                wireguardListeningPort:\n
-    \                 description: 'WireguardListeningPort controls the listening
-    port used\n                  by Wireguard. [Default: 51820]'\n                  type:
-    integer\n                wireguardMTU:\n                  description: 'WireguardMTU
-    controls the MTU on the Wireguard interface.\n                  See Configuring
-    MTU [Default: 1420]'\n                  type: integer\n                wireguardRoutingRulePriority:\n
-    \                 description: 'WireguardRoutingRulePriority controls the priority
-    value\n                  to use for the Wireguard routing rule. [Default: 99]'\n
-    \                 type: integer\n                xdpEnabled:\n                  description:
-    'XDPEnabled enables XDP acceleration for suitable untracked\n                  incoming
-    deny rules. [Default: true]'\n                  type: boolean\n                xdpRefreshInterval:\n
-    \                 description: 'XDPRefreshInterval is the period at which Felix
-    re-checks\n                  all XDP state to ensure that no other process has
-    accidentally broken\n                  Calico''s BPF maps or attached programs.
-    Set to 0 to disable XDP\n                  refresh. [Default: 90s]'\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: globalnetworkpolicies.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: GlobalNetworkPolicy\n    listKind:
-    GlobalNetworkPolicyList\n    plural: globalnetworkpolicies\n    singular: globalnetworkpolicy\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                applyOnForward:\n
-    \                 description: ApplyOnForward indicates to apply the rules in
-    this policy\n                    on forward traffic.\n                  type:
-    boolean\n                doNotTrack:\n                  description: DoNotTrack
-    indicates whether packets matched by the rules\n                    in this policy
-    should go through the data plane's connection tracking,\n                    such
-    as Linux conntrack.  If True, the rules in this policy are\n                    applied
-    before any data plane connection tracking, and packets allowed\n                    by
-    this policy are marked as not to be tracked.\n                  type: boolean\n
-    \               egress:\n                  description: The ordered set of egress
-    rules.  Each rule contains\n                    a set of packet match criteria
-    and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                namespaceSelector:\n                  description: NamespaceSelector
-    is an optional field for an expression\n                    used to select a pod
-    based on namespaces.\n                  type: string\n                order:\n
-    \                 description: Order is an optional field that specifies the order
-    in\n                    which the policy is applied. Policies with higher \"order\"
-    are applied\n                    after those with lower order.  If the order is
-    omitted, it may be\n                    considered to be \"infinite\" - i.e. the
-    policy will be applied last.  Policies\n                    with identical order
-    will be applied in alphanumerical order based\n                    on the Policy
-    \"Name\".\n                  type: number\n                preDNAT:\n                  description:
-    PreDNAT indicates to apply the rules in this policy before\n                    any
-    DNAT.\n                  type: boolean\n                selector:\n                  description:
-    \"The selector is an expression used to pick pick out\n                  the endpoints
-    that the policy should be applied to. \\n Selector\n                  expressions
-    follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n                  \\
-    ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel != \\\"string_literal\\\"\n
-    \                 \\  ->  not equal; also matches if label is not present \\tlabel
-    in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\", ... }  ->  true if the
-    value of label X is\n                  one of \\\"a\\\", \\\"b\\\", \\\"c\\\"
-    \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ... }  ->
-    \ true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress rules are present
-    in the policy.  The\n                  default is: \\n - [ PolicyTypeIngress ],
-    if there are no Egress rules\n                  (including the case where there
-    are   also no Ingress rules) \\n\n                  - [ PolicyTypeEgress ], if
-    there are Egress rules but no Ingress\n                  rules \\n - [ PolicyTypeIngress,
-    PolicyTypeEgress ], if there are\n                  both Ingress and Egress rules.
-    \\n When the policy is read back again,\n                  Types will always be
-    one of these values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: globalnetworksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: GlobalNetworkSet\n    listKind: GlobalNetworkSetList\n    plural:
-    globalnetworksets\n    singular: globalnetworkset\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs\n            that
-    share labels to allow rules to refer to them via selectors.  The labels\n            of
-    GlobalNetworkSet are not namespaced.\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: GlobalNetworkSetSpec contains the
-    specification for a NetworkSet\n                resource.\n              properties:\n
-    \               nets:\n                  description: The list of IP networks
-    that belong to this set.\n                  items:\n                    type:
-    string\n                  type: array\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: hostendpoints.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: HostEndpoint\n    listKind: HostEndpointList\n    plural:
-    hostendpoints\n    singular: hostendpoint\n  scope: Cluster\n  versions:\n    -
-    name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: HostEndpointSpec contains the specification
-    for a HostEndpoint\n                resource.\n              properties:\n                expectedIPs:\n
-    \                 description: \"The expected IP addresses (IPv4 and IPv6) of
-    the endpoint.\n                  If \\\"InterfaceName\\\" is not present, Calico
-    will look for an interface\n                  matching any of the IPs in the list
-    and apply policy to that. Note:\n                  \\tWhen using the selector
-    match criteria in an ingress or egress\n                  security Policy \\tor
-    Profile, Calico converts the selector into\n                  a set of IP addresses.
-    For host \\tendpoints, the ExpectedIPs field\n                  is used for that
-    purpose. (If only the interface \\tname is specified,\n                  Calico
-    does not learn the IPs of the interface for use in match\n                  \\tcriteria.)\"\n
-    \                 items:\n                    type: string\n                  type:
-    array\n                interfaceName:\n                  description: \"Either
-    \\\"*\\\", or the name of a specific Linux interface\n                  to apply
-    policy to; or empty.  \\\"*\\\" indicates that this HostEndpoint\n                  governs
-    all traffic to, from or through the default network namespace\n                  of
-    the host named by the \\\"Node\\\" field; entering and leaving that\n                  namespace
-    via any interface, including those from/to non-host-networked\n                  local
-    workloads. \\n If InterfaceName is not \\\"*\\\", this HostEndpoint\n                  only
-    governs traffic that enters or leaves the host through the\n                  specific
-    interface named by InterfaceName, or - when InterfaceName\n                  is
-    empty - through the specific interface that has one of the IPs\n                  in
-    ExpectedIPs. Therefore, when InterfaceName is empty, at least\n                  one
-    expected IP must be specified.  Only external interfaces (such\n                  as
-    “eth0”) are supported here; it isn't possible for a HostEndpoint\n                  to
-    protect traffic through a specific local workload interface.\n                  \\n
-    Note: Only some kinds of policy are implemented for \\\"*\\\" HostEndpoints;\n
-    \                 initially just pre-DNAT policy.  Please check Calico documentation\n
-    \                 for the latest position.\"\n                  type: string\n
-    \               node:\n                  description: The node name identifying
-    the Calico node instance.\n                  type: string\n                ports:\n
-    \                 description: Ports contains the endpoint's named ports, which
-    may\n                    be referenced in security policy rules.\n                  items:\n
-    \                   properties:\n                      name:\n                        type:
-    string\n                      port:\n                        type: integer\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                    required:\n                      - name\n                      -
-    port\n                      - protocol\n                    type: object\n                  type:
-    array\n                profiles:\n                  description: A list of identifiers
-    of security Profile objects that\n                    apply to this endpoint.
-    Each profile is applied in the order that\n                    they appear in
-    this list.  Profile rules are applied after the selector-based\n                    security
-    policy.\n                  items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: ipamblocks.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMBlock\n    listKind: IPAMBlockList\n
-    \   plural: ipamblocks\n    singular: ipamblock\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMBlockSpec contains the specification
-    for an IPAMBlock\n                resource.\n              properties:\n                affinity:\n
-    \                 type: string\n                allocations:\n                  items:\n
-    \                   type: integer\n                    # TODO: This nullable is
-    manually added in. We should update controller-gen\n                    # to handle
-    []*int properly itself.\n                    nullable: true\n                  type:
-    array\n                attributes:\n                  items:\n                    properties:\n
-    \                     handle_id:\n                        type: string\n                      secondary:\n
-    \                       additionalProperties:\n                          type:
-    string\n                        type: object\n                    type: object\n
-    \                 type: array\n                cidr:\n                  type:
-    string\n                deleted:\n                  type: boolean\n                strictAffinity:\n
-    \                 type: boolean\n                unallocated:\n                  items:\n
-    \                   type: integer\n                  type: array\n              required:\n
-    \               - allocations\n                - attributes\n                -
-    cidr\n                - strictAffinity\n                - unallocated\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMConfig\n    listKind: IPAMConfigList\n    plural: ipamconfigs\n
-    \   singular: ipamconfig\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMConfigSpec contains the specification
-    for an IPAMConfig\n                resource.\n              properties:\n                autoAllocateBlocks:\n
-    \                 type: boolean\n                maxBlocksPerHost:\n                  description:
-    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                    that
-    can be affine to each host.\n                  type: integer\n                strictAffinity:\n
-    \                 type: boolean\n              required:\n                - autoAllocateBlocks\n
-    \               - strictAffinity\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ipamhandles.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMHandle\n    listKind: IPAMHandleList\n    plural: ipamhandles\n
-    \   singular: ipamhandle\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMHandleSpec contains the specification
-    for an IPAMHandle\n                resource.\n              properties:\n                block:\n
-    \                 additionalProperties:\n                    type: integer\n                  type:
-    object\n                deleted:\n                  type: boolean\n                handleID:\n
-    \                 type: string\n              required:\n                - block\n
-    \               - handleID\n              type: object\n          type: object\n
-    \     served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ippools.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPPool\n    listKind: IPPoolList\n    plural: ippools\n    singular:
-    ippool\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPPoolSpec contains the specification
-    for an IPPool resource.\n              properties:\n                blockSize:\n
-    \                 description: The block size to use for IP address assignments
-    from\n                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.\n
-    \                 type: integer\n                cidr:\n                  description:
-    The pool CIDR.\n                  type: string\n                disabled:\n                  description:
-    When disabled is true, Calico IPAM will not assign addresses\n                    from
-    this pool.\n                  type: boolean\n                ipip:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  properties:\n                    enabled:\n                      description:
-    When enabled is true, ipip tunneling will be used\n                        to
-    deliver packets to destinations within this pool.\n                      type:
-    boolean\n                    mode:\n                      description: The IPIP
-    mode.  This can be one of \"always\" or \"cross-subnet\".  A\n                        mode
-    of \"always\" will also use IPIP tunneling for routing to\n                        destination
-    IP addresses within this pool.  A mode of \"cross-subnet\"\n                        will
-    only use IPIP tunneling when the destination node is on\n                        a
-    different subnet to the originating node.  The default value\n                        (if
-    not specified) is \"always\".\n                      type: string\n                  type:
-    object\n                ipipMode:\n                  description: Contains configuration
-    for IPIP tunneling for this pool.\n                    If not specified, then
-    this is defaulted to \"Never\" (i.e. IPIP tunneling\n                    is disabled).\n
-    \                 type: string\n                nat-outgoing:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  type: boolean\n                natOutgoing:\n                  description:
-    When nat-outgoing is true, packets sent from Calico networked\n                    containers
-    in this pool to destinations outside of this pool will\n                    be
-    masqueraded.\n                  type: boolean\n                nodeSelector:\n
-    \                 description: Allows IPPool to allocate for a specific node by
-    label\n                    selector.\n                  type: string\n                vxlanMode:\n
-    \                 description: Contains configuration for VXLAN tunneling for
-    this pool.\n                    If not specified, then this is defaulted to \"Never\"
-    (i.e. VXLAN\n                    tunneling is disabled).\n                  type:
-    string\n              required:\n                - cidr\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: kubecontrollersconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: KubeControllersConfiguration\n    listKind: KubeControllersConfigurationList\n
-    \   plural: kubecontrollersconfigurations\n    singular: kubecontrollersconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: KubeControllersConfigurationSpec
-    contains the values of the\n                Kubernetes controllers configuration.\n
-    \             properties:\n                controllers:\n                  description:
-    Controllers enables and configures individual Kubernetes\n                    controllers\n
-    \                 properties:\n                    namespace:\n                      description:
-    Namespace enables and configures the namespace controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   node:\n                      description: Node enables and
-    configures the node controller.\n                        Enabled by default, set
-    to nil to disable.\n                      properties:\n                        hostEndpoint:\n
-    \                         description: HostEndpoint controls syncing nodes to
-    host endpoints.\n                            Disabled by default, set to nil to
-    disable.\n                          properties:\n                            autoCreate:\n
-    \                             description: 'AutoCreate enables automatic creation
-    of\n                              host endpoints for every node. [Default: Disabled]'\n
-    \                             type: string\n                          type: object\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                       syncLabels:\n                          description: 'SyncLabels
-    controls whether to copy Kubernetes\n                          node labels to
-    Calico nodes. [Default: Enabled]'\n                          type: string\n                      type:
-    object\n                    policy:\n                      description: Policy
-    enables and configures the policy controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   serviceAccount:\n                      description: ServiceAccount
-    enables and configures the service\n                        account controller.
-    Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                    workloadEndpoint:\n                      description:
-    WorkloadEndpoint enables and configures the workload\n                        endpoint
-    controller. Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                  type: object\n                etcdV3CompactionPeriod:\n
-    \                 description: 'EtcdV3CompactionPeriod is the period between etcdv3\n
-    \                 compaction requests. Set to 0 to disable. [Default: 10m]'\n
-    \                 type: string\n                healthChecks:\n                  description:
-    'HealthChecks enables or disables support for health\n                  checks
-    [Default: Enabled]'\n                  type: string\n                logSeverityScreen:\n
-    \                 description: 'LogSeverityScreen is the log severity above which
-    logs\n                  are sent to the stdout. [Default: Info]'\n                  type:
-    string\n                prometheusMetricsPort:\n                  description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                    metrics
-    server should bind to. Set to 0 to disable. [Default: 9094]'\n                  type:
-    integer\n              required:\n                - controllers\n              type:
-    object\n            status:\n              description: KubeControllersConfigurationStatus
-    represents the status\n                of the configuration. It's useful for admins
-    to be able to see the actual\n                config that was applied, which can
-    be modified by environment variables\n                on the kube-controllers
-    process.\n              properties:\n                environmentVars:\n                  additionalProperties:\n
-    \                   type: string\n                  description: EnvironmentVars
-    contains the environment variables on\n                    the kube-controllers
-    that influenced the RunningConfig.\n                  type: object\n                runningConfig:\n
-    \                 description: RunningConfig contains the effective config that
-    is running\n                    in the kube-controllers pod, after merging the
-    API resource with\n                    any environment variables.\n                  properties:\n
-    \                   controllers:\n                      description: Controllers
-    enables and configures individual Kubernetes\n                        controllers\n
-    \                     properties:\n                        namespace:\n                          description:
-    Namespace enables and configures the namespace\n                            controller.
-    Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        node:\n
-    \                         description: Node enables and configures the node controller.\n
-    \                           Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           hostEndpoint:\n                              description:
-    HostEndpoint controls syncing nodes to host\n                                endpoints.
-    Disabled by default, set to nil to disable.\n                              properties:\n
-    \                               autoCreate:\n                                  description:
-    'AutoCreate enables automatic creation\n                                  of host
-    endpoints for every node. [Default: Disabled]'\n                                  type:
-    string\n                              type: object\n                            leakGracePeriod:\n
-    \                             description: 'LeakGracePeriod is the period used
-    by the\n                                controller to determine if an IP address
-    has been leaked.\n                                Set to 0 to disable IP garbage
-    collection. [Default:\n                                15m]'\n                              type:
-    string\n                            reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                            syncLabels:\n                              description:
-    'SyncLabels controls whether to copy Kubernetes\n                              node
-    labels to Calico nodes. [Default: Enabled]'\n                              type:
-    string\n                          type: object\n                        policy:\n
-    \                         description: Policy enables and configures the policy
-    controller.\n                            Enabled by default, set to nil to disable.\n
-    \                         properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        serviceAccount:\n
-    \                         description: ServiceAccount enables and configures the
-    service\n                            account controller. Enabled by default, set
-    to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        workloadEndpoint:\n
-    \                         description: WorkloadEndpoint enables and configures
-    the workload\n                            endpoint controller. Enabled by default,
-    set to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                      type: object\n
-    \                   etcdV3CompactionPeriod:\n                      description:
-    'EtcdV3CompactionPeriod is the period between etcdv3\n                      compaction
-    requests. Set to 0 to disable. [Default: 10m]'\n                      type: string\n
-    \                   healthChecks:\n                      description: 'HealthChecks
-    enables or disables support for health\n                      checks [Default:
-    Enabled]'\n                      type: string\n                    logSeverityScreen:\n
-    \                     description: 'LogSeverityScreen is the log severity above
-    which\n                      logs are sent to the stdout. [Default: Info]'\n                      type:
-    string\n                    prometheusMetricsPort:\n                      description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                        metrics
-    server should bind to. Set to 0 to disable. [Default:\n                        9094]'\n
-    \                     type: integer\n                  required:\n                    -
-    controllers\n                  type: object\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: networkpolicies.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkPolicy\n    listKind: NetworkPolicyList\n    plural:
-    networkpolicies\n    singular: networkpolicy\n  scope: Namespaced\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                egress:\n                  description:
-    The ordered set of egress rules.  Each rule contains\n                    a set
-    of packet match criteria and a corresponding action to apply.\n                  items:\n
-    \                   description: \"A Rule encapsulates a set of match criteria
-    and an\n                    action.  Both selector-based security Policy and security
-    Profiles\n                    reference rules - separated out as a list of rules
-    for both ingress\n                    and egress packet matching. \\n Each positive
-    match criteria has\n                    a negated version, prefixed with ”Not”.
-    All the match criteria\n                    within a rule must be satisfied for
-    a packet to match. A single\n                    rule can contain the positive
-    and negative version of a match\n                    and both must be satisfied
-    for the rule to match.\"\n                    properties:\n                      action:\n
-    \                       type: string\n                      destination:\n                        description:
-    Destination contains the match criteria that apply\n                          to
-    destination entity.\n                        properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                order:\n                  description: Order is an optional
-    field that specifies the order in\n                    which the policy is applied.
-    Policies with higher \"order\" are applied\n                    after those with
-    lower order.  If the order is omitted, it may be\n                    considered
-    to be \"infinite\" - i.e. the policy will be applied last.  Policies\n                    with
-    identical order will be applied in alphanumerical order based\n                    on
-    the Policy \"Name\".\n                  type: number\n                selector:\n
-    \                 description: \"The selector is an expression used to pick pick
-    out\n                  the endpoints that the policy should be applied to. \\n
-    Selector\n                  expressions follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n
-    \                 \\ ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel
-    != \\\"string_literal\\\"\n                  \\  ->  not equal; also matches if
-    label is not present \\tlabel in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\",
-    ... }  ->  true if the value of label X is\n                  one of \\\"a\\\",
-    \\\"b\\\", \\\"c\\\" \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ...
-    }  ->  true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress are present in the
-    policy.  The default\n                  is: \\n - [ PolicyTypeIngress ], if there
-    are no Egress rules (including\n                  the case where there are   also
-    no Ingress rules) \\n - [ PolicyTypeEgress\n                  ], if there are
-    Egress rules but no Ingress rules \\n - [ PolicyTypeIngress,\n                  PolicyTypeEgress
-    ], if there are both Ingress and Egress rules.\n                  \\n When the
-    policy is read back again, Types will always be one\n                  of these
-    values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: networksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkSet\n    listKind: NetworkSetList\n    plural: networksets\n
-    \   singular: networkset\n  scope: Namespaced\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          description: NetworkSet is the Namespaced-equivalent
-    of the GlobalNetworkSet.\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: NetworkSetSpec contains the specification
-    for a NetworkSet\n                resource.\n              properties:\n                nets:\n
-    \                 description: The list of IP networks that belong to this set.\n
-    \                 items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n---\n# Source: calico/templates/calico-kube-controllers-rbac.yaml\n\n#
-    Include a clusterrole for the kube-controllers component,\n# and bind it to the
-    calico-kube-controllers serviceaccount.\nkind: ClusterRole\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nrules:\n  # Nodes are watched to monitor for
-    deletions.\n  - apiGroups: [\"\"]\n    resources:\n      - nodes\n    verbs:\n
-    \     - watch\n      - list\n      - get\n  # Pods are watched to check for existence
-    as part of IPAM controller.\n  - apiGroups: [\"\"]\n    resources:\n      - pods\n
-    \   verbs:\n      - get\n      - list\n      - watch\n  # IPAM resources are manipulated
-    when nodes are deleted.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - ippools\n    verbs:\n      - list\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - blockaffinities\n      - ipamblocks\n      - ipamhandles\n
-    \   verbs:\n      - get\n      - list\n      - create\n      - update\n      -
-    delete\n      - watch\n  # kube-controllers manages hostendpoints.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - hostendpoints\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  #
-    Needs access to update clusterinformations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - clusterinformations\n    verbs:\n      - get\n      -
-    create\n      - update\n  # KubeControllersConfiguration is where it gets its
-    config\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - kubecontrollersconfigurations\n
-    \   verbs:\n      # read its own config\n      - get\n      # create a default
-    if none exists\n      - create\n      # update status\n      - update\n      #
-    watch for changes\n      - watch\n---\nkind: ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-kube-controllers\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-kube-controllers\n    namespace: kube-system\n---\n\n---\n# Source:
-    calico/templates/calico-node-rbac.yaml\n# Include a clusterrole for the calico-node
-    DaemonSet,\n# and bind it to the calico-node serviceaccount.\nkind: ClusterRole\napiVersion:
-    rbac.authorization.k8s.io/v1\nmetadata:\n  name: calico-node\nrules:\n  # The
-    CNI plugin needs to get pods, nodes, and namespaces.\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - pods\n      - nodes\n      - namespaces\n    verbs:\n
-    \     - get\n  # EndpointSlices are used for Service-based network policy rule\n
-    \ # enforcement.\n  - apiGroups: [\"discovery.k8s.io\"]\n    resources:\n      -
-    endpointslices\n    verbs:\n      - watch\n      - list\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - endpoints\n      - services\n    verbs:\n      # Used
-    to discover service IPs for advertisement.\n      - watch\n      - list\n      #
-    Used to discover Typhas.\n      - get\n  # Pod CIDR auto-detection on kubeadm
-    needs access to config maps.\n  - apiGroups: [\"\"]\n    resources:\n      - configmaps\n
-    \   verbs:\n      - get\n  - apiGroups: [\"\"]\n    resources:\n      - nodes/status\n
-    \   verbs:\n      # Needed for clearing NodeNetworkUnavailable flag.\n      -
-    patch\n      # Calico stores some configuration information in node annotations.\n
-    \     - update\n  # Watch for changes to Kubernetes NetworkPolicies.\n  - apiGroups:
-    [\"networking.k8s.io\"]\n    resources:\n      - networkpolicies\n    verbs:\n
-    \     - watch\n      - list\n  # Used by Calico for policy information.\n  - apiGroups:
-    [\"\"]\n    resources:\n      - pods\n      - namespaces\n      - serviceaccounts\n
-    \   verbs:\n      - list\n      - watch\n  # The CNI plugin patches pods/status.\n
-    \ - apiGroups: [\"\"]\n    resources:\n      - pods/status\n    verbs:\n      -
-    patch\n  # Calico monitors various CRDs for config.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - globalfelixconfigs\n      - felixconfigurations\n      -
-    bgppeers\n      - globalbgpconfigs\n      - bgpconfigurations\n      - ippools\n
-    \     - ipamblocks\n      - globalnetworkpolicies\n      - globalnetworksets\n
-    \     - networkpolicies\n      - networksets\n      - clusterinformations\n      -
-    hostendpoints\n      - blockaffinities\n    verbs:\n      - get\n      - list\n
-    \     - watch\n  # Calico must create and update some CRDs on startup.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - ippools\n      - felixconfigurations\n
-    \     - clusterinformations\n    verbs:\n      - create\n      - update\n  # Calico
-    stores some configuration information on the node.\n  - apiGroups: [\"\"]\n    resources:\n
-    \     - nodes\n    verbs:\n      - get\n      - list\n      - watch\n  # These
-    permissions are only required for upgrade from v2.6, and can\n  # be removed after
-    upgrade or on fresh installations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - bgpconfigurations\n      - bgppeers\n    verbs:\n      -
-    create\n      - update\n  # These permissions are required for Calico CNI to perform
-    IPAM allocations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n      - ipamblocks\n      - ipamhandles\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  -
-    apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - ipamconfigs\n
-    \   verbs:\n      - get\n  # Block affinities must also be watchable by confd
-    for route aggregation.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n    verbs:\n      - watch\n  # The Calico IPAM migration
-    needs to get daemonsets. These permissions can be\n  # removed if not upgrading
-    from an installation using host-local IPAM.\n  - apiGroups: [\"apps\"]\n    resources:\n
-    \     - daemonsets\n    verbs:\n      - get\n\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:
-    ClusterRoleBinding\nmetadata:\n  name: calico-node\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-node\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-node\n    namespace: kube-system\n\n---\n# Source: calico/templates/calico-node.yaml\n#
-    This manifest installs the calico-node container, as well\n# as the CNI plugins
-    and network config on\n# each master and worker node in a Kubernetes cluster.\nkind:
-    DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: calico-node\n  namespace: kube-system\n
-    \ labels:\n    k8s-app: calico-node\nspec:\n  selector:\n    matchLabels:\n      k8s-app:
-    calico-node\n  updateStrategy:\n    type: RollingUpdate\n    rollingUpdate:\n
-    \     maxUnavailable: 1\n  template:\n    metadata:\n      labels:\n        k8s-app:
-    calico-node\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n
-    \     hostNetwork: true\n      tolerations:\n        # Make sure calico-node gets
-    scheduled on all nodes.\n        - effect: NoSchedule\n          operator: Exists\n
-    \       # Mark the pod as a critical add-on for rescheduling.\n        - key:
-    CriticalAddonsOnly\n          operator: Exists\n        - effect: NoExecute\n
-    \         operator: Exists\n      serviceAccountName: calico-node\n      # Minimize
-    downtime during a rolling upgrade or deletion; tell Kubernetes to do a \"force\n
-    \     # deletion\": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.\n
-    \     terminationGracePeriodSeconds: 0\n      priorityClassName: system-node-critical\n
-    \     initContainers:\n        # This container performs upgrade from host-local
-    IPAM to calico-ipam.\n        # It can be deleted if this is a fresh installation,
-    or if you have already\n        # upgraded to use calico-ipam.\n        - name:
-    upgrade-ipam\n          image: calico/cni:v3.20.0\n          command: [\"/opt/cni/bin/calico-ipam\",
-    \"-upgrade\"]\n          envFrom:\n            - configMapRef:\n                #
-    Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for
-    eBPF mode.\n                name: kubernetes-services-endpoint\n                optional:
-    true\n          env:\n            - name: KUBERNETES_NODE_NAME\n              valueFrom:\n
-    \               fieldRef:\n                  fieldPath: spec.nodeName\n            -
-    name: CALICO_NETWORKING_BACKEND\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: calico_backend\n
-    \         volumeMounts:\n            - mountPath: /var/lib/cni/networks\n              name:
-    host-local-net-dir\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n          securityContext:\n            privileged: true\n        #
-    This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: calico/cni:v3.20.0\n
-    \         command: [\"/opt/cni/bin/install\"]\n          envFrom:\n            -
-    configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
-    to be overridden for eBPF mode.\n                name: kubernetes-services-endpoint\n
-    \               optional: true\n          env:\n            # Name of the CNI
-    config file to create.\n            - name: CNI_CONF_NAME\n              value:
-    \"10-calico.conflist\"\n            # The CNI network config to install on each
-    node.\n            - name: CNI_NETWORK_CONFIG\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: cni_network_config\n
-    \           # Set the hostname based on the k8s node name.\n            - name:
-    KUBERNETES_NODE_NAME\n              valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # CNI MTU Config variable\n            - name: CNI_MTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Prevents the container
-    from sleeping forever.\n            - name: SLEEP\n              value: \"false\"\n
-    \         volumeMounts:\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n            - mountPath: /host/etc/cni/net.d\n              name:
-    cni-net-dir\n          securityContext:\n            privileged: true\n        #
-    Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes\n
-    \       # to communicate with Felix over the Policy Sync API.\n        - name:
-    flexvol-driver\n          image: calico/pod2daemon-flexvol:v3.20.0\n          volumeMounts:\n
-    \           - name: flexvol-driver-host\n              mountPath: /host/driver\n
-    \         securityContext:\n            privileged: true\n      containers:\n
-    \       # Runs calico-node container on each Kubernetes node. This\n        #
-    container programs network policy and routes on each\n        # host.\n        -
-    name: calico-node\n          image: calico/node:v3.20.0\n          envFrom:\n
-    \           - configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and
-    KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.\n                name:
-    kubernetes-services-endpoint\n                optional: true\n          env:\n
-    \           # Use Kubernetes API as the backing datastore.\n            - name:
-    DATASTORE_TYPE\n              value: \"kubernetes\"\n            # Wait for the
-    datastore.\n            - name: WAIT_FOR_DATASTORE\n              value: \"true\"\n
-    \           # Set based on the k8s node name.\n            - name: NODENAME\n
-    \             valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # Choose the backend to use.\n            - name: CALICO_NETWORKING_BACKEND\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: calico_backend\n            # Cluster type
-    to identify the deployment type\n            - name: CLUSTER_TYPE\n              value:
-    \"k8s,bgp\"\n            # Auto-detect the BGP IP address.\n            - name:
-    IP\n              value: \"autodetect\"\n            # Enable VXLAN\n            -
-    name: CALICO_IPV4POOL_VXLAN\n              value: \"Always\"\n            # Set
-    MTU for tunnel device used if ipip is enabled\n            - name: FELIX_IPINIPMTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Set MTU for the
-    VXLAN tunnel device.\n            - name: FELIX_VXLANMTU\n              valueFrom:\n
-    \               configMapKeyRef:\n                  name: calico-config\n                  key:
-    veth_mtu\n            # Set MTU for the Wireguard tunnel device.\n            -
-    name: FELIX_WIREGUARDMTU\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: veth_mtu\n            #
-    The default IPv4 pool to create on startup if none exists. Pod IPs will be\n            #
-    chosen from this range. Changing this value after installation will have\n            #
-    no effect. This should fall within `--cluster-cidr`.\n            # - name: CALICO_IPV4POOL_CIDR\n
-    \           #   value: \"192.168.0.0/16\"\n            # Disable file logging
-    so `kubectl logs` works.\n            - name: CALICO_DISABLE_FILE_LOGGING\n              value:
-    \"true\"\n            # Set Felix endpoint to host default action to ACCEPT.\n
-    \           - name: FELIX_DEFAULTENDPOINTTOHOSTACTION\n              value: \"ACCEPT\"\n
-    \           # Disable IPv6 on Kubernetes.\n            - name: FELIX_IPV6SUPPORT\n
-    \             value: \"false\"\n            - name: FELIX_FEATUREDETECTOVERRIDE\n
-    \             value: \"ChecksumOffloadBroken=true\"\n            - name: FELIX_HEALTHENABLED\n
-    \             value: \"true\"\n          securityContext:\n            privileged:
-    true\n          resources:\n            requests:\n              cpu: 250m\n          livenessProbe:\n
-    \           exec:\n              command:\n                - /bin/calico-node\n
-    \               - -felix-live\n            periodSeconds: 10\n            initialDelaySeconds:
-    10\n            failureThreshold: 6\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /bin/calico-node\n                -
-    -felix-ready\n            periodSeconds: 10\n          volumeMounts:\n            -
-    mountPath: /host/etc/cni/net.d\n              name: cni-net-dir\n              readOnly:
-    false\n            - mountPath: /lib/modules\n              name: lib-modules\n
-    \             readOnly: true\n            - mountPath: /run/xtables.lock\n              name:
-    xtables-lock\n              readOnly: false\n            - mountPath: /var/run/calico\n
-    \             name: var-run-calico\n              readOnly: false\n            -
-    mountPath: /var/lib/calico\n              name: var-lib-calico\n              readOnly:
-    false\n            - name: policysync\n              mountPath: /var/run/nodeagent\n
-    \           # For eBPF mode, we need to be able to mount the BPF filesystem at
-    /sys/fs/bpf so we mount in the\n            # parent directory.\n            -
-    name: sysfs\n              mountPath: /sys/fs/\n              # Bidirectional
-    means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to
-    the host.\n              # If the host is known to mount that filesystem already
-    then Bidirectional can be omitted.\n              mountPropagation: Bidirectional\n
-    \           - name: cni-log-dir\n              mountPath: /var/log/calico/cni\n
-    \             readOnly: true\n      volumes:\n        # Used by calico-node.\n
-    \       - name: lib-modules\n          hostPath:\n            path: /lib/modules\n
-    \       - name: var-run-calico\n          hostPath:\n            path: /var/run/calico\n
-    \       - name: var-lib-calico\n          hostPath:\n            path: /var/lib/calico\n
-    \       - name: xtables-lock\n          hostPath:\n            path: /run/xtables.lock\n
-    \           type: FileOrCreate\n        - name: sysfs\n          hostPath:\n            path:
-    /sys/fs/\n            type: DirectoryOrCreate\n        # Used to install CNI.\n
-    \       - name: cni-bin-dir\n          hostPath:\n            path: /opt/cni/bin\n
-    \       - name: cni-net-dir\n          hostPath:\n            path: /etc/cni/net.d\n
-    \       # Used to access CNI logs.\n        - name: cni-log-dir\n          hostPath:\n
-    \           path: /var/log/calico/cni\n        # Mount in the directory for host-local
-    IPAM allocations. This is\n        # used when upgrading from host-local to calico-ipam,
-    and can be removed\n        # if not using the upgrade-ipam init container.\n
-    \       - name: host-local-net-dir\n          hostPath:\n            path: /var/lib/cni/networks\n
-    \       # Used to create per-pod Unix Domain Sockets\n        - name: policysync\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /var/run/nodeagent\n
-    \       # Used to install Flex Volume Driver\n        - name: flexvol-driver-host\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds\n---\n\napiVersion:
-    v1\nkind: ServiceAccount\nmetadata:\n  name: calico-node\n  namespace: kube-system\n\n---\n#
-    Source: calico/templates/calico-kube-controllers.yaml\n# See https://github.com/projectcalico/kube-controllers\napiVersion:
-    apps/v1\nkind: Deployment\nmetadata:\n  name: calico-kube-controllers\n  namespace:
-    kube-system\n  labels:\n    k8s-app: calico-kube-controllers\nspec:\n  # The controllers
-    can only have a single active instance.\n  replicas: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n  strategy:\n    type: Recreate\n  template:\n
-    \   metadata:\n      name: calico-kube-controllers\n      namespace: kube-system\n
-    \     labels:\n        k8s-app: calico-kube-controllers\n    spec:\n      nodeSelector:\n
-    \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
-    a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
-    Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
-    \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
-    \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
-    \         env:\n            # Choose which controllers to run.\n            -
-    name: ENABLED_CONTROLLERS\n              value: node\n            - name: DATASTORE_TYPE\n
-    \             value: kubernetes\n          livenessProbe:\n            exec:\n
-    \             command:\n              - /usr/bin/check-status\n              -
-    -l\n            periodSeconds: 10\n            initialDelaySeconds: 10\n            failureThreshold:
-    6\n            timeoutSeconds: 10\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /usr/bin/check-status\n                -
-    -r\n            periodSeconds: 10\n\n---\n\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n\n---\n\n# This manifest
-    creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler
-    to evict\n\napiVersion: policy/v1beta1\nkind: PodDisruptionBudget\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n  labels:\n    k8s-app:
-    calico-kube-controllers\nspec:\n  maxUnavailable: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n---\n# Source: calico/templates/calico-etcd-secrets.yaml\n\n---\n#
-    Source: calico/templates/calico-typha.yaml\n\n---\n# Source: calico/templates/configure-canal.yaml\n"
+  resources: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgpconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPConfiguration
+        listKind: BGPConfigurationList
+        plural: bgpconfigurations
+        singular: bgpconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: BGPConfiguration contains the configuration for any BGP routing.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPConfigurationSpec contains the values of the BGP configuration.
+                properties:
+                  asNumber:
+                    description: 'ASNumber is the default AS number used by a node. [Default:
+                      64512]'
+                    format: int32
+                    type: integer
+                  communities:
+                    description: Communities is a list of BGP community values and their
+                      arbitrary names for tagging routes.
+                    items:
+                      description: Community contains standard or large community value
+                        and its name.
+                      properties:
+                        name:
+                          description: Name given to community value.
+                          type: string
+                        value:
+                          description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                            For standard community use `aa:nn` format, where `aa` and
+                            `nn` are 16 bit number. For large community use `aa:nn:mm`
+                            format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                            `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                          pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                          type: string
+                      type: object
+                    type: array
+                  listenPort:
+                    description: ListenPort is the port where BGP protocol should listen.
+                      Defaults to 179
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: INFO]'
+                    type: string
+                  nodeToNodeMeshEnabled:
+                    description: 'NodeToNodeMeshEnabled sets whether full node to node
+                      BGP mesh is enabled. [Default: true]'
+                    type: boolean
+                  prefixAdvertisements:
+                    description: PrefixAdvertisements contains per-prefix advertisement
+                      configuration.
+                    items:
+                      description: PrefixAdvertisement configures advertisement properties
+                        for the specified CIDR.
+                      properties:
+                        cidr:
+                          description: CIDR for which properties should be advertised.
+                          type: string
+                        communities:
+                          description: Communities can be list of either community names
+                            already defined in `Specs.Communities` or community value
+                            of format `aa:nn` or `aa:nn:mm`. For standard community use
+                            `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                            large community use `aa:nn:mm` format, where `aa`, `nn` and
+                            `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                            `mm` are per-AS identifier.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  serviceClusterIPs:
+                    description: ServiceClusterIPs are the CIDR blocks from which service
+                      cluster IPs are allocated. If specified, Calico will advertise these
+                      blocks, as well as any cluster IPs within them.
+                    items:
+                      description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                        CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceExternalIPs:
+                    description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                      Service External IPs. Kubernetes Service ExternalIPs will only be
+                      advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceExternalIPBlock represents a single allowed
+                        External IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceLoadBalancerIPs:
+                    description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                      Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                      IPs will only be advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceLoadBalancerIPBlock represents a single allowed
+                        LoadBalancer IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgppeers.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPPeer
+        listKind: BGPPeerList
+        plural: bgppeers
+        singular: bgppeer
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPPeerSpec contains the specification for a BGPPeer resource.
+                properties:
+                  asNumber:
+                    description: The AS Number of the peer.
+                    format: int32
+                    type: integer
+                  keepOriginalNextHop:
+                    description: Option to keep the original nexthop field when routes
+                      are sent to a BGP Peer. Setting "true" configures the selected BGP
+                      Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                      in the specific branch of the Node on "bird.cfg".
+                    type: boolean
+                  maxRestartTime:
+                    description: Time to allow for software restart.  When specified,
+                      this is configured as the graceful restart timeout.  When not specified,
+                      the BIRD default of 120s is used.
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance that
+                      is targeted by this peer. If this is not set, and no nodeSelector
+                      is specified, then this BGP peer selects all nodes in the cluster.
+                    type: string
+                  nodeSelector:
+                    description: Selector for the nodes that should have this peering.  When
+                      this is set, the Node field must be empty.
+                    type: string
+                  password:
+                    description: Optional BGP password for the peerings generated by this
+                      BGPPeer resource.
+                    properties:
+                      secretKeyRef:
+                        description: Selects a key of a secret in the node pod's namespace.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be
+                              a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be
+                              defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  peerIP:
+                    description: The IP address of the peer followed by an optional port
+                      number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                      or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                      and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                      set in BGPConfiguration, then we use that port to peer.
+                    type: string
+                  peerSelector:
+                    description: Selector for the remote nodes to peer with.  When this
+                      is set, the PeerIP and ASNumber fields must be empty.  For each
+                      peering between the local node and selected remote nodes, we configure
+                      an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                      and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                      remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                      or the global default if that is not set.
+                    type: string
+                  sourceAddress:
+                    description: Specifies whether and how to configure a source address
+                      for the peerings generated by this BGPPeer resource.  Default value
+                      "UseNodeIP" means to configure the node IP as the source address.  "None"
+                      means not to configure a source address.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: blockaffinities.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BlockAffinity
+        listKind: BlockAffinityList
+        plural: blockaffinities
+        singular: blockaffinity
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BlockAffinitySpec contains the specification for a BlockAffinity
+                  resource.
+                properties:
+                  cidr:
+                    type: string
+                  deleted:
+                    description: Deleted indicates that this block affinity is being deleted.
+                      This field is a string for compatibility with older releases that
+                      mistakenly treat this field as a string.
+                    type: string
+                  node:
+                    type: string
+                  state:
+                    type: string
+                required:
+                - cidr
+                - deleted
+                - node
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: clusterinformations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: ClusterInformation
+        listKind: ClusterInformationList
+        plural: clusterinformations
+        singular: clusterinformation
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterInformation contains the cluster specific information.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterInformationSpec contains the values of describing
+                  the cluster.
+                properties:
+                  calicoVersion:
+                    description: CalicoVersion is the version of Calico that the cluster
+                      is running
+                    type: string
+                  clusterGUID:
+                    description: ClusterGUID is the GUID of the cluster
+                    type: string
+                  clusterType:
+                    description: ClusterType describes the type of the cluster
+                    type: string
+                  datastoreReady:
+                    description: DatastoreReady is used during significant datastore migrations
+                      to signal to components such as Felix that it should wait before
+                      accessing the datastore.
+                    type: boolean
+                  variant:
+                    description: Variant declares which variant of Calico should be active.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: felixconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: FelixConfiguration
+        listKind: FelixConfigurationList
+        plural: felixconfigurations
+        singular: felixconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: Felix Configuration contains the configuration for Felix.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: FelixConfigurationSpec contains the values of the Felix configuration.
+                properties:
+                  allowIPIPPacketsFromWorkloads:
+                    description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop IPIP encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  allowVXLANPacketsFromWorkloads:
+                    description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop VXLAN encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  awsSrcDstCheck:
+                    description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                      value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                      DoNothing]'
+                    enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                    type: string
+                  bpfConnectTimeLoadBalancingEnabled:
+                    description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                      controls whether Felix installs the connection-time load balancer.  The
+                      connect-time load balancer is required for the host to be able to
+                      reach Kubernetes services and it improves the performance of pod-to-service
+                      connections.  The only reason to disable it is for debugging purposes.  [Default:
+                      true]'
+                    type: boolean
+                  bpfDataIfacePattern:
+                    description: BPFDataIfacePattern is a regular expression that controls
+                      which interfaces Felix should attach BPF programs to in order to
+                      catch traffic to/from the network.  This needs to match the interfaces
+                      that Calico workload traffic flows over as well as any interfaces
+                      that handle incoming traffic to nodeports and services from outside
+                      the cluster.  It should not match the workload interfaces (usually
+                      named cali...).
+                    type: string
+                  bpfDisableUnprivileged:
+                    description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                      sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                      users cannot access Calico''s BPF maps and cannot insert their own
+                      BPF programs to interfere with Calico''s. [Default: true]'
+                    type: boolean
+                  bpfEnabled:
+                    description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                      [Default: false]'
+                    type: boolean
+                  bpfExtToServiceConnmark:
+                    description: 'BPFExtToServiceConnmark in BPF mode, controls a 32bit
+                      mark that is set on connections from an external client to a local
+                      service. This mark allows us to control how packets of that connection
+                      are routed within the host and how is routing intepreted by RPF
+                      check. [Default: 0]'
+                    type: integer
+                  bpfExternalServiceMode:
+                    description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                      from outside the cluster to services (node ports and cluster IPs)
+                      are forwarded to remote workloads.  If set to "Tunnel" then both
+                      request and response traffic is tunneled to the remote node.  If
+                      set to "DSR", the request traffic is tunneled but the response traffic
+                      is sent directly from the remote node.  In "DSR" mode, the remote
+                      node appears to use the IP of the ingress node; this requires a
+                      permissive L2 network.  [Default: Tunnel]'
+                    type: string
+                  bpfKubeProxyEndpointSlicesEnabled:
+                    description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                      whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                    type: boolean
+                  bpfKubeProxyIptablesCleanupEnabled:
+                    description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                      mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                      iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                      true]'
+                    type: boolean
+                  bpfKubeProxyMinSyncPeriod:
+                    description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                      minimum time between updates to the dataplane for Felix''s embedded
+                      kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                      reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                    type: string
+                  bpfLogLevel:
+                    description: 'BPFLogLevel controls the log level of the BPF programs
+                      when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                      logs are emitted to the BPF trace pipe, accessible with the command
+                      `tc exec bpf debug`. [Default: Off].'
+                    type: string
+                  chainInsertMode:
+                    description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                      top-level iptables chains by inserting a rule at the top of the
+                      chain or by appending a rule at the bottom. insert is the safe default
+                      since it prevents Calico''s rules from being bypassed. If you switch
+                      to append mode, be sure that the other rules in the chains signal
+                      acceptance by falling through to the Calico rules, otherwise the
+                      Calico policy will be bypassed. [Default: insert]'
+                    type: string
+                  dataplaneDriver:
+                    type: string
+                  debugDisableLogDropping:
+                    type: boolean
+                  debugMemoryProfilePath:
+                    type: string
+                  debugSimulateCalcGraphHangAfter:
+                    type: string
+                  debugSimulateDataplaneHangAfter:
+                    type: string
+                  defaultEndpointToHostAction:
+                    description: 'DefaultEndpointToHostAction controls what happens to
+                      traffic that goes from a workload endpoint to the host itself (after
+                      the traffic hits the endpoint egress policy). By default Calico
+                      blocks traffic from workload endpoints to the host itself with an
+                      iptables "DROP" action. If you want to allow some or all traffic
+                      from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                      RETURN if you have your own rules in the iptables "INPUT" chain;
+                      Calico will insert its rules at the top of that chain, then "RETURN"
+                      packets to the "INPUT" chain once it has completed processing workload
+                      endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                      from workloads after processing workload endpoint egress policy.
+                      [Default: Drop]'
+                    type: string
+                  deviceRouteProtocol:
+                    description: This defines the route protocol added to programmed device
+                      routes, by default this will be RTPROT_BOOT when left blank.
+                    type: integer
+                  deviceRouteSourceAddress:
+                    description: This is the source address to use on programmed device
+                      routes. By default the source address is left blank, leaving the
+                      kernel to choose the source address used.
+                    type: string
+                  disableConntrackInvalidCheck:
+                    type: boolean
+                  endpointReportingDelay:
+                    type: string
+                  endpointReportingEnabled:
+                    type: boolean
+                  externalNodesList:
+                    description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                      which may source tunnel traffic and have the tunneled traffic be
+                      accepted at calico nodes.
+                    items:
+                      type: string
+                    type: array
+                  failsafeInboundHostPorts:
+                    description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow incoming traffic to host endpoints
+                      on irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all inbound host ports, use the value
+                      none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                      udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  failsafeOutboundHostPorts:
+                    description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow outgoing traffic from host endpoints
+                      to irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all outbound host ports, use the value
+                      none. The default value opens etcd''s standard ports to ensure that
+                      Felix does not get cut off from etcd as well as allowing DHCP and
+                      DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                      tcp:6667, udp:53, udp:67]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  featureDetectOverride:
+                    description: FeatureDetectOverride is used to override the feature
+                      detection. Values are specified in a comma separated list with no
+                      spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                      "true" or "false" will force the feature, empty or omitted values
+                      are auto-detected.
+                    type: string
+                  genericXDPEnabled:
+                    description: 'GenericXDPEnabled enables Generic XDP so network cards
+                      that don''t support XDP offload or driver modes can use XDP. This
+                      is not recommended since it doesn''t provide better performance
+                      than iptables. [Default: false]'
+                    type: boolean
+                  healthEnabled:
+                    type: boolean
+                  healthHost:
+                    type: string
+                  healthPort:
+                    type: integer
+                  interfaceExclude:
+                    description: 'InterfaceExclude is a comma-separated list of interfaces
+                      that Felix should exclude when monitoring for host endpoints. The
+                      default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                      interface, which is used internally by kube-proxy. If you want to
+                      exclude multiple interface names using a single value, the list
+                      supports regular expressions. For regular expressions you must wrap
+                      the value with ''/''. For example having values ''/^kube/,veth1''
+                      will exclude all interfaces that begin with ''kube'' and also the
+                      interface ''veth1''. [Default: kube-ipvs0]'
+                    type: string
+                  interfacePrefix:
+                    description: 'InterfacePrefix is the interface name prefix that identifies
+                      workload endpoints and so distinguishes them from host endpoint
+                      interfaces. Note: in environments other than bare metal, the orchestrators
+                      configure this appropriately. For example our Kubernetes and Docker
+                      integrations set the ''cali'' value, and our OpenStack integration
+                      sets the ''tap'' value. [Default: cali]'
+                    type: string
+                  interfaceRefreshInterval:
+                    description: InterfaceRefreshInterval is the period at which Felix
+                      rescans local interfaces to verify their state. The rescan can be
+                      disabled by setting the interval to 0.
+                    type: string
+                  ipipEnabled:
+                    type: boolean
+                  ipipMTU:
+                    description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  ipsetsRefreshInterval:
+                    description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                      all iptables state to ensure that no other process has accidentally
+                      broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                      90s]'
+                    type: string
+                  iptablesBackend:
+                    description: IptablesBackend specifies which backend of iptables will
+                      be used. The default is legacy.
+                    type: string
+                  iptablesFilterAllowAction:
+                    type: string
+                  iptablesLockFilePath:
+                    description: 'IptablesLockFilePath is the location of the iptables
+                      lock file. You may need to change this if the lock file is not in
+                      its standard location (for example if you have mapped it into Felix''s
+                      container at a different path). [Default: /run/xtables.lock]'
+                    type: string
+                  iptablesLockProbeInterval:
+                    description: 'IptablesLockProbeInterval is the time that Felix will
+                      wait between attempts to acquire the iptables lock if it is not
+                      available. Lower values make Felix more responsive when the lock
+                      is contended, but use more CPU. [Default: 50ms]'
+                    type: string
+                  iptablesLockTimeout:
+                    description: 'IptablesLockTimeout is the time that Felix will wait
+                      for the iptables lock, or 0, to disable. To use this feature, Felix
+                      must share the iptables lock file with all other processes that
+                      also take the lock. When running Felix inside a container, this
+                      requires the /run directory of the host to be mounted into the calico/node
+                      or calico/felix container. [Default: 0s disabled]'
+                    type: string
+                  iptablesMangleAllowAction:
+                    type: string
+                  iptablesMarkMask:
+                    description: 'IptablesMarkMask is the mask that Felix selects its
+                      IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                      at least 8 bits set, none of which clash with any other mark bits
+                      in use on the system. [Default: 0xff000000]'
+                    format: int32
+                    type: integer
+                  iptablesNATOutgoingInterfaceFilter:
+                    type: string
+                  iptablesPostWriteCheckInterval:
+                    description: 'IptablesPostWriteCheckInterval is the period after Felix
+                      has done a write to the dataplane that it schedules an extra read
+                      back in order to check the write was not clobbered by another process.
+                      This should only occur if another application on the system doesn''t
+                      respect the iptables lock. [Default: 1s]'
+                    type: string
+                  iptablesRefreshInterval:
+                    description: 'IptablesRefreshInterval is the period at which Felix
+                      re-checks the IP sets in the dataplane to ensure that no other process
+                      has accidentally broken Calico''s rules. Set to 0 to disable IP
+                      sets refresh. Note: the default for this value is lower than the
+                      other refresh intervals as a workaround for a Linux kernel bug that
+                      was fixed in kernel version 4.11. If you are using v4.11 or greater
+                      you may want to set this to, a higher value to reduce Felix CPU
+                      usage. [Default: 10s]'
+                    type: string
+                  ipv6Support:
+                    type: boolean
+                  kubeNodePortRanges:
+                    description: 'KubeNodePortRanges holds list of port ranges used for
+                      service node ports. Only used if felix detects kube-proxy running
+                      in ipvs mode. Felix uses these ranges to separate host and workload
+                      traffic. [Default: 30000:32767].'
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  logFilePath:
+                    description: 'LogFilePath is the full path to the Felix log. Set to
+                      none to disable file logging. [Default: /var/log/calico/felix.log]'
+                    type: string
+                  logPrefix:
+                    description: 'LogPrefix is the log prefix that Felix uses when rendering
+                      LOG rules. [Default: calico-packet]'
+                    type: string
+                  logSeverityFile:
+                    description: 'LogSeverityFile is the log severity above which logs
+                      are sent to the log file. [Default: Info]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  logSeveritySys:
+                    description: 'LogSeveritySys is the log severity above which logs
+                      are sent to the syslog. Set to None for no logging to syslog. [Default:
+                      Info]'
+                    type: string
+                  maxIpsetSize:
+                    type: integer
+                  metadataAddr:
+                    description: 'MetadataAddr is the IP address or domain name of the
+                      server that can answer VM queries for cloud-init metadata. In OpenStack,
+                      this corresponds to the machine running nova-api (or in Ubuntu,
+                      nova-api-metadata). A value of none (case insensitive) means that
+                      Felix should not set up any NAT rule for the metadata path. [Default:
+                      127.0.0.1]'
+                    type: string
+                  metadataPort:
+                    description: 'MetadataPort is the port of the metadata server. This,
+                      combined with global.MetadataAddr (if not ''None''), is used to
+                      set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                      In most cases this should not need to be changed [Default: 8775].'
+                    type: integer
+                  mtuIfacePattern:
+                    description: MTUIfacePattern is a regular expression that controls
+                      which interfaces Felix should scan in order to calculate the host's
+                      MTU. This should not match workload interfaces (usually named cali...).
+                    type: string
+                  natOutgoingAddress:
+                    description: NATOutgoingAddress specifies an address to use when performing
+                      source NAT for traffic in a natOutgoing pool that is leaving the
+                      network. By default the address used is an address on the interface
+                      the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                    type: string
+                  natPortRange:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NATPortRange specifies the range of ports that is used
+                      for port mapping when doing outgoing NAT. When unset the default
+                      behavior of the network stack is used.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  netlinkTimeout:
+                    type: string
+                  openstackRegion:
+                    description: 'OpenstackRegion is the name of the region that a particular
+                      Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                      this must be configured somehow for each Felix (here in the datamodel,
+                      or in felix.cfg or the environment on each compute node), and must
+                      match the [calico] openstack_region value configured in neutron.conf
+                      on each node. [Default: Empty]'
+                    type: string
+                  policySyncPathPrefix:
+                    description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                      policy changes to external services, like Application layer policy.
+                      [Default: Empty]'
+                    type: string
+                  prometheusGoMetricsEnabled:
+                    description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusMetricsEnabled:
+                    description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                      server in Felix if set to true. [Default: false]'
+                    type: boolean
+                  prometheusMetricsHost:
+                    description: 'PrometheusMetricsHost is the host that the Prometheus
+                      metrics server should bind to. [Default: empty]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. [Default: 9091]'
+                    type: integer
+                  prometheusProcessMetricsEnabled:
+                    description: 'PrometheusProcessMetricsEnabled disables process metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusWireGuardMetricsEnabled:
+                    description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                      metrics collection, which the Prometheus client does by default,
+                      when set to false. This reduces the number of metrics reported,
+                      reducing Prometheus load. [Default: true]'
+                    type: boolean
+                  removeExternalRoutes:
+                    description: Whether or not to remove device routes that have not
+                      been programmed by Felix. Disabling this will allow external applications
+                      to also add device routes. This is enabled by default which means
+                      we will remove externally added routes.
+                    type: boolean
+                  reportingInterval:
+                    description: 'ReportingInterval is the interval at which Felix reports
+                      its status into the datastore or 0 to disable. Must be non-zero
+                      in OpenStack deployments. [Default: 30s]'
+                    type: string
+                  reportingTTL:
+                    description: 'ReportingTTL is the time-to-live setting for process-wide
+                      status reports. [Default: 90s]'
+                    type: string
+                  routeRefreshInterval:
+                    description: 'RouteRefreshInterval is the period at which Felix re-checks
+                      the routes in the dataplane to ensure that no other process has
+                      accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                      [Default: 90s]'
+                    type: string
+                  routeSource:
+                    description: 'RouteSource configures where Felix gets its routing
+                      information. - WorkloadIPs: use workload endpoints to construct
+                      routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                    type: string
+                  routeTableRange:
+                    description: Calico programs additional Linux route tables for various
+                      purposes.  RouteTableRange specifies the indices of the route tables
+                      that Calico should use.
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                    - max
+                    - min
+                    type: object
+                  serviceLoopPrevention:
+                    description: 'When service IP advertisement is enabled, prevent routing
+                      loops to service IPs that are not in use, by dropping or rejecting
+                      packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                      in which case such routing loops continue to be allowed. [Default:
+                      Drop]'
+                    type: string
+                  sidecarAccelerationEnabled:
+                    description: 'SidecarAccelerationEnabled enables experimental sidecar
+                      acceleration [Default: false]'
+                    type: boolean
+                  usageReportingEnabled:
+                    description: 'UsageReportingEnabled reports anonymous Calico version
+                      number and cluster size to projectcalico.org. Logs warnings returned
+                      by the usage server. For example, if a significant security vulnerability
+                      has been discovered in the version of Calico being used. [Default:
+                      true]'
+                    type: boolean
+                  usageReportingInitialDelay:
+                    description: 'UsageReportingInitialDelay controls the minimum delay
+                      before Felix makes a report. [Default: 300s]'
+                    type: string
+                  usageReportingInterval:
+                    description: 'UsageReportingInterval controls the interval at which
+                      Felix makes reports. [Default: 86400s]'
+                    type: string
+                  useInternalDataplaneDriver:
+                    type: boolean
+                  vxlanEnabled:
+                    type: boolean
+                  vxlanMTU:
+                    description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  vxlanPort:
+                    type: integer
+                  vxlanVNI:
+                    type: integer
+                  wireguardEnabled:
+                    description: 'WireguardEnabled controls whether Wireguard is enabled.
+                      [Default: false]'
+                    type: boolean
+                  wireguardHostEncryptionEnabled:
+                    description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                      host-to-host encryption is enabled. [Default: false]'
+                    type: boolean
+                  wireguardInterfaceName:
+                    description: 'WireguardInterfaceName specifies the name to use for
+                      the Wireguard interface. [Default: wg.calico]'
+                    type: string
+                  wireguardListeningPort:
+                    description: 'WireguardListeningPort controls the listening port used
+                      by Wireguard. [Default: 51820]'
+                    type: integer
+                  wireguardMTU:
+                    description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                      See Configuring MTU [Default: 1420]'
+                    type: integer
+                  wireguardRoutingRulePriority:
+                    description: 'WireguardRoutingRulePriority controls the priority value
+                      to use for the Wireguard routing rule. [Default: 99]'
+                    type: integer
+                  xdpEnabled:
+                    description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                      incoming deny rules. [Default: true]'
+                    type: boolean
+                  xdpRefreshInterval:
+                    description: 'XDPRefreshInterval is the period at which Felix re-checks
+                      all XDP state to ensure that no other process has accidentally broken
+                      Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                      refresh. [Default: 90s]'
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkPolicy
+        listKind: GlobalNetworkPolicyList
+        plural: globalnetworkpolicies
+        singular: globalnetworkpolicy
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  applyOnForward:
+                    description: ApplyOnForward indicates to apply the rules in this policy
+                      on forward traffic.
+                    type: boolean
+                  doNotTrack:
+                    description: DoNotTrack indicates whether packets matched by the rules
+                      in this policy should go through the data plane's connection tracking,
+                      such as Linux conntrack.  If True, the rules in this policy are
+                      applied before any data plane connection tracking, and packets allowed
+                      by this policy are marked as not to be tracked.
+                    type: boolean
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    description: NamespaceSelector is an optional field for an expression
+                      used to select a pod based on namespaces.
+                    type: string
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  preDNAT:
+                    description: PreDNAT indicates to apply the rules in this policy before
+                      any DNAT.
+                    type: boolean
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress rules are present in the policy.  The
+                      default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                      (including the case where there are   also no Ingress rules) \n
+                      - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                      rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                      both Ingress and Egress rules. \n When the policy is read back again,
+                      Types will always be one of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkSet
+        listKind: GlobalNetworkSetList
+        plural: globalnetworksets
+        singular: globalnetworkset
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+              that share labels to allow rules to refer to them via selectors.  The labels
+              of GlobalNetworkSet are not namespaced.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: hostendpoints.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: HostEndpoint
+        listKind: HostEndpointList
+        plural: hostendpoints
+        singular: hostendpoint
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: HostEndpointSpec contains the specification for a HostEndpoint
+                  resource.
+                properties:
+                  expectedIPs:
+                    description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                      If \"InterfaceName\" is not present, Calico will look for an interface
+                      matching any of the IPs in the list and apply policy to that. Note:
+                      \tWhen using the selector match criteria in an ingress or egress
+                      security Policy \tor Profile, Calico converts the selector into
+                      a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                      is used for that purpose. (If only the interface \tname is specified,
+                      Calico does not learn the IPs of the interface for use in match
+                      \tcriteria.)"
+                    items:
+                      type: string
+                    type: array
+                  interfaceName:
+                    description: "Either \"*\", or the name of a specific Linux interface
+                      to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                      governs all traffic to, from or through the default network namespace
+                      of the host named by the \"Node\" field; entering and leaving that
+                      namespace via any interface, including those from/to non-host-networked
+                      local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                      only governs traffic that enters or leaves the host through the
+                      specific interface named by InterfaceName, or - when InterfaceName
+                      is empty - through the specific interface that has one of the IPs
+                      in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                      one expected IP must be specified.  Only external interfaces (such
+                      as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                      to protect traffic through a specific local workload interface.
+                      \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                      initially just pre-DNAT policy.  Please check Calico documentation
+                      for the latest position."
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance.
+                    type: string
+                  ports:
+                    description: Ports contains the endpoint's named ports, which may
+                      be referenced in security policy rules.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  profiles:
+                    description: A list of identifiers of security Profile objects that
+                      apply to this endpoint. Each profile is applied in the order that
+                      they appear in this list.  Profile rules are applied after the selector-based
+                      security policy.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamblocks.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMBlock
+        listKind: IPAMBlockList
+        plural: ipamblocks
+        singular: ipamblock
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMBlockSpec contains the specification for an IPAMBlock
+                  resource.
+                properties:
+                  affinity:
+                    type: string
+                  allocations:
+                    items:
+                      nullable: true
+                      type: integer
+                    type: array
+                  attributes:
+                    items:
+                      properties:
+                        handle_id:
+                          type: string
+                        secondary:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    type: array
+                  cidr:
+                    type: string
+                  deleted:
+                    type: boolean
+                  strictAffinity:
+                    type: boolean
+                  unallocated:
+                    items:
+                      type: integer
+                    type: array
+                required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamconfigs.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMConfig
+        listKind: IPAMConfigList
+        plural: ipamconfigs
+        singular: ipamconfig
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMConfigSpec contains the specification for an IPAMConfig
+                  resource.
+                properties:
+                  autoAllocateBlocks:
+                    type: boolean
+                  maxBlocksPerHost:
+                    description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                      that can be affine to each host.
+                    type: integer
+                  strictAffinity:
+                    type: boolean
+                required:
+                - autoAllocateBlocks
+                - strictAffinity
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamhandles.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMHandle
+        listKind: IPAMHandleList
+        plural: ipamhandles
+        singular: ipamhandle
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMHandleSpec contains the specification for an IPAMHandle
+                  resource.
+                properties:
+                  block:
+                    additionalProperties:
+                      type: integer
+                    type: object
+                  deleted:
+                    type: boolean
+                  handleID:
+                    type: string
+                required:
+                - block
+                - handleID
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ippools.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPPool
+        listKind: IPPoolList
+        plural: ippools
+        singular: ippool
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPPoolSpec contains the specification for an IPPool resource.
+                properties:
+                  blockSize:
+                    description: The block size to use for IP address assignments from
+                      this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                    type: integer
+                  cidr:
+                    description: The pool CIDR.
+                    type: string
+                  disabled:
+                    description: When disabled is true, Calico IPAM will not assign addresses
+                      from this pool.
+                    type: boolean
+                  ipip:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    properties:
+                      enabled:
+                        description: When enabled is true, ipip tunneling will be used
+                          to deliver packets to destinations within this pool.
+                        type: boolean
+                      mode:
+                        description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                          mode of "always" will also use IPIP tunneling for routing to
+                          destination IP addresses within this pool.  A mode of "cross-subnet"
+                          will only use IPIP tunneling when the destination node is on
+                          a different subnet to the originating node.  The default value
+                          (if not specified) is "always".
+                        type: string
+                    type: object
+                  ipipMode:
+                    description: Contains configuration for IPIP tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                      is disabled).
+                    type: string
+                  nat-outgoing:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    type: boolean
+                  natOutgoing:
+                    description: When nat-outgoing is true, packets sent from Calico networked
+                      containers in this pool to destinations outside of this pool will
+                      be masqueraded.
+                    type: boolean
+                  nodeSelector:
+                    description: Allows IPPool to allocate for a specific node by label
+                      selector.
+                    type: string
+                  vxlanMode:
+                    description: Contains configuration for VXLAN tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                      tunneling is disabled).
+                    type: string
+                required:
+                - cidr
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubecontrollersconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: KubeControllersConfiguration
+        listKind: KubeControllersConfigurationList
+        plural: kubecontrollersconfigurations
+        singular: kubecontrollersconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeControllersConfigurationSpec contains the values of the
+                  Kubernetes controllers configuration.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host endpoints.
+                              Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation of
+                                  host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the controller
+                              to determine if an IP address has been leaked. Set to 0
+                              to disable IP garbage collection. [Default: 15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+              status:
+                description: KubeControllersConfigurationStatus represents the status
+                  of the configuration. It's useful for admins to be able to see the actual
+                  config that was applied, which can be modified by environment variables
+                  on the kube-controllers process.
+                properties:
+                  environmentVars:
+                    additionalProperties:
+                      type: string
+                    description: EnvironmentVars contains the environment variables on
+                      the kube-controllers that influenced the RunningConfig.
+                    type: object
+                  runningConfig:
+                    description: RunningConfig contains the effective config that is running
+                      in the kube-controllers pod, after merging the API resource with
+                      any environment variables.
+                    properties:
+                      controllers:
+                        description: Controllers enables and configures individual Kubernetes
+                          controllers
+                        properties:
+                          namespace:
+                            description: Namespace enables and configures the namespace
+                              controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          node:
+                            description: Node enables and configures the node controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              hostEndpoint:
+                                description: HostEndpoint controls syncing nodes to host
+                                  endpoints. Disabled by default, set to nil to disable.
+                                properties:
+                                  autoCreate:
+                                    description: 'AutoCreate enables automatic creation
+                                      of host endpoints for every node. [Default: Disabled]'
+                                    type: string
+                                type: object
+                              leakGracePeriod:
+                                description: 'LeakGracePeriod is the period used by the
+                                  controller to determine if an IP address has been leaked.
+                                  Set to 0 to disable IP garbage collection. [Default:
+                                  15m]'
+                                type: string
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                              syncLabels:
+                                description: 'SyncLabels controls whether to copy Kubernetes
+                                  node labels to Calico nodes. [Default: Enabled]'
+                                type: string
+                            type: object
+                          policy:
+                            description: Policy enables and configures the policy controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          serviceAccount:
+                            description: ServiceAccount enables and configures the service
+                              account controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          workloadEndpoint:
+                            description: WorkloadEndpoint enables and configures the workload
+                              endpoint controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                        type: object
+                      etcdV3CompactionPeriod:
+                        description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                          compaction requests. Set to 0 to disable. [Default: 10m]'
+                        type: string
+                      healthChecks:
+                        description: 'HealthChecks enables or disables support for health
+                          checks [Default: Enabled]'
+                        type: string
+                      logSeverityScreen:
+                        description: 'LogSeverityScreen is the log severity above which
+                          logs are sent to the stdout. [Default: Info]'
+                        type: string
+                      prometheusMetricsPort:
+                        description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                          metrics server should bind to. Set to 0 to disable. [Default:
+                          9094]'
+                        type: integer
+                    required:
+                    - controllers
+                    type: object
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkPolicy
+        listKind: NetworkPolicyList
+        plural: networkpolicies
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress are present in the policy.  The default
+                      is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                      the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                      ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                      PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                      \n When the policy is read back again, Types will always be one
+                      of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkSet
+        listKind: NetworkSetList
+        plural: networksets
+        singular: networkset
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: NetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-kube-controllers
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      verbs:
+      - list
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - hostendpoints
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - clusterinformations
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - kubecontrollersconfigurations
+      verbs:
+      - get
+      - create
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-node
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - namespaces
+      verbs:
+      - get
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - patch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - bgpconfigurations
+      - bgppeers
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ipamconfigs
+      verbs:
+      - get
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      verbs:
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - daemonsets
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-kube-controllers
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      calico_backend: vxlan
+      cni_network_config: |-
+        {
+          "name": "k8s-pod-network",
+          "cniVersion": "0.3.1",
+          "plugins": [
+            {
+              "type": "calico",
+              "log_level": "info",
+              "log_file_path": "/var/log/calico/cni/cni.log",
+              "datastore_type": "kubernetes",
+              "nodename": "__KUBERNETES_NODE_NAME__",
+              "mtu": __CNI_MTU__,
+              "ipam": {
+                  "type": "calico-ipam"
+              },
+              "policy": {
+                  "type": "k8s"
+              },
+              "kubernetes": {
+                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              }
+            },
+            {
+              "type": "portmap",
+              "snat": true,
+              "capabilities": {"portMappings": true}
+            },
+            {
+              "type": "bandwidth",
+              "capabilities": {"bandwidth": true}
+            }
+          ]
+        }
+      typha_service_name: none
+      veth_mtu: "1350"
+    kind: ConfigMap
+    metadata:
+      name: calico-config
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-kube-controllers
+          name: calico-kube-controllers
+          namespace: kube-system
+        spec:
+          containers:
+          - env:
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            image: docker.io/calico/kube-controllers:v3.20.3
+            livenessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -l
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-kube-controllers
+            readinessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -r
+              periodSeconds: 10
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: calico-kube-controllers
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: calico-node
+      name: calico-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+        spec:
+          containers:
+          - env:
+            - name: FELIX_FEATUREDETECTOVERRIDE
+              value: ChecksumOffloadBroken=true
+            - name: CALICO_IPV4POOL_VXLAN
+              value: Always
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            - name: CLUSTER_TYPE
+              value: k8s,bgp
+            - name: IP
+              value: autodetect
+            - name: CALICO_IPV4POOL_IPIP
+              value: Never
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_WIREGUARDMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_AWSSRCDSTCHECK
+              value: Disable
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: ACCEPT
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/node:v3.20.3
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -shutdown
+            livenessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-live
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-node
+            readinessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-ready
+              periodSeconds: 10
+              timeoutSeconds: 10
+            resources:
+              requests:
+                cpu: 250m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /var/run/nodeagent
+              name: policysync
+            - mountPath: /sys/fs/
+              mountPropagation: Bidirectional
+              name: sysfs
+            - mountPath: /var/log/calico/cni
+              name: cni-log-dir
+              readOnly: true
+          hostNetwork: true
+          initContainers:
+          - command:
+            - /opt/cni/bin/calico-ipam
+            - -upgrade
+            env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: upgrade-ipam
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          - command:
+            - /opt/cni/bin/install
+            env:
+            - name: CNI_CONF_NAME
+              value: 10-calico.conflist
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  key: cni_network_config
+                  name: calico-config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: SLEEP
+              value: "false"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: install-cni
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+            name: flexvol-driver
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/driver
+              name: flexvol-driver-host
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: calico-node
+          terminationGracePeriodSeconds: 0
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /lib/modules
+            name: lib-modules
+          - hostPath:
+              path: /var/run/calico
+            name: var-run-calico
+          - hostPath:
+              path: /var/lib/calico
+            name: var-lib-calico
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+          - hostPath:
+              path: /sys/fs/
+              type: DirectoryOrCreate
+            name: sysfs
+          - hostPath:
+              path: /opt/cni/bin
+            name: cni-bin-dir
+          - hostPath:
+              path: /etc/cni/net.d
+            name: cni-net-dir
+          - hostPath:
+              path: /var/log/calico/cni
+            name: cni-log-dir
+          - hostPath:
+              path: /var/lib/cni/networks
+            name: host-local-net-dir
+          - hostPath:
+              path: /var/run/nodeagent
+              type: DirectoryOrCreate
+            name: policysync
+          - hostPath:
+              path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+              type: DirectoryOrCreate
+            name: flexvol-driver-host
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
   windows-cni: "# strictAffinity required for windows\napiVersion: crd.projectcalico.org/v1\nkind:
     IPAMConfig\nmetadata:\n  name: default\nspec:\n  autoAllocateBlocks: true\n  strictAffinity:
     true\n---\nkind: ConfigMap\napiVersion: v1\nmetadata:\n  name: calico-static-rules\n

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -464,2440 +464,3985 @@ data:
     \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
     kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
     \   type: RollingUpdate\n"
-  resources: "---\n# Source: calico/templates/calico-config.yaml\n# This ConfigMap
-    is used to configure a self-hosted Calico installation.\nkind: ConfigMap\napiVersion:
-    v1\nmetadata:\n  name: calico-config\n  namespace: kube-system\ndata:\n  # Typha
-    is disabled.\n  typha_service_name: \"none\"\n  # Configure the backend to use.\n
-    \ calico_backend: \"vxlan\"\n  # On Azure, the underlying network has an MTU of
-    1400, even though the network interface will have an MTU of 1500.\n  # We set
-    this value to 1350 for “physical network MTU size minus 50” since we use VXLAN,
-    which uses a 50-byte header.\n  # If enabling Wireguard, this value should be
-    changed to 1340 (Wireguard uses a 60-byte header).\n  # https://docs.projectcalico.org/networking/mtu#determine-mtu-size\n
-    \ veth_mtu: \"1350\"\n  \n  # The CNI network configuration to install on each
-    node. The special\n  # values in this config will be automatically populated.\n
-    \ cni_network_config: |-\n    {\n      \"name\": \"k8s-pod-network\",\n      \"cniVersion\":
-    \"0.3.1\",\n      \"plugins\": [\n        {\n          \"type\": \"calico\",\n
-    \         \"log_level\": \"info\",\n          \"log_file_path\": \"/var/log/calico/cni/cni.log\",\n
-    \         \"datastore_type\": \"kubernetes\",\n          \"nodename\": \"__KUBERNETES_NODE_NAME__\",\n
-    \         \"mtu\": __CNI_MTU__,\n          \"ipam\": {\n              \"type\":
-    \"calico-ipam\"\n          },\n          \"policy\": {\n              \"type\":
-    \"k8s\"\n          },\n          \"kubernetes\": {\n              \"kubeconfig\":
-    \"__KUBECONFIG_FILEPATH__\"\n          }\n        },\n        {\n          \"type\":
-    \"portmap\",\n          \"snat\": true,\n          \"capabilities\": {\"portMappings\":
-    true}\n        },\n        {\n          \"type\": \"bandwidth\",\n          \"capabilities\":
-    {\"bandwidth\": true}\n        }\n      ]\n    }\n\n---\n# Source: calico/templates/kdd-crds.yaml\n\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: bgpconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPConfiguration\n    listKind: BGPConfigurationList\n    plural:
-    bgpconfigurations\n    singular: bgpconfiguration\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    BGPConfiguration contains the configuration for any BGP routing.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPConfigurationSpec contains the
-    values of the BGP configuration.\n              properties:\n                asNumber:\n
-    \                 description: 'ASNumber is the default AS number used by a node.
-    [Default:\n                  64512]'\n                  format: int32\n                  type:
-    integer\n                communities:\n                  description: Communities
-    is a list of BGP community values and their\n                    arbitrary names
-    for tagging routes.\n                  items:\n                    description:
-    Community contains standard or large community value\n                      and
-    its name.\n                    properties:\n                      name:\n                        description:
-    Name given to community value.\n                        type: string\n                      value:\n
-    \                       description: Value must be of format `aa:nn` or `aa:nn:mm`.\n
-    \                         For standard community use `aa:nn` format, where `aa`
-    and\n                          `nn` are 16 bit number. For large community use
-    `aa:nn:mm`\n                          format, where `aa`, `nn` and `mm` are 32
-    bit number. Where,\n                          `aa` is an AS Number, `nn` and `mm`
-    are per-AS identifier.\n                        pattern: ^(\\d+):(\\d+)$|^(\\d+):(\\d+):(\\d+)$\n
-    \                       type: string\n                    type: object\n                  type:
-    array\n                listenPort:\n                  description: ListenPort
-    is the port where BGP protocol should listen.\n                    Defaults to
-    179\n                  maximum: 65535\n                  minimum: 1\n                  type:
-    integer\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: INFO]'\n                  type: string\n                nodeToNodeMeshEnabled:\n
-    \                 description: 'NodeToNodeMeshEnabled sets whether full node to
-    node\n                  BGP mesh is enabled. [Default: true]'\n                  type:
-    boolean\n                prefixAdvertisements:\n                  description:
-    PrefixAdvertisements contains per-prefix advertisement\n                    configuration.\n
-    \                 items:\n                    description: PrefixAdvertisement
-    configures advertisement properties\n                      for the specified CIDR.\n
-    \                   properties:\n                      cidr:\n                        description:
-    CIDR for which properties should be advertised.\n                        type:
-    string\n                      communities:\n                        description:
-    Communities can be list of either community names\n                          already
-    defined in `Specs.Communities` or community value\n                          of
-    format `aa:nn` or `aa:nn:mm`. For standard community use\n                          `aa:nn`
-    format, where `aa` and `nn` are 16 bit number. For\n                          large
-    community use `aa:nn:mm` format, where `aa`, `nn` and\n                          `mm`
-    are 32 bit number. Where,`aa` is an AS Number, `nn` and\n                          `mm`
-    are per-AS identifier.\n                        items:\n                          type:
-    string\n                        type: array\n                    type: object\n
-    \                 type: array\n                serviceClusterIPs:\n                  description:
-    ServiceClusterIPs are the CIDR blocks from which service\n                    cluster
-    IPs are allocated. If specified, Calico will advertise these\n                    blocks,
-    as well as any cluster IPs within them.\n                  items:\n                    description:
-    ServiceClusterIPBlock represents a single allowed ClusterIP\n                      CIDR
-    block.\n                    properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n                serviceExternalIPs:\n
-    \                 description: ServiceExternalIPs are the CIDR blocks for Kubernetes\n
-    \                   Service External IPs. Kubernetes Service ExternalIPs will
-    only be\n                    advertised if they are within one of these blocks.\n
-    \                 items:\n                    description: ServiceExternalIPBlock
-    represents a single allowed\n                      External IP CIDR block.\n                    properties:\n
-    \                     cidr:\n                        type: string\n                    type:
-    object\n                  type: array\n                serviceLoadBalancerIPs:\n
-    \                 description: ServiceLoadBalancerIPs are the CIDR blocks for
-    Kubernetes\n                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress\n
-    \                   IPs will only be advertised if they are within one of these
-    blocks.\n                  items:\n                    description: ServiceLoadBalancerIPBlock
-    represents a single allowed\n                      LoadBalancer IP CIDR block.\n
-    \                   properties:\n                      cidr:\n                        type:
-    string\n                    type: object\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: bgppeers.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BGPPeer\n    listKind: BGPPeerList\n    plural: bgppeers\n
-    \   singular: bgppeer\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BGPPeerSpec contains the specification
-    for a BGPPeer resource.\n              properties:\n                asNumber:\n
-    \                 description: The AS Number of the peer.\n                  format:
-    int32\n                  type: integer\n                keepOriginalNextHop:\n
-    \                 description: Option to keep the original nexthop field when
-    routes\n                    are sent to a BGP Peer. Setting \"true\" configures
-    the selected BGP\n                    Peers node to use the \"next hop keep;\"
-    instead of \"next hop self;\"(default)\n                    in the specific branch
-    of the Node on \"bird.cfg\".\n                  type: boolean\n                maxRestartTime:\n
-    \                 description: Time to allow for software restart.  When specified,
-    this\n                    is configured as the graceful restart timeout.  When
-    not specified,\n                    the BIRD default of 120s is used.\n                  type:
-    string\n                node:\n                  description: The node name identifying
-    the Calico node instance that\n                    is targeted by this peer. If
-    this is not set, and no nodeSelector\n                    is specified, then this
-    BGP peer selects all nodes in the cluster.\n                  type: string\n                nodeSelector:\n
-    \                 description: Selector for the nodes that should have this peering.
-    \ When\n                    this is set, the Node field must be empty.\n                  type:
-    string\n                password:\n                  description: Optional BGP
-    password for the peerings generated by this\n                    BGPPeer resource.\n
-    \                 properties:\n                    secretKeyRef:\n                      description:
-    Selects a key of a secret in the node pod's namespace.\n                      properties:\n
-    \                       key:\n                          description: The key of
-    the secret to select from.  Must be\n                            a valid secret
-    key.\n                          type: string\n                        name:\n
-    \                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n
-    \                         TODO: Add other useful fields. apiVersion, kind, uid?'\n
-    \                         type: string\n                        optional:\n                          description:
-    Specify whether the Secret or its key must be\n                            defined\n
-    \                         type: boolean\n                      required:\n                        -
-    key\n                      type: object\n                  type: object\n                peerIP:\n
-    \                 description: The IP address of the peer followed by an optional
-    port\n                    number to peer with. If port number is given, format
-    should be `[<IPv6>]:port`\n                    or `<IPv4>:<port>` for IPv4. If
-    optional port number is not set,\n                    and this peer IP and ASNumber
-    belongs to a calico/node with ListenPort\n                    set in BGPConfiguration,
-    then we use that port to peer.\n                  type: string\n                peerSelector:\n
-    \                 description: Selector for the remote nodes to peer with.  When
-    this\n                    is set, the PeerIP and ASNumber fields must be empty.
-    \ For each\n                    peering between the local node and selected remote
-    nodes, we configure\n                    an IPv4 peering if both ends have NodeBGPSpec.IPv4Address
-    specified,\n                    and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address
-    specified.  The\n                    remote AS number comes from the remote node’s
-    NodeBGPSpec.ASNumber,\n                    or the global default if that is not
-    set.\n                  type: string\n                sourceAddress:\n                  description:
-    Specifies whether and how to configure a source address\n                    for
-    the peerings generated by this BGPPeer resource.  Default value\n                    \"UseNodeIP\"
-    means to configure the node IP as the source address.  \"None\"\n                    means
-    not to configure a source address.\n                  type: string\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: blockaffinities.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: BlockAffinity\n    listKind: BlockAffinityList\n    plural:
-    blockaffinities\n    singular: blockaffinity\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: BlockAffinitySpec contains the specification
-    for a BlockAffinity\n                resource.\n              properties:\n                cidr:\n
-    \                 type: string\n                deleted:\n                  description:
-    Deleted indicates that this block affinity is being deleted.\n                    This
-    field is a string for compatibility with older releases that\n                    mistakenly
-    treat this field as a string.\n                  type: string\n                node:\n
-    \                 type: string\n                state:\n                  type:
-    string\n              required:\n                - cidr\n                - deleted\n
-    \               - node\n                - state\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: clusterinformations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: ClusterInformation\n    listKind: ClusterInformationList\n
-    \   plural: clusterinformations\n    singular: clusterinformation\n  scope: Cluster\n
-    \ versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    ClusterInformation contains the cluster specific information.\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: ClusterInformationSpec contains
-    the values of describing\n                the cluster.\n              properties:\n
-    \               calicoVersion:\n                  description: CalicoVersion is
-    the version of Calico that the cluster\n                    is running\n                  type:
-    string\n                clusterGUID:\n                  description: ClusterGUID
-    is the GUID of the cluster\n                  type: string\n                clusterType:\n
-    \                 description: ClusterType describes the type of the cluster\n
-    \                 type: string\n                datastoreReady:\n                  description:
-    DatastoreReady is used during significant datastore migrations\n                    to
-    signal to components such as Felix that it should wait before\n                    accessing
-    the datastore.\n                  type: boolean\n                variant:\n                  description:
-    Variant declares which variant of Calico should be active.\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: felixconfigurations.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: FelixConfiguration\n    listKind:
-    FelixConfigurationList\n    plural: felixconfigurations\n    singular: felixconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         description: Felix Configuration contains the configuration for Felix.\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: FelixConfigurationSpec contains
-    the values of the Felix configuration.\n              properties:\n                allowIPIPPacketsFromWorkloads:\n
-    \                 description: 'AllowIPIPPacketsFromWorkloads controls whether
-    Felix\n                  will add a rule to drop IPIP encapsulated traffic from
-    workloads\n                  [Default: false]'\n                  type: boolean\n
-    \               allowVXLANPacketsFromWorkloads:\n                  description:
-    'AllowVXLANPacketsFromWorkloads controls whether Felix\n                  will
-    add a rule to drop VXLAN encapsulated traffic from workloads\n                  [Default:
-    false]'\n                  type: boolean\n                awsSrcDstCheck:\n                  description:
-    'Set source-destination-check on AWS EC2 instances. Accepted\n                  value
-    must be one of \"DoNothing\", \"Enabled\" or \"Disabled\". [Default:\n                  DoNothing]'\n
-    \                 enum:\n                    - DoNothing\n                    -
-    Enable\n                    - Disable\n                  type: string\n                bpfConnectTimeLoadBalancingEnabled:\n
-    \                 description: 'BPFConnectTimeLoadBalancingEnabled when in BPF
-    mode,\n                  controls whether Felix installs the connection-time load
-    balancer.  The\n                  connect-time load balancer is required for the
-    host to be able to\n                  reach Kubernetes services and it improves
-    the performance of pod-to-service\n                  connections.  The only reason
-    to disable it is for debugging purposes.  [Default:\n                  true]'\n
-    \                 type: boolean\n                bpfDataIfacePattern:\n                  description:
-    'BPFDataIfacePattern is a regular expression that controls\n                  which
-    interfaces Felix should attach BPF programs to in order to\n                  catch
-    traffic to/from the network.  This needs to match the interfaces\n                  that
-    Calico workload traffic flows over as well as any interfaces\n                  that
-    handle incoming traffic to nodeports and services from outside\n                  the
-    cluster.  It should not match the workload interfaces (usually\n                  named
-    cali...). [Default: ^(en.*|eth.*|tunl0$)]'\n                  type: string\n                bpfDisableUnprivileged:\n
-    \                 description: 'BPFDisableUnprivileged, if enabled, Felix sets
-    the kernel.unprivileged_bpf_disabled\n                  sysctl to disable unprivileged
-    use of BPF.  This ensures that unprivileged\n                  users cannot access
-    Calico''s BPF maps and cannot insert their own\n                  BPF programs
-    to interfere with Calico''s. [Default: true]'\n                  type: boolean\n
-    \               bpfEnabled:\n                  description: 'BPFEnabled, if enabled
-    Felix will use the BPF dataplane.\n                  [Default: false]'\n                  type:
-    boolean\n                bpfExtToServiceConnmark:\n                  description:
-    'BPFExtToServiceConnmark in BPF mode, control a 32bit\n                    mark
-    that is set on connections from an external client to a local\n                    service.
-    This mark allows us to control how packets of that connection\n                    are
-    routed within the host and how is routing intepreted by RPF\n                    check.
-    [Default: 0]'\n                  type: integer\n                bpfExternalServiceMode:\n
-    \                 description: 'BPFExternalServiceMode in BPF mode, controls how
-    connections\n                  from outside the cluster to services (node ports
-    and cluster IPs)\n                  are forwarded to remote workloads.  If set
-    to \"Tunnel\" then both\n                  request and response traffic is tunneled
-    to the remote node.  If\n                  set to \"DSR\", the request traffic
-    is tunneled but the response traffic\n                  is sent directly from
-    the remote node.  In \"DSR\" mode, the remote\n                  node appears
-    to use the IP of the ingress node; this requires a\n                  permissive
-    L2 network.  [Default: Tunnel]'\n                  type: string\n                bpfKubeProxyEndpointSlicesEnabled:\n
-    \                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode,
-    controls\n                    whether Felix's embedded kube-proxy accepts EndpointSlices
-    or not.\n                  type: boolean\n                bpfKubeProxyIptablesCleanupEnabled:\n
-    \                 description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled
-    in BPF\n                  mode, Felix will proactively clean up the upstream Kubernetes
-    kube-proxy''s\n                  iptables chains.  Should only be enabled if kube-proxy
-    is not running.  [Default:\n                  true]'\n                  type:
-    boolean\n                bpfKubeProxyMinSyncPeriod:\n                  description:
-    'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the\n                  minimum
-    time between updates to the dataplane for Felix''s embedded\n                  kube-proxy.
-    \ Lower values give reduced set-up latency.  Higher values\n                  reduce
-    Felix CPU usage by batching up more work.  [Default: 1s]'\n                  type:
-    string\n                bpfLogLevel:\n                  description: 'BPFLogLevel
-    controls the log level of the BPF programs\n                  when in BPF dataplane
-    mode.  One of \"Off\", \"Info\", or \"Debug\".  The\n                  logs are
-    emitted to the BPF trace pipe, accessible with the command\n                  `tc
-    exec bpf debug`. [Default: Off].'\n                  type: string\n                chainInsertMode:\n
-    \                 description: 'ChainInsertMode controls whether Felix hooks the
-    kernel’s\n                  top-level iptables chains by inserting a rule at the
-    top of the\n                  chain or by appending a rule at the bottom. insert
-    is the safe default\n                  since it prevents Calico’s rules from being
-    bypassed. If you switch\n                  to append mode, be sure that the other
-    rules in the chains signal\n                  acceptance by falling through to
-    the Calico rules, otherwise the\n                  Calico policy will be bypassed.
-    [Default: insert]'\n                  type: string\n                dataplaneDriver:\n
-    \                 type: string\n                debugDisableLogDropping:\n                  type:
-    boolean\n                debugMemoryProfilePath:\n                  type: string\n
-    \               debugSimulateCalcGraphHangAfter:\n                  type: string\n
-    \               debugSimulateDataplaneHangAfter:\n                  type: string\n
-    \               defaultEndpointToHostAction:\n                  description: 'DefaultEndpointToHostAction
-    controls what happens to\n                  traffic that goes from a workload
-    endpoint to the host itself (after\n                  the traffic hits the endpoint
-    egress policy). By default Calico\n                  blocks traffic from workload
-    endpoints to the host itself with an\n                  iptables “DROP” action.
-    If you want to allow some or all traffic\n                  from endpoint to host,
-    set this parameter to RETURN or ACCEPT. Use\n                  RETURN if you have
-    your own rules in the iptables “INPUT” chain;\n                  Calico will insert
-    its rules at the top of that chain, then “RETURN”\n                  packets to
-    the “INPUT” chain once it has completed processing workload\n                  endpoint
-    egress policy. Use ACCEPT to unconditionally accept packets\n                  from
-    workloads after processing workload endpoint egress policy.\n                  [Default:
-    Drop]'\n                  type: string\n                deviceRouteProtocol:\n
-    \                 description: This defines the route protocol added to programmed
-    device\n                    routes, by default this will be RTPROT_BOOT when left
-    blank.\n                  type: integer\n                deviceRouteSourceAddress:\n
-    \                 description: This is the source address to use on programmed
-    device\n                    routes. By default the source address is left blank,
-    leaving the\n                    kernel to choose the source address used.\n                  type:
-    string\n                disableConntrackInvalidCheck:\n                  type:
-    boolean\n                endpointReportingDelay:\n                  type: string\n
-    \               endpointReportingEnabled:\n                  type: boolean\n                externalNodesList:\n
-    \                 description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes\n
-    \                   which may source tunnel traffic and have the tunneled traffic
-    be\n                    accepted at calico nodes.\n                  items:\n
-    \                   type: string\n                  type: array\n                failsafeInboundHostPorts:\n
-    \                 description: 'FailsafeInboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow incoming traffic to
-    host endpoints\n                    on irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    inbound host ports, use the value\n                    none. The default value
-    allows ssh access and DHCP. [Default: tcp:22,\n                    udp:68, tcp:179,
-    tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'\n                  items:\n
-    \                   description: ProtoPort is combination of protocol, port, and
-    CIDR.\n                      Protocol and port must be specified.\n                    properties:\n
-    \                     net:\n                        type: string\n                      port:\n
-    \                       type: integer\n                      protocol:\n                        type:
-    string\n                    required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                failsafeOutboundHostPorts:\n
-    \                 description: 'FailsafeOutboundHostPorts is a list of UDP/TCP
-    ports\n                    and CIDRs that Felix will allow outgoing traffic from
-    host endpoints\n                    to irrespective of the security policy. This
-    is useful to avoid\n                    accidentally cutting off a host with incorrect
-    configuration. For\n                    back-compatibility, if the protocol is
-    not specified, it defaults\n                    to \"tcp\". If a CIDR is not specified,
-    it will allow traffic from\n                    all addresses. To disable all
-    outbound host ports, use the value\n                    none. The default value
-    opens etcd''s standard ports to ensure that\n                    Felix does not
-    get cut off from etcd as well as allowing DHCP and\n                    DNS. [Default:
-    tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,\n                    tcp:6667,
-    udp:53, udp:67]'\n                  items:\n                    description: ProtoPort
-    is combination of protocol, port, and CIDR.\n                      Protocol and
-    port must be specified.\n                    properties:\n                      net:\n
-    \                       type: string\n                      port:\n                        type:
-    integer\n                      protocol:\n                        type: string\n
-    \                   required:\n                      - port\n                      -
-    protocol\n                    type: object\n                  type: array\n                featureDetectOverride:\n
-    \                 description: FeatureDetectOverride is used to override the feature\n
-    \                   detection. Values are specified in a comma separated list
-    with no\n                    spaces, example; \"SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=\".\n
-    \                   \"true\" or \"false\" will force the feature, empty or omitted
-    values\n                    are auto-detected.\n                  type: string\n
-    \               genericXDPEnabled:\n                  description: 'GenericXDPEnabled
-    enables Generic XDP so network cards\n                  that don''t support XDP
-    offload or driver modes can use XDP. This\n                  is not recommended
-    since it doesn''t provide better performance\n                  than iptables.
-    [Default: false]'\n                  type: boolean\n                healthEnabled:\n
-    \                 type: boolean\n                healthHost:\n                  type:
-    string\n                healthPort:\n                  type: integer\n                interfaceExclude:\n
-    \                 description: 'InterfaceExclude is a comma-separated list of
-    interfaces\n                  that Felix should exclude when monitoring for host
-    endpoints. The\n                  default value ensures that Felix ignores Kubernetes''
-    IPVS dummy\n                  interface, which is used internally by kube-proxy.
-    If you want to\n                  exclude multiple interface names using a single
-    value, the list\n                  supports regular expressions. For regular expressions
-    you must wrap\n                  the value with ''/''. For example having values
-    ''/^kube/,veth1''\n                  will exclude all interfaces that begin with
-    ''kube'' and also the\n                  interface ''veth1''. [Default: kube-ipvs0]'\n
-    \                 type: string\n                interfacePrefix:\n                  description:
-    'InterfacePrefix is the interface name prefix that identifies\n                  workload
-    endpoints and so distinguishes them from host endpoint\n                  interfaces.
-    Note: in environments other than bare metal, the orchestrators\n                  configure
-    this appropriately. For example our Kubernetes and Docker\n                  integrations
-    set the ‘cali’ value, and our OpenStack integration\n                  sets the
-    ‘tap’ value. [Default: cali]'\n                  type: string\n                interfaceRefreshInterval:\n
-    \                 description: InterfaceRefreshInterval is the period at which
-    Felix\n                    rescans local interfaces to verify their state. The
-    rescan can be\n                    disabled by setting the interval to 0.\n                  type:
-    string\n                ipipEnabled:\n                  type: boolean\n                ipipMTU:\n
-    \                 description: 'IPIPMTU is the MTU to set on the tunnel device.
-    See\n                  Configuring MTU [Default: 1440]'\n                  type:
-    integer\n                ipsetsRefreshInterval:\n                  description:
-    'IpsetsRefreshInterval is the period at which Felix re-checks\n                  all
-    iptables state to ensure that no other process has accidentally\n                  broken
-    Calico’s rules. Set to 0 to disable iptables refresh. [Default:\n                  90s]'\n
-    \                 type: string\n                iptablesBackend:\n                  description:
-    IptablesBackend specifies which backend of iptables will\n                    be
-    used. The default is legacy.\n                  type: string\n                iptablesFilterAllowAction:\n
-    \                 type: string\n                iptablesLockFilePath:\n                  description:
-    'IptablesLockFilePath is the location of the iptables\n                  lock
-    file. You may need to change this if the lock file is not in\n                  its
-    standard location (for example if you have mapped it into Felix’s\n                  container
-    at a different path). [Default: /run/xtables.lock]'\n                  type: string\n
-    \               iptablesLockProbeInterval:\n                  description: 'IptablesLockProbeInterval
-    is the time that Felix will\n                  wait between attempts to acquire
-    the iptables lock if it is not\n                  available. Lower values make
-    Felix more responsive when the lock\n                  is contended, but use more
-    CPU. [Default: 50ms]'\n                  type: string\n                iptablesLockTimeout:\n
-    \                 description: 'IptablesLockTimeout is the time that Felix will
-    wait\n                  for the iptables lock, or 0, to disable. To use this feature,
-    Felix\n                  must share the iptables lock file with all other processes
-    that\n                  also take the lock. When running Felix inside a container,
-    this\n                  requires the /run directory of the host to be mounted
-    into the calico/node\n                  or calico/felix container. [Default: 0s
-    disabled]'\n                  type: string\n                iptablesMangleAllowAction:\n
-    \                 type: string\n                iptablesMarkMask:\n                  description:
-    'IptablesMarkMask is the mask that Felix selects its\n                  IPTables
-    Mark bits from. Should be a 32 bit hexadecimal number with\n                  at
-    least 8 bits set, none of which clash with any other mark bits\n                  in
-    use on the system. [Default: 0xff000000]'\n                  format: int32\n                  type:
-    integer\n                iptablesNATOutgoingInterfaceFilter:\n                  type:
-    string\n                iptablesPostWriteCheckInterval:\n                  description:
-    'IptablesPostWriteCheckInterval is the period after Felix\n                  has
-    done a write to the dataplane that it schedules an extra read\n                  back
-    in order to check the write was not clobbered by another process.\n                  This
-    should only occur if another application on the system doesn’t\n                  respect
-    the iptables lock. [Default: 1s]'\n                  type: string\n                iptablesRefreshInterval:\n
-    \                 description: 'IptablesRefreshInterval is the period at which
-    Felix\n                    re-checks the IP sets in the dataplane to ensure that
-    no other process\n                    has accidentally broken Calico''s rules.
-    Set to 0 to disable IP\n                    sets refresh. Note: the default for
-    this value is lower than the\n                    other refresh intervals as a
-    workaround for a Linux kernel bug that\n                    was fixed in kernel
-    version 4.11. If you are using v4.11 or greater\n                    you may want
-    to set this to, a higher value to reduce Felix CPU\n                    usage.
-    [Default: 10s]'\n                  type: string\n                ipv6Support:\n
-    \                 type: boolean\n                kubeNodePortRanges:\n                  description:
-    'KubeNodePortRanges holds list of port ranges used for\n                  service
-    node ports. Only used if felix detects kube-proxy running\n                  in
-    ipvs mode. Felix uses these ranges to separate host and workload\n                  traffic.
-    [Default: 30000:32767].'\n                  items:\n                    anyOf:\n
-    \                     - type: integer\n                      - type: string\n
-    \                   pattern: ^.*\n                    x-kubernetes-int-or-string:
-    true\n                  type: array\n                logFilePath:\n                  description:
-    'LogFilePath is the full path to the Felix log. Set to\n                  none
-    to disable file logging. [Default: /var/log/calico/felix.log]'\n                  type:
-    string\n                logPrefix:\n                  description: 'LogPrefix
-    is the log prefix that Felix uses when rendering\n                  LOG rules.
-    [Default: calico-packet]'\n                  type: string\n                logSeverityFile:\n
-    \                 description: 'LogSeverityFile is the log severity above which
-    logs\n                  are sent to the log file. [Default: Info]'\n                  type:
-    string\n                logSeverityScreen:\n                  description: 'LogSeverityScreen
-    is the log severity above which logs\n                  are sent to the stdout.
-    [Default: Info]'\n                  type: string\n                logSeveritySys:\n
-    \                 description: 'LogSeveritySys is the log severity above which
-    logs\n                  are sent to the syslog. Set to None for no logging to
-    syslog. [Default:\n                  Info]'\n                  type: string\n
-    \               maxIpsetSize:\n                  type: integer\n                metadataAddr:\n
-    \                 description: 'MetadataAddr is the IP address or domain name
-    of the\n                  server that can answer VM queries for cloud-init metadata.
-    In OpenStack,\n                  this corresponds to the machine running nova-api
-    (or in Ubuntu,\n                  nova-api-metadata). A value of none (case insensitive)
-    means that\n                  Felix should not set up any NAT rule for the metadata
-    path. [Default:\n                  127.0.0.1]'\n                  type: string\n
-    \               metadataPort:\n                  description: 'MetadataPort is
-    the port of the metadata server. This,\n                  combined with global.MetadataAddr
-    (if not ‘None’), is used to set\n                  up a NAT rule, from 169.254.169.254:80
-    to MetadataAddr:MetadataPort.\n                  In most cases this should not
-    need to be changed [Default: 8775].'\n                  type: integer\n                mtuIfacePattern:\n
-    \                 description: MTUIfacePattern is a regular expression that controls\n
-    \                   which interfaces Felix should scan in order to calculate the
-    host's\n                    MTU. This should not match workload interfaces (usually
-    named cali...).\n                  type: string\n                natOutgoingAddress:\n
-    \                 description: NATOutgoingAddress specifies an address to use
-    when performing\n                    source NAT for traffic in a natOutgoing pool
-    that is leaving the\n                    network. By default the address used
-    is an address on the interface\n                    the traffic is leaving on
-    (ie it uses the iptables MASQUERADE target)\n                  type: string\n
-    \               natPortRange:\n                  anyOf:\n                    -
-    type: integer\n                    - type: string\n                  description:
-    NATPortRange specifies the range of ports that is used\n                    for
-    port mapping when doing outgoing NAT. When unset the default\n                    behavior
-    of the network stack is used.\n                  pattern: ^.*\n                  x-kubernetes-int-or-string:
-    true\n                netlinkTimeout:\n                  type: string\n                openstackRegion:\n
-    \                 description: 'OpenstackRegion is the name of the region that
-    a particular\n                  Felix belongs to. In a multi-region Calico/OpenStack
-    deployment,\n                  this must be configured somehow for each Felix
-    (here in the datamodel,\n                  or in felix.cfg or the environment
-    on each compute node), and must\n                  match the [calico] openstack_region
-    value configured in neutron.conf\n                  on each node. [Default: Empty]'\n
-    \                 type: string\n                policySyncPathPrefix:\n                  description:
-    'PolicySyncPathPrefix is used to by Felix to communicate\n                  policy
-    changes to external services, like Application layer policy.\n                  [Default:
-    Empty]'\n                  type: string\n                prometheusGoMetricsEnabled:\n
-    \                 description: 'PrometheusGoMetricsEnabled disables Go runtime
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                prometheusMetricsEnabled:\n                  description:
-    'PrometheusMetricsEnabled enables the Prometheus metrics\n                  server
-    in Felix if set to true. [Default: false]'\n                  type: boolean\n
-    \               prometheusMetricsHost:\n                  description: 'PrometheusMetricsHost
-    is the host that the Prometheus\n                  metrics server should bind
-    to. [Default: empty]'\n                  type: string\n                prometheusMetricsPort:\n
-    \                 description: 'PrometheusMetricsPort is the TCP port that the
-    Prometheus\n                  metrics server should bind to. [Default: 9091]'\n
-    \                 type: integer\n                prometheusProcessMetricsEnabled:\n
-    \                 description: 'PrometheusProcessMetricsEnabled disables process
-    metrics\n                  collection, which the Prometheus client does by default,
-    when set\n                  to false. This reduces the number of metrics reported,
-    reducing\n                  Prometheus load. [Default: true]'\n                  type:
-    boolean\n                removeExternalRoutes:\n                  description:
-    Whether or not to remove device routes that have not\n                    been
-    programmed by Felix. Disabling this will allow external applications\n                    to
-    also add device routes. This is enabled by default which means\n                    we
-    will remove externally added routes.\n                  type: boolean\n                reportingInterval:\n
-    \                 description: 'ReportingInterval is the interval at which Felix
-    reports\n                  its status into the datastore or 0 to disable. Must
-    be non-zero\n                  in OpenStack deployments. [Default: 30s]'\n                  type:
-    string\n                reportingTTL:\n                  description: 'ReportingTTL
-    is the time-to-live setting for process-wide\n                  status reports.
-    [Default: 90s]'\n                  type: string\n                routeRefreshInterval:\n
-    \                 description: 'RouterefreshInterval is the period at which Felix
-    re-checks\n                  the routes in the dataplane to ensure that no other
-    process has\n                  accidentally broken Calico’s rules. Set to 0 to
-    disable route refresh.\n                  [Default: 90s]'\n                  type:
-    string\n                routeSource:\n                  description: 'RouteSource
-    configures where Felix gets its routing\n                  information. - WorkloadIPs:
-    use workload endpoints to construct\n                  routes. - CalicoIPAM: the
-    default - use IPAM data to construct routes.'\n                  type: string\n
-    \               routeTableRange:\n                  description: Calico programs
-    additional Linux route tables for various\n                    purposes.  RouteTableRange
-    specifies the indices of the route tables\n                    that Calico should
-    use.\n                  properties:\n                    max:\n                      type:
-    integer\n                    min:\n                      type: integer\n                  required:\n
-    \                   - max\n                    - min\n                  type:
-    object\n                serviceLoopPrevention:\n                  description:
-    'When service IP advertisement is enabled, prevent routing\n                    loops
-    to service IPs that are not in use, by dropping or rejecting\n                    packets
-    that do not get DNAT''d by kube-proxy. Unless set to \"Disabled\",\n                    in
-    which case such routing loops continue to be allowed. [Default:\n                    Drop]'\n
-    \                 type: string\n                sidecarAccelerationEnabled:\n
-    \                 description: 'SidecarAccelerationEnabled enables experimental
-    sidecar\n                  acceleration [Default: false]'\n                  type:
-    boolean\n                usageReportingEnabled:\n                  description:
-    'UsageReportingEnabled reports anonymous Calico version\n                  number
-    and cluster size to projectcalico.org. Logs warnings returned\n                  by
-    the usage server. For example, if a significant security vulnerability\n                  has
-    been discovered in the version of Calico being used. [Default:\n                  true]'\n
-    \                 type: boolean\n                usageReportingInitialDelay:\n
-    \                 description: 'UsageReportingInitialDelay controls the minimum
-    delay\n                  before Felix makes a report. [Default: 300s]'\n                  type:
-    string\n                usageReportingInterval:\n                  description:
-    'UsageReportingInterval controls the interval at which\n                  Felix
-    makes reports. [Default: 86400s]'\n                  type: string\n                useInternalDataplaneDriver:\n
-    \                 type: boolean\n                vxlanEnabled:\n                  type:
-    boolean\n                vxlanMTU:\n                  description: 'VXLANMTU is
-    the MTU to set on the tunnel device. See\n                  Configuring MTU [Default:
-    1440]'\n                  type: integer\n                vxlanPort:\n                  type:
-    integer\n                vxlanVNI:\n                  type: integer\n                wireguardEnabled:\n
-    \                 description: 'WireguardEnabled controls whether Wireguard is
-    enabled.\n                  [Default: false]'\n                  type: boolean\n
-    \               wireguardInterfaceName:\n                  description: 'WireguardInterfaceName
-    specifies the name to use for\n                  the Wireguard interface. [Default:
-    wg.calico]'\n                  type: string\n                wireguardListeningPort:\n
-    \                 description: 'WireguardListeningPort controls the listening
-    port used\n                  by Wireguard. [Default: 51820]'\n                  type:
-    integer\n                wireguardMTU:\n                  description: 'WireguardMTU
-    controls the MTU on the Wireguard interface.\n                  See Configuring
-    MTU [Default: 1420]'\n                  type: integer\n                wireguardRoutingRulePriority:\n
-    \                 description: 'WireguardRoutingRulePriority controls the priority
-    value\n                  to use for the Wireguard routing rule. [Default: 99]'\n
-    \                 type: integer\n                xdpEnabled:\n                  description:
-    'XDPEnabled enables XDP acceleration for suitable untracked\n                  incoming
-    deny rules. [Default: true]'\n                  type: boolean\n                xdpRefreshInterval:\n
-    \                 description: 'XDPRefreshInterval is the period at which Felix
-    re-checks\n                  all XDP state to ensure that no other process has
-    accidentally broken\n                  Calico''s BPF maps or attached programs.
-    Set to 0 to disable XDP\n                  refresh. [Default: 90s]'\n                  type:
-    string\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: globalnetworkpolicies.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: GlobalNetworkPolicy\n    listKind:
-    GlobalNetworkPolicyList\n    plural: globalnetworkpolicies\n    singular: globalnetworkpolicy\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                applyOnForward:\n
-    \                 description: ApplyOnForward indicates to apply the rules in
-    this policy\n                    on forward traffic.\n                  type:
-    boolean\n                doNotTrack:\n                  description: DoNotTrack
-    indicates whether packets matched by the rules\n                    in this policy
-    should go through the data plane's connection tracking,\n                    such
-    as Linux conntrack.  If True, the rules in this policy are\n                    applied
-    before any data plane connection tracking, and packets allowed\n                    by
-    this policy are marked as not to be tracked.\n                  type: boolean\n
-    \               egress:\n                  description: The ordered set of egress
-    rules.  Each rule contains\n                    a set of packet match criteria
-    and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                namespaceSelector:\n                  description: NamespaceSelector
-    is an optional field for an expression\n                    used to select a pod
-    based on namespaces.\n                  type: string\n                order:\n
-    \                 description: Order is an optional field that specifies the order
-    in\n                    which the policy is applied. Policies with higher \"order\"
-    are applied\n                    after those with lower order.  If the order is
-    omitted, it may be\n                    considered to be \"infinite\" - i.e. the
-    policy will be applied last.  Policies\n                    with identical order
-    will be applied in alphanumerical order based\n                    on the Policy
-    \"Name\".\n                  type: number\n                preDNAT:\n                  description:
-    PreDNAT indicates to apply the rules in this policy before\n                    any
-    DNAT.\n                  type: boolean\n                selector:\n                  description:
-    \"The selector is an expression used to pick pick out\n                  the endpoints
-    that the policy should be applied to. \\n Selector\n                  expressions
-    follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n                  \\
-    ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel != \\\"string_literal\\\"\n
-    \                 \\  ->  not equal; also matches if label is not present \\tlabel
-    in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\", ... }  ->  true if the
-    value of label X is\n                  one of \\\"a\\\", \\\"b\\\", \\\"c\\\"
-    \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ... }  ->
-    \ true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress rules are present
-    in the policy.  The\n                  default is: \\n - [ PolicyTypeIngress ],
-    if there are no Egress rules\n                  (including the case where there
-    are   also no Ingress rules) \\n\n                  - [ PolicyTypeEgress ], if
-    there are Egress rules but no Ingress\n                  rules \\n - [ PolicyTypeIngress,
-    PolicyTypeEgress ], if there are\n                  both Ingress and Egress rules.
-    \\n When the policy is read back again,\n                  Types will always be
-    one of these values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: globalnetworksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: GlobalNetworkSet\n    listKind: GlobalNetworkSetList\n    plural:
-    globalnetworksets\n    singular: globalnetworkset\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          description:
-    GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs\n            that
-    share labels to allow rules to refer to them via selectors.  The labels\n            of
-    GlobalNetworkSet are not namespaced.\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: GlobalNetworkSetSpec contains the
-    specification for a NetworkSet\n                resource.\n              properties:\n
-    \               nets:\n                  description: The list of IP networks
-    that belong to this set.\n                  items:\n                    type:
-    string\n                  type: array\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: hostendpoints.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: HostEndpoint\n    listKind: HostEndpointList\n    plural:
-    hostendpoints\n    singular: hostendpoint\n  scope: Cluster\n  versions:\n    -
-    name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n            apiVersion:\n
-    \             description: 'APIVersion defines the versioned schema of this representation\n
-    \             of an object. Servers should convert recognized schemas to the latest\n
-    \             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: HostEndpointSpec contains the specification
-    for a HostEndpoint\n                resource.\n              properties:\n                expectedIPs:\n
-    \                 description: \"The expected IP addresses (IPv4 and IPv6) of
-    the endpoint.\n                  If \\\"InterfaceName\\\" is not present, Calico
-    will look for an interface\n                  matching any of the IPs in the list
-    and apply policy to that. Note:\n                  \\tWhen using the selector
-    match criteria in an ingress or egress\n                  security Policy \\tor
-    Profile, Calico converts the selector into\n                  a set of IP addresses.
-    For host \\tendpoints, the ExpectedIPs field\n                  is used for that
-    purpose. (If only the interface \\tname is specified,\n                  Calico
-    does not learn the IPs of the interface for use in match\n                  \\tcriteria.)\"\n
-    \                 items:\n                    type: string\n                  type:
-    array\n                interfaceName:\n                  description: \"Either
-    \\\"*\\\", or the name of a specific Linux interface\n                  to apply
-    policy to; or empty.  \\\"*\\\" indicates that this HostEndpoint\n                  governs
-    all traffic to, from or through the default network namespace\n                  of
-    the host named by the \\\"Node\\\" field; entering and leaving that\n                  namespace
-    via any interface, including those from/to non-host-networked\n                  local
-    workloads. \\n If InterfaceName is not \\\"*\\\", this HostEndpoint\n                  only
-    governs traffic that enters or leaves the host through the\n                  specific
-    interface named by InterfaceName, or - when InterfaceName\n                  is
-    empty - through the specific interface that has one of the IPs\n                  in
-    ExpectedIPs. Therefore, when InterfaceName is empty, at least\n                  one
-    expected IP must be specified.  Only external interfaces (such\n                  as
-    “eth0”) are supported here; it isn't possible for a HostEndpoint\n                  to
-    protect traffic through a specific local workload interface.\n                  \\n
-    Note: Only some kinds of policy are implemented for \\\"*\\\" HostEndpoints;\n
-    \                 initially just pre-DNAT policy.  Please check Calico documentation\n
-    \                 for the latest position.\"\n                  type: string\n
-    \               node:\n                  description: The node name identifying
-    the Calico node instance.\n                  type: string\n                ports:\n
-    \                 description: Ports contains the endpoint's named ports, which
-    may\n                    be referenced in security policy rules.\n                  items:\n
-    \                   properties:\n                      name:\n                        type:
-    string\n                      port:\n                        type: integer\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                    required:\n                      - name\n                      -
-    port\n                      - protocol\n                    type: object\n                  type:
-    array\n                profiles:\n                  description: A list of identifiers
-    of security Profile objects that\n                    apply to this endpoint.
-    Each profile is applied in the order that\n                    they appear in
-    this list.  Profile rules are applied after the selector-based\n                    security
-    policy.\n                  items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind:
-    CustomResourceDefinition\nmetadata:\n  annotations:\n    controller-gen.kubebuilder.io/version:
-    (devel)\n  creationTimestamp: null\n  name: ipamblocks.crd.projectcalico.org\nspec:\n
-    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMBlock\n    listKind: IPAMBlockList\n
-    \   plural: ipamblocks\n    singular: ipamblock\n  scope: Cluster\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMBlockSpec contains the specification
-    for an IPAMBlock\n                resource.\n              properties:\n                affinity:\n
-    \                 type: string\n                allocations:\n                  items:\n
-    \                   type: integer\n                    # TODO: This nullable is
-    manually added in. We should update controller-gen\n                    # to handle
-    []*int properly itself.\n                    nullable: true\n                  type:
-    array\n                attributes:\n                  items:\n                    properties:\n
-    \                     handle_id:\n                        type: string\n                      secondary:\n
-    \                       additionalProperties:\n                          type:
-    string\n                        type: object\n                    type: object\n
-    \                 type: array\n                cidr:\n                  type:
-    string\n                deleted:\n                  type: boolean\n                strictAffinity:\n
-    \                 type: boolean\n                unallocated:\n                  items:\n
-    \                   type: integer\n                  type: array\n              required:\n
-    \               - allocations\n                - attributes\n                -
-    cidr\n                - strictAffinity\n                - unallocated\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMConfig\n    listKind: IPAMConfigList\n    plural: ipamconfigs\n
-    \   singular: ipamconfig\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMConfigSpec contains the specification
-    for an IPAMConfig\n                resource.\n              properties:\n                autoAllocateBlocks:\n
-    \                 type: boolean\n                maxBlocksPerHost:\n                  description:
-    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                    that
-    can be affine to each host.\n                  type: integer\n                strictAffinity:\n
-    \                 type: boolean\n              required:\n                - autoAllocateBlocks\n
-    \               - strictAffinity\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ipamhandles.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPAMHandle\n    listKind: IPAMHandleList\n    plural: ipamhandles\n
-    \   singular: ipamhandle\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPAMHandleSpec contains the specification
-    for an IPAMHandle\n                resource.\n              properties:\n                block:\n
-    \                 additionalProperties:\n                    type: integer\n                  type:
-    object\n                deleted:\n                  type: boolean\n                handleID:\n
-    \                 type: string\n              required:\n                - block\n
-    \               - handleID\n              type: object\n          type: object\n
-    \     served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: ippools.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: IPPool\n    listKind: IPPoolList\n    plural: ippools\n    singular:
-    ippool\n  scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: IPPoolSpec contains the specification
-    for an IPPool resource.\n              properties:\n                blockSize:\n
-    \                 description: The block size to use for IP address assignments
-    from\n                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.\n
-    \                 type: integer\n                cidr:\n                  description:
-    The pool CIDR.\n                  type: string\n                disabled:\n                  description:
-    When disabled is true, Calico IPAM will not assign addresses\n                    from
-    this pool.\n                  type: boolean\n                ipip:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  properties:\n                    enabled:\n                      description:
-    When enabled is true, ipip tunneling will be used\n                        to
-    deliver packets to destinations within this pool.\n                      type:
-    boolean\n                    mode:\n                      description: The IPIP
-    mode.  This can be one of \"always\" or \"cross-subnet\".  A\n                        mode
-    of \"always\" will also use IPIP tunneling for routing to\n                        destination
-    IP addresses within this pool.  A mode of \"cross-subnet\"\n                        will
-    only use IPIP tunneling when the destination node is on\n                        a
-    different subnet to the originating node.  The default value\n                        (if
-    not specified) is \"always\".\n                      type: string\n                  type:
-    object\n                ipipMode:\n                  description: Contains configuration
-    for IPIP tunneling for this pool.\n                    If not specified, then
-    this is defaulted to \"Never\" (i.e. IPIP tunneling\n                    is disabled).\n
-    \                 type: string\n                nat-outgoing:\n                  description:
-    'Deprecated: this field is only used for APIv1 backwards\n                  compatibility.
-    Setting this field is not allowed, this field is\n                  for internal
-    use only.'\n                  type: boolean\n                natOutgoing:\n                  description:
-    When nat-outgoing is true, packets sent from Calico networked\n                    containers
-    in this pool to destinations outside of this pool will\n                    be
-    masqueraded.\n                  type: boolean\n                nodeSelector:\n
-    \                 description: Allows IPPool to allocate for a specific node by
-    label\n                    selector.\n                  type: string\n                vxlanMode:\n
-    \                 description: Contains configuration for VXLAN tunneling for
-    this pool.\n                    If not specified, then this is defaulted to \"Never\"
-    (i.e. VXLAN\n                    tunneling is disabled).\n                  type:
-    string\n              required:\n                - cidr\n              type: object\n
-    \         type: object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n
-    \   kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: kubecontrollersconfigurations.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: KubeControllersConfiguration\n    listKind: KubeControllersConfigurationList\n
-    \   plural: kubecontrollersconfigurations\n    singular: kubecontrollersconfiguration\n
-    \ scope: Cluster\n  versions:\n    - name: v1\n      schema:\n        openAPIV3Schema:\n
-    \         properties:\n            apiVersion:\n              description: 'APIVersion
-    defines the versioned schema of this representation\n              of an object.
-    Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: KubeControllersConfigurationSpec
-    contains the values of the\n                Kubernetes controllers configuration.\n
-    \             properties:\n                controllers:\n                  description:
-    Controllers enables and configures individual Kubernetes\n                    controllers\n
-    \                 properties:\n                    namespace:\n                      description:
-    Namespace enables and configures the namespace controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   node:\n                      description: Node enables and
-    configures the node controller.\n                        Enabled by default, set
-    to nil to disable.\n                      properties:\n                        hostEndpoint:\n
-    \                         description: HostEndpoint controls syncing nodes to
-    host endpoints.\n                            Disabled by default, set to nil to
-    disable.\n                          properties:\n                            autoCreate:\n
-    \                             description: 'AutoCreate enables automatic creation
-    of\n                              host endpoints for every node. [Default: Disabled]'\n
-    \                             type: string\n                          type: object\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                       syncLabels:\n                          description: 'SyncLabels
-    controls whether to copy Kubernetes\n                          node labels to
-    Calico nodes. [Default: Enabled]'\n                          type: string\n                      type:
-    object\n                    policy:\n                      description: Policy
-    enables and configures the policy controller.\n                        Enabled
-    by default, set to nil to disable.\n                      properties:\n                        reconcilerPeriod:\n
-    \                         description: 'ReconcilerPeriod is the period to perform
-    reconciliation\n                          with the Calico datastore. [Default:
-    5m]'\n                          type: string\n                      type: object\n
-    \                   serviceAccount:\n                      description: ServiceAccount
-    enables and configures the service\n                        account controller.
-    Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                    workloadEndpoint:\n                      description:
-    WorkloadEndpoint enables and configures the workload\n                        endpoint
-    controller. Enabled by default, set to nil to disable.\n                      properties:\n
-    \                       reconcilerPeriod:\n                          description:
-    'ReconcilerPeriod is the period to perform reconciliation\n                          with
-    the Calico datastore. [Default: 5m]'\n                          type: string\n
-    \                     type: object\n                  type: object\n                etcdV3CompactionPeriod:\n
-    \                 description: 'EtcdV3CompactionPeriod is the period between etcdv3\n
-    \                 compaction requests. Set to 0 to disable. [Default: 10m]'\n
-    \                 type: string\n                healthChecks:\n                  description:
-    'HealthChecks enables or disables support for health\n                  checks
-    [Default: Enabled]'\n                  type: string\n                logSeverityScreen:\n
-    \                 description: 'LogSeverityScreen is the log severity above which
-    logs\n                  are sent to the stdout. [Default: Info]'\n                  type:
-    string\n                prometheusMetricsPort:\n                  description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                    metrics
-    server should bind to. Set to 0 to disable. [Default: 9094]'\n                  type:
-    integer\n              required:\n                - controllers\n              type:
-    object\n            status:\n              description: KubeControllersConfigurationStatus
-    represents the status\n                of the configuration. It's useful for admins
-    to be able to see the actual\n                config that was applied, which can
-    be modified by environment variables\n                on the kube-controllers
-    process.\n              properties:\n                environmentVars:\n                  additionalProperties:\n
-    \                   type: string\n                  description: EnvironmentVars
-    contains the environment variables on\n                    the kube-controllers
-    that influenced the RunningConfig.\n                  type: object\n                runningConfig:\n
-    \                 description: RunningConfig contains the effective config that
-    is running\n                    in the kube-controllers pod, after merging the
-    API resource with\n                    any environment variables.\n                  properties:\n
-    \                   controllers:\n                      description: Controllers
-    enables and configures individual Kubernetes\n                        controllers\n
-    \                     properties:\n                        namespace:\n                          description:
-    Namespace enables and configures the namespace\n                            controller.
-    Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        node:\n
-    \                         description: Node enables and configures the node controller.\n
-    \                           Enabled by default, set to nil to disable.\n                          properties:\n
-    \                           hostEndpoint:\n                              description:
-    HostEndpoint controls syncing nodes to host\n                                endpoints.
-    Disabled by default, set to nil to disable.\n                              properties:\n
-    \                               autoCreate:\n                                  description:
-    'AutoCreate enables automatic creation\n                                  of host
-    endpoints for every node. [Default: Disabled]'\n                                  type:
-    string\n                              type: object\n                            leakGracePeriod:\n
-    \                             description: 'LeakGracePeriod is the period used
-    by the\n                                controller to determine if an IP address
-    has been leaked.\n                                Set to 0 to disable IP garbage
-    collection. [Default:\n                                15m]'\n                              type:
-    string\n                            reconcilerPeriod:\n                              description:
-    'ReconcilerPeriod is the period to perform\n                              reconciliation
-    with the Calico datastore. [Default:\n                              5m]'\n                              type:
-    string\n                            syncLabels:\n                              description:
-    'SyncLabels controls whether to copy Kubernetes\n                              node
-    labels to Calico nodes. [Default: Enabled]'\n                              type:
-    string\n                          type: object\n                        policy:\n
-    \                         description: Policy enables and configures the policy
-    controller.\n                            Enabled by default, set to nil to disable.\n
-    \                         properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        serviceAccount:\n
-    \                         description: ServiceAccount enables and configures the
-    service\n                            account controller. Enabled by default, set
-    to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                        workloadEndpoint:\n
-    \                         description: WorkloadEndpoint enables and configures
-    the workload\n                            endpoint controller. Enabled by default,
-    set to nil to disable.\n                          properties:\n                            reconcilerPeriod:\n
-    \                             description: 'ReconcilerPeriod is the period to
-    perform\n                              reconciliation with the Calico datastore.
-    [Default:\n                              5m]'\n                              type:
-    string\n                          type: object\n                      type: object\n
-    \                   etcdV3CompactionPeriod:\n                      description:
-    'EtcdV3CompactionPeriod is the period between etcdv3\n                      compaction
-    requests. Set to 0 to disable. [Default: 10m]'\n                      type: string\n
-    \                   healthChecks:\n                      description: 'HealthChecks
-    enables or disables support for health\n                      checks [Default:
-    Enabled]'\n                      type: string\n                    logSeverityScreen:\n
-    \                     description: 'LogSeverityScreen is the log severity above
-    which\n                      logs are sent to the stdout. [Default: Info]'\n                      type:
-    string\n                    prometheusMetricsPort:\n                      description:
-    'PrometheusMetricsPort is the TCP port that the Prometheus\n                        metrics
-    server should bind to. Set to 0 to disable. [Default:\n                        9094]'\n
-    \                     type: integer\n                  required:\n                    -
-    controllers\n                  type: object\n              type: object\n          type:
-    object\n      served: true\n      storage: true\nstatus:\n  acceptedNames:\n    kind:
-    \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n\n---\n\n---\napiVersion:
-    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  annotations:\n
-    \   controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp: null\n
-    \ name: networkpolicies.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkPolicy\n    listKind: NetworkPolicyList\n    plural:
-    networkpolicies\n    singular: networkpolicy\n  scope: Namespaced\n  versions:\n
-    \   - name: v1\n      schema:\n        openAPIV3Schema:\n          properties:\n
-    \           apiVersion:\n              description: 'APIVersion defines the versioned
-    schema of this representation\n              of an object. Servers should convert
-    recognized schemas to the latest\n              internal value, and may reject
-    unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              properties:\n                egress:\n                  description:
-    The ordered set of egress rules.  Each rule contains\n                    a set
-    of packet match criteria and a corresponding action to apply.\n                  items:\n
-    \                   description: \"A Rule encapsulates a set of match criteria
-    and an\n                    action.  Both selector-based security Policy and security
-    Profiles\n                    reference rules - separated out as a list of rules
-    for both ingress\n                    and egress packet matching. \\n Each positive
-    match criteria has\n                    a negated version, prefixed with ”Not”.
-    All the match criteria\n                    within a rule must be satisfied for
-    a packet to match. A single\n                    rule can contain the positive
-    and negative version of a match\n                    and both must be satisfied
-    for the rule to match.\"\n                    properties:\n                      action:\n
-    \                       type: string\n                      destination:\n                        description:
-    Destination contains the match criteria that apply\n                          to
-    destination entity.\n                        properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                ingress:\n                  description: The ordered set
-    of ingress rules.  Each rule contains\n                    a set of packet match
-    criteria and a corresponding action to apply.\n                  items:\n                    description:
-    \"A Rule encapsulates a set of match criteria and an\n                    action.
-    \ Both selector-based security Policy and security Profiles\n                    reference
-    rules - separated out as a list of rules for both ingress\n                    and
-    egress packet matching. \\n Each positive match criteria has\n                    a
-    negated version, prefixed with ”Not”. All the match criteria\n                    within
-    a rule must be satisfied for a packet to match. A single\n                    rule
-    can contain the positive and negative version of a match\n                    and
-    both must be satisfied for the rule to match.\"\n                    properties:\n
-    \                     action:\n                        type: string\n                      destination:\n
-    \                       description: Destination contains the match criteria that
-    apply\n                          to destination entity.\n                        properties:\n
-    \                         namespaceSelector:\n                            description:
-    \"NamespaceSelector is an optional field that\n                            contains
-    a selector expression. Only traffic that originates\n                            from
-    (or terminates at) endpoints within the selected\n                            namespaces
-    will be matched. When both NamespaceSelector\n                            and
-    Selector are defined on the same rule, then only workload\n                            endpoints
-    that are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                      http:\n                        description:
-    HTTP contains match criteria that apply to HTTP\n                          requests.\n
-    \                       properties:\n                          methods:\n                            description:
-    Methods is an optional field that restricts\n                              the
-    rule to apply only to HTTP requests that use one of\n                              the
-    listed HTTP Methods (e.g. GET, PUT, etc.) Multiple\n                              methods
-    are OR'd together.\n                            items:\n                              type:
-    string\n                            type: array\n                          paths:\n
-    \                           description: 'Paths is an optional field that restricts\n
-    \                           the rule to apply to HTTP requests that use one of
-    the\n                            listed HTTP Paths. Multiple paths are OR''d together.\n
-    \                           e.g: - exact: /foo - prefix: /bar NOTE: Each entry
-    may\n                            ONLY specify either a `exact` or a `prefix` match.
-    The\n                            validator will check for it.'\n                            items:\n
-    \                             description: 'HTTPPath specifies an HTTP path to
-    match.\n                              It may be either of the form: exact: <path>:
-    which matches\n                              the path exactly or prefix: <path-prefix>:
-    which matches\n                              the path prefix'\n                              properties:\n
-    \                               exact:\n                                  type:
-    string\n                                prefix:\n                                  type:
-    string\n                              type: object\n                            type:
-    array\n                        type: object\n                      icmp:\n                        description:
-    ICMP is an optional field that restricts the rule\n                          to
-    apply to a specific type and code of ICMP traffic.  This\n                          should
-    only be specified if the Protocol field is set to \"ICMP\"\n                          or
-    \"ICMPv6\".\n                        properties:\n                          code:\n
-    \                           description: Match on a specific ICMP code.  If specified,\n
-    \                             the Type value must also be specified. This is a
-    technical\n                              limitation imposed by the kernel’s iptables
-    firewall,\n                              which Calico uses to enforce the rule.\n
-    \                           type: integer\n                          type:\n                            description:
-    Match on a specific ICMP type.  For example\n                              a value
-    of 8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      ipVersion:\n
-    \                       description: IPVersion is an optional field that restricts
-    the\n                          rule to only match a specific IP version.\n                        type:
-    integer\n                      metadata:\n                        description:
-    Metadata contains additional information for this\n                          rule\n
-    \                       properties:\n                          annotations:\n
-    \                           additionalProperties:\n                              type:
-    string\n                            description: Annotations is a set of key value
-    pairs that\n                              give extra information about the rule\n
-    \                           type: object\n                        type: object\n
-    \                     notICMP:\n                        description: NotICMP is
-    the negated version of the ICMP field.\n                        properties:\n
-    \                         code:\n                            description: Match
-    on a specific ICMP code.  If specified,\n                              the Type
-    value must also be specified. This is a technical\n                              limitation
-    imposed by the kernel’s iptables firewall,\n                              which
-    Calico uses to enforce the rule.\n                            type: integer\n
-    \                         type:\n                            description: Match
-    on a specific ICMP type.  For example\n                              a value of
-    8 refers to ICMP Echo Request (i.e. pings).\n                            type:
-    integer\n                        type: object\n                      notProtocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: NotProtocol is the negated
-    version of the Protocol\n                          field.\n                        pattern:
-    ^.*\n                        x-kubernetes-int-or-string: true\n                      protocol:\n
-    \                       anyOf:\n                          - type: integer\n                          -
-    type: string\n                        description: \"Protocol is an optional field
-    that restricts the\n                        rule to only apply to traffic of a
-    specific IP protocol. Required\n                        if any of the EntityRules
-    contain Ports (because ports only\n                        apply to certain protocols).
-    \\n Must be one of these string\n                        values: \\\"TCP\\\",
-    \\\"UDP\\\", \\\"ICMP\\\", \\\"ICMPv6\\\", \\\"SCTP\\\",\n                        \\\"UDPLite\\\"
-    or an integer in the range 1-255.\"\n                        pattern: ^.*\n                        x-kubernetes-int-or-string:
-    true\n                      source:\n                        description: Source
-    contains the match criteria that apply to\n                          source entity.\n
-    \                       properties:\n                          namespaceSelector:\n
-    \                           description: \"NamespaceSelector is an optional field
-    that\n                            contains a selector expression. Only traffic
-    that originates\n                            from (or terminates at) endpoints
-    within the selected\n                            namespaces will be matched. When
-    both NamespaceSelector\n                            and Selector are defined on
-    the same rule, then only workload\n                            endpoints that
-    are matched by both selectors will be selected\n                            by
-    the rule. \\n For NetworkPolicy, an empty NamespaceSelector\n                            implies
-    that the Selector is limited to selecting only\n                            workload
-    endpoints in the same namespace as the NetworkPolicy.\n                            \\n
-    For NetworkPolicy, `global()` NamespaceSelector implies\n                            that
-    the Selector is limited to selecting only GlobalNetworkSet\n                            or
-    HostEndpoint. \\n For GlobalNetworkPolicy, an empty\n                            NamespaceSelector
-    implies the Selector applies to workload\n                            endpoints
-    across all namespaces.\"\n                            type: string\n                          nets:\n
-    \                           description: Nets is an optional field that restricts
-    the\n                              rule to only apply to traffic that originates
-    from (or\n                              terminates at) IP addresses in any of
-    the given subnets.\n                            items:\n                              type:
-    string\n                            type: array\n                          notNets:\n
-    \                           description: NotNets is the negated version of the
-    Nets\n                              field.\n                            items:\n
-    \                             type: string\n                            type:
-    array\n                          notPorts:\n                            description:
-    NotPorts is the negated version of the Ports\n                              field.
-    Since only some protocols have ports, if any ports\n                              are
-    specified it requires the Protocol match in the Rule\n                              to
-    be set to \"TCP\" or \"UDP\".\n                            items:\n                              anyOf:\n
-    \                               - type: integer\n                                -
-    type: string\n                              pattern: ^.*\n                              x-kubernetes-int-or-string:
-    true\n                            type: array\n                          notSelector:\n
-    \                           description: NotSelector is the negated version of
-    the Selector\n                              field.  See Selector field for subtleties
-    with negated\n                              selectors.\n                            type:
-    string\n                          ports:\n                            description:
-    \"Ports is an optional field that restricts\n                            the rule
-    to only apply to traffic that has a source (destination)\n                            port
-    that matches one of these ranges/values. This value\n                            is
-    a list of integers or strings that represent ranges\n                            of
-    ports. \\n Since only some protocols have ports, if\n                            any
-    ports are specified it requires the Protocol match\n                            in
-    the Rule to be set to \\\"TCP\\\" or \\\"UDP\\\".\"\n                            items:\n
-    \                             anyOf:\n                                - type:
-    integer\n                                - type: string\n                              pattern:
-    ^.*\n                              x-kubernetes-int-or-string: true\n                            type:
-    array\n                          selector:\n                            description:
-    \"Selector is an optional field that contains\n                            a selector
-    expression (see Policy for sample syntax).\n                            \\ Only
-    traffic that originates from (terminates at) endpoints\n                            matching
-    the selector will be matched. \\n Note that: in\n                            addition
-    to the negated version of the Selector (see NotSelector\n                            below),
-    the selector expression syntax itself supports\n                            negation.
-    \ The two types of negation are subtly different.\n                            One
-    negates the set of matched endpoints, the other negates\n                            the
-    whole match: \\n \\tSelector = \\\"!has(my_label)\\\" matches\n                            packets
-    that are from other Calico-controlled \\tendpoints\n                            that
-    do not have the label “my_label”. \\n \\tNotSelector\n                            =
-    \\\"has(my_label)\\\" matches packets that are not from\n                            Calico-controlled
-    \\tendpoints that do have the label “my_label”.\n                            \\n
-    The effect is that the latter will accept packets from\n                            non-Calico
-    sources whereas the former is limited to packets\n                            from
-    Calico-controlled endpoints.\"\n                            type: string\n                          serviceAccounts:\n
-    \                           description: ServiceAccounts is an optional field
-    that restricts\n                              the rule to only apply to traffic
-    that originates from\n                              (or terminates at) a pod running
-    as a matching service\n                              account.\n                            properties:\n
-    \                             names:\n                                description:
-    Names is an optional field that restricts\n                                  the
-    rule to only apply to traffic that originates\n                                  from
-    (or terminates at) a pod running as a service\n                                  account
-    whose name is in the list.\n                                items:\n                                  type:
-    string\n                                type: array\n                              selector:\n
-    \                               description: Selector is an optional field that
-    restricts\n                                  the rule to only apply to traffic
-    that originates\n                                  from (or terminates at) a pod
-    running as a service\n                                  account that matches the
-    given label selector. If\n                                  both Names and Selector
-    are specified then they are\n                                  AND'ed.\n                                type:
-    string\n                            type: object\n                          services:\n
-    \                           description: \"Services is an optional field that
-    contains\n                              options for matching Kubernetes Services.
-    If specified,\n                              only traffic that originates from
-    or terminates at endpoints\n                              within the selected
-    service(s) will be matched, and only\n                              to/from each
-    endpoint's port. \\n Services cannot be specified\n                              on
-    the same rule as Selector, NotSelector, NamespaceSelector,\n                              Ports,
-    NotPorts, Nets, NotNets or ServiceAccounts. \\n\n                              Only
-    valid on egress rules.\"\n                            properties:\n                              name:\n
-    \                               description: Name specifies the name of a Kubernetes\n
-    \                                 Service to match.\n                                type:
-    string\n                              namespace:\n                                description:
-    Namespace specifies the namespace of the\n                                  given
-    Service. If left empty, the rule will match\n                                  within
-    this policy's namespace.\n                                type: string\n                            type:
-    object\n                        type: object\n                    required:\n
-    \                     - action\n                    type: object\n                  type:
-    array\n                order:\n                  description: Order is an optional
-    field that specifies the order in\n                    which the policy is applied.
-    Policies with higher \"order\" are applied\n                    after those with
-    lower order.  If the order is omitted, it may be\n                    considered
-    to be \"infinite\" - i.e. the policy will be applied last.  Policies\n                    with
-    identical order will be applied in alphanumerical order based\n                    on
-    the Policy \"Name\".\n                  type: number\n                selector:\n
-    \                 description: \"The selector is an expression used to pick pick
-    out\n                  the endpoints that the policy should be applied to. \\n
-    Selector\n                  expressions follow this syntax: \\n \\tlabel == \\\"string_literal\\\"\n
-    \                 \\ ->  comparison, e.g. my_label == \\\"foo bar\\\" \\tlabel
-    != \\\"string_literal\\\"\n                  \\  ->  not equal; also matches if
-    label is not present \\tlabel in\n                  { \\\"a\\\", \\\"b\\\", \\\"c\\\",
-    ... }  ->  true if the value of label X is\n                  one of \\\"a\\\",
-    \\\"b\\\", \\\"c\\\" \\tlabel not in { \\\"a\\\", \\\"b\\\", \\\"c\\\",\n                  ...
-    }  ->  true if the value of label X is not one of \\\"a\\\", \\\"b\\\",\n                  \\\"c\\\"
-    \\thas(label_name)  -> True if that label is present \\t! expr\n                  ->
-    negation of expr \\texpr && expr  -> Short-circuit and \\texpr\n                  ||
-    expr  -> Short-circuit or \\t( expr ) -> parens for grouping \\tall()\n                  or
-    the empty selector -> matches all endpoints. \\n Label names are\n                  allowed
-    to contain alphanumerics, -, _ and /. String literals are\n                  more
-    permissive but they do not support escape characters. \\n Examples\n                  (with
-    made-up labels): \\n \\ttype == \\\"webserver\\\" && deployment\n                  ==
-    \\\"prod\\\" \\ttype in {\\\"frontend\\\", \\\"backend\\\"} \\tdeployment !=\n
-    \                 \\\"dev\\\" \\t! has(label_name)\"\n                  type:
-    string\n                serviceAccountSelector:\n                  description:
-    ServiceAccountSelector is an optional field for an expression\n                    used
-    to select a pod based on service accounts.\n                  type: string\n                types:\n
-    \                 description: \"Types indicates whether this policy applies to
-    ingress,\n                  or to egress, or to both.  When not explicitly specified
-    (and so\n                  the value on creation is empty or nil), Calico defaults
-    Types according\n                  to what Ingress and Egress are present in the
-    policy.  The default\n                  is: \\n - [ PolicyTypeIngress ], if there
-    are no Egress rules (including\n                  the case where there are   also
-    no Ingress rules) \\n - [ PolicyTypeEgress\n                  ], if there are
-    Egress rules but no Ingress rules \\n - [ PolicyTypeIngress,\n                  PolicyTypeEgress
-    ], if there are both Ingress and Egress rules.\n                  \\n When the
-    policy is read back again, Types will always be one\n                  of these
-    values, never empty or nil.\"\n                  items:\n                    description:
-    PolicyType enumerates the possible values of the PolicySpec\n                      Types
-    field.\n                    type: string\n                  type: array\n              type:
-    object\n          type: object\n      served: true\n      storage: true\nstatus:\n
-    \ acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions:
-    []\n\n---\n\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n
-    \ annotations:\n    controller-gen.kubebuilder.io/version: (devel)\n  creationTimestamp:
-    null\n  name: networksets.crd.projectcalico.org\nspec:\n  group: crd.projectcalico.org\n
-    \ names:\n    kind: NetworkSet\n    listKind: NetworkSetList\n    plural: networksets\n
-    \   singular: networkset\n  scope: Namespaced\n  versions:\n    - name: v1\n      schema:\n
-    \       openAPIV3Schema:\n          description: NetworkSet is the Namespaced-equivalent
-    of the GlobalNetworkSet.\n          properties:\n            apiVersion:\n              description:
-    'APIVersion defines the versioned schema of this representation\n              of
-    an object. Servers should convert recognized schemas to the latest\n              internal
-    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
-    \             type: string\n            kind:\n              description: 'Kind
-    is a string value representing the REST resource this\n              object represents.
-    Servers may infer this from the endpoint the client\n              submits requests
-    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
-    \             type: string\n            metadata:\n              type: object\n
-    \           spec:\n              description: NetworkSetSpec contains the specification
-    for a NetworkSet\n                resource.\n              properties:\n                nets:\n
-    \                 description: The list of IP networks that belong to this set.\n
-    \                 items:\n                    type: string\n                  type:
-    array\n              type: object\n          type: object\n      served: true\n
-    \     storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
-    \ conditions: []\n  storedVersions: []\n\n---\n---\n# Source: calico/templates/calico-kube-controllers-rbac.yaml\n\n#
-    Include a clusterrole for the kube-controllers component,\n# and bind it to the
-    calico-kube-controllers serviceaccount.\nkind: ClusterRole\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nrules:\n  # Nodes are watched to monitor for
-    deletions.\n  - apiGroups: [\"\"]\n    resources:\n      - nodes\n    verbs:\n
-    \     - watch\n      - list\n      - get\n  # Pods are watched to check for existence
-    as part of IPAM controller.\n  - apiGroups: [\"\"]\n    resources:\n      - pods\n
-    \   verbs:\n      - get\n      - list\n      - watch\n  # IPAM resources are manipulated
-    when nodes are deleted.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - ippools\n    verbs:\n      - list\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - blockaffinities\n      - ipamblocks\n      - ipamhandles\n
-    \   verbs:\n      - get\n      - list\n      - create\n      - update\n      -
-    delete\n      - watch\n  # kube-controllers manages hostendpoints.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - hostendpoints\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  #
-    Needs access to update clusterinformations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - clusterinformations\n    verbs:\n      - get\n      -
-    create\n      - update\n  # KubeControllersConfiguration is where it gets its
-    config\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - kubecontrollersconfigurations\n
-    \   verbs:\n      # read its own config\n      - get\n      # create a default
-    if none exists\n      - create\n      # update status\n      - update\n      #
-    watch for changes\n      - watch\n---\nkind: ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n
-    \ name: calico-kube-controllers\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-kube-controllers\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-kube-controllers\n    namespace: kube-system\n---\n\n---\n# Source:
-    calico/templates/calico-node-rbac.yaml\n# Include a clusterrole for the calico-node
-    DaemonSet,\n# and bind it to the calico-node serviceaccount.\nkind: ClusterRole\napiVersion:
-    rbac.authorization.k8s.io/v1\nmetadata:\n  name: calico-node\nrules:\n  # The
-    CNI plugin needs to get pods, nodes, and namespaces.\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - pods\n      - nodes\n      - namespaces\n    verbs:\n
-    \     - get\n  # EndpointSlices are used for Service-based network policy rule\n
-    \ # enforcement.\n  - apiGroups: [\"discovery.k8s.io\"]\n    resources:\n      -
-    endpointslices\n    verbs:\n      - watch\n      - list\n  - apiGroups: [\"\"]\n
-    \   resources:\n      - endpoints\n      - services\n    verbs:\n      # Used
-    to discover service IPs for advertisement.\n      - watch\n      - list\n      #
-    Used to discover Typhas.\n      - get\n  # Pod CIDR auto-detection on kubeadm
-    needs access to config maps.\n  - apiGroups: [\"\"]\n    resources:\n      - configmaps\n
-    \   verbs:\n      - get\n  - apiGroups: [\"\"]\n    resources:\n      - nodes/status\n
-    \   verbs:\n      # Needed for clearing NodeNetworkUnavailable flag.\n      -
-    patch\n      # Calico stores some configuration information in node annotations.\n
-    \     - update\n  # Watch for changes to Kubernetes NetworkPolicies.\n  - apiGroups:
-    [\"networking.k8s.io\"]\n    resources:\n      - networkpolicies\n    verbs:\n
-    \     - watch\n      - list\n  # Used by Calico for policy information.\n  - apiGroups:
-    [\"\"]\n    resources:\n      - pods\n      - namespaces\n      - serviceaccounts\n
-    \   verbs:\n      - list\n      - watch\n  # The CNI plugin patches pods/status.\n
-    \ - apiGroups: [\"\"]\n    resources:\n      - pods/status\n    verbs:\n      -
-    patch\n  # Calico monitors various CRDs for config.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - globalfelixconfigs\n      - felixconfigurations\n      -
-    bgppeers\n      - globalbgpconfigs\n      - bgpconfigurations\n      - ippools\n
-    \     - ipamblocks\n      - globalnetworkpolicies\n      - globalnetworksets\n
-    \     - networkpolicies\n      - networksets\n      - clusterinformations\n      -
-    hostendpoints\n      - blockaffinities\n    verbs:\n      - get\n      - list\n
-    \     - watch\n  # Calico must create and update some CRDs on startup.\n  - apiGroups:
-    [\"crd.projectcalico.org\"]\n    resources:\n      - ippools\n      - felixconfigurations\n
-    \     - clusterinformations\n    verbs:\n      - create\n      - update\n  # Calico
-    stores some configuration information on the node.\n  - apiGroups: [\"\"]\n    resources:\n
-    \     - nodes\n    verbs:\n      - get\n      - list\n      - watch\n  # These
-    permissions are only required for upgrade from v2.6, and can\n  # be removed after
-    upgrade or on fresh installations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n
-    \   resources:\n      - bgpconfigurations\n      - bgppeers\n    verbs:\n      -
-    create\n      - update\n  # These permissions are required for Calico CNI to perform
-    IPAM allocations.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n      - ipamblocks\n      - ipamhandles\n    verbs:\n
-    \     - get\n      - list\n      - create\n      - update\n      - delete\n  -
-    apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n      - ipamconfigs\n
-    \   verbs:\n      - get\n  # Block affinities must also be watchable by confd
-    for route aggregation.\n  - apiGroups: [\"crd.projectcalico.org\"]\n    resources:\n
-    \     - blockaffinities\n    verbs:\n      - watch\n  # The Calico IPAM migration
-    needs to get daemonsets. These permissions can be\n  # removed if not upgrading
-    from an installation using host-local IPAM.\n  - apiGroups: [\"apps\"]\n    resources:\n
-    \     - daemonsets\n    verbs:\n      - get\n\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:
-    ClusterRoleBinding\nmetadata:\n  name: calico-node\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
-    \ kind: ClusterRole\n  name: calico-node\nsubjects:\n  - kind: ServiceAccount\n
-    \   name: calico-node\n    namespace: kube-system\n\n---\n# Source: calico/templates/calico-node.yaml\n#
-    This manifest installs the calico-node container, as well\n# as the CNI plugins
-    and network config on\n# each master and worker node in a Kubernetes cluster.\nkind:
-    DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: calico-node\n  namespace: kube-system\n
-    \ labels:\n    k8s-app: calico-node\nspec:\n  selector:\n    matchLabels:\n      k8s-app:
-    calico-node\n  updateStrategy:\n    type: RollingUpdate\n    rollingUpdate:\n
-    \     maxUnavailable: 1\n  template:\n    metadata:\n      labels:\n        k8s-app:
-    calico-node\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n
-    \     hostNetwork: true\n      tolerations:\n        # Make sure calico-node gets
-    scheduled on all nodes.\n        - effect: NoSchedule\n          operator: Exists\n
-    \       # Mark the pod as a critical add-on for rescheduling.\n        - key:
-    CriticalAddonsOnly\n          operator: Exists\n        - effect: NoExecute\n
-    \         operator: Exists\n      serviceAccountName: calico-node\n      # Minimize
-    downtime during a rolling upgrade or deletion; tell Kubernetes to do a \"force\n
-    \     # deletion\": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.\n
-    \     terminationGracePeriodSeconds: 0\n      priorityClassName: system-node-critical\n
-    \     initContainers:\n        # This container performs upgrade from host-local
-    IPAM to calico-ipam.\n        # It can be deleted if this is a fresh installation,
-    or if you have already\n        # upgraded to use calico-ipam.\n        - name:
-    upgrade-ipam\n          image: calico/cni:v3.20.0\n          command: [\"/opt/cni/bin/calico-ipam\",
-    \"-upgrade\"]\n          envFrom:\n            - configMapRef:\n                #
-    Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for
-    eBPF mode.\n                name: kubernetes-services-endpoint\n                optional:
-    true\n          env:\n            - name: KUBERNETES_NODE_NAME\n              valueFrom:\n
-    \               fieldRef:\n                  fieldPath: spec.nodeName\n            -
-    name: CALICO_NETWORKING_BACKEND\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: calico_backend\n
-    \         volumeMounts:\n            - mountPath: /var/lib/cni/networks\n              name:
-    host-local-net-dir\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n          securityContext:\n            privileged: true\n        #
-    This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: calico/cni:v3.20.0\n
-    \         command: [\"/opt/cni/bin/install\"]\n          envFrom:\n            -
-    configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
-    to be overridden for eBPF mode.\n                name: kubernetes-services-endpoint\n
-    \               optional: true\n          env:\n            # Name of the CNI
-    config file to create.\n            - name: CNI_CONF_NAME\n              value:
-    \"10-calico.conflist\"\n            # The CNI network config to install on each
-    node.\n            - name: CNI_NETWORK_CONFIG\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: cni_network_config\n
-    \           # Set the hostname based on the k8s node name.\n            - name:
-    KUBERNETES_NODE_NAME\n              valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # CNI MTU Config variable\n            - name: CNI_MTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Prevents the container
-    from sleeping forever.\n            - name: SLEEP\n              value: \"false\"\n
-    \         volumeMounts:\n            - mountPath: /host/opt/cni/bin\n              name:
-    cni-bin-dir\n            - mountPath: /host/etc/cni/net.d\n              name:
-    cni-net-dir\n          securityContext:\n            privileged: true\n        #
-    Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes\n
-    \       # to communicate with Felix over the Policy Sync API.\n        - name:
-    flexvol-driver\n          image: calico/pod2daemon-flexvol:v3.20.0\n          volumeMounts:\n
-    \           - name: flexvol-driver-host\n              mountPath: /host/driver\n
-    \         securityContext:\n            privileged: true\n      containers:\n
-    \       # Runs calico-node container on each Kubernetes node. This\n        #
-    container programs network policy and routes on each\n        # host.\n        -
-    name: calico-node\n          image: calico/node:v3.20.0\n          envFrom:\n
-    \           - configMapRef:\n                # Allow KUBERNETES_SERVICE_HOST and
-    KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.\n                name:
-    kubernetes-services-endpoint\n                optional: true\n          env:\n
-    \           # Use Kubernetes API as the backing datastore.\n            - name:
-    DATASTORE_TYPE\n              value: \"kubernetes\"\n            # Wait for the
-    datastore.\n            - name: WAIT_FOR_DATASTORE\n              value: \"true\"\n
-    \           # Set based on the k8s node name.\n            - name: NODENAME\n
-    \             valueFrom:\n                fieldRef:\n                  fieldPath:
-    spec.nodeName\n            # Choose the backend to use.\n            - name: CALICO_NETWORKING_BACKEND\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: calico_backend\n            # Cluster type
-    to identify the deployment type\n            - name: CLUSTER_TYPE\n              value:
-    \"k8s,bgp\"\n            # Auto-detect the BGP IP address.\n            - name:
-    IP\n              value: \"autodetect\"\n            # Enable VXLAN\n            -
-    name: CALICO_IPV4POOL_VXLAN\n              value: \"Always\"\n            # Set
-    MTU for tunnel device used if ipip is enabled\n            - name: FELIX_IPINIPMTU\n
-    \             valueFrom:\n                configMapKeyRef:\n                  name:
-    calico-config\n                  key: veth_mtu\n            # Set MTU for the
-    VXLAN tunnel device.\n            - name: FELIX_VXLANMTU\n              valueFrom:\n
-    \               configMapKeyRef:\n                  name: calico-config\n                  key:
-    veth_mtu\n            # Set MTU for the Wireguard tunnel device.\n            -
-    name: FELIX_WIREGUARDMTU\n              valueFrom:\n                configMapKeyRef:\n
-    \                 name: calico-config\n                  key: veth_mtu\n            #
-    The default IPv4 pool to create on startup if none exists. Pod IPs will be\n            #
-    chosen from this range. Changing this value after installation will have\n            #
-    no effect. This should fall within `--cluster-cidr`.\n            # - name: CALICO_IPV4POOL_CIDR\n
-    \           #   value: \"192.168.0.0/16\"\n            # Disable file logging
-    so `kubectl logs` works.\n            - name: CALICO_DISABLE_FILE_LOGGING\n              value:
-    \"true\"\n            # Set Felix endpoint to host default action to ACCEPT.\n
-    \           - name: FELIX_DEFAULTENDPOINTTOHOSTACTION\n              value: \"ACCEPT\"\n
-    \           # Disable IPv6 on Kubernetes.\n            - name: FELIX_IPV6SUPPORT\n
-    \             value: \"false\"\n            - name: FELIX_FEATUREDETECTOVERRIDE\n
-    \             value: \"ChecksumOffloadBroken=true\"\n            - name: FELIX_HEALTHENABLED\n
-    \             value: \"true\"\n          securityContext:\n            privileged:
-    true\n          resources:\n            requests:\n              cpu: 250m\n          livenessProbe:\n
-    \           exec:\n              command:\n                - /bin/calico-node\n
-    \               - -felix-live\n            periodSeconds: 10\n            initialDelaySeconds:
-    10\n            failureThreshold: 6\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /bin/calico-node\n                -
-    -felix-ready\n            periodSeconds: 10\n          volumeMounts:\n            -
-    mountPath: /host/etc/cni/net.d\n              name: cni-net-dir\n              readOnly:
-    false\n            - mountPath: /lib/modules\n              name: lib-modules\n
-    \             readOnly: true\n            - mountPath: /run/xtables.lock\n              name:
-    xtables-lock\n              readOnly: false\n            - mountPath: /var/run/calico\n
-    \             name: var-run-calico\n              readOnly: false\n            -
-    mountPath: /var/lib/calico\n              name: var-lib-calico\n              readOnly:
-    false\n            - name: policysync\n              mountPath: /var/run/nodeagent\n
-    \           # For eBPF mode, we need to be able to mount the BPF filesystem at
-    /sys/fs/bpf so we mount in the\n            # parent directory.\n            -
-    name: sysfs\n              mountPath: /sys/fs/\n              # Bidirectional
-    means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to
-    the host.\n              # If the host is known to mount that filesystem already
-    then Bidirectional can be omitted.\n              mountPropagation: Bidirectional\n
-    \           - name: cni-log-dir\n              mountPath: /var/log/calico/cni\n
-    \             readOnly: true\n      volumes:\n        # Used by calico-node.\n
-    \       - name: lib-modules\n          hostPath:\n            path: /lib/modules\n
-    \       - name: var-run-calico\n          hostPath:\n            path: /var/run/calico\n
-    \       - name: var-lib-calico\n          hostPath:\n            path: /var/lib/calico\n
-    \       - name: xtables-lock\n          hostPath:\n            path: /run/xtables.lock\n
-    \           type: FileOrCreate\n        - name: sysfs\n          hostPath:\n            path:
-    /sys/fs/\n            type: DirectoryOrCreate\n        # Used to install CNI.\n
-    \       - name: cni-bin-dir\n          hostPath:\n            path: /opt/cni/bin\n
-    \       - name: cni-net-dir\n          hostPath:\n            path: /etc/cni/net.d\n
-    \       # Used to access CNI logs.\n        - name: cni-log-dir\n          hostPath:\n
-    \           path: /var/log/calico/cni\n        # Mount in the directory for host-local
-    IPAM allocations. This is\n        # used when upgrading from host-local to calico-ipam,
-    and can be removed\n        # if not using the upgrade-ipam init container.\n
-    \       - name: host-local-net-dir\n          hostPath:\n            path: /var/lib/cni/networks\n
-    \       # Used to create per-pod Unix Domain Sockets\n        - name: policysync\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /var/run/nodeagent\n
-    \       # Used to install Flex Volume Driver\n        - name: flexvol-driver-host\n
-    \         hostPath:\n            type: DirectoryOrCreate\n            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds\n---\n\napiVersion:
-    v1\nkind: ServiceAccount\nmetadata:\n  name: calico-node\n  namespace: kube-system\n\n---\n#
-    Source: calico/templates/calico-kube-controllers.yaml\n# See https://github.com/projectcalico/kube-controllers\napiVersion:
-    apps/v1\nkind: Deployment\nmetadata:\n  name: calico-kube-controllers\n  namespace:
-    kube-system\n  labels:\n    k8s-app: calico-kube-controllers\nspec:\n  # The controllers
-    can only have a single active instance.\n  replicas: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n  strategy:\n    type: Recreate\n  template:\n
-    \   metadata:\n      name: calico-kube-controllers\n      namespace: kube-system\n
-    \     labels:\n        k8s-app: calico-kube-controllers\n    spec:\n      nodeSelector:\n
-    \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
-    a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
-    Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
-    \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
-    \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
-    \         env:\n            # Choose which controllers to run.\n            -
-    name: ENABLED_CONTROLLERS\n              value: node\n            - name: DATASTORE_TYPE\n
-    \             value: kubernetes\n          livenessProbe:\n            exec:\n
-    \             command:\n              - /usr/bin/check-status\n              -
-    -l\n            periodSeconds: 10\n            initialDelaySeconds: 10\n            failureThreshold:
-    6\n            timeoutSeconds: 10\n          readinessProbe:\n            exec:\n
-    \             command:\n                - /usr/bin/check-status\n                -
-    -r\n            periodSeconds: 10\n\n---\n\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n\n---\n\n# This manifest
-    creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler
-    to evict\n\napiVersion: policy/v1beta1\nkind: PodDisruptionBudget\nmetadata:\n
-    \ name: calico-kube-controllers\n  namespace: kube-system\n  labels:\n    k8s-app:
-    calico-kube-controllers\nspec:\n  maxUnavailable: 1\n  selector:\n    matchLabels:\n
-    \     k8s-app: calico-kube-controllers\n---\n# Source: calico/templates/calico-etcd-secrets.yaml\n\n---\n#
-    Source: calico/templates/calico-typha.yaml\n\n---\n# Source: calico/templates/configure-canal.yaml\n"
+  resources: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgpconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPConfiguration
+        listKind: BGPConfigurationList
+        plural: bgpconfigurations
+        singular: bgpconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: BGPConfiguration contains the configuration for any BGP routing.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPConfigurationSpec contains the values of the BGP configuration.
+                properties:
+                  asNumber:
+                    description: 'ASNumber is the default AS number used by a node. [Default:
+                      64512]'
+                    format: int32
+                    type: integer
+                  communities:
+                    description: Communities is a list of BGP community values and their
+                      arbitrary names for tagging routes.
+                    items:
+                      description: Community contains standard or large community value
+                        and its name.
+                      properties:
+                        name:
+                          description: Name given to community value.
+                          type: string
+                        value:
+                          description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                            For standard community use `aa:nn` format, where `aa` and
+                            `nn` are 16 bit number. For large community use `aa:nn:mm`
+                            format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                            `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                          pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                          type: string
+                      type: object
+                    type: array
+                  listenPort:
+                    description: ListenPort is the port where BGP protocol should listen.
+                      Defaults to 179
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: INFO]'
+                    type: string
+                  nodeToNodeMeshEnabled:
+                    description: 'NodeToNodeMeshEnabled sets whether full node to node
+                      BGP mesh is enabled. [Default: true]'
+                    type: boolean
+                  prefixAdvertisements:
+                    description: PrefixAdvertisements contains per-prefix advertisement
+                      configuration.
+                    items:
+                      description: PrefixAdvertisement configures advertisement properties
+                        for the specified CIDR.
+                      properties:
+                        cidr:
+                          description: CIDR for which properties should be advertised.
+                          type: string
+                        communities:
+                          description: Communities can be list of either community names
+                            already defined in `Specs.Communities` or community value
+                            of format `aa:nn` or `aa:nn:mm`. For standard community use
+                            `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                            large community use `aa:nn:mm` format, where `aa`, `nn` and
+                            `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                            `mm` are per-AS identifier.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  serviceClusterIPs:
+                    description: ServiceClusterIPs are the CIDR blocks from which service
+                      cluster IPs are allocated. If specified, Calico will advertise these
+                      blocks, as well as any cluster IPs within them.
+                    items:
+                      description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                        CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceExternalIPs:
+                    description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                      Service External IPs. Kubernetes Service ExternalIPs will only be
+                      advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceExternalIPBlock represents a single allowed
+                        External IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceLoadBalancerIPs:
+                    description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                      Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                      IPs will only be advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceLoadBalancerIPBlock represents a single allowed
+                        LoadBalancer IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgppeers.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPPeer
+        listKind: BGPPeerList
+        plural: bgppeers
+        singular: bgppeer
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPPeerSpec contains the specification for a BGPPeer resource.
+                properties:
+                  asNumber:
+                    description: The AS Number of the peer.
+                    format: int32
+                    type: integer
+                  keepOriginalNextHop:
+                    description: Option to keep the original nexthop field when routes
+                      are sent to a BGP Peer. Setting "true" configures the selected BGP
+                      Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                      in the specific branch of the Node on "bird.cfg".
+                    type: boolean
+                  maxRestartTime:
+                    description: Time to allow for software restart.  When specified,
+                      this is configured as the graceful restart timeout.  When not specified,
+                      the BIRD default of 120s is used.
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance that
+                      is targeted by this peer. If this is not set, and no nodeSelector
+                      is specified, then this BGP peer selects all nodes in the cluster.
+                    type: string
+                  nodeSelector:
+                    description: Selector for the nodes that should have this peering.  When
+                      this is set, the Node field must be empty.
+                    type: string
+                  password:
+                    description: Optional BGP password for the peerings generated by this
+                      BGPPeer resource.
+                    properties:
+                      secretKeyRef:
+                        description: Selects a key of a secret in the node pod's namespace.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be
+                              a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be
+                              defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  peerIP:
+                    description: The IP address of the peer followed by an optional port
+                      number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                      or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                      and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                      set in BGPConfiguration, then we use that port to peer.
+                    type: string
+                  peerSelector:
+                    description: Selector for the remote nodes to peer with.  When this
+                      is set, the PeerIP and ASNumber fields must be empty.  For each
+                      peering between the local node and selected remote nodes, we configure
+                      an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                      and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                      remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                      or the global default if that is not set.
+                    type: string
+                  sourceAddress:
+                    description: Specifies whether and how to configure a source address
+                      for the peerings generated by this BGPPeer resource.  Default value
+                      "UseNodeIP" means to configure the node IP as the source address.  "None"
+                      means not to configure a source address.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: blockaffinities.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BlockAffinity
+        listKind: BlockAffinityList
+        plural: blockaffinities
+        singular: blockaffinity
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BlockAffinitySpec contains the specification for a BlockAffinity
+                  resource.
+                properties:
+                  cidr:
+                    type: string
+                  deleted:
+                    description: Deleted indicates that this block affinity is being deleted.
+                      This field is a string for compatibility with older releases that
+                      mistakenly treat this field as a string.
+                    type: string
+                  node:
+                    type: string
+                  state:
+                    type: string
+                required:
+                - cidr
+                - deleted
+                - node
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: clusterinformations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: ClusterInformation
+        listKind: ClusterInformationList
+        plural: clusterinformations
+        singular: clusterinformation
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterInformation contains the cluster specific information.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterInformationSpec contains the values of describing
+                  the cluster.
+                properties:
+                  calicoVersion:
+                    description: CalicoVersion is the version of Calico that the cluster
+                      is running
+                    type: string
+                  clusterGUID:
+                    description: ClusterGUID is the GUID of the cluster
+                    type: string
+                  clusterType:
+                    description: ClusterType describes the type of the cluster
+                    type: string
+                  datastoreReady:
+                    description: DatastoreReady is used during significant datastore migrations
+                      to signal to components such as Felix that it should wait before
+                      accessing the datastore.
+                    type: boolean
+                  variant:
+                    description: Variant declares which variant of Calico should be active.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: felixconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: FelixConfiguration
+        listKind: FelixConfigurationList
+        plural: felixconfigurations
+        singular: felixconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: Felix Configuration contains the configuration for Felix.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: FelixConfigurationSpec contains the values of the Felix configuration.
+                properties:
+                  allowIPIPPacketsFromWorkloads:
+                    description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop IPIP encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  allowVXLANPacketsFromWorkloads:
+                    description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop VXLAN encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  awsSrcDstCheck:
+                    description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                      value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                      DoNothing]'
+                    enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                    type: string
+                  bpfConnectTimeLoadBalancingEnabled:
+                    description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                      controls whether Felix installs the connection-time load balancer.  The
+                      connect-time load balancer is required for the host to be able to
+                      reach Kubernetes services and it improves the performance of pod-to-service
+                      connections.  The only reason to disable it is for debugging purposes.  [Default:
+                      true]'
+                    type: boolean
+                  bpfDataIfacePattern:
+                    description: BPFDataIfacePattern is a regular expression that controls
+                      which interfaces Felix should attach BPF programs to in order to
+                      catch traffic to/from the network.  This needs to match the interfaces
+                      that Calico workload traffic flows over as well as any interfaces
+                      that handle incoming traffic to nodeports and services from outside
+                      the cluster.  It should not match the workload interfaces (usually
+                      named cali...).
+                    type: string
+                  bpfDisableUnprivileged:
+                    description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                      sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                      users cannot access Calico''s BPF maps and cannot insert their own
+                      BPF programs to interfere with Calico''s. [Default: true]'
+                    type: boolean
+                  bpfEnabled:
+                    description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                      [Default: false]'
+                    type: boolean
+                  bpfExtToServiceConnmark:
+                    description: 'BPFExtToServiceConnmark in BPF mode, controls a 32bit
+                      mark that is set on connections from an external client to a local
+                      service. This mark allows us to control how packets of that connection
+                      are routed within the host and how is routing intepreted by RPF
+                      check. [Default: 0]'
+                    type: integer
+                  bpfExternalServiceMode:
+                    description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                      from outside the cluster to services (node ports and cluster IPs)
+                      are forwarded to remote workloads.  If set to "Tunnel" then both
+                      request and response traffic is tunneled to the remote node.  If
+                      set to "DSR", the request traffic is tunneled but the response traffic
+                      is sent directly from the remote node.  In "DSR" mode, the remote
+                      node appears to use the IP of the ingress node; this requires a
+                      permissive L2 network.  [Default: Tunnel]'
+                    type: string
+                  bpfKubeProxyEndpointSlicesEnabled:
+                    description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                      whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                    type: boolean
+                  bpfKubeProxyIptablesCleanupEnabled:
+                    description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                      mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                      iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                      true]'
+                    type: boolean
+                  bpfKubeProxyMinSyncPeriod:
+                    description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                      minimum time between updates to the dataplane for Felix''s embedded
+                      kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                      reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                    type: string
+                  bpfLogLevel:
+                    description: 'BPFLogLevel controls the log level of the BPF programs
+                      when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                      logs are emitted to the BPF trace pipe, accessible with the command
+                      `tc exec bpf debug`. [Default: Off].'
+                    type: string
+                  chainInsertMode:
+                    description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                      top-level iptables chains by inserting a rule at the top of the
+                      chain or by appending a rule at the bottom. insert is the safe default
+                      since it prevents Calico''s rules from being bypassed. If you switch
+                      to append mode, be sure that the other rules in the chains signal
+                      acceptance by falling through to the Calico rules, otherwise the
+                      Calico policy will be bypassed. [Default: insert]'
+                    type: string
+                  dataplaneDriver:
+                    type: string
+                  debugDisableLogDropping:
+                    type: boolean
+                  debugMemoryProfilePath:
+                    type: string
+                  debugSimulateCalcGraphHangAfter:
+                    type: string
+                  debugSimulateDataplaneHangAfter:
+                    type: string
+                  defaultEndpointToHostAction:
+                    description: 'DefaultEndpointToHostAction controls what happens to
+                      traffic that goes from a workload endpoint to the host itself (after
+                      the traffic hits the endpoint egress policy). By default Calico
+                      blocks traffic from workload endpoints to the host itself with an
+                      iptables "DROP" action. If you want to allow some or all traffic
+                      from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                      RETURN if you have your own rules in the iptables "INPUT" chain;
+                      Calico will insert its rules at the top of that chain, then "RETURN"
+                      packets to the "INPUT" chain once it has completed processing workload
+                      endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                      from workloads after processing workload endpoint egress policy.
+                      [Default: Drop]'
+                    type: string
+                  deviceRouteProtocol:
+                    description: This defines the route protocol added to programmed device
+                      routes, by default this will be RTPROT_BOOT when left blank.
+                    type: integer
+                  deviceRouteSourceAddress:
+                    description: This is the source address to use on programmed device
+                      routes. By default the source address is left blank, leaving the
+                      kernel to choose the source address used.
+                    type: string
+                  disableConntrackInvalidCheck:
+                    type: boolean
+                  endpointReportingDelay:
+                    type: string
+                  endpointReportingEnabled:
+                    type: boolean
+                  externalNodesList:
+                    description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                      which may source tunnel traffic and have the tunneled traffic be
+                      accepted at calico nodes.
+                    items:
+                      type: string
+                    type: array
+                  failsafeInboundHostPorts:
+                    description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow incoming traffic to host endpoints
+                      on irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all inbound host ports, use the value
+                      none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                      udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  failsafeOutboundHostPorts:
+                    description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow outgoing traffic from host endpoints
+                      to irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all outbound host ports, use the value
+                      none. The default value opens etcd''s standard ports to ensure that
+                      Felix does not get cut off from etcd as well as allowing DHCP and
+                      DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                      tcp:6667, udp:53, udp:67]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  featureDetectOverride:
+                    description: FeatureDetectOverride is used to override the feature
+                      detection. Values are specified in a comma separated list with no
+                      spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                      "true" or "false" will force the feature, empty or omitted values
+                      are auto-detected.
+                    type: string
+                  genericXDPEnabled:
+                    description: 'GenericXDPEnabled enables Generic XDP so network cards
+                      that don''t support XDP offload or driver modes can use XDP. This
+                      is not recommended since it doesn''t provide better performance
+                      than iptables. [Default: false]'
+                    type: boolean
+                  healthEnabled:
+                    type: boolean
+                  healthHost:
+                    type: string
+                  healthPort:
+                    type: integer
+                  interfaceExclude:
+                    description: 'InterfaceExclude is a comma-separated list of interfaces
+                      that Felix should exclude when monitoring for host endpoints. The
+                      default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                      interface, which is used internally by kube-proxy. If you want to
+                      exclude multiple interface names using a single value, the list
+                      supports regular expressions. For regular expressions you must wrap
+                      the value with ''/''. For example having values ''/^kube/,veth1''
+                      will exclude all interfaces that begin with ''kube'' and also the
+                      interface ''veth1''. [Default: kube-ipvs0]'
+                    type: string
+                  interfacePrefix:
+                    description: 'InterfacePrefix is the interface name prefix that identifies
+                      workload endpoints and so distinguishes them from host endpoint
+                      interfaces. Note: in environments other than bare metal, the orchestrators
+                      configure this appropriately. For example our Kubernetes and Docker
+                      integrations set the ''cali'' value, and our OpenStack integration
+                      sets the ''tap'' value. [Default: cali]'
+                    type: string
+                  interfaceRefreshInterval:
+                    description: InterfaceRefreshInterval is the period at which Felix
+                      rescans local interfaces to verify their state. The rescan can be
+                      disabled by setting the interval to 0.
+                    type: string
+                  ipipEnabled:
+                    type: boolean
+                  ipipMTU:
+                    description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  ipsetsRefreshInterval:
+                    description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                      all iptables state to ensure that no other process has accidentally
+                      broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                      90s]'
+                    type: string
+                  iptablesBackend:
+                    description: IptablesBackend specifies which backend of iptables will
+                      be used. The default is legacy.
+                    type: string
+                  iptablesFilterAllowAction:
+                    type: string
+                  iptablesLockFilePath:
+                    description: 'IptablesLockFilePath is the location of the iptables
+                      lock file. You may need to change this if the lock file is not in
+                      its standard location (for example if you have mapped it into Felix''s
+                      container at a different path). [Default: /run/xtables.lock]'
+                    type: string
+                  iptablesLockProbeInterval:
+                    description: 'IptablesLockProbeInterval is the time that Felix will
+                      wait between attempts to acquire the iptables lock if it is not
+                      available. Lower values make Felix more responsive when the lock
+                      is contended, but use more CPU. [Default: 50ms]'
+                    type: string
+                  iptablesLockTimeout:
+                    description: 'IptablesLockTimeout is the time that Felix will wait
+                      for the iptables lock, or 0, to disable. To use this feature, Felix
+                      must share the iptables lock file with all other processes that
+                      also take the lock. When running Felix inside a container, this
+                      requires the /run directory of the host to be mounted into the calico/node
+                      or calico/felix container. [Default: 0s disabled]'
+                    type: string
+                  iptablesMangleAllowAction:
+                    type: string
+                  iptablesMarkMask:
+                    description: 'IptablesMarkMask is the mask that Felix selects its
+                      IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                      at least 8 bits set, none of which clash with any other mark bits
+                      in use on the system. [Default: 0xff000000]'
+                    format: int32
+                    type: integer
+                  iptablesNATOutgoingInterfaceFilter:
+                    type: string
+                  iptablesPostWriteCheckInterval:
+                    description: 'IptablesPostWriteCheckInterval is the period after Felix
+                      has done a write to the dataplane that it schedules an extra read
+                      back in order to check the write was not clobbered by another process.
+                      This should only occur if another application on the system doesn''t
+                      respect the iptables lock. [Default: 1s]'
+                    type: string
+                  iptablesRefreshInterval:
+                    description: 'IptablesRefreshInterval is the period at which Felix
+                      re-checks the IP sets in the dataplane to ensure that no other process
+                      has accidentally broken Calico''s rules. Set to 0 to disable IP
+                      sets refresh. Note: the default for this value is lower than the
+                      other refresh intervals as a workaround for a Linux kernel bug that
+                      was fixed in kernel version 4.11. If you are using v4.11 or greater
+                      you may want to set this to, a higher value to reduce Felix CPU
+                      usage. [Default: 10s]'
+                    type: string
+                  ipv6Support:
+                    type: boolean
+                  kubeNodePortRanges:
+                    description: 'KubeNodePortRanges holds list of port ranges used for
+                      service node ports. Only used if felix detects kube-proxy running
+                      in ipvs mode. Felix uses these ranges to separate host and workload
+                      traffic. [Default: 30000:32767].'
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  logFilePath:
+                    description: 'LogFilePath is the full path to the Felix log. Set to
+                      none to disable file logging. [Default: /var/log/calico/felix.log]'
+                    type: string
+                  logPrefix:
+                    description: 'LogPrefix is the log prefix that Felix uses when rendering
+                      LOG rules. [Default: calico-packet]'
+                    type: string
+                  logSeverityFile:
+                    description: 'LogSeverityFile is the log severity above which logs
+                      are sent to the log file. [Default: Info]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  logSeveritySys:
+                    description: 'LogSeveritySys is the log severity above which logs
+                      are sent to the syslog. Set to None for no logging to syslog. [Default:
+                      Info]'
+                    type: string
+                  maxIpsetSize:
+                    type: integer
+                  metadataAddr:
+                    description: 'MetadataAddr is the IP address or domain name of the
+                      server that can answer VM queries for cloud-init metadata. In OpenStack,
+                      this corresponds to the machine running nova-api (or in Ubuntu,
+                      nova-api-metadata). A value of none (case insensitive) means that
+                      Felix should not set up any NAT rule for the metadata path. [Default:
+                      127.0.0.1]'
+                    type: string
+                  metadataPort:
+                    description: 'MetadataPort is the port of the metadata server. This,
+                      combined with global.MetadataAddr (if not ''None''), is used to
+                      set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                      In most cases this should not need to be changed [Default: 8775].'
+                    type: integer
+                  mtuIfacePattern:
+                    description: MTUIfacePattern is a regular expression that controls
+                      which interfaces Felix should scan in order to calculate the host's
+                      MTU. This should not match workload interfaces (usually named cali...).
+                    type: string
+                  natOutgoingAddress:
+                    description: NATOutgoingAddress specifies an address to use when performing
+                      source NAT for traffic in a natOutgoing pool that is leaving the
+                      network. By default the address used is an address on the interface
+                      the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                    type: string
+                  natPortRange:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NATPortRange specifies the range of ports that is used
+                      for port mapping when doing outgoing NAT. When unset the default
+                      behavior of the network stack is used.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  netlinkTimeout:
+                    type: string
+                  openstackRegion:
+                    description: 'OpenstackRegion is the name of the region that a particular
+                      Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                      this must be configured somehow for each Felix (here in the datamodel,
+                      or in felix.cfg or the environment on each compute node), and must
+                      match the [calico] openstack_region value configured in neutron.conf
+                      on each node. [Default: Empty]'
+                    type: string
+                  policySyncPathPrefix:
+                    description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                      policy changes to external services, like Application layer policy.
+                      [Default: Empty]'
+                    type: string
+                  prometheusGoMetricsEnabled:
+                    description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusMetricsEnabled:
+                    description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                      server in Felix if set to true. [Default: false]'
+                    type: boolean
+                  prometheusMetricsHost:
+                    description: 'PrometheusMetricsHost is the host that the Prometheus
+                      metrics server should bind to. [Default: empty]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. [Default: 9091]'
+                    type: integer
+                  prometheusProcessMetricsEnabled:
+                    description: 'PrometheusProcessMetricsEnabled disables process metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusWireGuardMetricsEnabled:
+                    description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                      metrics collection, which the Prometheus client does by default,
+                      when set to false. This reduces the number of metrics reported,
+                      reducing Prometheus load. [Default: true]'
+                    type: boolean
+                  removeExternalRoutes:
+                    description: Whether or not to remove device routes that have not
+                      been programmed by Felix. Disabling this will allow external applications
+                      to also add device routes. This is enabled by default which means
+                      we will remove externally added routes.
+                    type: boolean
+                  reportingInterval:
+                    description: 'ReportingInterval is the interval at which Felix reports
+                      its status into the datastore or 0 to disable. Must be non-zero
+                      in OpenStack deployments. [Default: 30s]'
+                    type: string
+                  reportingTTL:
+                    description: 'ReportingTTL is the time-to-live setting for process-wide
+                      status reports. [Default: 90s]'
+                    type: string
+                  routeRefreshInterval:
+                    description: 'RouteRefreshInterval is the period at which Felix re-checks
+                      the routes in the dataplane to ensure that no other process has
+                      accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                      [Default: 90s]'
+                    type: string
+                  routeSource:
+                    description: 'RouteSource configures where Felix gets its routing
+                      information. - WorkloadIPs: use workload endpoints to construct
+                      routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                    type: string
+                  routeTableRange:
+                    description: Calico programs additional Linux route tables for various
+                      purposes.  RouteTableRange specifies the indices of the route tables
+                      that Calico should use.
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                    - max
+                    - min
+                    type: object
+                  serviceLoopPrevention:
+                    description: 'When service IP advertisement is enabled, prevent routing
+                      loops to service IPs that are not in use, by dropping or rejecting
+                      packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                      in which case such routing loops continue to be allowed. [Default:
+                      Drop]'
+                    type: string
+                  sidecarAccelerationEnabled:
+                    description: 'SidecarAccelerationEnabled enables experimental sidecar
+                      acceleration [Default: false]'
+                    type: boolean
+                  usageReportingEnabled:
+                    description: 'UsageReportingEnabled reports anonymous Calico version
+                      number and cluster size to projectcalico.org. Logs warnings returned
+                      by the usage server. For example, if a significant security vulnerability
+                      has been discovered in the version of Calico being used. [Default:
+                      true]'
+                    type: boolean
+                  usageReportingInitialDelay:
+                    description: 'UsageReportingInitialDelay controls the minimum delay
+                      before Felix makes a report. [Default: 300s]'
+                    type: string
+                  usageReportingInterval:
+                    description: 'UsageReportingInterval controls the interval at which
+                      Felix makes reports. [Default: 86400s]'
+                    type: string
+                  useInternalDataplaneDriver:
+                    type: boolean
+                  vxlanEnabled:
+                    type: boolean
+                  vxlanMTU:
+                    description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  vxlanPort:
+                    type: integer
+                  vxlanVNI:
+                    type: integer
+                  wireguardEnabled:
+                    description: 'WireguardEnabled controls whether Wireguard is enabled.
+                      [Default: false]'
+                    type: boolean
+                  wireguardHostEncryptionEnabled:
+                    description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                      host-to-host encryption is enabled. [Default: false]'
+                    type: boolean
+                  wireguardInterfaceName:
+                    description: 'WireguardInterfaceName specifies the name to use for
+                      the Wireguard interface. [Default: wg.calico]'
+                    type: string
+                  wireguardListeningPort:
+                    description: 'WireguardListeningPort controls the listening port used
+                      by Wireguard. [Default: 51820]'
+                    type: integer
+                  wireguardMTU:
+                    description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                      See Configuring MTU [Default: 1420]'
+                    type: integer
+                  wireguardRoutingRulePriority:
+                    description: 'WireguardRoutingRulePriority controls the priority value
+                      to use for the Wireguard routing rule. [Default: 99]'
+                    type: integer
+                  xdpEnabled:
+                    description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                      incoming deny rules. [Default: true]'
+                    type: boolean
+                  xdpRefreshInterval:
+                    description: 'XDPRefreshInterval is the period at which Felix re-checks
+                      all XDP state to ensure that no other process has accidentally broken
+                      Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                      refresh. [Default: 90s]'
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkPolicy
+        listKind: GlobalNetworkPolicyList
+        plural: globalnetworkpolicies
+        singular: globalnetworkpolicy
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  applyOnForward:
+                    description: ApplyOnForward indicates to apply the rules in this policy
+                      on forward traffic.
+                    type: boolean
+                  doNotTrack:
+                    description: DoNotTrack indicates whether packets matched by the rules
+                      in this policy should go through the data plane's connection tracking,
+                      such as Linux conntrack.  If True, the rules in this policy are
+                      applied before any data plane connection tracking, and packets allowed
+                      by this policy are marked as not to be tracked.
+                    type: boolean
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    description: NamespaceSelector is an optional field for an expression
+                      used to select a pod based on namespaces.
+                    type: string
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  preDNAT:
+                    description: PreDNAT indicates to apply the rules in this policy before
+                      any DNAT.
+                    type: boolean
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress rules are present in the policy.  The
+                      default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                      (including the case where there are   also no Ingress rules) \n
+                      - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                      rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                      both Ingress and Egress rules. \n When the policy is read back again,
+                      Types will always be one of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkSet
+        listKind: GlobalNetworkSetList
+        plural: globalnetworksets
+        singular: globalnetworkset
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+              that share labels to allow rules to refer to them via selectors.  The labels
+              of GlobalNetworkSet are not namespaced.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: hostendpoints.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: HostEndpoint
+        listKind: HostEndpointList
+        plural: hostendpoints
+        singular: hostendpoint
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: HostEndpointSpec contains the specification for a HostEndpoint
+                  resource.
+                properties:
+                  expectedIPs:
+                    description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                      If \"InterfaceName\" is not present, Calico will look for an interface
+                      matching any of the IPs in the list and apply policy to that. Note:
+                      \tWhen using the selector match criteria in an ingress or egress
+                      security Policy \tor Profile, Calico converts the selector into
+                      a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                      is used for that purpose. (If only the interface \tname is specified,
+                      Calico does not learn the IPs of the interface for use in match
+                      \tcriteria.)"
+                    items:
+                      type: string
+                    type: array
+                  interfaceName:
+                    description: "Either \"*\", or the name of a specific Linux interface
+                      to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                      governs all traffic to, from or through the default network namespace
+                      of the host named by the \"Node\" field; entering and leaving that
+                      namespace via any interface, including those from/to non-host-networked
+                      local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                      only governs traffic that enters or leaves the host through the
+                      specific interface named by InterfaceName, or - when InterfaceName
+                      is empty - through the specific interface that has one of the IPs
+                      in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                      one expected IP must be specified.  Only external interfaces (such
+                      as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                      to protect traffic through a specific local workload interface.
+                      \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                      initially just pre-DNAT policy.  Please check Calico documentation
+                      for the latest position."
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance.
+                    type: string
+                  ports:
+                    description: Ports contains the endpoint's named ports, which may
+                      be referenced in security policy rules.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  profiles:
+                    description: A list of identifiers of security Profile objects that
+                      apply to this endpoint. Each profile is applied in the order that
+                      they appear in this list.  Profile rules are applied after the selector-based
+                      security policy.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamblocks.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMBlock
+        listKind: IPAMBlockList
+        plural: ipamblocks
+        singular: ipamblock
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMBlockSpec contains the specification for an IPAMBlock
+                  resource.
+                properties:
+                  affinity:
+                    type: string
+                  allocations:
+                    items:
+                      nullable: true
+                      type: integer
+                    type: array
+                  attributes:
+                    items:
+                      properties:
+                        handle_id:
+                          type: string
+                        secondary:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    type: array
+                  cidr:
+                    type: string
+                  deleted:
+                    type: boolean
+                  strictAffinity:
+                    type: boolean
+                  unallocated:
+                    items:
+                      type: integer
+                    type: array
+                required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamconfigs.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMConfig
+        listKind: IPAMConfigList
+        plural: ipamconfigs
+        singular: ipamconfig
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMConfigSpec contains the specification for an IPAMConfig
+                  resource.
+                properties:
+                  autoAllocateBlocks:
+                    type: boolean
+                  maxBlocksPerHost:
+                    description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                      that can be affine to each host.
+                    type: integer
+                  strictAffinity:
+                    type: boolean
+                required:
+                - autoAllocateBlocks
+                - strictAffinity
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamhandles.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMHandle
+        listKind: IPAMHandleList
+        plural: ipamhandles
+        singular: ipamhandle
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMHandleSpec contains the specification for an IPAMHandle
+                  resource.
+                properties:
+                  block:
+                    additionalProperties:
+                      type: integer
+                    type: object
+                  deleted:
+                    type: boolean
+                  handleID:
+                    type: string
+                required:
+                - block
+                - handleID
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ippools.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPPool
+        listKind: IPPoolList
+        plural: ippools
+        singular: ippool
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPPoolSpec contains the specification for an IPPool resource.
+                properties:
+                  blockSize:
+                    description: The block size to use for IP address assignments from
+                      this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                    type: integer
+                  cidr:
+                    description: The pool CIDR.
+                    type: string
+                  disabled:
+                    description: When disabled is true, Calico IPAM will not assign addresses
+                      from this pool.
+                    type: boolean
+                  ipip:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    properties:
+                      enabled:
+                        description: When enabled is true, ipip tunneling will be used
+                          to deliver packets to destinations within this pool.
+                        type: boolean
+                      mode:
+                        description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                          mode of "always" will also use IPIP tunneling for routing to
+                          destination IP addresses within this pool.  A mode of "cross-subnet"
+                          will only use IPIP tunneling when the destination node is on
+                          a different subnet to the originating node.  The default value
+                          (if not specified) is "always".
+                        type: string
+                    type: object
+                  ipipMode:
+                    description: Contains configuration for IPIP tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                      is disabled).
+                    type: string
+                  nat-outgoing:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    type: boolean
+                  natOutgoing:
+                    description: When nat-outgoing is true, packets sent from Calico networked
+                      containers in this pool to destinations outside of this pool will
+                      be masqueraded.
+                    type: boolean
+                  nodeSelector:
+                    description: Allows IPPool to allocate for a specific node by label
+                      selector.
+                    type: string
+                  vxlanMode:
+                    description: Contains configuration for VXLAN tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                      tunneling is disabled).
+                    type: string
+                required:
+                - cidr
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubecontrollersconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: KubeControllersConfiguration
+        listKind: KubeControllersConfigurationList
+        plural: kubecontrollersconfigurations
+        singular: kubecontrollersconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeControllersConfigurationSpec contains the values of the
+                  Kubernetes controllers configuration.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host endpoints.
+                              Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation of
+                                  host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the controller
+                              to determine if an IP address has been leaked. Set to 0
+                              to disable IP garbage collection. [Default: 15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+              status:
+                description: KubeControllersConfigurationStatus represents the status
+                  of the configuration. It's useful for admins to be able to see the actual
+                  config that was applied, which can be modified by environment variables
+                  on the kube-controllers process.
+                properties:
+                  environmentVars:
+                    additionalProperties:
+                      type: string
+                    description: EnvironmentVars contains the environment variables on
+                      the kube-controllers that influenced the RunningConfig.
+                    type: object
+                  runningConfig:
+                    description: RunningConfig contains the effective config that is running
+                      in the kube-controllers pod, after merging the API resource with
+                      any environment variables.
+                    properties:
+                      controllers:
+                        description: Controllers enables and configures individual Kubernetes
+                          controllers
+                        properties:
+                          namespace:
+                            description: Namespace enables and configures the namespace
+                              controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          node:
+                            description: Node enables and configures the node controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              hostEndpoint:
+                                description: HostEndpoint controls syncing nodes to host
+                                  endpoints. Disabled by default, set to nil to disable.
+                                properties:
+                                  autoCreate:
+                                    description: 'AutoCreate enables automatic creation
+                                      of host endpoints for every node. [Default: Disabled]'
+                                    type: string
+                                type: object
+                              leakGracePeriod:
+                                description: 'LeakGracePeriod is the period used by the
+                                  controller to determine if an IP address has been leaked.
+                                  Set to 0 to disable IP garbage collection. [Default:
+                                  15m]'
+                                type: string
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                              syncLabels:
+                                description: 'SyncLabels controls whether to copy Kubernetes
+                                  node labels to Calico nodes. [Default: Enabled]'
+                                type: string
+                            type: object
+                          policy:
+                            description: Policy enables and configures the policy controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          serviceAccount:
+                            description: ServiceAccount enables and configures the service
+                              account controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          workloadEndpoint:
+                            description: WorkloadEndpoint enables and configures the workload
+                              endpoint controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                        type: object
+                      etcdV3CompactionPeriod:
+                        description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                          compaction requests. Set to 0 to disable. [Default: 10m]'
+                        type: string
+                      healthChecks:
+                        description: 'HealthChecks enables or disables support for health
+                          checks [Default: Enabled]'
+                        type: string
+                      logSeverityScreen:
+                        description: 'LogSeverityScreen is the log severity above which
+                          logs are sent to the stdout. [Default: Info]'
+                        type: string
+                      prometheusMetricsPort:
+                        description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                          metrics server should bind to. Set to 0 to disable. [Default:
+                          9094]'
+                        type: integer
+                    required:
+                    - controllers
+                    type: object
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkPolicy
+        listKind: NetworkPolicyList
+        plural: networkpolicies
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                                Only valid on egress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress are present in the policy.  The default
+                      is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                      the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                      ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                      PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                      \n When the policy is read back again, Types will always be one
+                      of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkSet
+        listKind: NetworkSetList
+        plural: networksets
+        singular: networkset
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: NetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-kube-controllers
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      verbs:
+      - list
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - hostendpoints
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - clusterinformations
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - kubecontrollersconfigurations
+      verbs:
+      - get
+      - create
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-node
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - namespaces
+      verbs:
+      - get
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - patch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - bgpconfigurations
+      - bgppeers
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ipamconfigs
+      verbs:
+      - get
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      verbs:
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - daemonsets
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-kube-controllers
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      calico_backend: vxlan
+      cni_network_config: |-
+        {
+          "name": "k8s-pod-network",
+          "cniVersion": "0.3.1",
+          "plugins": [
+            {
+              "type": "calico",
+              "log_level": "info",
+              "log_file_path": "/var/log/calico/cni/cni.log",
+              "datastore_type": "kubernetes",
+              "nodename": "__KUBERNETES_NODE_NAME__",
+              "mtu": __CNI_MTU__,
+              "ipam": {
+                  "type": "calico-ipam"
+              },
+              "policy": {
+                  "type": "k8s"
+              },
+              "kubernetes": {
+                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              }
+            },
+            {
+              "type": "portmap",
+              "snat": true,
+              "capabilities": {"portMappings": true}
+            },
+            {
+              "type": "bandwidth",
+              "capabilities": {"bandwidth": true}
+            }
+          ]
+        }
+      typha_service_name: none
+      veth_mtu: "1350"
+    kind: ConfigMap
+    metadata:
+      name: calico-config
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-kube-controllers
+          name: calico-kube-controllers
+          namespace: kube-system
+        spec:
+          containers:
+          - env:
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            image: docker.io/calico/kube-controllers:v3.20.3
+            livenessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -l
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-kube-controllers
+            readinessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -r
+              periodSeconds: 10
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: calico-kube-controllers
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: calico-node
+      name: calico-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+        spec:
+          containers:
+          - env:
+            - name: FELIX_FEATUREDETECTOVERRIDE
+              value: ChecksumOffloadBroken=true
+            - name: CALICO_IPV4POOL_VXLAN
+              value: Always
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            - name: CLUSTER_TYPE
+              value: k8s,bgp
+            - name: IP
+              value: autodetect
+            - name: CALICO_IPV4POOL_IPIP
+              value: Never
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_WIREGUARDMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_AWSSRCDSTCHECK
+              value: Disable
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: ACCEPT
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/node:v3.20.3
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -shutdown
+            livenessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-live
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-node
+            readinessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-ready
+              periodSeconds: 10
+              timeoutSeconds: 10
+            resources:
+              requests:
+                cpu: 250m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /var/run/nodeagent
+              name: policysync
+            - mountPath: /sys/fs/
+              mountPropagation: Bidirectional
+              name: sysfs
+            - mountPath: /var/log/calico/cni
+              name: cni-log-dir
+              readOnly: true
+          hostNetwork: true
+          initContainers:
+          - command:
+            - /opt/cni/bin/calico-ipam
+            - -upgrade
+            env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: upgrade-ipam
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          - command:
+            - /opt/cni/bin/install
+            env:
+            - name: CNI_CONF_NAME
+              value: 10-calico.conflist
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  key: cni_network_config
+                  name: calico-config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: SLEEP
+              value: "false"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.20.3
+            name: install-cni
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+            name: flexvol-driver
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/driver
+              name: flexvol-driver-host
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: calico-node
+          terminationGracePeriodSeconds: 0
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /lib/modules
+            name: lib-modules
+          - hostPath:
+              path: /var/run/calico
+            name: var-run-calico
+          - hostPath:
+              path: /var/lib/calico
+            name: var-lib-calico
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+          - hostPath:
+              path: /sys/fs/
+              type: DirectoryOrCreate
+            name: sysfs
+          - hostPath:
+              path: /opt/cni/bin
+            name: cni-bin-dir
+          - hostPath:
+              path: /etc/cni/net.d
+            name: cni-net-dir
+          - hostPath:
+              path: /var/log/calico/cni
+            name: cni-log-dir
+          - hostPath:
+              path: /var/lib/cni/networks
+            name: host-local-net-dir
+          - hostPath:
+              path: /var/run/nodeagent
+              type: DirectoryOrCreate
+            name: policysync
+          - hostPath:
+              path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+              type: DirectoryOrCreate
+            name: flexvol-driver-host
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
   windows-cni: "# strictAffinity required for windows\napiVersion: crd.projectcalico.org/v1\nkind:
     IPAMConfig\nmetadata:\n  name: default\nspec:\n  autoAllocateBlocks: true\n  strictAffinity:
     true\n---\nkind: ConfigMap\napiVersion: v1\nmetadata:\n  name: calico-static-rules\n

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -4157,7 +4157,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.20.3
+            image: docker.io/calico/kube-controllers:v3.20.4
             livenessProbe:
               exec:
                 command:
@@ -4267,7 +4267,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.20.3
+            image: docker.io/calico/node:v3.20.4
             lifecycle:
               preStop:
                 exec:
@@ -4339,7 +4339,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: upgrade-ipam
             securityContext:
               privileged: true
@@ -4373,7 +4373,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.20.3
+            image: docker.io/calico/cni:v3.20.4
             name: install-cni
             securityContext:
               privileged: true
@@ -4382,7 +4382,7 @@ data:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-          - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+          - image: docker.io/calico/pod2daemon-flexvol:v3.20.4
             name: flexvol-driver
             securityContext:
               privileged: true
@@ -4490,7 +4490,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.20.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.20.4-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -4509,7 +4509,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.20.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.20.4-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -4520,7 +4520,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.20.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.20.4-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Instead of keeping a static Calico manifests in the repo, this PR uses the Kustomize feature to pull a base manifest from a url to get the vxlan manifest from https://docs.projectcalico.org/v3.20/manifests/calico-vxlan.yaml and makes a few patches necessary for Azure and IPv6. This will make sure we don't drift from the recommended Calico configuration and will make updating the Calico version a lot easier.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
partly addresses #1917 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Generate calico manifests from source
```
