### PR TITLE
Support specifying golang version for CI

### DIFF
--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -42,7 +42,22 @@ EOF
   fi
 }
 
-verify_go_version
+install_go_with_version() {
+  echo "Install golang ${GO_VERSION}"
+  GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
+  curl -LO "https://go.dev/dl/${GO_TARBALL}"
+  if [[ -d /usr/local/go ]]; then
+    mv /usr/local/go /usr/local/go.old
+  fi
+  tar xzf "${GO_TARBALL}" -C /usr/local
+  rm "${GO_TARBALL}"
+}
+
+if [[ -n "${GO_VERSION:-}" ]]; then
+  install_go_with_version
+else
+  verify_go_version
+fi
 
 # Explicitly opt into go modules, even though we're inside a GOPATH directory
 export GO111MODULE=on


### PR DESCRIPTION
Sometimes we need to specify golang version instead of
changing variants in test-infra repo.

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support specifying golang version for CI.
```
