### PR TITLE
Don't ignore kubeconfig directory in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ envfile
 kind.kubeconfig
 minikube.kubeconfig
 kubeconfig
+!kubeconfig/
 
 # ssh keys
 .ssh*


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
We are using `go mod vendor` for our internal builds and the current `.gitignore` excludes `sigs.k8s.io/cluster-api/util/kubeconfig` package from the vendor directory which breaks the build. I added `!kubeconfig/` to make it not ignore kubeconfig package and still ignore kubeconfig when it's a file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't ignore kubeconfig directory in git
```
