### PR TITLE
Use a list for Azure services in reconcilers

### DIFF
--- a/azure/errors.go
+++ b/azure/errors.go
@@ -26,9 +26,6 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
-// ErrNotOwned is returned when a resource can't be deleted because it isn't owned.
-var ErrNotOwned = errors.New("resource is not managed and cannot be deleted")
-
 const codeResourceGroupNotFound = "ResourceGroupNotFound"
 
 // ResourceGroupNotFound parses the error to check if it's a resource group not found error.

--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -24,18 +24,16 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-// Reconciler is a generic interface used by components offering a type of service.
-// Example: virtualnetworks service would offer Reconcile/Delete methods.
+// Reconciler is a generic interface for a controller reconciler which has Reconcile and Delete methods.
 type Reconciler interface {
 	Reconcile(ctx context.Context) error
 	Delete(ctx context.Context) error
 }
 
-// CredentialGetter is a Service which knows how to retrieve credentials for an Azure
-// resource in a resource group.
-type CredentialGetter interface {
+// ServiceReconciler is an Azure service reconciler which can reconcile an Azure service.
+type ServiceReconciler interface {
+	Name() string
 	Reconciler
-	GetCredentials(ctx context.Context, group string, cluster string) ([]byte, error)
 }
 
 // Authorizer is an interface which can get the subscription ID, base URI, and authorizer for an Azure service.

--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -33,6 +33,7 @@ type Reconciler interface {
 // ServiceReconciler is an Azure service reconciler which can reconcile an Azure service.
 type ServiceReconciler interface {
 	Name() string
+	IsManaged(ctx context.Context) (bool, error)
 	Reconciler
 }
 

--- a/azure/mock_azure/azure_mock.go
+++ b/azure/mock_azure/azure_mock.go
@@ -81,31 +81,31 @@ func (mr *MockReconcilerMockRecorder) Reconcile(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockReconciler)(nil).Reconcile), ctx)
 }
 
-// MockCredentialGetter is a mock of CredentialGetter interface.
-type MockCredentialGetter struct {
+// MockServiceReconciler is a mock of ServiceReconciler interface.
+type MockServiceReconciler struct {
 	ctrl     *gomock.Controller
-	recorder *MockCredentialGetterMockRecorder
+	recorder *MockServiceReconcilerMockRecorder
 }
 
-// MockCredentialGetterMockRecorder is the mock recorder for MockCredentialGetter.
-type MockCredentialGetterMockRecorder struct {
-	mock *MockCredentialGetter
+// MockServiceReconcilerMockRecorder is the mock recorder for MockServiceReconciler.
+type MockServiceReconcilerMockRecorder struct {
+	mock *MockServiceReconciler
 }
 
-// NewMockCredentialGetter creates a new mock instance.
-func NewMockCredentialGetter(ctrl *gomock.Controller) *MockCredentialGetter {
-	mock := &MockCredentialGetter{ctrl: ctrl}
-	mock.recorder = &MockCredentialGetterMockRecorder{mock}
+// NewMockServiceReconciler creates a new mock instance.
+func NewMockServiceReconciler(ctrl *gomock.Controller) *MockServiceReconciler {
+	mock := &MockServiceReconciler{ctrl: ctrl}
+	mock.recorder = &MockServiceReconcilerMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockCredentialGetter) EXPECT() *MockCredentialGetterMockRecorder {
+func (m *MockServiceReconciler) EXPECT() *MockServiceReconcilerMockRecorder {
 	return m.recorder
 }
 
 // Delete mocks base method.
-func (m *MockCredentialGetter) Delete(ctx context.Context) error {
+func (m *MockServiceReconciler) Delete(ctx context.Context) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", ctx)
 	ret0, _ := ret[0].(error)
@@ -113,28 +113,27 @@ func (m *MockCredentialGetter) Delete(ctx context.Context) error {
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockCredentialGetterMockRecorder) Delete(ctx interface{}) *gomock.Call {
+func (mr *MockServiceReconcilerMockRecorder) Delete(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockCredentialGetter)(nil).Delete), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockServiceReconciler)(nil).Delete), ctx)
 }
 
-// GetCredentials mocks base method.
-func (m *MockCredentialGetter) GetCredentials(ctx context.Context, group, cluster string) ([]byte, error) {
+// Name mocks base method.
+func (m *MockServiceReconciler) Name() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCredentials", ctx, group, cluster)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
 }
 
-// GetCredentials indicates an expected call of GetCredentials.
-func (mr *MockCredentialGetterMockRecorder) GetCredentials(ctx, group, cluster interface{}) *gomock.Call {
+// Name indicates an expected call of Name.
+func (mr *MockServiceReconcilerMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentials", reflect.TypeOf((*MockCredentialGetter)(nil).GetCredentials), ctx, group, cluster)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockServiceReconciler)(nil).Name))
 }
 
 // Reconcile mocks base method.
-func (m *MockCredentialGetter) Reconcile(ctx context.Context) error {
+func (m *MockServiceReconciler) Reconcile(ctx context.Context) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Reconcile", ctx)
 	ret0, _ := ret[0].(error)
@@ -142,9 +141,9 @@ func (m *MockCredentialGetter) Reconcile(ctx context.Context) error {
 }
 
 // Reconcile indicates an expected call of Reconcile.
-func (mr *MockCredentialGetterMockRecorder) Reconcile(ctx interface{}) *gomock.Call {
+func (mr *MockServiceReconcilerMockRecorder) Reconcile(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockCredentialGetter)(nil).Reconcile), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockServiceReconciler)(nil).Reconcile), ctx)
 }
 
 // MockAuthorizer is a mock of Authorizer interface.

--- a/azure/mock_azure/azure_mock.go
+++ b/azure/mock_azure/azure_mock.go
@@ -118,6 +118,21 @@ func (mr *MockServiceReconcilerMockRecorder) Delete(ctx interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockServiceReconciler)(nil).Delete), ctx)
 }
 
