### PR TITLE
[release-1.1] Support node-role.kubernetes.io/control-plane tolerations and taints

### DIFF
--- a/hack/log/log-dump-daemonset.yaml
+++ b/hack/log/log-dump-daemonset.yaml
@@ -29,6 +29,10 @@ spec:
         key: node-role.kubernetes.io/master
         operator: Equal
         value: "true"
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Equal
+        value: "true"
       - effect: NoExecute
         operator: Exists
       - effect: NoSchedule

--- a/templates/addons/calico-ipv6.yaml
+++ b/templates/addons/calico-ipv6.yaml
@@ -4015,6 +4015,8 @@ spec:
           operator: Exists
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       serviceAccountName: calico-kube-controllers
       priorityClassName: system-cluster-critical
       containers:

--- a/templates/addons/calico.yaml
+++ b/templates/addons/calico.yaml
@@ -4082,6 +4082,8 @@ spec:
           operator: Exists
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       serviceAccountName: calico-kube-controllers
       priorityClassName: system-cluster-critical
       containers:

--- a/templates/addons/metrics-server/metrics-server.yaml
+++ b/templates/addons/metrics-server/metrics-server.yaml
@@ -176,6 +176,9 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: tmp-dir

--- a/templates/addons/metrics-server/patches/control-plane-toleration.yaml
+++ b/templates/addons/metrics-server/patches/control-plane-toleration.yaml
@@ -12,3 +12,6 @@ spec:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"
         effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/control-plane"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -3292,6 +3292,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - emptyDir: {}
             name: tmp-dir

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -2978,6 +2978,7 @@ data:
     \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
     a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
     Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
+    \       - key: node-role.kubernetes.io/control-plane\n          effect: NoSchedule\n
     \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
     \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
     \         env:\n            # Choose which controllers to run.\n            -

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -3292,6 +3292,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - emptyDir: {}
             name: tmp-dir

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -2978,6 +2978,7 @@ data:
     \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
     a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
     Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
+    \       - key: node-role.kubernetes.io/control-plane\n          effect: NoSchedule\n
     \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
     \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
     \         env:\n            # Choose which controllers to run.\n            -

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -2681,6 +2681,7 @@ data:
     \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
     a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
     Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
+    \       - key: node-role.kubernetes.io/control-plane\n          effect: NoSchedule\n
     \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
     \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
     \         env:\n            # Choose which controllers to run.\n            -

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
@@ -3001,6 +3001,7 @@ data:
     \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
     a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
     Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
+    \       - key: node-role.kubernetes.io/control-plane\n          effect: NoSchedule\n
     \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
     \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
     \         env:\n            # Choose which controllers to run.\n            -

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -4318,6 +4318,8 @@ data:
               operator: Exists
             - key: node-role.kubernetes.io/master
               effect: NoSchedule
+            - key: node-role.kubernetes.io/control-plane
+              effect: NoSchedule
           serviceAccountName: calico-kube-controllers
           priorityClassName: system-cluster-critical
           containers:

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -2954,6 +2954,7 @@ data:
     \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
     a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
     Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
+    \       - key: node-role.kubernetes.io/control-plane\n          effect: NoSchedule\n
     \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
     \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
     \         env:\n            # Choose which controllers to run.\n            -

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -2767,6 +2767,7 @@ data:
     \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
     a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
     Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
+    \       - key: node-role.kubernetes.io/control-plane\n          effect: NoSchedule\n
     \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
     \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
     \         env:\n            # Choose which controllers to run.\n            -

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -9022,6 +9022,7 @@ data:
     \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
     a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
     Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
+    \       - key: node-role.kubernetes.io/control-plane\n          effect: NoSchedule\n
     \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
     \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
     \         env:\n            # Choose which controllers to run.\n            -

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -2688,6 +2688,7 @@ data:
     \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
     a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
     Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
+    \       - key: node-role.kubernetes.io/control-plane\n          effect: NoSchedule\n
     \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
     \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
     \         env:\n            # Choose which controllers to run.\n            -

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -2790,6 +2790,7 @@ data:
     \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
     a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
     Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
+    \       - key: node-role.kubernetes.io/control-plane\n          effect: NoSchedule\n
     \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
     \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
     \         env:\n            # Choose which controllers to run.\n            -

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -2857,6 +2857,7 @@ data:
     \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
     a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
     Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
+    \       - key: node-role.kubernetes.io/control-plane\n          effect: NoSchedule\n
     \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
     \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
     \         env:\n            # Choose which controllers to run.\n            -

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -2879,6 +2879,7 @@ data:
     \       kubernetes.io/os: linux\n      tolerations:\n        # Mark the pod as
     a critical add-on for rescheduling.\n        - key: CriticalAddonsOnly\n          operator:
     Exists\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n
+    \       - key: node-role.kubernetes.io/control-plane\n          effect: NoSchedule\n
     \     serviceAccountName: calico-kube-controllers\n      priorityClassName: system-cluster-critical\n
     \     containers:\n        - name: calico-kube-controllers\n          image: calico/kube-controllers:v3.20.0\n
     \         env:\n            # Choose which controllers to run.\n            -

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -26,8 +26,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
-    - name: v1.0.4
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.4/core-components.yaml
+    - name: v1.1.2
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.2/core-components.yaml
       type: url
       files:
       - sourcePath: "../data/shared/v1beta1/metadata.yaml"
@@ -57,8 +57,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
-    - name: v1.0.4
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.4/bootstrap-components.yaml
+    - name: v1.1.2
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.2/bootstrap-components.yaml
       type: url
       files:
       - sourcePath: "../data/shared/v1beta1/metadata.yaml"
@@ -87,8 +87,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
-    - name: v1.0.4
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.4/control-plane-components.yaml
+    - name: v1.1.2
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.2/control-plane-components.yaml
       type: url
       files:
       - sourcePath: "../data/shared/v1beta1/metadata.yaml"

--- a/test/e2e/data/shared/v1beta1/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1/metadata.yaml
@@ -2,6 +2,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
   - major: 1
+    minor: 1
+    contract: v1beta1
+  - major: 1
     minor: 0
     contract: v1beta1
   - major: 0


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This a manual cherry-pick of #2098 to fix k/k presubmits using release-1.1 that broke since https://github.com/kubernetes/kubeadm/issues/2200 merged in k8s main. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support node-role.kubernetes.io/control-plane tolerations and taints
```
