### PR TITLE
test: timeout log collection operations

### DIFF
--- a/test/e2e/retry.go
+++ b/test/e2e/retry.go
@@ -33,15 +33,9 @@ const (
 	retryBackoffSteps           = 3
 )
 
-// retryWithExponentialBackOff retries the function until it returns nil,
-// or until the number of attempts (steps) has reached the maximum value.
-func retryWithExponentialBackOff(fn func() error) error {
-	backoff := wait.Backoff{
-		Duration: retryBackoffInitialDuration,
-		Factor:   retryBackoffFactor,
-		Jitter:   retryBackoffJitter,
-		Steps:    retryBackoffSteps,
-	}
+// retryWithTimeout retries the function until it returns true,
+// or a timeout is reached.
+func retryWithTimeout(interval, timeout time.Duration, fn func() error) error {
 	retryFn := func(fn func() error) func() (bool, error) {
 		return func() (bool, error) {
 			err := fn()
@@ -51,5 +45,5 @@ func retryWithExponentialBackOff(fn func() error) error {
 			return false, err
 		}
 	}
-	return wait.ExponentialBackoff(backoff, retryFn(fn))
+	return wait.PollImmediate(interval, timeout, retryFn(fn))
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind flake

**What this PR does / why we need it**:

This PR changes the E2E log collection implementation such that we timeout after 1 minute instead of simply retrying 3 times w/ exponential backoff. This is to ensure that any "stuck" operations don't block forward progress. We have observed many tests that prow times out after 4 hours that suggest log collection at root cause.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2237

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
