### PR TITLE
:sparkling: Set InternalDNS address on machines

### DIFF
--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -128,7 +128,12 @@ func (s *Service) getAddresses(ctx context.Context, vm compute.VirtualMachine, r
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.Service.getAddresses")
 	defer done()
 
-	var addresses []corev1.NodeAddress
+	addresses := []corev1.NodeAddress{
+		{
+			Type:    corev1.NodeInternalDNS,
+			Address: to.String(vm.Name),
+		},
+	}
 	if vm.NetworkProfile.NetworkInterfaces == nil {
 		return addresses, nil
 	}

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -53,7 +53,8 @@ var (
 		BootstrapData:     "fake data",
 	}
 	fakeExistingVM = compute.VirtualMachine{
-		ID: to.StringPtr("test-vm-id"),
+		ID:   to.StringPtr("test-vm-id"),
+		Name: to.StringPtr("test-vm-name"),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			ProvisioningState: to.StringPtr("Succeeded"),
 			NetworkProfile: &compute.NetworkProfile{
@@ -89,6 +90,10 @@ var (
 		},
 	}
 	fakeNodeAddresses = []corev1.NodeAddress{
+		{
+			Type:    corev1.NodeInternalDNS,
+			Address: "test-vm-name",
+		},
 		{
 			Type:    corev1.NodeInternalIP,
 			Address: "10.0.0.5",


### PR DESCRIPTION
Right now we never set the InternalDNS address for machines, which some
consumers expect to be there. This change fixes that.
The approach is copied from capa:
https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/cf6fea721385d490b570b4cf119defea705b3320/controllers/awscluster_controller.go#L331-L377

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Azuremachines .status.addresses now contains the InternalDNS address
```
