### PR TITLE
refactor api/*/tags.go to move annotation name constants to azure/const.go

### DIFF
--- a/api/v1beta1/tags.go
+++ b/api/v1beta1/tags.go
@@ -135,12 +135,14 @@ const (
 	// which tracks the AdditionalTags in the Machine Provider Config.
 	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 	// for annotation formatting rules.
+	// Deprecated: use azure.VMTagsLastAppliedAnnotation instead. This constant will be removed in v1beta2.
 	VMTagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-azure-last-applied-tags-vm"
 
 	// RGTagsLastAppliedAnnotation is the key for the Azure Cluster object annotation
 	// which tracks the AdditionalTags for Resource Group which is part in the Azure Cluster.
 	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 	// for annotation formatting rules.
+	// Deprecated: use azure.RGTagsLastAppliedAnnotation instead. This constant will be removed in v1beta2.
 	RGTagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-azure-last-applied-tags-rg"
 )
 

--- a/azure/const.go
+++ b/azure/const.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+const (
+	// VMTagsLastAppliedAnnotation is the key for the machine object annotation
+	// which tracks the AdditionalTags in the Machine Provider Config.
+	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+	// for annotation formatting rules.
+	VMTagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-azure-last-applied-tags-vm"
+
+	// RGTagsLastAppliedAnnotation is the key for the Azure Cluster object annotation
+	// which tracks the AdditionalTags for Resource Group which is part in the Azure Cluster.
+	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+	// for annotation formatting rules.
+	RGTagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-azure-last-applied-tags-rg"
+)

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -947,7 +947,7 @@ func (s *ClusterScope) TagsSpecs() []azure.TagsSpec {
 		{
 			Scope:      azure.ResourceGroupID(s.SubscriptionID(), s.ResourceGroup()),
 			Tags:       s.AdditionalTags(),
-			Annotation: infrav1.RGTagsLastAppliedAnnotation,
+			Annotation: azure.RGTagsLastAppliedAnnotation,
 		},
 	}
 }

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -177,7 +177,7 @@ func (m *MachineScope) TagsSpecs() []azure.TagsSpec {
 		{
 			Scope:      azure.VMID(m.SubscriptionID(), m.ResourceGroup(), m.Name()),
 			Tags:       m.AdditionalTags(),
-			Annotation: infrav1.VMTagsLastAppliedAnnotation,
+			Annotation: azure.VMTagsLastAppliedAnnotation,
 		},
 	}
 }

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -757,7 +757,7 @@ func (s *ManagedControlPlaneScope) TagsSpecs() []azure.TagsSpec {
 		{
 			Scope:      azure.ResourceGroupID(s.SubscriptionID(), s.ResourceGroup()),
 			Tags:       s.AdditionalTags(),
-			Annotation: infrav1.RGTagsLastAppliedAnnotation,
+			Annotation: azure.RGTagsLastAppliedAnnotation,
 		},
 	}
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Refactors `api/*/tags.go` to move `VMTagsLastAppliedAnnotation` and `RGTagsLastAppliedAnnotation` to `azure/const.go`

**Which issue(s) this PR fixes** :
Fixes #1789 

**Special notes for your reviewer**:
- Reference conversation https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1721#discussion_r729918672

<!-- _Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._ -->

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecated: infrav1.RGTagsLastAppliedAnnotation, infrav1.VMTagsLastAppliedAnnotation will be removed in v1beta2. Use azure.RGTagsLastAppliedAnnotation, azure.VMTagsLastAppliedAnnotation instead.
```
