### PR TITLE
add Eventually() to retryable k8s E2E operations

### DIFF
--- a/test/e2e/aks.go
+++ b/test/e2e/aks.go
@@ -188,7 +188,7 @@ func WaitForControlPlaneMachinesToExist(ctx context.Context, input WaitForContro
 		ammpList := &infrav1exp.AzureManagedMachinePoolList{}
 
 		if err := input.Lister.List(ctx, ammpList, opt1, opt2); err != nil {
-			Logf("Failed to get machinePool: %+v", err)
+			LogWarningf("Failed to get machinePool: %+v", err)
 			return false
 		}
 
@@ -202,7 +202,7 @@ func WaitForControlPlaneMachinesToExist(ctx context.Context, input WaitForContro
 				ownerMachinePool := &clusterv1exp.MachinePool{}
 				if err := input.Getter.Get(ctx, types.NamespacedName{Namespace: input.Namespace, Name: ref.Name},
 					ownerMachinePool); err != nil {
-					Logf("Failed to get machinePool: %+v", err)
+					LogWarningf("Failed to get machinePool: %+v", err)
 					return false
 				}
 				if len(ownerMachinePool.Status.NodeRefs) >= minReplicas.value(ownerMachinePool) {

--- a/test/e2e/azure_failuredomains.go
+++ b/test/e2e/azure_failuredomains.go
@@ -62,11 +62,17 @@ func AzureFailureDomainsSpec(ctx context.Context, inputGetter func() AzureFailur
 		By("Ensuring zones match CAPI failure domains")
 
 		// fetch updated cluster object to ensure Status.FailureDomains is up-to-date
-		err := input.BootstrapClusterProxy.GetClient().Get(ctx,
-			apimachinerytypes.NamespacedName{
-				Namespace: input.Namespace.Name,
-				Name:      input.ClusterName,
-			}, input.Cluster)
+		Eventually(func() error {
+			err := input.BootstrapClusterProxy.GetClient().Get(ctx,
+				apimachinerytypes.NamespacedName{
+					Namespace: input.Namespace.Name,
+					Name:      input.ClusterName,
+				}, input.Cluster)
+			if err != nil {
+				LogWarning(err.Error())
+			}
+			return err
+		}, retryableOperationTimeout, retryableOperationSleepBetweenRetries).Should(Succeed())
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(input.Cluster.Status.FailureDomains)).To(Equal(len(zones)))
 		for _, z := range zones {

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -61,7 +61,10 @@ import (
 )
 
 const (
-	sshPort = "22"
+	sshPort                               = "22"
+	deleteOperationTimeout                = 20 * time.Minute
+	retryableOperationTimeout             = 30 * time.Second
+	retryableOperationSleepBetweenRetries = 3 * time.Second
 )
 
 // deploymentsClientAdapter adapts a Deployment to work with WaitForDeploymentsAvailable.

--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -22,10 +22,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	typedappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -36,8 +38,10 @@ import (
 )
 
 const (
-	ExternalLoadbalancer = LoadbalancerType("external")
-	InternalLoadbalancer = LoadbalancerType("internal")
+	ExternalLoadbalancer                   = LoadbalancerType("external")
+	InternalLoadbalancer                   = LoadbalancerType("internal")
+	deploymentOperationTimeout             = 30 * time.Second
+	deploymentOperationSleepBetweenRetries = 3 * time.Second
 )
 
 type (
@@ -128,11 +132,16 @@ func (d *Builder) AddContainerPort(name, portName string, portNumber int32, prot
 }
 
 func (d *Builder) Deploy(ctx context.Context, clientset *kubernetes.Clientset) (*appsv1.Deployment, error) {
-	deployment, err := d.Client(clientset).Create(ctx, d.deployment, metav1.CreateOptions{})
-	if err != nil {
-		log.Printf("Error trying to deploy %s in namespace %s:%s\n", d.deployment.Name, d.deployment.ObjectMeta.Namespace, err.Error())
-		return nil, err
-	}
+	var deployment *appsv1.Deployment
+	Eventually(func() error {
+		var err error
+		deployment, err = d.Client(clientset).Create(ctx, d.deployment, metav1.CreateOptions{})
+		if err != nil {
+			log.Printf("Error trying to deploy %s in namespace %s:%s\n", d.deployment.Name, d.deployment.ObjectMeta.Namespace, err.Error())
+			return err
+		}
+		return nil
+	}, deploymentOperationTimeout, deploymentOperationSleepBetweenRetries).Should(Succeed())
 
 	return deployment, nil
 }
@@ -146,15 +155,20 @@ func (d *Builder) GetPodsFromDeployment(ctx context.Context, clientset *kubernet
 		LabelSelector: labels.Set(d.deployment.Labels).String(),
 		Limit:         100,
 	}
-	pods, err := clientset.CoreV1().Pods(d.deployment.GetNamespace()).List(ctx, opts)
-	if err != nil {
-		log.Printf("Error trying to get the pods from deployment %s:%s\n", d.deployment.GetName(), err.Error())
-		return nil, err
-	}
+	var pods *corev1.PodList
+	Eventually(func() error {
+		var err error
+		pods, err = clientset.CoreV1().Pods(d.deployment.GetNamespace()).List(ctx, opts)
+		if err != nil {
+			log.Printf("Error trying to get the pods from deployment %s:%s\n", d.deployment.GetName(), err.Error())
+			return err
+		}
+		return nil
+	}, deploymentOperationTimeout, deploymentOperationSleepBetweenRetries).Should(Succeed())
 	return pods.Items, nil
 }
 
-func (d *Builder) GetService(ports []corev1.ServicePort, lbtype LoadbalancerType) *corev1.Service {
+func (d *Builder) CreateServiceResourceSpec(ports []corev1.ServicePort, lbtype LoadbalancerType) *corev1.Service {
 	suffix := "elb"
 	annotations := map[string]string{}
 	if lbtype == InternalLoadbalancer {

--- a/test/e2e/kubernetes/job/job.go
+++ b/test/e2e/kubernetes/job/job.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 )
 
-func CreateCurlJob(name, endpoint string) *batchv1.Job {
+func CreateCurlJobResourceSpec(name, endpoint string) *batchv1.Job {
 	name = name + util.RandomString(5)
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -19,9 +19,11 @@ limitations under the License.
 package pod
 
 import (
-	"bytes"
+	"fmt"
 	"os"
+	"time"
 
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -29,7 +31,12 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 )
 
-func Exec(clientset *kubernetes.Clientset, config *restclient.Config, pod v1.Pod, command []string) error {
+const (
+	podExecOperationTimeout             = 3 * time.Minute
+	podExecOperationSleepBetweenRetries = 3 * time.Second
+)
+
+func Exec(clientset *kubernetes.Clientset, config *restclient.Config, pod v1.Pod, command []string, testSuccess bool) error {
 	req := clientset.CoreV1().RESTClient().Post().Resource("pods").Name(pod.GetName()).
 		Namespace(pod.GetNamespace()).SubResource("exec")
 	option := &v1.PodExecOptions{
@@ -39,6 +46,9 @@ func Exec(clientset *kubernetes.Clientset, config *restclient.Config, pod v1.Pod
 		Stderr:  true,
 		TTY:     true,
 	}
+	if !testSuccess {
+		option.Stderr = false
+	}
 	req.VersionedParams(
 		option,
 		scheme.ParameterCodec,
@@ -47,41 +57,20 @@ func Exec(clientset *kubernetes.Clientset, config *restclient.Config, pod v1.Pod
 	if err != nil {
 		return err
 	}
-	err = exec.Stream(remotecommand.StreamOptions{
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-	})
-	if err != nil {
-		return err
-	}
+	Eventually(func() error {
+		err = exec.Stream(remotecommand.StreamOptions{
+			Stdout: os.Stdout,
+			Stderr: os.Stderr,
+		})
+		if testSuccess {
+			return err
+		}
+		// If we get here we are validating that the command returned an expected error
+		if err == nil {
+			return fmt.Errorf("Expected error from command %s but got nil", command)
+		}
+		return nil
+	}, podExecOperationTimeout, podExecOperationSleepBetweenRetries).Should(Succeed())
 
 	return nil
-}
-
-func ExecWithOutput(clientset *kubernetes.Clientset, config *restclient.Config, pod v1.Pod, command []string) (*bytes.Buffer, error) {
-	req := clientset.CoreV1().RESTClient().Post().Resource("pods").Name(pod.GetName()).
-		Namespace(pod.GetNamespace()).SubResource("exec")
-	option := &v1.PodExecOptions{
-		Command: command,
-		Stdin:   false,
-		Stdout:  true,
-		Stderr:  true,
-		TTY:     true,
-	}
-	req.VersionedParams(
-		option,
-		scheme.ParameterCodec,
-	)
-	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
-	if err != nil {
-		return nil, err
-	}
-	stdout := bytes.NewBuffer(nil)
-	err = exec.Stream(remotecommand.StreamOptions{
-		Stdout: stdout,
-		// needs to be populated or else exec hangs, but we don't need the output. Failures write to stdout when TTY enabled.
-		Stderr: bytes.NewBuffer(nil),
-	})
-
-	return stdout, err
 }

--- a/test/e2e/log.go
+++ b/test/e2e/log.go
@@ -38,7 +38,17 @@ func Logf(format string, args ...interface{}) {
 	logf("INFO", format, args...)
 }
 
+// LogWarningf prints warning logs with a timestamp and formatting.
+func LogWarningf(format string, args ...interface{}) {
+	logf("WARNING", format, args...)
+}
+
 // Log prints info logs with a timestamp.
 func Log(message string) {
 	logf("INFO", message)
+}
+
+// Log prints warning logs with a timestamp.
+func LogWarning(message string) {
+	logf("WARNING", message)
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR introduces retries to E2E tests so that transient errors can be absorbed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2120

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
