### PR TITLE
Change version skew listing to a link to CAPI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,8 @@ This provider's versions are compatible with the following versions of Cluster A
 
 ### Kubernetes Versions
 
-This provider's versions are able to install and manage the following versions of Kubernetes:
+The Azure provider is able to install and manage the [versions of Kubernetes supported by the Cluster API (CAPI) project](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions).
 
-|  | Azure Provider `v0.4.x` | Azure Provider `v0.5.x` | Azure Provider `v1.0.x` |
-|---|---|---|---|
-| Kubernetes 1.16 | ✓ |  |  |
-| Kubernetes 1.17 | ✓ |  |  |
-| Kubernetes 1.18 | ✓ | ✓ | ✓ |
-| Kubernetes 1.19 | ✓ | ✓ | ✓ |
-| Kubernetes 1.20 | ✓ | ✓ | ✓ |
-| Kubernetes 1.21 | ✓ | ✓ | ✓ |
-| Kubernetes 1.22 |   | ✓ | ✓ |
 
 #### Managed Clusters (AKS)
 


### PR DESCRIPTION
Signed-off-by: Bridget Kromhout <bridget@kromhout.org>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:

The README currently includes a list of supported Kubernetes versions which needs to be manually updated every few months, and also may lead readers to believe that the CAPZ project can provide support for older versions of Kubernetes which are unsupported by CAPI and deprecated in k/k itself. To remove this potential confusion, I propose linking to the CAPI docs for the canonical Kubernetes version support policy.


**Release note**:

```release-note
NONE
```