+// IsManaged mocks base method.
+func (m *MockServiceReconciler) IsManaged(ctx context.Context) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsManaged", ctx)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsManaged indicates an expected call of IsManaged.
+func (mr *MockServiceReconcilerMockRecorder) IsManaged(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsManaged", reflect.TypeOf((*MockServiceReconciler)(nil).IsManaged), ctx)
+}
+
 // Name mocks base method.
 func (m *MockServiceReconciler) Name() string {
 	m.ctrl.T.Helper()

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -860,8 +860,6 @@ func (s *ClusterScope) UpdateDeleteStatus(condition clusterv1.ConditionType, ser
 	switch {
 	case err == nil:
 		conditions.MarkFalse(s.AzureCluster, condition, infrav1.DeletedReason, clusterv1.ConditionSeverityInfo, "%s successfully deleted", service)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(s.AzureCluster, condition, infrav1.DeletingReason, clusterv1.ConditionSeverityInfo, "%s deleting", service)
 	default:
@@ -874,8 +872,6 @@ func (s *ClusterScope) UpdatePutStatus(condition clusterv1.ConditionType, servic
 	switch {
 	case err == nil:
 		conditions.MarkTrue(s.AzureCluster, condition)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(s.AzureCluster, condition, infrav1.CreatingReason, clusterv1.ConditionSeverityInfo, "%s creating or updating", service)
 	default:
@@ -888,8 +884,6 @@ func (s *ClusterScope) UpdatePatchStatus(condition clusterv1.ConditionType, serv
 	switch {
 	case err == nil:
 		conditions.MarkTrue(s.AzureCluster, condition)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(s.AzureCluster, condition, infrav1.UpdatingReason, clusterv1.ConditionSeverityInfo, "%s updating", service)
 	default:

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -665,8 +665,6 @@ func (m *MachineScope) UpdateDeleteStatus(condition clusterv1.ConditionType, ser
 	switch {
 	case err == nil:
 		conditions.MarkFalse(m.AzureMachine, condition, infrav1.DeletedReason, clusterv1.ConditionSeverityInfo, "%s successfully deleted", service)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(m.AzureMachine, condition, infrav1.DeletingReason, clusterv1.ConditionSeverityInfo, "%s deleting", service)
 	default:
@@ -679,8 +677,6 @@ func (m *MachineScope) UpdatePutStatus(condition clusterv1.ConditionType, servic
 	switch {
 	case err == nil:
 		conditions.MarkTrue(m.AzureMachine, condition)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(m.AzureMachine, condition, infrav1.CreatingReason, clusterv1.ConditionSeverityInfo, "%s creating or updating", service)
 	default:
@@ -693,8 +689,6 @@ func (m *MachineScope) UpdatePatchStatus(condition clusterv1.ConditionType, serv
 	switch {
 	case err == nil:
 		conditions.MarkTrue(m.AzureMachine, condition)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(m.AzureMachine, condition, infrav1.UpdatingReason, clusterv1.ConditionSeverityInfo, "%s updating", service)
 	default:

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -626,8 +626,6 @@ func (m *MachinePoolScope) UpdateDeleteStatus(condition clusterv1.ConditionType,
 	switch {
 	case err == nil:
 		conditions.MarkFalse(m.AzureMachinePool, condition, infrav1.DeletedReason, clusterv1.ConditionSeverityInfo, "%s successfully deleted", service)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(m.AzureMachinePool, condition, infrav1.DeletingReason, clusterv1.ConditionSeverityInfo, "%s deleting", service)
 	default:
@@ -640,8 +638,6 @@ func (m *MachinePoolScope) UpdatePutStatus(condition clusterv1.ConditionType, se
 	switch {
 	case err == nil:
 		conditions.MarkTrue(m.AzureMachinePool, condition)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(m.AzureMachinePool, condition, infrav1.CreatingReason, clusterv1.ConditionSeverityInfo, "%s creating or updating", service)
 	default:
@@ -654,8 +650,6 @@ func (m *MachinePoolScope) UpdatePatchStatus(condition clusterv1.ConditionType, 
 	switch {
 	case err == nil:
 		conditions.MarkTrue(m.AzureMachinePool, condition)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(m.AzureMachinePool, condition, infrav1.UpdatingReason, clusterv1.ConditionSeverityInfo, "%s updating", service)
 	default:

--- a/azure/scope/machinepoolmachine.go
+++ b/azure/scope/machinepoolmachine.go
@@ -184,8 +184,6 @@ func (s *MachinePoolMachineScope) UpdateDeleteStatus(condition clusterv1.Conditi
 	switch {
 	case err == nil:
 		conditions.MarkFalse(s.AzureMachinePoolMachine, condition, infrav1.DeletedReason, clusterv1.ConditionSeverityInfo, "%s successfully deleted", service)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(s.AzureMachinePoolMachine, condition, infrav1.DeletingReason, clusterv1.ConditionSeverityInfo, "%s deleting", service)
 	default:
@@ -198,8 +196,6 @@ func (s *MachinePoolMachineScope) UpdatePutStatus(condition clusterv1.ConditionT
 	switch {
 	case err == nil:
 		conditions.MarkTrue(s.AzureMachinePoolMachine, condition)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(s.AzureMachinePoolMachine, condition, infrav1.CreatingReason, clusterv1.ConditionSeverityInfo, "%s creating or updating", service)
 	default:
@@ -212,8 +208,6 @@ func (s *MachinePoolMachineScope) UpdatePatchStatus(condition clusterv1.Conditio
 	switch {
 	case err == nil:
 		conditions.MarkTrue(s.AzureMachinePoolMachine, condition)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(s.AzureMachinePoolMachine, condition, infrav1.UpdatingReason, clusterv1.ConditionSeverityInfo, "%s updating", service)
 	default:

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -695,8 +695,6 @@ func (s *ManagedControlPlaneScope) UpdateDeleteStatus(condition clusterv1.Condit
 	switch {
 	case err == nil:
 		conditions.MarkFalse(s.PatchTarget, condition, infrav1.DeletedReason, clusterv1.ConditionSeverityInfo, "%s successfully deleted", service)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(s.PatchTarget, condition, infrav1.DeletingReason, clusterv1.ConditionSeverityInfo, "%s deleting", service)
 	default:
@@ -709,8 +707,6 @@ func (s *ManagedControlPlaneScope) UpdatePutStatus(condition clusterv1.Condition
 	switch {
 	case err == nil:
 		conditions.MarkTrue(s.PatchTarget, condition)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(s.PatchTarget, condition, infrav1.CreatingReason, clusterv1.ConditionSeverityInfo, "%s creating or updating", service)
 	default:
@@ -723,8 +719,6 @@ func (s *ManagedControlPlaneScope) UpdatePatchStatus(condition clusterv1.Conditi
 	switch {
 	case err == nil:
 		conditions.MarkTrue(s.PatchTarget, condition)
-	case errors.Is(err, azure.ErrNotOwned):
-		// do nothing
 	case azure.IsOperationNotDoneError(err):
 		conditions.MarkFalse(s.PatchTarget, condition, infrav1.UpdatingReason, clusterv1.ConditionSeverityInfo, "%s updating", service)
 	default:

--- a/azure/services/agentpools/agentpools.go
+++ b/azure/services/agentpools/agentpools.go
@@ -31,6 +31,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
+const serviceName = "agentpools"
+
 // ManagedMachinePoolScope defines the scope interface for a managed machine pool.
 type ManagedMachinePoolScope interface {
 	azure.ClusterDescriber
@@ -55,6 +57,11 @@ func New(scope ManagedMachinePoolScope) *Service {
 		scope:  scope,
 		Client: NewClient(scope),
 	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
 }
 
 // Reconcile idempotently creates or updates a agent pool, if possible.

--- a/azure/services/availabilitysets/availabilitysets.go
+++ b/azure/services/availabilitysets/availabilitysets.go
@@ -57,6 +57,11 @@ func New(scope AvailabilitySetScope, skuCache *resourceskus.Cache) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
+}
+
 // Reconcile creates or updates availability sets.
 func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "availabilitysets.Service.Reconcile")

--- a/azure/services/availabilitysets/availabilitysets.go
+++ b/azure/services/availabilitysets/availabilitysets.go
@@ -119,3 +119,8 @@ func (s *Service) Delete(ctx context.Context) error {
 	s.Scope.UpdateDeleteStatus(infrav1.AvailabilitySetReadyCondition, serviceName, resultingErr)
 	return resultingErr
 }
+
+// IsManaged returns always returns true as CAPZ does not support BYO availability set.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/bastionhosts/bastionhosts.go
+++ b/azure/services/bastionhosts/bastionhosts.go
@@ -92,3 +92,8 @@ func (s *Service) Delete(ctx context.Context) error {
 	s.Scope.UpdateDeleteStatus(infrav1.BastionHostReadyCondition, serviceName, resultingErr)
 	return resultingErr
 }
+
+// IsManaged returns always returns true as CAPZ does not support BYO bastion.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/bastionhosts/bastionhosts.go
+++ b/azure/services/bastionhosts/bastionhosts.go
@@ -50,6 +50,11 @@ func New(scope BastionScope) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
+}
+
 // Reconcile gets/creates/updates a bastion host.
 func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "bastionhosts.Service.Reconcile")

--- a/azure/services/disks/disks.go
+++ b/azure/services/disks/disks.go
@@ -91,3 +91,8 @@ func (s *Service) Delete(ctx context.Context) error {
 	s.Scope.UpdateDeleteStatus(infrav1.DisksReadyCondition, serviceName, result)
 	return result
 }
+
+// IsManaged returns always returns true as CAPZ does not support BYO disk.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/disks/disks.go
+++ b/azure/services/disks/disks.go
@@ -50,6 +50,11 @@ func New(scope DiskScope) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
+}
+
 // Reconcile on disk is currently no-op. OS disks should only be deleted and will create with the VM automatically.
 func (s *Service) Reconcile(ctx context.Context) error {
 	_, _, done := tele.StartSpanWithLogger(ctx, "disks.Service.Reconcile")

--- a/azure/services/groups/groups.go
+++ b/azure/services/groups/groups.go
@@ -93,7 +93,7 @@ func (s *Service) Delete(ctx context.Context) error {
 	}
 
 	// check that the resource group is not BYO.
-	managed, err := s.IsGroupManaged(ctx)
+	managed, err := s.IsManaged(ctx)
 	if err != nil {
 		if azure.ResourceNotFound(err) {
 			// already deleted or doesn't exist, cleanup status and return.
@@ -104,8 +104,8 @@ func (s *Service) Delete(ctx context.Context) error {
 		return errors.Wrap(err, "could not get resource group management state")
 	}
 	if !managed {
-		log.V(2).Info("Should not delete resource group in unmanaged mode")
-		return azure.ErrNotOwned
+		log.V(2).Info("Skipping resource group deletion in unmanaged mode")
+		return nil
 	}
 
 	err = s.DeleteResource(ctx, groupSpec, ServiceName)
@@ -113,10 +113,10 @@ func (s *Service) Delete(ctx context.Context) error {
 	return err
 }
 
-// IsGroupManaged returns true if the resource group has an owned tag with the cluster name as value,
+// IsManaged returns true if the resource group has an owned tag with the cluster name as value,
 // meaning that the resource group's lifecycle is managed.
-func (s *Service) IsGroupManaged(ctx context.Context) (bool, error) {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.Service.IsGroupManaged")
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.Service.IsManaged")
 	defer done()
 
 	groupSpec := s.Scope.GroupSpec()

--- a/azure/services/groups/groups.go
+++ b/azure/services/groups/groups.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-const serviceName = "group"
+const ServiceName = "group"
 
 // Service provides operations on Azure resources.
 type Service struct {
@@ -56,6 +56,11 @@ func New(scope GroupScope) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return ServiceName
+}
+
 // Reconcile gets/creates/updates a resource group.
 func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.Service.Reconcile")
@@ -69,8 +74,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		return nil
 	}
 
-	_, err := s.CreateResource(ctx, groupSpec, serviceName)
-	s.Scope.UpdatePutStatus(infrav1.ResourceGroupReadyCondition, serviceName, err)
+	_, err := s.CreateResource(ctx, groupSpec, ServiceName)
+	s.Scope.UpdatePutStatus(infrav1.ResourceGroupReadyCondition, ServiceName, err)
 	return err
 }
 
@@ -92,8 +97,8 @@ func (s *Service) Delete(ctx context.Context) error {
 	if err != nil {
 		if azure.ResourceNotFound(err) {
 			// already deleted or doesn't exist, cleanup status and return.
-			s.Scope.DeleteLongRunningOperationState(groupSpec.ResourceName(), serviceName)
-			s.Scope.UpdateDeleteStatus(infrav1.ResourceGroupReadyCondition, serviceName, nil)
+			s.Scope.DeleteLongRunningOperationState(groupSpec.ResourceName(), ServiceName)
+			s.Scope.UpdateDeleteStatus(infrav1.ResourceGroupReadyCondition, ServiceName, nil)
 			return nil
 		}
 		return errors.Wrap(err, "could not get resource group management state")
@@ -103,8 +108,8 @@ func (s *Service) Delete(ctx context.Context) error {
 		return azure.ErrNotOwned
 	}
 
-	err = s.DeleteResource(ctx, groupSpec, serviceName)
-	s.Scope.UpdateDeleteStatus(infrav1.ResourceGroupReadyCondition, serviceName, err)
+	err = s.DeleteResource(ctx, groupSpec, ServiceName)
+	s.Scope.UpdateDeleteStatus(infrav1.ResourceGroupReadyCondition, ServiceName, err)
 	return err
 }
 

--- a/azure/services/groups/groups_test.go
+++ b/azure/services/groups/groups_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/groups/mock_groups"
 	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
@@ -146,7 +145,7 @@ func TestDeleteGroups(t *testing.T) {
 		},
 		{
 			name:          "resource group is not managed by capz",
-			expectedError: azure.ErrNotOwned.Error(),
+			expectedError: "",
 			expect: func(s *mock_groups.MockGroupScopeMockRecorder, m *mock_groups.MockclientMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				s.GroupSpec().AnyTimes().Return(&fakeGroupSpec)
 				m.Get(gomockinternal.AContext(), &fakeGroupSpec).Return(sampleBYOGroup, nil)

--- a/azure/services/groups/groups_test.go
+++ b/azure/services/groups/groups_test.go
@@ -74,8 +74,8 @@ func TestReconcileGroups(t *testing.T) {
 			expectedError: "",
 			expect: func(s *mock_groups.MockGroupScopeMockRecorder, m *mock_groups.MockclientMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				s.GroupSpec().Return(&fakeGroupSpec)
-				r.CreateResource(gomockinternal.AContext(), &fakeGroupSpec, serviceName).Return(nil, nil)
-				s.UpdatePutStatus(infrav1.ResourceGroupReadyCondition, serviceName, nil)
+				r.CreateResource(gomockinternal.AContext(), &fakeGroupSpec, ServiceName).Return(nil, nil)
+				s.UpdatePutStatus(infrav1.ResourceGroupReadyCondition, ServiceName, nil)
 			},
 		},
 		{
@@ -83,8 +83,8 @@ func TestReconcileGroups(t *testing.T) {
 			expectedError: "#: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_groups.MockGroupScopeMockRecorder, m *mock_groups.MockclientMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				s.GroupSpec().Return(&fakeGroupSpec)
-				r.CreateResource(gomockinternal.AContext(), &fakeGroupSpec, serviceName).Return(nil, internalError)
-				s.UpdatePutStatus(infrav1.ResourceGroupReadyCondition, serviceName, internalError)
+				r.CreateResource(gomockinternal.AContext(), &fakeGroupSpec, ServiceName).Return(nil, internalError)
+				s.UpdatePutStatus(infrav1.ResourceGroupReadyCondition, ServiceName, internalError)
 			},
 		},
 	}
@@ -140,8 +140,8 @@ func TestDeleteGroups(t *testing.T) {
 				s.GroupSpec().AnyTimes().Return(&fakeGroupSpec)
 				m.Get(gomockinternal.AContext(), &fakeGroupSpec).Return(sampleManagedGroup, nil)
 				s.ClusterName().Return("test-cluster")
-				r.DeleteResource(gomockinternal.AContext(), &fakeGroupSpec, serviceName).Return(nil)
-				s.UpdateDeleteStatus(infrav1.ResourceGroupReadyCondition, serviceName, nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakeGroupSpec, ServiceName).Return(nil)
+				s.UpdateDeleteStatus(infrav1.ResourceGroupReadyCondition, ServiceName, nil)
 			},
 		},
 		{
@@ -167,8 +167,8 @@ func TestDeleteGroups(t *testing.T) {
 			expect: func(s *mock_groups.MockGroupScopeMockRecorder, m *mock_groups.MockclientMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				s.GroupSpec().AnyTimes().Return(&fakeGroupSpec)
 				m.Get(gomockinternal.AContext(), &fakeGroupSpec).Return(resources.Group{}, notFoundError)
-				s.DeleteLongRunningOperationState("test-group", serviceName)
-				s.UpdateDeleteStatus(infrav1.ResourceGroupReadyCondition, serviceName, nil)
+				s.DeleteLongRunningOperationState("test-group", ServiceName)
+				s.UpdateDeleteStatus(infrav1.ResourceGroupReadyCondition, ServiceName, nil)
 			},
 		},
 		{
@@ -178,8 +178,8 @@ func TestDeleteGroups(t *testing.T) {
 				s.GroupSpec().AnyTimes().Return(&fakeGroupSpec)
 				m.Get(gomockinternal.AContext(), &fakeGroupSpec).Return(sampleManagedGroup, nil)
 				s.ClusterName().Return("test-cluster")
-				r.DeleteResource(gomockinternal.AContext(), &fakeGroupSpec, serviceName).Return(internalError)
-				s.UpdateDeleteStatus(infrav1.ResourceGroupReadyCondition, serviceName, gomockinternal.ErrStrEq("#: Internal Server Error: StatusCode=500"))
+				r.DeleteResource(gomockinternal.AContext(), &fakeGroupSpec, ServiceName).Return(internalError)
+				s.UpdateDeleteStatus(infrav1.ResourceGroupReadyCondition, ServiceName, gomockinternal.ErrStrEq("#: Internal Server Error: StatusCode=500"))
 			},
 		},
 	}

--- a/azure/services/inboundnatrules/inboundnatrules.go
+++ b/azure/services/inboundnatrules/inboundnatrules.go
@@ -54,6 +54,11 @@ func New(scope InboundNatScope) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
+}
+
 // Reconcile gets/creates/updates an inbound NAT rule.
 func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.Service.Reconcile")

--- a/azure/services/inboundnatrules/inboundnatrules.go
+++ b/azure/services/inboundnatrules/inboundnatrules.go
@@ -138,3 +138,8 @@ func (s *Service) Delete(ctx context.Context) error {
 	s.Scope.UpdateDeleteStatus(infrav1.InboundNATRulesReadyCondition, serviceName, result)
 	return result
 }
+
+// IsManaged returns always returns true as CAPZ does not support BYO inbound NAT rules.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/loadbalancers/loadbalancers.go
+++ b/azure/services/loadbalancers/loadbalancers.go
@@ -55,6 +55,11 @@ func New(scope LBScope) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
+}
+
 // Reconcile gets/creates/updates a load balancer.
 func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "loadbalancers.Service.Reconcile")

--- a/azure/services/loadbalancers/loadbalancers.go
+++ b/azure/services/loadbalancers/loadbalancers.go
@@ -117,3 +117,8 @@ func (s *Service) Delete(ctx context.Context) error {
 	s.Scope.UpdateDeleteStatus(infrav1.LoadBalancersReadyCondition, serviceName, result)
 	return result
 }
+
+// IsManaged returns always returns true as CAPZ does not support BYO load balancers.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/managedclusters/managedclusters.go
+++ b/azure/services/managedclusters/managedclusters.go
@@ -377,3 +377,8 @@ func (s *Service) Delete(ctx context.Context) error {
 	klog.V(2).Infof("successfully deleted managed cluster %s ", s.Scope.ClusterName())
 	return nil
 }
+
+// IsManaged returns always returns true as CAPZ does not support BYO managed cluster.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/managedclusters/managedclusters.go
+++ b/azure/services/managedclusters/managedclusters.go
@@ -35,6 +35,8 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
+const serviceName = "managedclusters"
+
 var (
 	defaultUser     = "azureuser"
 	managedIdentity = "msi"
@@ -143,6 +145,11 @@ func New(scope ManagedClusterScope) *Service {
 		Scope:  scope,
 		Client: NewClient(scope),
 	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
 }
 
 // Reconcile idempotently creates or updates a managed cluster, if possible.

--- a/azure/services/natgateways/natgateways.go
+++ b/azure/services/natgateways/natgateways.go
@@ -67,11 +67,11 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
 	defer cancel()
 
-	if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
+	if managed, err := s.IsManaged(ctx); err == nil && !managed {
 		log.V(4).Info("Skipping nat gateways reconcile in custom vnet mode")
-
-		s.Scope.UpdatePutStatus(infrav1.NATGatewaysReadyCondition, serviceName, nil)
 		return nil
+	} else if err != nil {
+		return errors.Wrap(err, "failed to check if NAT gateways are managed")
 	}
 
 	// We go through the list of NatGatewaySpecs to reconcile each one, independently of the resultingErr of the previous one.
@@ -115,11 +115,11 @@ func (s *Service) Delete(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
 	defer cancel()
 
-	if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
+	if managed, err := s.IsManaged(ctx); err == nil && !managed {
 		log.V(4).Info("Skipping nat gateway deletion in custom vnet mode")
-
-		s.Scope.UpdateDeleteStatus(infrav1.NATGatewaysReadyCondition, serviceName, nil)
 		return nil
+	} else if err != nil {
+		return errors.Wrap(err, "failed to check if NAT gateways are managed")
 	}
 
 	specs := s.Scope.NatGatewaySpecs()
@@ -140,4 +140,12 @@ func (s *Service) Delete(ctx context.Context) error {
 	}
 	s.Scope.UpdateDeleteStatus(infrav1.NATGatewaysReadyCondition, serviceName, resultingErr)
 	return resultingErr
+}
+
+// IsManaged returns true if the NAT gateways' lifecycles are managed.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	_, _, done := tele.StartSpanWithLogger(ctx, "natgateways.Service.IsManaged")
+	defer done()
+
+	return s.Scope.IsVnetManaged(), nil
 }

--- a/azure/services/natgateways/natgateways.go
+++ b/azure/services/natgateways/natgateways.go
@@ -53,6 +53,11 @@ func New(scope NatGatewayScope) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
+}
+
 // Reconcile gets/creates/updates a NAT gateway.
 // Only when the NAT gateway 'Name' property is defined we create the NAT gateway: it's opt-in.
 func (s *Service) Reconcile(ctx context.Context) error {

--- a/azure/services/networkinterfaces/networkinterfaces.go
+++ b/azure/services/networkinterfaces/networkinterfaces.go
@@ -53,6 +53,11 @@ func New(scope NICScope, skuCache *resourceskus.Cache) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
+}
+
 // Reconcile gets/creates/updates a network interface.
 func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.Service.Reconcile")

--- a/azure/services/networkinterfaces/networkinterfaces.go
+++ b/azure/services/networkinterfaces/networkinterfaces.go
@@ -115,3 +115,8 @@ func (s *Service) Delete(ctx context.Context) error {
 	s.Scope.UpdateDeleteStatus(infrav1.NetworkInterfaceReadyCondition, serviceName, result)
 	return result
 }
+
+// IsManaged returns always returns true as CAPZ does not support BYO network interfaces.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/privatedns/privatedns.go
+++ b/azure/services/privatedns/privatedns.go
@@ -28,6 +28,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
+const serviceName = "privatedns"
+
 // Scope defines the scope interface for a private dns service.
 type Scope interface {
 	azure.ClusterDescriber
@@ -46,6 +48,11 @@ func New(scope Scope) *Service {
 		Scope:  scope,
 		client: newClient(scope),
 	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
 }
 
 // Reconcile creates or updates the private zone, links it to the vnet, and creates DNS records.

--- a/azure/services/privatedns/privatedns.go
+++ b/azure/services/privatedns/privatedns.go
@@ -226,3 +226,9 @@ func (s *Service) isVnetLinkManaged(ctx context.Context, resourceGroupName, zone
 	tags := converters.MapToTags(zone.Tags)
 	return tags.HasOwned(s.Scope.ClusterName()), nil
 }
+
+// IsManaged returns always returns true.
+// TODO: separate private DNS and VNet links so we can implement the IsManaged method for each.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/publicips/publicips.go
+++ b/azure/services/publicips/publicips.go
@@ -156,3 +156,8 @@ func (s *Service) isIPManaged(ctx context.Context, ipName string) (bool, error) 
 	tags := converters.MapToTags(ip.Tags)
 	return tags.HasOwned(s.Scope.ClusterName()), nil
 }
+
+// IsManaged returns always returns true as public IPs are managed on a one-by-one basis.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/publicips/publicips.go
+++ b/azure/services/publicips/publicips.go
@@ -29,6 +29,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
+const serviceName = "publicips"
+
 // PublicIPScope defines the scope interface for a public IP service.
 type PublicIPScope interface {
 	azure.ClusterDescriber
@@ -47,6 +49,11 @@ func New(scope PublicIPScope) *Service {
 		Scope:  scope,
 		Client: NewClient(scope),
 	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
 }
 
 // Reconcile gets/creates/updates a public ip.

--- a/azure/services/roleassignments/roleassignments.go
+++ b/azure/services/roleassignments/roleassignments.go
@@ -31,7 +31,10 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-const azureBuiltInContributorID = "b24988ac-6180-42a0-ab88-20f7382dd24c"
+const (
+	azureBuiltInContributorID = "b24988ac-6180-42a0-ab88-20f7382dd24c"
+	serviceName               = "roleassignments"
+)
 
 // RoleAssignmentScope defines the scope interface for a role assignment service.
 type RoleAssignmentScope interface {
@@ -55,6 +58,11 @@ func New(scope RoleAssignmentScope) *Service {
 		virtualMachinesGetter:        virtualmachines.NewClient(scope),
 		virtualMachineScaleSetClient: scalesets.NewClient(scope),
 	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
 }
 
 // Reconcile creates a role assignment.

--- a/azure/services/roleassignments/roleassignments.go
+++ b/azure/services/roleassignments/roleassignments.go
@@ -155,3 +155,8 @@ func (s *Service) Delete(ctx context.Context) error {
 
 	return nil
 }
+
+// IsManaged returns always returns true as CAPZ does not support BYO role assignments.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/routetables/routetables.go
+++ b/azure/services/routetables/routetables.go
@@ -51,6 +51,11 @@ func New(scope RouteTableScope) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
+}
+
 // Reconcile gets/creates/updates route tables.
 func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "routetables.Service.Reconcile")

--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -742,3 +742,8 @@ func getSecurityProfile(vmssSpec azure.ScaleSetSpec, sku resourceskus.SKU) (*com
 		EncryptionAtHost: to.BoolPtr(*vmssSpec.SecurityProfile.EncryptionAtHost),
 	}, nil
 }
+
+// IsManaged returns always returns true as CAPZ does not support BYO scale set.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -35,6 +35,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
+const serviceName = "scalesets"
+
 type (
 	// ScaleSetScope defines the scope interface for a scale sets service.
 	ScaleSetScope interface {
@@ -59,13 +61,18 @@ type (
 	}
 )
 
-// NewService creates a new service.
-func NewService(scope ScaleSetScope, skuCache *resourceskus.Cache) *Service {
+// New creates a new service.
+func New(scope ScaleSetScope, skuCache *resourceskus.Cache) *Service {
 	return &Service{
 		Client:           NewClient(scope),
 		Scope:            scope,
 		resourceSKUCache: skuCache,
 	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
 }
 
 // Reconcile idempotently gets, creates, and updates a scale set.

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -92,7 +92,7 @@ func TestNewService(t *testing.T) {
 		ClusterScope:     s,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
-	actual := NewService(mps, resourceskus.NewStaticCache(nil, ""))
+	actual := New(mps, resourceskus.NewStaticCache(nil, ""))
 	g.Expect(actual).ToNot(BeNil())
 }
 

--- a/azure/services/scalesetvms/scalesetvms.go
+++ b/azure/services/scalesetvms/scalesetvms.go
@@ -54,6 +54,11 @@ func NewService(scope ScaleSetVMScope) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
+}
+
 // Reconcile idempotently gets, creates, and updates a scale set.
 func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesetvms.Service.Reconcile")

--- a/azure/services/securitygroups/securitygroups.go
+++ b/azure/services/securitygroups/securitygroups.go
@@ -51,6 +51,11 @@ func New(scope NSGScope) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
+}
+
 // Reconcile gets/creates/updates network security groups.
 func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "securitygroups.Service.Reconcile")

--- a/azure/services/subnets/subnets.go
+++ b/azure/services/subnets/subnets.go
@@ -55,6 +55,11 @@ func New(scope SubnetScope) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
+}
+
 // Reconcile gets/creates/updates a subnet.
 func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "subnets.Service.Reconcile")

--- a/azure/services/tags/tags.go
+++ b/azure/services/tags/tags.go
@@ -194,3 +194,8 @@ func tagsChanged(lastAppliedTags map[string]interface{}, desiredTags map[string]
 	// in dst. Nothing changed.
 	return changed, createdOrUpdated, deleted, newAnnotation
 }
+
+// IsManaged returns always returns true as CAPZ does not support BYO tags.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/tags/tags.go
+++ b/azure/services/tags/tags.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
+const serviceName = "tags"
+
 // TagScope defines the scope interface for a tags service.
 type TagScope interface {
 	azure.Authorizer
@@ -48,6 +50,11 @@ func New(scope TagScope) *Service {
 		Scope:  scope,
 		client: newClient(scope),
 	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
 }
 
 // Reconcile ensures tags are correct.

--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -67,6 +67,11 @@ func New(scope VMScope) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
+}
+
 // Reconcile gets/creates/updates a virtual machine.
 func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.Service.Reconcile")

--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -225,3 +225,8 @@ func getResourceNameByID(resourceID string) string {
 	resourceName := explodedResourceID[len(explodedResourceID)-1]
 	return resourceName
 }
+
+// IsManaged returns always returns true as CAPZ does not support BYO VM.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/virtualnetworks/virtualnetworks.go
+++ b/azure/services/virtualnetworks/virtualnetworks.go
@@ -59,6 +59,11 @@ func New(scope VNetScope) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
+}
+
 func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualnetworks.Service.Reconcile")
 	defer done()

--- a/azure/services/virtualnetworks/virtualnetworks.go
+++ b/azure/services/virtualnetworks/virtualnetworks.go
@@ -114,7 +114,7 @@ func (s *Service) Delete(ctx context.Context) error {
 	}
 
 	// Check that the vnet is not BYO.
-	managed, err := s.IsManaged(ctx, vnetSpec)
+	managed, err := s.IsManaged(ctx)
 	if err != nil {
 		if azure.ResourceNotFound(err) {
 			// already deleted or doesn't exist, cleanup status and return.
@@ -136,10 +136,11 @@ func (s *Service) Delete(ctx context.Context) error {
 
 // IsManaged returns true if the virtual network has an owned tag with the cluster name as value,
 // meaning that the vnet's lifecycle is managed.
-func (s *Service) IsManaged(ctx context.Context, spec azure.ResourceSpecGetter) (bool, error) {
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualnetworks.Service.IsManaged")
 	defer done()
 
+	spec := s.Scope.VNetSpec()
 	if spec == nil {
 		return false, errors.New("cannot get vnet to check if it is managed: spec is nil")
 	}

--- a/azure/services/vmextensions/vmextensions.go
+++ b/azure/services/vmextensions/vmextensions.go
@@ -100,3 +100,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 func (s *Service) Delete(_ context.Context) error {
 	return nil
 }
+
+// IsManaged returns always returns true as CAPZ does not support BYO VM extension.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/vmextensions/vmextensions.go
+++ b/azure/services/vmextensions/vmextensions.go
@@ -26,6 +26,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
+const serviceName = "vmextensions"
+
 // VMExtensionScope defines the scope interface for a vm extension service.
 type VMExtensionScope interface {
 	azure.ClusterDescriber
@@ -45,6 +47,11 @@ func New(scope VMExtensionScope) *Service {
 		Scope:  scope,
 		client: newClient(scope),
 	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
 }
 
 // Reconcile creates or updates the VM extension.

--- a/azure/services/vmssextensions/vmssextensions.go
+++ b/azure/services/vmssextensions/vmssextensions.go
@@ -77,3 +77,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 func (s *Service) Delete(_ context.Context) error {
 	return nil
 }
+
+// IsManaged returns always returns true as CAPZ does not support BYO VMSS extension.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/vmssextensions/vmssextensions.go
+++ b/azure/services/vmssextensions/vmssextensions.go
@@ -25,6 +25,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
+const serviceName = "vmssextensions"
+
 // VMSSExtensionScope defines the scope interface for a vmss extension service.
 type VMSSExtensionScope interface {
 	azure.ClusterDescriber
@@ -44,6 +46,11 @@ func New(scope VMSSExtensionScope) *Service {
 		Scope:  scope,
 		client: newClient(scope),
 	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
 }
 
 // Reconcile creates or updates the VMSS extension.

--- a/azure/services/vnetpeerings/vnetpeerings.go
+++ b/azure/services/vnetpeerings/vnetpeerings.go
@@ -111,3 +111,8 @@ func (s *Service) Delete(ctx context.Context) error {
 	s.Scope.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, serviceName, result)
 	return result
 }
+
+// IsManaged returns always returns true as CAPZ does not support BYO VNet peering.
+func (s *Service) IsManaged(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/azure/services/vnetpeerings/vnetpeerings.go
+++ b/azure/services/vnetpeerings/vnetpeerings.go
@@ -50,6 +50,11 @@ func New(scope VnetPeeringScope) *Service {
 	}
 }
 
+// Name returns the service name.
+func (s *Service) Name() string {
+	return serviceName
+}
+
 // Reconcile gets/creates/updates a peering.
 func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "vnetpeerings.Service.Reconcile")

--- a/controllers/azurecluster_reconciler_test.go
+++ b/controllers/azurecluster_reconciler_test.go
@@ -107,7 +107,16 @@ func TestAzureClusterServiceDelete(t *testing.T) {
 			expect: func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
 				gomock.InOrder(
 					grp.Name().Return(groups.ServiceName),
+					grp.IsManaged(gomockinternal.AContext()).Return(true, nil),
 					grp.Delete(gomockinternal.AContext()).Return(nil))
+			},
+		},
+		"Error when checking if resource group is managed": {
+			expectedError: "failed to determine if the AzureCluster resource group is managed: an error happened",
+			expect: func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
+				gomock.InOrder(
+					grp.Name().Return(groups.ServiceName),
+					grp.IsManaged(gomockinternal.AContext()).Return(false, errors.New("an error happened")))
 			},
 		},
 		"Resource Group delete fails": {
@@ -115,6 +124,7 @@ func TestAzureClusterServiceDelete(t *testing.T) {
 			expect: func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
 				gomock.InOrder(
 					grp.Name().Return(groups.ServiceName),
+					grp.IsManaged(gomockinternal.AContext()).Return(true, nil),
 					grp.Delete(gomockinternal.AContext()).Return(errors.New("internal error")))
 			},
 		},
@@ -123,10 +133,11 @@ func TestAzureClusterServiceDelete(t *testing.T) {
 			expect: func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
 				gomock.InOrder(
 					grp.Name().Return(groups.ServiceName),
-					grp.Delete(gomockinternal.AContext()).Return(azure.ErrNotOwned),
+					grp.IsManaged(gomockinternal.AContext()).Return(false, nil),
 					three.Delete(gomockinternal.AContext()).Return(nil),
 					two.Delete(gomockinternal.AContext()).Return(nil),
-					one.Delete(gomockinternal.AContext()).Return(nil))
+					one.Delete(gomockinternal.AContext()).Return(nil),
+					grp.Delete(gomockinternal.AContext()).Return(nil))
 			},
 		},
 		"service delete fails": {
@@ -134,7 +145,7 @@ func TestAzureClusterServiceDelete(t *testing.T) {
 			expect: func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
 				gomock.InOrder(
 					grp.Name().Return(groups.ServiceName),
-					grp.Delete(gomockinternal.AContext()).Return(azure.ErrNotOwned),
+					grp.IsManaged(gomockinternal.AContext()).Return(false, nil),
 					three.Delete(gomockinternal.AContext()).Return(nil),
 					two.Delete(gomockinternal.AContext()).Return(errors.New("some error happened")),
 					two.Name().Return("two"))

--- a/controllers/azuremachine_reconciler_test.go
+++ b/controllers/azuremachine_reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,13 +28,12 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
-	"sigs.k8s.io/cluster-api-provider-azure/azure/services/groups"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
 	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-func TestAzureClusterServiceReconcile(t *testing.T) {
+func TestAzureMachineServiceReconcile(t *testing.T) {
 	cases := map[string]struct {
 		expectedError string
 		expect        func(one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder)
@@ -49,12 +48,12 @@ func TestAzureClusterServiceReconcile(t *testing.T) {
 			},
 		},
 		"service reconcile fails": {
-			expectedError: "failed to reconcile AzureCluster service two: some error happened",
+			expectedError: "failed to reconcile AzureMachine service foo: some error happened",
 			expect: func(one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
 				gomock.InOrder(
 					one.Reconcile(gomockinternal.AContext()).Return(nil),
 					two.Reconcile(gomockinternal.AContext()).Return(errors.New("some error happened")),
-					two.Name().Return("two"))
+					two.Name().Return("foo"))
 			},
 		},
 	}
@@ -73,10 +72,18 @@ func TestAzureClusterServiceReconcile(t *testing.T) {
 
 			tc.expect(svcOneMock.EXPECT(), svcTwoMock.EXPECT(), svcThreeMock.EXPECT())
 
-			s := &azureClusterService{
-				scope: &scope.ClusterScope{
-					Cluster:      &clusterv1.Cluster{},
-					AzureCluster: &infrav1.AzureCluster{},
+			s := &azureMachineService{
+				scope: &scope.MachineScope{
+					ClusterScoper: &scope.ClusterScope{
+						AzureCluster: &infrav1.AzureCluster{},
+						Cluster:      &clusterv1.Cluster{},
+					},
+					Machine: &clusterv1.Machine{},
+					AzureMachine: &infrav1.AzureMachine{
+						Spec: infrav1.AzureMachineSpec{
+							SubnetName: "test-subnet",
+						},
+					},
 				},
 				services: []azure.ServiceReconciler{
 					svcOneMock,
@@ -97,47 +104,27 @@ func TestAzureClusterServiceReconcile(t *testing.T) {
 	}
 }
 
-func TestAzureClusterServiceDelete(t *testing.T) {
+func TestAzureMachineServiceDelete(t *testing.T) {
 	cases := map[string]struct {
 		expectedError string
-		expect        func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder)
+		expect        func(one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder)
 	}{
-		"Resource Group is deleted successfully": {
+		"all services deleted in order": {
 			expectedError: "",
-			expect: func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
+			expect: func(one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
 				gomock.InOrder(
-					grp.Name().Return(groups.ServiceName),
-					grp.Delete(gomockinternal.AContext()).Return(nil))
-			},
-		},
-		"Resource Group delete fails": {
-			expectedError: "failed to delete resource group: internal error",
-			expect: func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
-				gomock.InOrder(
-					grp.Name().Return(groups.ServiceName),
-					grp.Delete(gomockinternal.AContext()).Return(errors.New("internal error")))
-			},
-		},
-		"Resource Group not owned by cluster": {
-			expectedError: "",
-			expect: func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
-				gomock.InOrder(
-					grp.Name().Return(groups.ServiceName),
-					grp.Delete(gomockinternal.AContext()).Return(azure.ErrNotOwned),
 					three.Delete(gomockinternal.AContext()).Return(nil),
 					two.Delete(gomockinternal.AContext()).Return(nil),
 					one.Delete(gomockinternal.AContext()).Return(nil))
 			},
 		},
 		"service delete fails": {
-			expectedError: "failed to delete AzureCluster service two: some error happened",
-			expect: func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
+			expectedError: "failed to delete AzureMachine service test-service-two: some error happened",
+			expect: func(one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
 				gomock.InOrder(
-					grp.Name().Return(groups.ServiceName),
-					grp.Delete(gomockinternal.AContext()).Return(azure.ErrNotOwned),
 					three.Delete(gomockinternal.AContext()).Return(nil),
 					two.Delete(gomockinternal.AContext()).Return(errors.New("some error happened")),
-					two.Name().Return("two"))
+					two.Name().Return("test-service-two"))
 			},
 		},
 	}
@@ -150,19 +137,22 @@ func TestAzureClusterServiceDelete(t *testing.T) {
 			t.Parallel()
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
-			groupsMock := mock_azure.NewMockServiceReconciler(mockCtrl)
 			svcOneMock := mock_azure.NewMockServiceReconciler(mockCtrl)
 			svcTwoMock := mock_azure.NewMockServiceReconciler(mockCtrl)
 			svcThreeMock := mock_azure.NewMockServiceReconciler(mockCtrl)
 
-			tc.expect(groupsMock.EXPECT(), svcOneMock.EXPECT(), svcTwoMock.EXPECT(), svcThreeMock.EXPECT())
+			tc.expect(svcOneMock.EXPECT(), svcTwoMock.EXPECT(), svcThreeMock.EXPECT())
 
-			s := &azureClusterService{
-				scope: &scope.ClusterScope{
-					AzureCluster: &infrav1.AzureCluster{},
+			s := &azureMachineService{
+				scope: &scope.MachineScope{
+					ClusterScoper: &scope.ClusterScope{
+						AzureCluster: &infrav1.AzureCluster{},
+						Cluster:      &clusterv1.Cluster{},
+					},
+					Machine:      &clusterv1.Machine{},
+					AzureMachine: &infrav1.AzureMachine{},
 				},
 				services: []azure.ServiceReconciler{
-					groupsMock,
 					svcOneMock,
 					svcTwoMock,
 					svcThreeMock,

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -575,7 +575,7 @@ func ShouldDeleteIndividualResources(ctx context.Context, clusterScope *scope.Cl
 		return true
 	}
 	grpSvc := groups.New(clusterScope)
-	managed, err := grpSvc.IsGroupManaged(ctx)
+	managed, err := grpSvc.IsManaged(ctx)
 	// Since this is a best effort attempt to speed up delete, we don't fail the delete if we can't get the RG status.
 	// Instead, take the long way and delete all resources one by one.
 	return err != nil || !managed

--- a/exp/controllers/azuremachinepool_controller_unit_test.go
+++ b/exp/controllers/azuremachinepool_controller_unit_test.go
@@ -67,7 +67,7 @@ func Test_newAzureMachinePoolService(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(subject).NotTo(BeNil())
-	g.Expect(subject.virtualMachinesScaleSetSvc).NotTo(BeNil())
+	g.Expect(subject.services).NotTo(HaveLen(0))
 	g.Expect(subject.skuCache).NotTo(BeNil())
 }
 

--- a/exp/controllers/azuremachinepool_reconciler_test.go
+++ b/exp/controllers/azuremachinepool_reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,13 +28,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
-	"sigs.k8s.io/cluster-api-provider-azure/azure/services/groups"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capiv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 )
 
-func TestAzureClusterServiceReconcile(t *testing.T) {
+func TestAzureMachinePoolServiceReconcile(t *testing.T) {
 	cases := map[string]struct {
 		expectedError string
 		expect        func(one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder)
@@ -49,12 +50,12 @@ func TestAzureClusterServiceReconcile(t *testing.T) {
 			},
 		},
 		"service reconcile fails": {
-			expectedError: "failed to reconcile AzureCluster service two: some error happened",
+			expectedError: "failed to reconcile AzureMachinePool service foo: some error happened",
 			expect: func(one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
 				gomock.InOrder(
 					one.Reconcile(gomockinternal.AContext()).Return(nil),
 					two.Reconcile(gomockinternal.AContext()).Return(errors.New("some error happened")),
-					two.Name().Return("two"))
+					two.Name().Return("foo"))
 			},
 		},
 	}
@@ -73,10 +74,20 @@ func TestAzureClusterServiceReconcile(t *testing.T) {
 
 			tc.expect(svcOneMock.EXPECT(), svcTwoMock.EXPECT(), svcThreeMock.EXPECT())
 
-			s := &azureClusterService{
-				scope: &scope.ClusterScope{
-					Cluster:      &clusterv1.Cluster{},
-					AzureCluster: &infrav1.AzureCluster{},
+			s := &azureMachinePoolService{
+				scope: &scope.MachinePoolScope{
+					ClusterScoper: &scope.ClusterScope{
+						AzureCluster: &infrav1.AzureCluster{},
+						Cluster:      &clusterv1.Cluster{},
+					},
+					MachinePool: &capiv1exp.MachinePool{},
+					AzureMachinePool: &infrav1exp.AzureMachinePool{
+						Spec: infrav1exp.AzureMachinePoolSpec{
+							Template: infrav1exp.AzureMachinePoolMachineTemplate{
+								SubnetName: "test-subnet",
+							},
+						},
+					},
 				},
 				services: []azure.ServiceReconciler{
 					svcOneMock,
@@ -97,47 +108,27 @@ func TestAzureClusterServiceReconcile(t *testing.T) {
 	}
 }
 
-func TestAzureClusterServiceDelete(t *testing.T) {
+func TestAzureMachinePoolServiceDelete(t *testing.T) {
 	cases := map[string]struct {
 		expectedError string
-		expect        func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder)
+		expect        func(one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder)
 	}{
-		"Resource Group is deleted successfully": {
+		"all services deleted in order": {
 			expectedError: "",
-			expect: func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
+			expect: func(one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
 				gomock.InOrder(
-					grp.Name().Return(groups.ServiceName),
-					grp.Delete(gomockinternal.AContext()).Return(nil))
-			},
-		},
-		"Resource Group delete fails": {
-			expectedError: "failed to delete resource group: internal error",
-			expect: func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
-				gomock.InOrder(
-					grp.Name().Return(groups.ServiceName),
-					grp.Delete(gomockinternal.AContext()).Return(errors.New("internal error")))
-			},
-		},
-		"Resource Group not owned by cluster": {
-			expectedError: "",
-			expect: func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
-				gomock.InOrder(
-					grp.Name().Return(groups.ServiceName),
-					grp.Delete(gomockinternal.AContext()).Return(azure.ErrNotOwned),
 					three.Delete(gomockinternal.AContext()).Return(nil),
 					two.Delete(gomockinternal.AContext()).Return(nil),
 					one.Delete(gomockinternal.AContext()).Return(nil))
 			},
 		},
 		"service delete fails": {
-			expectedError: "failed to delete AzureCluster service two: some error happened",
-			expect: func(grp *mock_azure.MockServiceReconcilerMockRecorder, one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
+			expectedError: "failed to delete AzureMachinePool service test-service-two: some error happened",
+			expect: func(one *mock_azure.MockServiceReconcilerMockRecorder, two *mock_azure.MockServiceReconcilerMockRecorder, three *mock_azure.MockServiceReconcilerMockRecorder) {
 				gomock.InOrder(
-					grp.Name().Return(groups.ServiceName),
-					grp.Delete(gomockinternal.AContext()).Return(azure.ErrNotOwned),
 					three.Delete(gomockinternal.AContext()).Return(nil),
 					two.Delete(gomockinternal.AContext()).Return(errors.New("some error happened")),
-					two.Name().Return("two"))
+					two.Name().Return("test-service-two"))
 			},
 		},
 	}
@@ -150,19 +141,22 @@ func TestAzureClusterServiceDelete(t *testing.T) {
 			t.Parallel()
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
-			groupsMock := mock_azure.NewMockServiceReconciler(mockCtrl)
 			svcOneMock := mock_azure.NewMockServiceReconciler(mockCtrl)
 			svcTwoMock := mock_azure.NewMockServiceReconciler(mockCtrl)
 			svcThreeMock := mock_azure.NewMockServiceReconciler(mockCtrl)
 
-			tc.expect(groupsMock.EXPECT(), svcOneMock.EXPECT(), svcTwoMock.EXPECT(), svcThreeMock.EXPECT())
+			tc.expect(svcOneMock.EXPECT(), svcTwoMock.EXPECT(), svcThreeMock.EXPECT())
 
-			s := &azureClusterService{
-				scope: &scope.ClusterScope{
-					AzureCluster: &infrav1.AzureCluster{},
+			s := &azureMachinePoolService{
+				scope: &scope.MachinePoolScope{
+					ClusterScoper: &scope.ClusterScope{
+						AzureCluster: &infrav1.AzureCluster{},
+						Cluster:      &clusterv1.Cluster{},
+					},
+					MachinePool:      &capiv1exp.MachinePool{},
+					AzureMachinePool: &infrav1exp.AzureMachinePool{},
 				},
 				services: []azure.ServiceReconciler{
-					groupsMock,
 					svcOneMock,
 					svcTwoMock,
 					svcThreeMock,

--- a/exp/controllers/azuremanagedcontrolplane_reconciler.go
+++ b/exp/controllers/azuremanagedcontrolplane_reconciler.go
@@ -35,25 +35,23 @@ import (
 
 // azureManagedControlPlaneService contains the services required by the cluster controller.
 type azureManagedControlPlaneService struct {
-	kubeclient         client.Client
-	scope              managedclusters.ManagedClusterScope
-	managedClustersSvc azure.Reconciler
-	groupsSvc          azure.Reconciler
-	vnetSvc            azure.Reconciler
-	subnetsSvc         azure.Reconciler
-	tagsSvc            azure.Reconciler
+	kubeclient client.Client
+	scope      managedclusters.ManagedClusterScope
+	services   []azure.ServiceReconciler
 }
 
 // newAzureManagedControlPlaneReconciler populates all the services based on input scope.
 func newAzureManagedControlPlaneReconciler(scope *scope.ManagedControlPlaneScope) *azureManagedControlPlaneService {
 	return &azureManagedControlPlaneService{
-		kubeclient:         scope.Client,
-		scope:              scope,
-		managedClustersSvc: managedclusters.New(scope),
-		groupsSvc:          groups.New(scope),
-		vnetSvc:            virtualnetworks.New(scope),
-		subnetsSvc:         subnets.New(scope),
-		tagsSvc:            tags.New(scope),
+		kubeclient: scope.Client,
+		scope:      scope,
+		services: []azure.ServiceReconciler{
+			groups.New(scope),
+			virtualnetworks.New(scope),
+			subnets.New(scope),
+			managedclusters.New(scope),
+			tags.New(scope),
+		},
 	}
 }
 
@@ -62,29 +60,14 @@ func (r *azureManagedControlPlaneService) Reconcile(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureManagedControlPlaneService.Reconcile")
 	defer done()
 
-	if err := r.groupsSvc.Reconcile(ctx); err != nil {
-		return errors.Wrap(err, "failed to reconcile managed cluster resource group")
-	}
-
-	if err := r.vnetSvc.Reconcile(ctx); err != nil {
-		return errors.Wrap(err, "failed to reconcile virtual network")
-	}
-
-	if err := r.subnetsSvc.Reconcile(ctx); err != nil {
-		return errors.Wrap(err, "failed to reconcile subnet")
-	}
-
-	// Send to Azure for create/update.
-	if err := r.managedClustersSvc.Reconcile(ctx); err != nil {
-		return errors.Wrapf(err, "failed to reconcile managed cluster")
+	for _, service := range r.services {
+		if err := service.Reconcile(ctx); err != nil {
+			return errors.Wrapf(err, "failed to reconcile AzureManagedControlPlane service %s", service.Name())
+		}
 	}
 
 	if err := r.reconcileKubeconfig(ctx); err != nil {
 		return errors.Wrap(err, "failed to reconcile kubeconfig secret")
-	}
-
-	if err := r.tagsSvc.Reconcile(ctx); err != nil {
-		return errors.Wrap(err, "unable to update tags")
 	}
 
 	return nil
@@ -95,16 +78,11 @@ func (r *azureManagedControlPlaneService) Delete(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureManagedControlPlaneService.Delete")
 	defer done()
 
-	if err := r.managedClustersSvc.Delete(ctx); err != nil {
-		return errors.Wrapf(err, "failed to delete managed cluster")
-	}
-
-	if err := r.vnetSvc.Delete(ctx); err != nil {
-		return errors.Wrap(err, "failed to delete virtual network")
-	}
-
-	if err := r.groupsSvc.Delete(ctx); err != nil && !errors.Is(err, azure.ErrNotOwned) {
-		return errors.Wrap(err, "failed to delete managed cluster resource group")
+	// Delete services in reverse order of creation.
+	for i := len(r.services) - 1; i >= 0; i-- {
+		if err := r.services[i].Delete(ctx); err != nil {
+			return errors.Wrapf(err, "failed to delete AzureManagedControlPlane service %s", r.services[i].Name())
+		}
 	}
 
 	return nil


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Since we are reconciling (and deleting in reverse order) Azure services one by one in reconcilers, this is a small optimization to move the reconcile and delete to a list and range through the services instead of making a Reconcile/Delete call for each. This is possible now that we've refactored all services to implement `Azure.Reconciler`. Also adds unit tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use a list for Azure services in AzureCluster and AzureMachine reconcilers
```
