### PR TITLE
Fix compiler errors when viewing e2e tests in the IDE's

### DIFF
--- a/test/e2e/aks.go
+++ b/test/e2e/aks.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/test/e2e/azure_failuredomains.go
+++ b/test/e2e/azure_failuredomains.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/test/e2e/azure_gpu.go
+++ b/test/e2e/azure_gpu.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/test/e2e/azure_net_pol.go
+++ b/test/e2e/azure_net_pol.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/test/e2e/azure_selfhosted.go
+++ b/test/e2e/azure_selfhosted.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -29,18 +29,14 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2019-06-01/insights"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/blang/semver"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/ginkgo/reporters"
@@ -57,55 +53,6 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	kubesystem  = "kube-system"
-	activitylog = "azure-activity-logs"
-)
-
-// Test suite flags
-var (
-	// configPath is the path to the e2e config file.
-	configPath string
-
-	// useExistingCluster instructs the test to use the current cluster instead of creating a new one (default discovery rules apply).
-	useExistingCluster bool
-
-	// artifactFolder is the folder to store e2e test artifacts.
-	artifactFolder string
-
-	// skipCleanup prevents cleanup of test resources e.g. for debug purposes.
-	skipCleanup bool
-)
-
-// Test suite global vars
-var (
-	// e2eConfig to be used for this test, read from configPath.
-	e2eConfig *clusterctl.E2EConfig
-
-	// clusterctlConfigPath to be used for this test, created by generating a clusterctl local repository
-	// with the providers specified in the configPath.
-	clusterctlConfigPath string
-
-	// bootstrapClusterProvider manages provisioning of the the bootstrap cluster to be used for the e2e tests.
-	// Please note that provisioning will be skipped if e2e.use-existing-cluster is provided.
-	bootstrapClusterProvider bootstrap.ClusterProvider
-
-	// bootstrapClusterProxy allows to interact with the bootstrap cluster to be used for the e2e tests.
-	bootstrapClusterProxy framework.ClusterProxy
-
-	// kubetestConfigFilePath is the path to the kubetest configuration file
-	kubetestConfigFilePath string
-
-	// kubetestRepoListPath
-	kubetestRepoListPath string
-
-	// useCIArtifacts specifies whether or not to use the latest build from the main branch of the Kubernetes repository
-	useCIArtifacts bool
-
-	// usePRArtifacts specifies whether or not to use the build from a PR of the Kubernetes repository
-	usePRArtifacts bool
 )
 
 type (
@@ -461,121 +408,4 @@ func tearDown(bootstrapClusterProvider bootstrap.ClusterProvider, bootstrapClust
 	if bootstrapClusterProvider != nil {
 		bootstrapClusterProvider.Dispose(context.TODO())
 	}
-}
-
-// resolveKubernetesVersions looks at Kubernetes versions set as variables in the e2e config and sets them to a valid k8s version
-// that has an existing capi offer image available. For example, if the version is "stable-1.22", the function will set it to the latest 1.22 version that has a published reference image.
-func resolveKubernetesVersions(config *clusterctl.E2EConfig) {
-	ubuntuSkus := getImageSkusInOffer(context.TODO(), os.Getenv(AzureLocation), capiImagePublisher, capiOfferName)
-	ubuntuVersions := parseImageSkuNames(ubuntuSkus)
-
-	windowsSkus := getImageSkusInOffer(context.TODO(), os.Getenv(AzureLocation), capiImagePublisher, capiWindowsOfferName)
-	windowsVersions := parseImageSkuNames(windowsSkus)
-
-	// find the intersection of ubuntu and windows versions available, since we need an image for both.
-	var versions semver.Versions
-	for k, v := range ubuntuVersions {
-		if _, ok := windowsVersions[k]; ok {
-			versions = append(versions, v)
-		}
-	}
-
-	if config.HasVariable(capi_e2e.KubernetesVersion) {
-		resolveKubernetesVersion(config, versions, capi_e2e.KubernetesVersion)
-	}
-	if config.HasVariable(capi_e2e.KubernetesVersionUpgradeFrom) {
-		resolveKubernetesVersion(config, versions, capi_e2e.KubernetesVersionUpgradeFrom)
-	}
-	if config.HasVariable(capi_e2e.KubernetesVersionUpgradeTo) {
-		resolveKubernetesVersion(config, versions, capi_e2e.KubernetesVersionUpgradeTo)
-	}
-}
-
-func resolveKubernetesVersion(config *clusterctl.E2EConfig, versions semver.Versions, varName string) {
-	v := getLatestSkuForMinor(config.GetVariable(varName), versions)
-	if _, ok := os.LookupEnv(varName); ok {
-		Expect(os.Setenv(varName, v)).To(Succeed())
-	}
-	config.Variables[varName] = v
-}
-
-// getImageSkusInOffer returns all skus for an offer that have at least one image.
-func getImageSkusInOffer(ctx context.Context, location, publisher, offer string) []string {
-	settings, err := auth.GetSettingsFromEnvironment()
-	Expect(err).NotTo(HaveOccurred())
-	subscriptionID := settings.GetSubscriptionID()
-	authorizer, err := settings.GetAuthorizer()
-	Expect(err).NotTo(HaveOccurred())
-	imagesClient := compute.NewVirtualMachineImagesClient(subscriptionID)
-	imagesClient.Authorizer = authorizer
-
-	Byf("Finding image skus for offer %s/%s in %s", publisher, offer, location)
-
-	res, err := imagesClient.ListSkus(ctx, location, publisher, offer)
-	Expect(err).NotTo(HaveOccurred())
-
-	var skus []string
-	if res.Value != nil {
-		skus = make([]string, len(*res.Value))
-		for i, sku := range *res.Value {
-			// we have to do this to make sure the SKU has existing images
-			// see https://github.com/Azure/azure-cli/issues/20115.
-			res, err := imagesClient.List(ctx, location, publisher, offer, *sku.Name, "", nil, "")
-			Expect(err).NotTo(HaveOccurred())
-			if res.Value != nil && len(*res.Value) > 0 {
-				skus[i] = *sku.Name
-			}
-		}
-	}
-	return skus
-}
-
-// parseImageSkuNames parses SKU names in format "k8s-1dot17dot2-os-123" to extract the Kubernetes version.
-// it returns a sorted list of all k8s versions found.
-func parseImageSkuNames(skus []string) map[string]semver.Version {
-	capiSku := regexp.MustCompile(`^k8s-(0|[1-9][0-9]*)dot(0|[1-9][0-9]*)dot(0|[1-9][0-9]*)-[a-z]*.*$`)
-	versions := make(map[string]semver.Version, len(skus))
-	for _, sku := range skus {
-		match := capiSku.FindStringSubmatch(sku)
-		if len(match) != 0 {
-			stringVer := fmt.Sprintf("%s.%s.%s", match[1], match[2], match[3])
-			versions[stringVer] = semver.MustParse(stringVer)
-		}
-	}
-
-	return versions
-}
-
-// getLatestSkuForMinor gets the latest available patch version in the provided list of sku versions that corresponds to the provided k8s version.
-func getLatestSkuForMinor(version string, skus semver.Versions) string {
-	isStable, match := validateStableReleaseString(version)
-	if isStable {
-		// if the version is in the format "stable-1.21", we find the latest 1.21.x version.
-		major, err := strconv.ParseUint(match[1], 10, 64)
-		Expect(err).NotTo(HaveOccurred())
-		minor, err := strconv.ParseUint(match[2], 10, 64)
-		Expect(err).NotTo(HaveOccurred())
-		semver.Sort(skus)
-		for i := len(skus) - 1; i >= 0; i-- {
-			if skus[i].Major == major && skus[i].Minor == minor {
-				version = "v" + skus[i].String()
-				break
-			}
-		}
-	} else if v, err := semver.ParseTolerant(version); err == nil {
-		if len(v.Pre) == 0 {
-			// if the version is in the format "v1.21.2", we make sure we have an existing image for it.
-			Expect(skus).To(ContainElement(v), fmt.Sprintf("Provided Kubernetes version %s does not have a corresponding VM image in the capi offer", version))
-		}
-	}
-	// otherwise, we just return the version as-is. This allows for versions in other formats, such as "latest" or "latest-1.21".
-	return version
-}
-
-// validateStableReleaseString validates the string format that declares "get be the latest stable release for this <Major>.<Minor>"
-// it should be called wherever we process a stable version string expression like "stable-1.22"
-func validateStableReleaseString(stableVersion string) (bool, []string) {
-	stableReleaseFormat := regexp.MustCompile(`^stable-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
-	matches := stableReleaseFormat.FindStringSubmatch(stableVersion)
-	return len(matches) > 0, matches
 }

--- a/test/e2e/e2e_suite_vars.go
+++ b/test/e2e/e2e_suite_vars.go
@@ -1,0 +1,75 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+)
+
+const (
+	kubesystem  = "kube-system"
+	activitylog = "azure-activity-logs"
+)
+
+// Test suite flags
+var (
+	// configPath is the path to the e2e config file.
+	configPath string
+
+	// useExistingCluster instructs the test to use the current cluster instead of creating a new one (default discovery rules apply).
+	useExistingCluster bool
+
+	// artifactFolder is the folder to store e2e test artifacts.
+	artifactFolder string
+
+	// skipCleanup prevents cleanup of test resources e.g. for debug purposes.
+	skipCleanup bool
+)
+
+// Test suite global vars
+var (
+	// e2eConfig to be used for this test, read from configPath.
+	e2eConfig *clusterctl.E2EConfig
+
+	// clusterctlConfigPath to be used for this test, created by generating a clusterctl local repository
+	// with the providers specified in the configPath.
+	clusterctlConfigPath string
+
+	// bootstrapClusterProvider manages provisioning of the the bootstrap cluster to be used for the e2e tests.
+	// Please note that provisioning will be skipped if e2e.use-existing-cluster is provided.
+	bootstrapClusterProvider bootstrap.ClusterProvider
+
+	// bootstrapClusterProxy allows to interact with the bootstrap cluster to be used for the e2e tests.
+	bootstrapClusterProxy framework.ClusterProxy
+
+	// kubetestConfigFilePath is the path to the kubetest configuration file
+	kubetestConfigFilePath string
+
+	// kubetestRepoListPath
+	kubetestRepoListPath string
+
+	// useCIArtifacts specifies whether or not to use the latest build from the main branch of the Kubernetes repository
+	useCIArtifacts bool
+
+	// usePRArtifacts specifies whether or not to use the build from a PR of the Kubernetes repository
+	usePRArtifacts bool
+)

--- a/test/e2e/kubernetes/job/job.go
+++ b/test/e2e/kubernetes/job/job.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/test/e2e/kubernetes/namespace/namespace.go
+++ b/test/e2e/kubernetes/namespace/namespace.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/test/e2e/kubernetes/networkpolicy/networkpolicy.go
+++ b/test/e2e/kubernetes/networkpolicy/networkpolicy.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/test/e2e/kubernetes/windows/windows.go
+++ b/test/e2e/kubernetes/windows/windows.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/test/e2e/kubescape.go
+++ b/test/e2e/kubescape.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/test/e2e/log.go
+++ b/test/e2e/log.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The Kubernetes Authors.
 

--- a/test/e2e/retry.go
+++ b/test/e2e/retry.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change

/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

When viewing the e2e suite in vscode or golang it throughs compilier errors which prevent functionality like goto or find references. This moves the variables from `_test` to a non test file which allows it to build properly.  This also allows for some additional entry points to be created (I've created one for gmsa which makes testing faster). 

This also added the 1.17 build tags to the files missing it in this directory.

![image](https://user-images.githubusercontent.com/648372/155812774-94f5f7c4-fde4-47a4-a3e6-4ba1c797ff06.png)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
