### PR TITLE
use converters for AKS SDK agentpool definition

### DIFF
--- a/azure/converters/managedagentpool.go
+++ b/azure/converters/managedagentpool.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package converters
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-05-01/containerservice"
+	"github.com/Azure/go-autorest/autorest/to"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
+)
+
+// AgentPoolToManagedClusterAgentPoolProfile converts a AgentPoolSpec to an Azure SDK ManagedClusterAgentPoolProfile used in managedcluster reconcile.
+func AgentPoolToManagedClusterAgentPoolProfile(pool azure.AgentPoolSpec) containerservice.ManagedClusterAgentPoolProfile {
+	return containerservice.ManagedClusterAgentPoolProfile{
+		Name:                &pool.Name,
+		VMSize:              &pool.SKU,
+		OsType:              containerservice.OSTypeLinux,
+		OsDiskSizeGB:        &pool.OSDiskSizeGB,
+		Count:               &pool.Replicas,
+		Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
+		OrchestratorVersion: pool.Version,
+		VnetSubnetID:        &pool.VnetSubnetID,
+		Mode:                containerservice.AgentPoolMode(pool.Mode),
+		EnableAutoScaling:   pool.EnableAutoScaling,
+		MaxCount:            pool.MaxCount,
+		MinCount:            pool.MinCount,
+		NodeTaints:          &pool.NodeTaints,
+		AvailabilityZones:   &pool.AvailabilityZones,
+		MaxPods:             pool.MaxPods,
+		OsDiskType:          containerservice.OSDiskType(to.String(pool.OsDiskType)),
+		NodeLabels:          pool.NodeLabels,
+		EnableUltraSSD:      pool.EnableUltraSSD,
+	}
+}
+
+// AgentPoolToContainerServiceAgentPool converts a AgentPoolSpec to an Azure SDK AgentPool used in agentpool reconcile.
+func AgentPoolToContainerServiceAgentPool(pool azure.AgentPoolSpec) containerservice.AgentPool {
+	return containerservice.AgentPool{
+		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
+			VMSize:              &pool.SKU,
+			OsType:              containerservice.OSTypeLinux,
+			OsDiskSizeGB:        &pool.OSDiskSizeGB,
+			Count:               &pool.Replicas,
+			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
+			OrchestratorVersion: pool.Version,
+			VnetSubnetID:        &pool.VnetSubnetID,
+			Mode:                containerservice.AgentPoolMode(pool.Mode),
+			EnableAutoScaling:   pool.EnableAutoScaling,
+			MaxCount:            pool.MaxCount,
+			MinCount:            pool.MinCount,
+			NodeTaints:          &pool.NodeTaints,
+			AvailabilityZones:   &pool.AvailabilityZones,
+			MaxPods:             pool.MaxPods,
+			OsDiskType:          containerservice.OSDiskType(to.String(pool.OsDiskType)),
+			NodeLabels:          pool.NodeLabels,
+			EnableUltraSSD:      pool.EnableUltraSSD,
+		},
+	}
+}

