### PR TITLE
Don't default RoleAssignmentName on machine templates

### DIFF
--- a/api/v1beta1/azuremachine_webhook_test.go
+++ b/api/v1beta1/azuremachine_webhook_test.go
@@ -613,3 +613,15 @@ func createMachineWithOsDiskCacheType(cacheType string) *AzureMachine {
 	machine.Spec.OSDisk.CachingType = cacheType
 	return machine
 }
+
+func createMachineWithRoleAssignmentName() *AzureMachine {
+	machine := &AzureMachine{
+		Spec: AzureMachineSpec{
+			SSHPublicKey:       validSSHPublicKey,
+			OSDisk:             validOSDisk,
+			Identity:           VMIdentitySystemAssigned,
+			RoleAssignmentName: "c6e3443d-bc11-4335-8819-ab6637b10586",
+		},
+	}
+	return machine
+}

--- a/api/v1beta1/azuremachinetemplate_webhook_test.go
+++ b/api/v1beta1/azuremachinetemplate_webhook_test.go
@@ -124,6 +124,11 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 			),
 			wantErr: true,
 		},
+		{
+			name:            "azuremachinetemplate with RoleAssignmentName",
+			machineTemplate: createAzureMachineTemplateFromMachine(createMachineWithRoleAssignmentName()),
+			wantErr:         true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

While using `SystemAssigned` identity, I can't use more than 1 replica for my control plane. Or more than 1 replica on my `MachineDeployments`.

The problem is that `AzureMachineTemplate` has a `RoleAssignmentName` field for the name of the role assignment, which is then used when creating `AzureMachines`. But if more than one `AzureMachine` or VM is created out of this `AzureMachineTemplate` (i.e having more than 1 VM for the control plane, or even more than 1 replica in a `MachineDeployment`) the VM creation will fail with Azure API error `RoleAssignmentUpdateNotPermitted` saying `Tenant ID, application ID, principal ID, and scope are not allowed to be updated`.

**Special notes for your reviewer**:

I see that the templates used for e2e tests normally use only 1 replica for tests, that may explain why this hasn't been spotted so far.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix 'SystemAssigned' identity by removing the defaulting of 'RoleAssignmentName' on 'AzureMachineTemplate' so that every 'AzureMachine'  defaults to a random 'RoleAssignmentName'.
```
