### PR TITLE
Bump CAPI init with binary version for v1alpha4 upgrade test

### DIFF
--- a/test/e2e/capi_test.go
+++ b/test/e2e/capi_test.go
@@ -247,7 +247,7 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 						ArtifactFolder:            artifactFolder,
 						SkipCleanup:               skipCleanup,
 						InitWithProvidersContract: "v1alpha4",
-						InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.4/clusterctl-{OS}-{ARCH}",
+						InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/clusterctl-{OS}-{ARCH}",
 						PreInit:                   getPreInitFunc(ctx),
 					}
 				})


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:  We missed this reference to clusterctl when bumping CAPI versions to fix the cert manager clusterctl issue. [slack thread](https://kubernetes.slack.com/archives/CEX9HENG7/p1644892151874999?thread_ts=1644344138.330009&cid=CEX9HENG7)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
