### PR TITLE
Fix outbound lb conversion for v1alpha3 clusters

### DIFF
--- a/api/v1alpha3/azurecluster_conversion.go
+++ b/api/v1alpha3/azurecluster_conversion.go
@@ -42,11 +42,34 @@ func (src *AzureCluster) ConvertTo(dstRaw conversion.Hub) error {
 			dst.Annotations = nil
 		}
 	}
+
+	// set default control plane outbound lb for private v1alpha3 clusters.
+	if src.Spec.NetworkSpec.APIServerLB.Type == Internal {
+		dst.Spec.NetworkSpec.ControlPlaneOutboundLB = &infrav1beta1.LoadBalancerSpec{
+			FrontendIPsCount: pointer.Int32Ptr(1),
+		}
+		// We also need to set the defaults here because "get" won't set defaults, and hence there is no mismatch when a client
+		// gets a v1alpha3 cluster.
+		dst.SetControlPlaneOutboundLBDefaults()
+	}
+
+	// set default node plane outbound lb for all v1alpha3 clusters.
+	dst.Spec.NetworkSpec.NodeOutboundLB = &infrav1beta1.LoadBalancerSpec{
+		FrontendIPsCount: pointer.Int32Ptr(1),
+	}
+	// We also need to set the defaults here because "get" won't set defaults, and hence there is no mismatch when a client
+	// gets a v1alpha3 cluster.
+	dst.SetNodeOutboundLBDefaults()
+
 	// Manually restore data.
 	restored := &infrav1beta1.AzureCluster{}
 	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
 		return err
 	}
+
+	// override outbound lb if it's present in restored.
+	dst.Spec.NetworkSpec.ControlPlaneOutboundLB = restored.Spec.NetworkSpec.ControlPlaneOutboundLB
+	dst.Spec.NetworkSpec.NodeOutboundLB = restored.Spec.NetworkSpec.NodeOutboundLB
 
 	dst.Spec.NetworkSpec.PrivateDNSZoneName = restored.Spec.NetworkSpec.PrivateDNSZoneName
 
@@ -54,24 +77,6 @@ func (src *AzureCluster) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.NetworkSpec.APIServerLB.IdleTimeoutInMinutes = restored.Spec.NetworkSpec.APIServerLB.IdleTimeoutInMinutes
 	dst.Spec.CloudProviderConfigOverrides = restored.Spec.CloudProviderConfigOverrides
 	dst.Spec.BastionSpec = restored.Spec.BastionSpec
-
-	// set default control plane outbound lb for private v1alpha3 clusters
-	if src.Spec.NetworkSpec.APIServerLB.Type == Internal && restored.Spec.NetworkSpec.ControlPlaneOutboundLB == nil {
-		dst.Spec.NetworkSpec.ControlPlaneOutboundLB = &infrav1beta1.LoadBalancerSpec{
-			FrontendIPsCount: pointer.Int32Ptr(1),
-		}
-	} else {
-		dst.Spec.NetworkSpec.ControlPlaneOutboundLB = restored.Spec.NetworkSpec.ControlPlaneOutboundLB
-	}
-
-	// set default node plane outbound lb for all v1alpha3 clusters
-	if restored.Spec.NetworkSpec.NodeOutboundLB == nil {
-		dst.Spec.NetworkSpec.NodeOutboundLB = &infrav1beta1.LoadBalancerSpec{
-			FrontendIPsCount: pointer.Int32Ptr(1),
-		}
-	} else {
-		dst.Spec.NetworkSpec.NodeOutboundLB = restored.Spec.NetworkSpec.NodeOutboundLB
-	}
 
 	// Here we manually restore outbound security rules. Since v1alpha3 only supports ingress ("Inbound") rules, all v1alpha4/v1beta1 outbound rules are dropped when an AzureCluster
 	// is converted to v1alpha3. We loop through all security group rules. For all previously existing outbound rules we restore the full rule.

--- a/api/v1beta1/azurecluster_default.go
+++ b/api/v1beta1/azurecluster_default.go
@@ -57,8 +57,8 @@ func (c *AzureCluster) setNetworkSpecDefaults() {
 	c.setSubnetDefaults()
 	c.setVnetPeeringDefaults()
 	c.setAPIServerLBDefaults()
-	c.setNodeOutboundLBDefaults()
-	c.setControlPlaneOutboundLBDefaults()
+	c.SetNodeOutboundLBDefaults()
+	c.SetControlPlaneOutboundLBDefaults()
 }
 
 func (c *AzureCluster) setResourceGroupDefault() {
@@ -194,7 +194,7 @@ func (c *AzureCluster) setAPIServerLBDefaults() {
 	}
 }
 
-func (c *AzureCluster) setNodeOutboundLBDefaults() {
+func (c *AzureCluster) SetNodeOutboundLBDefaults() {
 	if c.Spec.NetworkSpec.NodeOutboundLB == nil {
 		if c.Spec.NetworkSpec.APIServerLB.Type == Internal {
 			return
@@ -230,7 +230,7 @@ func (c *AzureCluster) setNodeOutboundLBDefaults() {
 	c.setOutboundLBFrontendIPs(lb, generateNodeOutboundIPName)
 }
 
-func (c *AzureCluster) setControlPlaneOutboundLBDefaults() {
+func (c *AzureCluster) SetControlPlaneOutboundLBDefaults() {
 	lb := c.Spec.NetworkSpec.ControlPlaneOutboundLB
 
 	if lb == nil {

--- a/api/v1beta1/azurecluster_default_test.go
+++ b/api/v1beta1/azurecluster_default_test.go
@@ -1596,7 +1596,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		tc := c
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.cluster.setNodeOutboundLBDefaults()
+			tc.cluster.SetNodeOutboundLBDefaults()
 			if !reflect.DeepEqual(tc.cluster, tc.output) {
 				expected, _ := json.MarshalIndent(tc.output, "", "\t")
 				actual, _ := json.MarshalIndent(tc.cluster, "", "\t")
@@ -1728,7 +1728,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 		tc := c
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.cluster.setControlPlaneOutboundLBDefaults()
+			tc.cluster.SetControlPlaneOutboundLBDefaults()
 			if !reflect.DeepEqual(tc.cluster, tc.output) {
 				expected, _ := json.MarshalIndent(tc.output, "", "\t")
 				actual, _ := json.MarshalIndent(tc.cluster, "", "\t")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Fixes outbound load balancer conversion logic for v1alpha3 clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2175 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix outbound lb conversion for v1alpha3 clusters
```
