### PR TITLE
ci: Ci entrypoint windows 2022 support

### DIFF
--- a/azure/defaults_test.go
+++ b/azure/defaults_test.go
@@ -34,8 +34,7 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 
 	var tests = []struct {
 		k8sVersion     string
-		os             string
-		osVersion      string
+		osAndVersion   string
 		expectedResult string
 		expectedError  bool
 	}{
@@ -43,50 +42,43 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			k8sVersion:     "v1.14.9",
 			expectedResult: "k8s-1dot14dot9-ubuntu-1804",
 			expectedError:  false,
-			os:             "ubuntu",
-			osVersion:      "1804",
+			osAndVersion:   "ubuntu-1804",
 		},
 		{
 			k8sVersion:     "v1.14.10",
 			expectedResult: "k8s-1dot14dot10-ubuntu-1804",
 			expectedError:  false,
-			os:             "ubuntu",
-			osVersion:      "1804",
+			osAndVersion:   "ubuntu-1804",
 		},
 		{
 			k8sVersion:     "v1.15.6",
 			expectedResult: "k8s-1dot15dot6-ubuntu-1804",
 			expectedError:  false,
-			os:             "ubuntu",
-			osVersion:      "1804",
+			osAndVersion:   "ubuntu-1804",
 		},
 		{
 			k8sVersion:     "v1.15.7",
 			expectedResult: "k8s-1dot15dot7-ubuntu-1804",
 			expectedError:  false,
-			os:             "ubuntu",
-			osVersion:      "1804",
+			osAndVersion:   "ubuntu-1804",
 		},
 		{
 			k8sVersion:     "v1.16.3",
 			expectedResult: "k8s-1dot16dot3-ubuntu-1804",
 			expectedError:  false,
-			os:             "ubuntu",
-			osVersion:      "1804",
+			osAndVersion:   "ubuntu-1804",
 		},
 		{
 			k8sVersion:     "v1.16.4",
 			expectedResult: "k8s-1dot16dot4-ubuntu-1804",
 			expectedError:  false,
-			os:             "ubuntu",
-			osVersion:      "1804",
+			osAndVersion:   "ubuntu-1804",
 		},
 		{
 			k8sVersion:     "1.12.0",
 			expectedResult: "k8s-1dot12dot0-ubuntu-1804",
 			expectedError:  false,
-			os:             "ubuntu",
-			osVersion:      "1804",
+			osAndVersion:   "ubuntu-1804",
 		},
 		{
 			k8sVersion:     "1.1.notvalid.semver",
@@ -97,42 +89,37 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			k8sVersion:     "v1.19.3",
 			expectedResult: "k8s-1dot19dot3-windows-2019",
 			expectedError:  false,
-			os:             "windows",
-			osVersion:      "2019",
+			osAndVersion:   "windows-2019",
 		},
 		{
 			k8sVersion:     "v1.20.8",
 			expectedResult: "k8s-1dot20dot8-windows-2019",
 			expectedError:  false,
-			os:             "windows",
-			osVersion:      "2019",
+			osAndVersion:   "windows-2019",
 		},
 		{
 			k8sVersion:     "v1.21.2",
 			expectedResult: "k8s-1dot21dot2-windows-2019",
 			expectedError:  false,
-			os:             "windows",
-			osVersion:      "2019",
+			osAndVersion:   "windows-2019",
 		},
 		{
 			k8sVersion:     "v1.20.8",
 			expectedResult: "k8s-1dot20dot8-ubuntu-2004",
 			expectedError:  false,
-			os:             "ubuntu",
-			osVersion:      "2004",
+			osAndVersion:   "ubuntu-2004",
 		},
 		{
 			k8sVersion:     "v1.21.2",
 			expectedResult: "k8s-1dot21dot2-ubuntu-2004",
 			expectedError:  false,
-			os:             "ubuntu",
-			osVersion:      "2004",
+			osAndVersion:   "ubuntu-2004",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.k8sVersion, func(t *testing.T) {
-			id, err := getDefaultImageSKUID(test.k8sVersion, test.os, test.osVersion)
+			id, err := getDefaultImageSKUID(test.k8sVersion, test.osAndVersion)
 
 			if test.expectedError {
 				g.Expect(err).To(HaveOccurred())
@@ -288,4 +275,95 @@ func TestMSCorrelationIDSendDecorator(t *testing.T) {
 	g.Expect(
 		receivedReq.Header.Get(string(tele.CorrIDKeyVal)),
 	).To(Equal(string(corrID)))
+}
+
+func TestGetDefaultWindowsImage(t *testing.T) {
+	g := NewWithT(t)
+
+	var tests = []struct {
+		name          string
+		k8sVersion    string
+		runtime       string
+		osVersion     string
+		expectedSKU   string
+		expectedError bool
+	}{
+		{
+			name:          "no k8sVersion",
+			k8sVersion:    "1.1.1.1.1.1",
+			runtime:       "",
+			osVersion:     "",
+			expectedSKU:   "",
+			expectedError: true,
+		},
+		{
+			name:          "1.21.* - default runtime - default osVersion",
+			k8sVersion:    "v1.21.4",
+			runtime:       "",
+			osVersion:     "",
+			expectedSKU:   "k8s-1dot21dot4-windows-2019",
+			expectedError: false,
+		},
+		{
+			name:          "1.21.* - dockershim runtime - default osVersion",
+			k8sVersion:    "v1.21.4",
+			runtime:       "dockershim",
+			osVersion:     "",
+			expectedSKU:   "k8s-1dot21dot4-windows-2019",
+			expectedError: false,
+		},
+		{
+			name:          "1.21.* - containerd runtime - default osVersion",
+			k8sVersion:    "v1.21.4",
+			runtime:       "containerd",
+			osVersion:     "",
+			expectedSKU:   "",
+			expectedError: true,
+		},
+		{
+			name:          "1.23.* - containerd runtime - default osVersion",
+			k8sVersion:    "v1.23.2",
+			runtime:       "containerd",
+			osVersion:     "",
+			expectedSKU:   "k8s-1dot23dot2-windows-2019-containerd",
+			expectedError: false,
+		},
+		{
+			name:          "1.23.* - default runtime - 2019 osVersion",
+			k8sVersion:    "v1.23.2",
+			runtime:       "",
+			osVersion:     "windows-2019",
+			expectedSKU:   "k8s-1dot23dot2-windows-2019-containerd",
+			expectedError: false,
+		},
+		{
+			name:          "1.23.* - default runtime - 2022 osVersion",
+			k8sVersion:    "v1.23.2",
+			runtime:       "",
+			osVersion:     "windows-2022",
+			expectedSKU:   "k8s-1dot23dot2-windows-2022-containerd",
+			expectedError: false,
+		},
+		{
+			name:          "1.23.* - containerd runtime - 2022 osVersion",
+			k8sVersion:    "v1.23.2",
+			runtime:       "containerd",
+			osVersion:     "windows-2022",
+			expectedSKU:   "k8s-1dot23dot2-windows-2022-containerd",
+			expectedError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			image, err := GetDefaultWindowsImage(test.k8sVersion, test.runtime, test.osVersion)
+
+			if test.expectedError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(image.Marketplace.SKU).To(Equal(test.expectedSKU))
+			}
+		})
+	}
 }

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -628,8 +628,9 @@ func (m *MachineScope) GetVMImage(ctx context.Context) (*infrav1.Image, error) {
 
 	if m.AzureMachine.Spec.OSDisk.OSType == azure.WindowsOS {
 		runtime := m.AzureMachine.Annotations["runtime"]
-		log.Info("No image specified for machine, using default Windows Image", "machine", m.AzureMachine.GetName(), "runtime", runtime)
-		return azure.GetDefaultWindowsImage(to.String(m.Machine.Spec.Version), runtime)
+		windowsServerVersion := m.AzureMachine.Annotations["windowsServerVersion"]
+		log.Info("No image specified for machine, using default Windows Image", "machine", m.AzureMachine.GetName(), "runtime", runtime, "windowsServerVersion", windowsServerVersion)
+		return azure.GetDefaultWindowsImage(to.String(m.Machine.Spec.Version), runtime, windowsServerVersion)
 	}
 
 	log.Info("No image specified for machine, using default Linux Image", "machine", m.AzureMachine.GetName())

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -1189,7 +1189,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 				},
 			},
 			want: func() *infrav1.Image {
-				image, _ := azure.GetDefaultWindowsImage("1.20.1", "dockershim")
+				image, _ := azure.GetDefaultWindowsImage("1.20.1", "dockershim", "")
 				return image
 			}(),
 			wantErr: false,
