### PR TITLE
Fix race condition when creating resource group with custom user tags

### DIFF
--- a/azure/services/groups/spec.go
+++ b/azure/services/groups/spec.go
@@ -56,13 +56,13 @@ func (s *GroupSpec) Parameters(existing interface{}) (params interface{}, err er
 	}
 	return resources.Group{
 		Location: to.StringPtr(s.Location),
-		// We create only CAPZ default tags. User defined additional tags
-		// are created and updated using tags service.
+		// User defined additional tags are created with the resource group and updated using tags service.
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
 			Name:        to.StringPtr(s.Name),
 			Role:        to.StringPtr(infrav1.CommonRole),
+			Additional:  s.AdditionalTags,
 		})),
 	}, nil
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Fixes a race condition with custom user-defined tags. Currently, if a user defines custom tags, the group is first created with the default set of tags and then the custom tags are added in the tags service. This can cause issues if the subscription has automation running that checks for certain tags to perform automated cleanup or apply policies. This makes sure the tags are added right away when the group is first created, then updated separately by the tags service as needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure additional tags are added right away when the group is created
```
