### PR TITLE
Revert "Apidiff test runs only if the changes are in api/ and exp/api/"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,11 +191,9 @@ clean-temporary: ## Remove all temporary files and folders.
 clean-release: ## Remove the release folder.
 	rm -rf $(RELEASE_DIR)
 
-APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
-
 .PHONY: apidiff
 apidiff: $(GO_APIDIFF) ## Check for API differences.
-	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible
+	$(GO_APIDIFF) $(shell git rev-parse origin/main) --print-compatible
 
 .PHONY: format-tiltfile
 format-tiltfile: ## Format the Tiltfile.

--- a/scripts/ci-apidiff.sh
+++ b/scripts/ci-apidiff.sh
@@ -20,12 +20,9 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
-cd "${REPO_ROOT}"
-APICHANGE=$(git --no-pager diff --name-only FETCH_HEAD)
-if echo "${APICHANGE}" | grep "^api/\|/api/" 
-then
-    echo "*** Running go-apidiff ***"
-    APIDIFF_OLD_COMMIT="${PULL_BASE_SHA}" make apidiff
-else
-    echo "No files under api/ or exp/api/ changed."
-fi
+APIDIFF="${REPO_ROOT}/hack/tools/bin/go-apidiff"
+
+cd "${REPO_ROOT}" && make "${APIDIFF##*/}"
+echo "*** Running go-apidiff ***"
+
+${APIDIFF} "${PULL_BASE_SHA}" --print-compatible


### PR DESCRIPTION
This reverts commit b9485967420a956fca56e2770d86139665eebb17.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Despite our best efforts, somehow the changes in #2206 don't seem to work as expected. This means that new PRs will run the `pull-cluster-api-provider-azure-apidiff` job as a no-op, missing bugs that may be introduced into API files. So we agreed in [today's CAPZ Office Hours](https://youtu.be/b-jliSDwfsc) to revert it while we figure things out.

**Which issue(s) this PR fixes**:
Refs #2206, #2051

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