@@ -1217,7 +1217,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 				},
 			},
 			want: func() *infrav1.Image {
-				image, _ := azure.GetDefaultWindowsImage("1.22.1", "containerd")
+				image, _ := azure.GetDefaultWindowsImage("1.22.1", "containerd", "")
 				return image
 			}(),
 			wantErr: false,
@@ -1248,7 +1248,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 				},
 			},
 			want: func() *infrav1.Image {
-				image, _ := azure.GetDefaultWindowsImage("1.22.1", "dockershim")
+				image, _ := azure.GetDefaultWindowsImage("1.22.1", "dockershim", "")
 				return image
 			}(),
 			wantErr: false,
@@ -1279,7 +1279,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 				},
 			},
 			want: func() *infrav1.Image {
-				image, _ := azure.GetDefaultWindowsImage("1.21.1", "dockershim")
+				image, _ := azure.GetDefaultWindowsImage("1.21.1", "dockershim", "")
 				return image
 			}(),
 			wantErr: false,
@@ -1311,6 +1311,68 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: true,
+		},
+		{
+			name: "if no image is specified and os specified is windows with windowsServerVersion annotation set to 2019, retrurns 2019 image",
+			machineScope: MachineScope{
+				Machine: &clusterv1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machine-name",
+					},
+					Spec: clusterv1.MachineSpec{
+						Version: pointer.String("1.23.3"),
+					},
+				},
+				AzureMachine: &infrav1.AzureMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machine-name",
+						Annotations: map[string]string{
+							"windowsServerVersion": "windows-2019",
+						},
+					},
+					Spec: infrav1.AzureMachineSpec{
+						OSDisk: infrav1.OSDisk{
+							OSType: azure.WindowsOS,
+						},
+					},
+				},
+			},
+			want: func() *infrav1.Image {
+				image, _ := azure.GetDefaultWindowsImage("1.23.3", "", "windows-2019")
+				return image
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "if no image is specified and os specified is windows with windowsServerVersion annotation set to 2022, retrurns 2022 image",
+			machineScope: MachineScope{
+				Machine: &clusterv1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machine-name",
+					},
+					Spec: clusterv1.MachineSpec{
+						Version: pointer.String("1.23.3"),
+					},
+				},
+				AzureMachine: &infrav1.AzureMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machine-name",
+						Annotations: map[string]string{
+							"windowsServerVersion": "windows-2022",
+						},
+					},
+					Spec: infrav1.AzureMachineSpec{
+						OSDisk: infrav1.OSDisk{
+							OSType: azure.WindowsOS,
+						},
+					},
+				},
+			},
+			want: func() *infrav1.Image {
+				image, _ := azure.GetDefaultWindowsImage("1.23.3", "", "windows-2022")
+				return image
+			}(),
+			wantErr: false,
 		},
 		{
 			name: "if no image and OS is specified, returns linux image",

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -551,8 +551,9 @@ func (m *MachinePoolScope) GetVMImage(ctx context.Context) (*infrav1.Image, erro
 	)
 	if m.AzureMachinePool.Spec.Template.OSDisk.OSType == azure.WindowsOS {
 		runtime := m.AzureMachinePool.Annotations["runtime"]
-		log.V(4).Info("No image specified for machine, using default Windows Image", "machine", m.MachinePool.GetName(), "runtime", runtime)
-		defaultImage, err = azure.GetDefaultWindowsImage(to.String(m.MachinePool.Spec.Template.Spec.Version), runtime)
+		windowsServerVersion := m.AzureMachinePool.Annotations["windowsServerVersion"]
+		log.V(4).Info("No image specified for machine, using default Windows Image", "machine", m.MachinePool.GetName(), "runtime", runtime, "windowsServerVersion", windowsServerVersion)
+		defaultImage, err = azure.GetDefaultWindowsImage(to.String(m.MachinePool.Spec.Template.Spec.Version), runtime, windowsServerVersion)
 	} else {
 		defaultImage, err = azure.GetDefaultUbuntuImage(to.String(m.MachinePool.Spec.Template.Spec.Version))
 	}

--- a/templates/cluster-template-windows-containerd.yaml
+++ b/templates/cluster-template-windows-containerd.yaml
@@ -262,6 +262,9 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        runtime: containerd
     spec:
       osDisk:
         diskSizeGB: 128

--- a/templates/flavors/windows-containerd/machine-deployment-windows.yaml
+++ b/templates/flavors/windows-containerd/machine-deployment-windows.yaml
@@ -30,6 +30,9 @@ metadata:
     runtime: containerd
 spec:
   template:
+    metadata:
+      annotations:
+        runtime: containerd
     spec:
       vmSize: ${AZURE_NODE_MACHINE_TYPE}
       osDisk:

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -400,6 +400,10 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        runtime: containerd
+        windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
     spec:
       image:
         marketplace:

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -400,6 +400,10 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        runtime: containerd
+        windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
     spec:
       image:
         marketplace:

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -251,6 +251,10 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        runtime: containerd
+        windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
     spec:
       osDisk:
         diskSizeGB: 128

--- a/templates/test/ci/patches/windows-server-version.yaml
+++ b/templates/test/ci/patches/windows-server-version.yaml
@@ -1,0 +1,9 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-win
+spec:
+  template:
+    metadata:
+      annotations:
+        windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}

--- a/templates/test/ci/prow/kustomization.yaml
+++ b/templates/test/ci/prow/kustomization.yaml
@@ -19,6 +19,7 @@ patchesStrategicMerge:
   - ../../../flavors/base-windows-containerd/kubeadm-control-plane.yaml
   - ../patches/windows-containerd-patch.yaml
   - ../patches/windows-csi-proxy-enabled.yaml
+  - ../patches/windows-server-version.yaml
 patches:
 - target:
     group: bootstrap.cluster.x-k8s.io

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -343,6 +343,10 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        runtime: containerd
+        windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
     spec:
       image:
         marketplace:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR allows for testing different versions of Windows server without the need to create multiple templates.

For `AzureMachineTemplate` objects with `osType: windows` if `osVersion` attribute will be used to pick which image SKU to use when creating a default image SKU.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 2139

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
