### PR TITLE
fix(rbac): add namespace list permission

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -110,6 +110,7 @@ func (acr *AzureClusterReconciler) SetupWithManager(ctx context.Context, mgr ctr
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=azuremachinetemplates;azuremachinetemplates/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=azureclusteridentities;azureclusteridentities/status,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;
 
 // Reconcile idempotently gets, creates, and updates a cluster.
 func (acr *AzureClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {


### PR DESCRIPTION
Signed-off-by: Ashutosh Kumar <sonasingh46@gmail.com>

/kind bug

**What this PR does / why we need it**:
This PR adds namespace list permission for capz
manager as it is needed by it in case of identity
reference on azurecluster object.


**Special notes for your reviewer**:

Do we need some release notes for this?
**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Adds list namespace permission for capz component
```