--- a/azure/converters/managedagentpool_test.go
+++ b/azure/converters/managedagentpool_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package converters
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-05-01/containerservice"
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
+)
+
+func Test_AgentPoolToManagedClusterAgentPoolProfile(t *testing.T) {
+	cases := []struct {
+		name   string
+		pool   azure.AgentPoolSpec
+		expect func(*GomegaWithT, containerservice.ManagedClusterAgentPoolProfile)
+	}{
+		{
+			name: "Should set all values correctly",
+			pool: azure.AgentPoolSpec{
+				SKU:               "Standard_D2s_v3",
+				OSDiskSizeGB:      100,
+				Replicas:          2,
+				Version:           to.StringPtr("1.22.6"),
+				VnetSubnetID:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-123/providers/Microsoft.Network/virtualNetworks/vnet-123/subnets/subnet-123",
+				Mode:              "User",
+				EnableAutoScaling: to.BoolPtr(true),
+				MaxCount:          to.Int32Ptr(5),
+				MinCount:          to.Int32Ptr(2),
+				NodeTaints:        []string{"key1=value1:NoSchedule"},
+				AvailabilityZones: []string{"zone1"},
+				MaxPods:           to.Int32Ptr(60),
+				OsDiskType:        to.StringPtr(string(containerservice.OSDiskTypeManaged)),
+				NodeLabels: map[string]*string{
+					"custom": to.StringPtr("default"),
+				},
+				Name: "agentpool1",
+			},
+
+			expect: func(g *GomegaWithT, result containerservice.ManagedClusterAgentPoolProfile) {
+				g.Expect(result).To(Equal(containerservice.ManagedClusterAgentPoolProfile{
+					Name:                to.StringPtr("agentpool1"),
+					VMSize:              to.StringPtr("Standard_D2s_v3"),
+					OsType:              containerservice.OSTypeLinux,
+					OsDiskSizeGB:        to.Int32Ptr(100),
+					Count:               to.Int32Ptr(2),
+					Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
+					OrchestratorVersion: to.StringPtr("1.22.6"),
+					VnetSubnetID:        to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-123/providers/Microsoft.Network/virtualNetworks/vnet-123/subnets/subnet-123"),
+					Mode:                containerservice.AgentPoolModeUser,
+					EnableAutoScaling:   to.BoolPtr(true),
+					MaxCount:            to.Int32Ptr(5),
+					MinCount:            to.Int32Ptr(2),
+					NodeTaints:          to.StringSlicePtr([]string{"key1=value1:NoSchedule"}),
+					AvailabilityZones:   to.StringSlicePtr([]string{"zone1"}),
+					MaxPods:             to.Int32Ptr(60),
+					OsDiskType:          containerservice.OSDiskTypeManaged,
+					NodeLabels: map[string]*string{
+						"custom": to.StringPtr("default"),
+					},
+				}))
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+			result := AgentPoolToManagedClusterAgentPoolProfile(c.pool)
+			c.expect(g, result)
+		})
+	}
+}
+
+func Test_AgentPoolToAgentPoolToContainerServiceAgentPool(t *testing.T) {
+	cases := []struct {
+		name   string
+		pool   azure.AgentPoolSpec
+		expect func(*GomegaWithT, containerservice.AgentPool)
+	}{
+		{
+			name: "Should set all values correctly",
+			pool: azure.AgentPoolSpec{
+				Name:              "agentpool1",
+				SKU:               "Standard_D2s_v3",
+				OSDiskSizeGB:      100,
+				Replicas:          2,
+				Version:           to.StringPtr("1.22.6"),
+				VnetSubnetID:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-123/providers/Microsoft.Network/virtualNetworks/vnet-123/subnets/subnet-123",
+				Mode:              "User",
+				EnableAutoScaling: to.BoolPtr(true),
+				MaxCount:          to.Int32Ptr(5),
+				MinCount:          to.Int32Ptr(2),
+				NodeTaints:        []string{"key1=value1:NoSchedule"},
+				AvailabilityZones: []string{"zone1"},
+				MaxPods:           to.Int32Ptr(60),
+				OsDiskType:        to.StringPtr(string(containerservice.OSDiskTypeManaged)),
+				NodeLabels: map[string]*string{
+					"custom": to.StringPtr("default"),
+				},
+			},
+
+			expect: func(g *GomegaWithT, result containerservice.AgentPool) {
+				g.Expect(result).To(Equal(containerservice.AgentPool{
+					ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
+						VMSize:              to.StringPtr("Standard_D2s_v3"),
+						OsType:              containerservice.OSTypeLinux,
+						OsDiskSizeGB:        to.Int32Ptr(100),
+						Count:               to.Int32Ptr(2),
+						Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
+						OrchestratorVersion: to.StringPtr("1.22.6"),
+						VnetSubnetID:        to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-123/providers/Microsoft.Network/virtualNetworks/vnet-123/subnets/subnet-123"),
+						Mode:                containerservice.AgentPoolModeUser,
+						EnableAutoScaling:   to.BoolPtr(true),
+						MaxCount:            to.Int32Ptr(5),
+						MinCount:            to.Int32Ptr(2),
+						NodeTaints:          to.StringSlicePtr([]string{"key1=value1:NoSchedule"}),
+						AvailabilityZones:   to.StringSlicePtr([]string{"zone1"}),
+						MaxPods:             to.Int32Ptr(60),
+						OsDiskType:          containerservice.OSDiskTypeManaged,
+						NodeLabels: map[string]*string{
+							"custom": to.StringPtr("default"),
+						},
+					},
+				}))
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+			result := AgentPoolToContainerServiceAgentPool(c.pool)
+			c.expect(g, result)
+		})
+	}
+}

--- a/azure/services/managedclusters/managedclusters.go
+++ b/azure/services/managedclusters/managedclusters.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/klog/v2"
 	infrav1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 	"sigs.k8s.io/cluster-api-provider-azure/util/maps"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -264,20 +265,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 	for i := range managedClusterSpec.AgentPools {
 		pool := managedClusterSpec.AgentPools[i]
-		profile := containerservice.ManagedClusterAgentPoolProfile{
-			Name:                &pool.Name,
-			VMSize:              &pool.SKU,
-			OsDiskSizeGB:        &pool.OSDiskSizeGB,
-			Count:               &pool.Replicas,
-			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
-			VnetSubnetID:        &managedClusterSpec.VnetSubnetID,
-			Mode:                containerservice.AgentPoolMode(pool.Mode),
-			AvailabilityZones:   &pool.AvailabilityZones,
-			MaxPods:             pool.MaxPods,
-			OrchestratorVersion: pool.Version,
-			OsDiskType:          containerservice.OSDiskType(to.String(pool.OsDiskType)),
-			EnableUltraSSD:      pool.EnableUltraSSD,
-		}
+		profile := converters.AgentPoolToManagedClusterAgentPoolProfile(pool)
 		*managedCluster.AgentPoolProfiles = append(*managedCluster.AgentPoolProfiles, profile)
 	}
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:
Azure SDK provides two ways to manage agentpool spec for an AKS cluster
- containerservice.ManagedClusterAgentPoolProfileProperties
- containerservice.ManagedClusterAgentPoolProfile

`ManagedClusterAgentPoolProfile` is used for ManagedCluster reconcile https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/services/managedclusters/managedclusters.go#L267 

And `ManagedClusterAgentPoolProfileProperties` is used in AgentPools reconcile https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/services/agentpools/agentpools.go#L77

we generally want to favor AgentPools reconcile but the first-time creation of pools might fell into the  ManagedCluster reconcile if it's triggered first. This forces us to update all `Immutable` properties in `ManagedCluster` reconcile otherwise the agentpool might end up in an error state. 

As `containerservice.ManagedClusterAgentPoolProfileProperties` and `containerservice.ManagedClusterAgentPoolProfile` are two different types we cannot have one method and re-use it. We already unified the `AgentPoolSpec` generation in https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1976

**Which issue(s) this PR fixes**:
This PR proposes to use a converters package helper method to gather at one place how AgentPool Spec for Azure SDK is generated. This will make it easier to do changes in the future where contributors might miss one of https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/services/agentpools/agentpools.go or 
https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/services/managedclusters/managedclusters.go
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
