### PR TITLE
e2e: wait 5 mins for LB create

### DIFF
--- a/test/e2e/azure_lb.go
+++ b/test/e2e/azure_lb.go
@@ -42,6 +42,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/test/e2e/kubernetes/windows"
 )
 
+const waitForLBCreateTimeout = 5 * time.Minute
+
 // AzureLBSpecInput is the input for AzureLBSpec.
 type AzureLBSpecInput struct {
 	BootstrapClusterProxy framework.ClusterProxy
@@ -151,7 +153,7 @@ func AzureLBSpec(ctx context.Context, inputGetter func() AzureLBSpecInput) {
 				return err
 			}
 			return nil
-		}, retryableOperationTimeout, retryableOperationSleepBetweenRetries).Should(Succeed())
+		}, waitForLBCreateTimeout, retryableOperationSleepBetweenRetries).Should(Succeed())
 		ilbIP := extractServiceIp(svc)
 
 		ilbJob := job.CreateCurlJobResourceSpec("curl-to-ilb-job", ilbIP)
@@ -222,7 +224,7 @@ func AzureLBSpec(ctx context.Context, inputGetter func() AzureLBSpecInput) {
 			return err
 		}
 		return nil
-	}, retryableOperationTimeout, retryableOperationSleepBetweenRetries).Should(Succeed())
+	}, waitForLBCreateTimeout, retryableOperationSleepBetweenRetries).Should(Succeed())
 
 	elbIP := extractServiceIp(svc)
 	Log("starting to create curl-to-elb job")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind flake

**What this PR does / why we need it**:

Observed a flake waiting for LB create here:

https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/2160/pull-cluster-api-provider-azure-e2e/1501991622571724800/build-log.txt

This PR increases the timeout tolerance for the creation of a LoadBalancer to 5 mins from 30 seconds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
