### PR TITLE
Apidiff test runs only if the changes are in api/ and exp/api/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,9 +191,11 @@ clean-temporary: ## Remove all temporary files and folders.
 clean-release: ## Remove the release folder.
 	rm -rf $(RELEASE_DIR)
 
+APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
+
 .PHONY: apidiff
 apidiff: $(GO_APIDIFF) ## Check for API differences.
-	$(GO_APIDIFF) $(shell git rev-parse origin/main) --print-compatible
+	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible
 
 .PHONY: format-tiltfile
 format-tiltfile: ## Format the Tiltfile.

--- a/scripts/ci-apidiff.sh
+++ b/scripts/ci-apidiff.sh
@@ -20,9 +20,12 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
-APIDIFF="${REPO_ROOT}/hack/tools/bin/go-apidiff"
-
-cd "${REPO_ROOT}" && make "${APIDIFF##*/}"
-echo "*** Running go-apidiff ***"
-
-${APIDIFF} "${PULL_BASE_SHA}" --print-compatible
+cd "${REPO_ROOT}"
+APICHANGE=$(git --no-pager diff --name-only FETCH_HEAD)
+if echo "${APICHANGE}" | grep "^api/\|/api/" 
+then
+    echo "*** Running go-apidiff ***"
+    APIDIFF_OLD_COMMIT="${PULL_BASE_SHA}" make apidiff
+else
+    echo "No files under api/ or exp/api/ changed."
+fi


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR will limit the apidiff test to run only if there are changes made in the directory api/ and exp/api/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2051 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
