### PR TITLE
wait longer for private cluster to account for add’l bastion create time

### DIFF
--- a/test/e2e/azure_privatecluster.go
+++ b/test/e2e/azure_privatecluster.go
@@ -149,7 +149,7 @@ func AzurePrivateClusterSpec(ctx context.Context, inputGetter func() AzurePrivat
 			ControlPlaneMachineCount: pointer.Int64Ptr(3),
 			WorkerMachineCount:       pointer.Int64Ptr(1),
 		},
-		WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
+		WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-private-cluster"),
 		WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
 		WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
 	}, result)

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -215,6 +215,7 @@ variables:
 intervals:
   default/wait-controllers: ["3m", "10s"]
   default/wait-cluster: ["20m", "10s"]
+  default/wait-private-cluster: ["30m", "10s"]
   default/wait-control-plane: ["20m", "10s"]
   default/wait-worker-nodes: ["20m", "10s"]
   default/wait-delete-cluster: ["30m", "10s"]


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

In observance of recent private cluster failures, let's increase the timeout that we enforce to wait for cluster provisioning. Using a common timeout value across private clusters and public clusters probably isn't the best idea, as the Azure bastion service can regularly take 5+ mins to come online (which is additive blocking time compared to public cluster scenario).

This PR increases the timeout to 40 mins to account for observed 20+ minute Azure bastion create times.

Examples of recent PR flakes:

- https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/2209/pull-cluster-api-provider-azure-e2e/1512495713999654912
- https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/2209/pull-cluster-api-provider-azure-e2e/1511121447714557952
- https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/2215/pull-cluster-api-provider-azure-e2e/1511128382417408000

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
