### PR TITLE
:bug: Skip InboundNatRule reconciliation if no LB is configured

### DIFF
--- a/azure/services/inboundnatrules/inboundnatrules_test.go
+++ b/azure/services/inboundnatrules/inboundnatrules_test.go
@@ -125,6 +125,16 @@ func TestReconcileInboundNATRule(t *testing.T) {
 			},
 		},
 		{
+			name:          "No LB, Nat rule reconciliation is skipped",
+			expectedError: "",
+			expect: func(s *mock_inboundnatrules.MockInboundNatScopeMockRecorder,
+				m *mock_inboundnatrules.MockclientMockRecorder,
+				r *mock_async.MockReconcilerMockRecorder) {
+				s.APIServerLBName().AnyTimes().Return("")
+				s.UpdatePutStatus(infrav1.InboundNATRulesReadyCondition, serviceName, nil)
+			},
+		},
+		{
 			name:          "fail to get existing rules",
 			expectedError: "failed to get existing NAT rules: #: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_inboundnatrules.MockInboundNatScopeMockRecorder,


### PR DESCRIPTION
Clusters might be externally managed in which case the apiserver
endpoint might be in a different Azure account or on a different
platform altogether. In this case, there are no inboundnatrules for the
LB to reconcile, so skip doing that if the LB name is empty.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:
/kind feature

/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
If a cluster has no APIServer LoadBalancer configured, the InboundNATRule reconciliaton for machines will be skippped
```
