### PR TITLE
fix(templates): add identity ref patch to kustomize

### DIFF
--- a/templates/cluster-template-system-assigned-identity.yaml
+++ b/templates/cluster-template-system-assigned-identity.yaml
@@ -25,6 +25,10 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureClusterIdentity
+    name: ${CLUSTER_IDENTITY_NAME}
   location: ${AZURE_LOCATION}
   networkSpec:
     subnets:

--- a/templates/cluster-template-user-assigned-identity.yaml
+++ b/templates/cluster-template-user-assigned-identity.yaml
@@ -25,6 +25,10 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureClusterIdentity
+    name: ${CLUSTER_IDENTITY_NAME}
   location: ${AZURE_LOCATION}
   networkSpec:
     subnets:

--- a/templates/flavors/system-assigned-identity/kustomization.yaml
+++ b/templates/flavors/system-assigned-identity/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - ../default/machine-deployment.yaml
 patchesStrategicMerge:
   - patches/system-assigned-identity.yaml
+  - ../../azure-cluster-identity/azurecluster-identity-ref.yaml

--- a/templates/flavors/user-assigned-identity/kustomization.yaml
+++ b/templates/flavors/user-assigned-identity/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - ../default/machine-deployment.yaml
 patchesStrategicMerge:
   - patches/user-assigned-identity.yaml
+  - ../../azure-cluster-identity/azurecluster-identity-ref.yaml


### PR DESCRIPTION
Signed-off-by: Ashutosh Kumar <sonasingh46@gmail.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
This PR adds identity ref patch to kustomize. 

/kind bug


**What this PR does / why we need it**:
This PRs fix a bug for system-assigned-identity flavor where the identity ref was not update in the AzureCluster spec. 


- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Fix template for system-assigned-identiy flavor 
```
