### PR TITLE
Drop disable flag from calico spec so calico pod goes ready

### DIFF
--- a/templates/addons/calico.yaml
+++ b/templates/addons/calico.yaml
@@ -3786,8 +3786,6 @@ spec:
             configMapKeyRef:
               key: veth_mtu
               name: calico-config
-        - name: FELIX_AWSSRCDSTCHECK
-          value: Disable
         - name: CALICO_DISABLE_FILE_LOGGING
           value: "true"
         - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/templates/addons/calico/kustomization.yaml
+++ b/templates/addons/calico/kustomization.yaml
@@ -8,3 +8,9 @@ patches:
 - path: patches/calico-node.yaml
   target:
     kind: DaemonSet
+- target:
+    version: v1
+    kind: DaemonSet
+    name: calico-node
+    namespace: kube-system
+  path: patches/remove-aws-reference.yaml

--- a/templates/addons/calico/patches/remove-aws-reference.yaml
+++ b/templates/addons/calico/patches/remove-aws-reference.yaml
@@ -1,0 +1,5 @@
+# Drops the FELIX_AWSSRCDSTCHECK field
+# json patch doesn't allow for dropping fields in array by name
+# https://github.com/projectcalico/calico/issues/5101
+- op: remove
+  path: "/spec/template/spec/containers/0/env/12"

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -4364,8 +4364,6 @@ data:
                 configMapKeyRef:
                   key: veth_mtu
                   name: calico-config
-            - name: FELIX_AWSSRCDSTCHECK
-              value: Disable
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -4364,8 +4364,6 @@ data:
                 configMapKeyRef:
                   key: veth_mtu
                   name: calico-config
-            - name: FELIX_AWSSRCDSTCHECK
-              value: Disable
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -4059,8 +4059,6 @@ data:
                 configMapKeyRef:
                   key: veth_mtu
                   name: calico-config
-            - name: FELIX_AWSSRCDSTCHECK
-              value: Disable
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
@@ -4373,8 +4373,6 @@ data:
                 configMapKeyRef:
                   key: veth_mtu
                   name: calico-config
-            - name: FELIX_AWSSRCDSTCHECK
-              value: Disable
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -4326,8 +4326,6 @@ data:
                 configMapKeyRef:
                   key: veth_mtu
                   name: calico-config
-            - name: FELIX_AWSSRCDSTCHECK
-              value: Disable
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -4139,8 +4139,6 @@ data:
                 configMapKeyRef:
                   key: veth_mtu
                   name: calico-config
-            - name: FELIX_AWSSRCDSTCHECK
-              value: Disable
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -7968,8 +7968,6 @@ data:
                 configMapKeyRef:
                   key: veth_mtu
                   name: calico-config
-            - name: FELIX_AWSSRCDSTCHECK
-              value: Disable
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -4068,8 +4068,6 @@ data:
                 configMapKeyRef:
                   key: veth_mtu
                   name: calico-config
-            - name: FELIX_AWSSRCDSTCHECK
-              value: Disable
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -4164,8 +4164,6 @@ data:
                 configMapKeyRef:
                   key: veth_mtu
                   name: calico-config
-            - name: FELIX_AWSSRCDSTCHECK
-              value: Disable
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -4229,8 +4229,6 @@ data:
                 configMapKeyRef:
                   key: veth_mtu
                   name: calico-config
-            - name: FELIX_AWSSRCDSTCHECK
-              value: Disable
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -4253,8 +4253,6 @@ data:
                 configMapKeyRef:
                   key: veth_mtu
                   name: calico-config
-            - name: FELIX_AWSSRCDSTCHECK
-              value: Disable
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

The PR https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2021 uses the calico manifests upstream. Those manifest have a bug in them that they reference AWS: https://github.com/projectcalico/calico/issues/5101

This wasn't caught in our e2e tests because we do not check if all the pods are ready (https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2063) and even though it wasn't "ready" calico was functioning.  It was caught in the conformance tests because the test suite check all pods are ready.
 
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

this isn't really a nice solution but jsonpatch doesn't allow removing named fields from arrays.  The alternative is to copy all the variables and replace the env array completely.  As we plan to upgrade very quickly to the calico 3.22 release which doesn't have this issue and this is a quick fix to unblock conformance tests but happy to go other way.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
