### PR TITLE
Update make target when ccm test

### DIFF
--- a/scripts/ci-build-azure-ccm.sh
+++ b/scripts/ci-build-azure-ccm.sh
@@ -49,8 +49,15 @@ setup() {
 
 main() {
     if [[ "$(can_reuse_artifacts)" == "false" ]]; then
-        echo "Building Azure cloud controller manager and cloud node manager..."
-        make -C "${AZURE_CLOUD_PROVIDER_ROOT}" image push
+        echo "Build Linux Azure amd64 cloud controller manager"
+        make -C "${AZURE_CLOUD_PROVIDER_ROOT}" build-ccm-image-amd64 push-ccm-image-amd64
+        if [[ -n "${TEST_WINDOWS:-}" ]]; then
+            echo "Building Linux amd64 and Windows ltsc2022 amd64 cloud node managers"
+            make -C "${AZURE_CLOUD_PROVIDER_ROOT}" build-node-image-linux-amd64 push-node-image-linux-amd64 push-node-image-windows-ltsc2022-amd64 manifest-node-manager-image-windows-ltsc2022-amd64
+        else
+            echo "Building Linux amd64 cloud node manager"
+            make -C "${AZURE_CLOUD_PROVIDER_ROOT}" build-node-image-linux-amd64 push-node-image-linux-push-name-amd64
+        fi
     fi
 }
 


### PR DESCRIPTION
Linux and Windows tests should only build images they needed instead of
build everything.

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Linux and Windows tests should only build images they needed instead of
build everything.

related: https://github.com/kubernetes-sigs/cloud-provider-azure/issues/1358

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Cloud provider Linux and Windows tests should only build images they needed instead of
build everything.
```
