### PR TITLE
[release-1.1] fix outbound lb conversion for v1alpha3 clusters

### DIFF
--- a/api/v1beta1/azurecluster_default.go
+++ b/api/v1beta1/azurecluster_default.go
@@ -55,8 +55,8 @@ func (c *AzureCluster) setNetworkSpecDefaults() {
 	c.setSubnetDefaults()
 	c.setVnetPeeringDefaults()
 	c.setAPIServerLBDefaults()
-	c.setNodeOutboundLBDefaults()
-	c.setControlPlaneOutboundLBDefaults()
+	c.SetNodeOutboundLBDefaults()
+	c.SetControlPlaneOutboundLBDefaults()
 }
 
 func (c *AzureCluster) setResourceGroupDefault() {
@@ -205,7 +205,7 @@ func (c *AzureCluster) setAPIServerLBDefaults() {
 	}
 }
 
-func (c *AzureCluster) setNodeOutboundLBDefaults() {
+func (c *AzureCluster) SetNodeOutboundLBDefaults() {
 	if c.Spec.NetworkSpec.NodeOutboundLB == nil {
 		if c.Spec.NetworkSpec.APIServerLB.Type == Internal {
 			return
@@ -245,7 +245,7 @@ func (c *AzureCluster) setNodeOutboundLBDefaults() {
 	c.setOutboundLBFrontendIPs(lb, generateNodeOutboundIPName)
 }
 
-func (c *AzureCluster) setControlPlaneOutboundLBDefaults() {
+func (c *AzureCluster) SetControlPlaneOutboundLBDefaults() {
 	// public clusters don't need control plane outbound lb
 	if c.Spec.NetworkSpec.APIServerLB.Type == Public {
 		return

--- a/api/v1beta1/azurecluster_default_test.go
+++ b/api/v1beta1/azurecluster_default_test.go
@@ -1386,7 +1386,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		tc := c
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.cluster.setNodeOutboundLBDefaults()
+			tc.cluster.SetNodeOutboundLBDefaults()
 			if !reflect.DeepEqual(tc.cluster, tc.output) {
 				expected, _ := json.MarshalIndent(tc.output, "", "\t")
 				actual, _ := json.MarshalIndent(tc.cluster, "", "\t")
@@ -1508,7 +1508,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 		tc := c
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.cluster.setControlPlaneOutboundLBDefaults()
+			tc.cluster.SetControlPlaneOutboundLBDefaults()
 			if !reflect.DeepEqual(tc.cluster, tc.output) {
 				expected, _ := json.MarshalIndent(tc.output, "", "\t")
 				actual, _ := json.MarshalIndent(tc.cluster, "", "\t")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Backports https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2176

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

cherry pick bot didn't work because there were merge conflicts.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix outbound lb conversion for v1alpha3 clusters
```
