### PR TITLE
[release-0.5] Update CAPI test framework to fix etcd upgrade test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	k8s.io/kubectl v0.21.4
 	k8s.io/utils v0.0.0-20210802155522-efc7438f0176
 	sigs.k8s.io/cluster-api v0.4.7
-	sigs.k8s.io/cluster-api/test v0.4.7
+	sigs.k8s.io/cluster-api/test v0.4.8-0.20220215165403-0234afe87ffe
 	sigs.k8s.io/controller-runtime v0.9.7
 	sigs.k8s.io/kind v0.11.1
 	sigs.k8s.io/yaml v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1568,8 +1568,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyz
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/cluster-api v0.4.7 h1:XzIn48gZAEDyxP/fMcGqOfrgMSLwbcUMgyPRqMeZTjs=
 sigs.k8s.io/cluster-api v0.4.7/go.mod h1:KKycu4yJEm1sxKG5UaHX9ZnYxRiBzJsFjJVmvMQUP2k=
-sigs.k8s.io/cluster-api/test v0.4.7 h1:v+CNc+nW4lolK+mHdnUvQheSbiR6kcbA/8dKgu2VALI=
-sigs.k8s.io/cluster-api/test v0.4.7/go.mod h1:QSthG8w6jaeNE9hwDxntAspluG8xPJFzi1ptSGoNNbw=
+sigs.k8s.io/cluster-api/test v0.4.8-0.20220215165403-0234afe87ffe h1:crJUYFTDjs+TSlVDBQX8TELROgymRvoKxeSnlwNjCFA=
+sigs.k8s.io/cluster-api/test v0.4.8-0.20220215165403-0234afe87ffe/go.mod h1:QSthG8w6jaeNE9hwDxntAspluG8xPJFzi1ptSGoNNbw=
 sigs.k8s.io/controller-runtime v0.9.7 h1:DlHMlAyLpgEITVvNsuZqMbf8/sJl9HirmCZIeR5H9mQ=
 sigs.k8s.io/controller-runtime v0.9.7/go.mod h1:nExcHcQ2zvLMeoO9K7rOesGCmgu32srN5SENvpAEbGA=
 sigs.k8s.io/kind v0.11.1 h1:pVzOkhUwMBrCB0Q/WllQDO3v14Y+o2V0tFgjTqIUjwA=


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#capz-periodic-e2e-full-v1alpha was fixed by https://github.com/kubernetes-sigs/cluster-api/pull/6127. Updating the CAPI test framework version to include the cherry-pick commit. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
