### PR TITLE
WIP: Get Windows container images from ghcr.io instead of docker.io

### DIFF
--- a/templates/addons/windows/calico/calico.yaml
+++ b/templates/addons/windows/calico/calico.yaml
@@ -163,7 +163,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: sigwindowstools/calico-install:v3.22.1-hostprocess
+          image: ghcr.io/kubernetes-sigs/sig-windows/calico-install:v3.22.1-hostprocess
           args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1"]
           imagePullPolicy: Always
           env:
@@ -205,7 +205,7 @@ spec:
               runAsUserName: "NT AUTHORITY\\system"
       containers:
       - name: calico-node-startup
-        image: sigwindowstools/calico-node:v3.22.1-hostprocess
+        image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess
         args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1"]
         workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/"
         imagePullPolicy: Always
@@ -232,7 +232,7 @@ spec:
         - name: VXLAN_VNI
           value: "4096"
       - name: calico-node-felix
-        image: sigwindowstools/calico-node:v3.22.1-hostprocess
+        image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess
         args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1"]
         imagePullPolicy: Always
         workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/"

--- a/templates/addons/windows/calico/kube-proxy-windows.yaml
+++ b/templates/addons/windows/calico/kube-proxy-windows.yaml
@@ -21,7 +21,7 @@ spec:
           runAsUserName: "NT AUTHORITY\\system"
       hostNetwork: true
       containers:
-      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess
+      - image: ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess
         args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1"]
         workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/"
         name: kube-proxy

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -474,8 +474,8 @@ spec:
 
           # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
           # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-          ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
-          ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
+          ctr.exe -n k8s.io images pull ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:v1.23.1-calico-hostprocess
+          ctr.exe -n k8s.io images tag ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:v1.23.1-calico-hostprocess "ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
           kubeadm.exe version -o=short
           kubectl.exe version --client=true --short=true
@@ -584,7 +584,7 @@ data:
     \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
     kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
     true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
+    true\n      containers:\n      - image: ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
     kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
@@ -4955,7 +4955,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.22.1-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: ghcr.io/kubernetes-sigs/sig-windows/calico-install:v3.22.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -4974,7 +4974,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.22.1-hostprocess\n
+    \     - name: calico-node-startup\n        image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -4985,21 +4985,21 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.22.1-hostprocess\n        args:
-    [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
-    Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
-    \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n
-    \       - name: calico-static-rules\n          mountPath: /calico/static-rules.json\n
-    \         subPath: static-rules.json\n        env:\n        - name: POD_NAME\n
-    \         valueFrom:\n            fieldRef:\n              apiVersion: v1\n              fieldPath:
-    metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: metadata.namespace\n        -
-    name: VXLAN_VNI\n          value: \"4096\"\n        - name: KUBECONFIG\n          value:
-    \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n      - name: calico-config-windows\n
-    \       configMap:\n          name: calico-config-windows\n      - name: calico-static-rules\n
-    \       configMap:\n          name: calico-static-rules\n      # Used to install
-    CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
-    \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
+    \       image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess\n
+    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n
+    \       imagePullPolicy: Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n
+    \       volumeMounts:\n        - name: calico-config-windows\n          mountPath:
+    /etc/kube-calico-windows/\n        - name: calico-static-rules\n          mountPath:
+    /calico/static-rules.json\n          subPath: static-rules.json\n        env:\n
+    \       - name: POD_NAME\n          valueFrom:\n            fieldRef:\n              apiVersion:
+    v1\n              fieldPath: metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n
+    \           fieldRef:\n              apiVersion: v1\n              fieldPath:
+    metadata.namespace\n        - name: VXLAN_VNI\n          value: \"4096\"\n        -
+    name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n
+    \     - name: calico-config-windows\n        configMap:\n          name: calico-config-windows\n
+    \     - name: calico-static-rules\n        configMap:\n          name: calico-static-rules\n
+    \     # Used to install CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path:
+    /opt/cni/bin\n      - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
     \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
 kind: ConfigMap
 metadata:

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -474,8 +474,8 @@ spec:
 
           # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
           # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-          ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
-          ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
+          ctr.exe -n k8s.io images pull ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:v1.23.1-calico-hostprocess
+          ctr.exe -n k8s.io images tag ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:v1.23.1-calico-hostprocess "ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
           kubeadm.exe version -o=short
           kubectl.exe version --client=true --short=true
@@ -584,7 +584,7 @@ data:
     \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
     kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
     true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
+    true\n      containers:\n      - image: ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
     kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
@@ -4955,7 +4955,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.22.1-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: ghcr.io/kubernetes-sigs/sig-windows/calico-install:v3.22.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -4974,7 +4974,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.22.1-hostprocess\n
+    \     - name: calico-node-startup\n        image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -4985,21 +4985,21 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.22.1-hostprocess\n        args:
-    [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
-    Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
-    \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n
-    \       - name: calico-static-rules\n          mountPath: /calico/static-rules.json\n
-    \         subPath: static-rules.json\n        env:\n        - name: POD_NAME\n
-    \         valueFrom:\n            fieldRef:\n              apiVersion: v1\n              fieldPath:
-    metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: metadata.namespace\n        -
-    name: VXLAN_VNI\n          value: \"4096\"\n        - name: KUBECONFIG\n          value:
-    \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n      - name: calico-config-windows\n
-    \       configMap:\n          name: calico-config-windows\n      - name: calico-static-rules\n
-    \       configMap:\n          name: calico-static-rules\n      # Used to install
-    CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
-    \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
+    \       image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess\n
+    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n
+    \       imagePullPolicy: Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n
+    \       volumeMounts:\n        - name: calico-config-windows\n          mountPath:
+    /etc/kube-calico-windows/\n        - name: calico-static-rules\n          mountPath:
+    /calico/static-rules.json\n          subPath: static-rules.json\n        env:\n
+    \       - name: POD_NAME\n          valueFrom:\n            fieldRef:\n              apiVersion:
+    v1\n              fieldPath: metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n
+    \           fieldRef:\n              apiVersion: v1\n              fieldPath:
+    metadata.namespace\n        - name: VXLAN_VNI\n          value: \"4096\"\n        -
+    name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n
+    \     - name: calico-config-windows\n        configMap:\n          name: calico-config-windows\n
+    \     - name: calico-static-rules\n        configMap:\n          name: calico-static-rules\n
+    \     # Used to install CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path:
+    /opt/cni/bin\n      - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
     \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
 kind: ConfigMap
 metadata:

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -464,8 +464,8 @@ spec:
 
       # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
       # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-      ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
-      ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
+      ctr.exe -n k8s.io images pull ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:v1.23.1-calico-hostprocess
+      ctr.exe -n k8s.io images tag ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:v1.23.1-calico-hostprocess "ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
       kubeadm.exe version -o=short
       kubectl.exe version --client=true --short=true
@@ -524,7 +524,7 @@ data:
     \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
     kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
     true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
+    true\n      containers:\n      - image: ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
     kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
@@ -4895,7 +4895,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.22.1-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: ghcr.io/kubernetes-sigs/sig-windows/calico-install:v3.22.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -4914,7 +4914,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.22.1-hostprocess\n
+    \     - name: calico-node-startup\n        image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -4925,21 +4925,21 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.22.1-hostprocess\n        args:
-    [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
-    Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
-    \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n
-    \       - name: calico-static-rules\n          mountPath: /calico/static-rules.json\n
-    \         subPath: static-rules.json\n        env:\n        - name: POD_NAME\n
-    \         valueFrom:\n            fieldRef:\n              apiVersion: v1\n              fieldPath:
-    metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: metadata.namespace\n        -
-    name: VXLAN_VNI\n          value: \"4096\"\n        - name: KUBECONFIG\n          value:
-    \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n      - name: calico-config-windows\n
-    \       configMap:\n          name: calico-config-windows\n      - name: calico-static-rules\n
-    \       configMap:\n          name: calico-static-rules\n      # Used to install
-    CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
-    \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
+    \       image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess\n
+    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n
+    \       imagePullPolicy: Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n
+    \       volumeMounts:\n        - name: calico-config-windows\n          mountPath:
+    /etc/kube-calico-windows/\n        - name: calico-static-rules\n          mountPath:
+    /calico/static-rules.json\n          subPath: static-rules.json\n        env:\n
+    \       - name: POD_NAME\n          valueFrom:\n            fieldRef:\n              apiVersion:
+    v1\n              fieldPath: metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n
+    \           fieldRef:\n              apiVersion: v1\n              fieldPath:
+    metadata.namespace\n        - name: VXLAN_VNI\n          value: \"4096\"\n        -
+    name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n
+    \     - name: calico-config-windows\n        configMap:\n          name: calico-config-windows\n
+    \     - name: calico-static-rules\n        configMap:\n          name: calico-static-rules\n
+    \     # Used to install CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path:
+    /opt/cni/bin\n      - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
     \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
 kind: ConfigMap
 metadata:

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -337,7 +337,7 @@ data:
     \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
     kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
     true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
+    true\n      containers:\n      - image: ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
     kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
@@ -4708,7 +4708,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.22.1-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: ghcr.io/kubernetes-sigs/sig-windows/calico-install:v3.22.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -4727,7 +4727,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.22.1-hostprocess\n
+    \     - name: calico-node-startup\n        image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -4738,21 +4738,21 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.22.1-hostprocess\n        args:
-    [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
-    Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
-    \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n
-    \       - name: calico-static-rules\n          mountPath: /calico/static-rules.json\n
-    \         subPath: static-rules.json\n        env:\n        - name: POD_NAME\n
-    \         valueFrom:\n            fieldRef:\n              apiVersion: v1\n              fieldPath:
-    metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: metadata.namespace\n        -
-    name: VXLAN_VNI\n          value: \"4096\"\n        - name: KUBECONFIG\n          value:
-    \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n      - name: calico-config-windows\n
-    \       configMap:\n          name: calico-config-windows\n      - name: calico-static-rules\n
-    \       configMap:\n          name: calico-static-rules\n      # Used to install
-    CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
-    \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
+    \       image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess\n
+    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n
+    \       imagePullPolicy: Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n
+    \       volumeMounts:\n        - name: calico-config-windows\n          mountPath:
+    /etc/kube-calico-windows/\n        - name: calico-static-rules\n          mountPath:
+    /calico/static-rules.json\n          subPath: static-rules.json\n        env:\n
+    \       - name: POD_NAME\n          valueFrom:\n            fieldRef:\n              apiVersion:
+    v1\n              fieldPath: metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n
+    \           fieldRef:\n              apiVersion: v1\n              fieldPath:
+    metadata.namespace\n        - name: VXLAN_VNI\n          value: \"4096\"\n        -
+    name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n
+    \     - name: calico-config-windows\n        configMap:\n          name: calico-config-windows\n
+    \     - name: calico-static-rules\n        configMap:\n          name: calico-static-rules\n
+    \     # Used to install CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path:
+    /opt/cni/bin\n      - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
     \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
 kind: ConfigMap
 metadata:

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -380,7 +380,7 @@ data:
     \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
     kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
     true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
+    true\n      containers:\n      - image: ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
     kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
@@ -4751,7 +4751,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.22.1-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: ghcr.io/kubernetes-sigs/sig-windows/calico-install:v3.22.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -4770,7 +4770,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.22.1-hostprocess\n
+    \     - name: calico-node-startup\n        image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -4781,21 +4781,21 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.22.1-hostprocess\n        args:
-    [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
-    Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
-    \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n
-    \       - name: calico-static-rules\n          mountPath: /calico/static-rules.json\n
-    \         subPath: static-rules.json\n        env:\n        - name: POD_NAME\n
-    \         valueFrom:\n            fieldRef:\n              apiVersion: v1\n              fieldPath:
-    metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: metadata.namespace\n        -
-    name: VXLAN_VNI\n          value: \"4096\"\n        - name: KUBECONFIG\n          value:
-    \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n      - name: calico-config-windows\n
-    \       configMap:\n          name: calico-config-windows\n      - name: calico-static-rules\n
-    \       configMap:\n          name: calico-static-rules\n      # Used to install
-    CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
-    \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
+    \       image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess\n
+    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n
+    \       imagePullPolicy: Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n
+    \       volumeMounts:\n        - name: calico-config-windows\n          mountPath:
+    /etc/kube-calico-windows/\n        - name: calico-static-rules\n          mountPath:
+    /calico/static-rules.json\n          subPath: static-rules.json\n        env:\n
+    \       - name: POD_NAME\n          valueFrom:\n            fieldRef:\n              apiVersion:
+    v1\n              fieldPath: metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n
+    \           fieldRef:\n              apiVersion: v1\n              fieldPath:
+    metadata.namespace\n        - name: VXLAN_VNI\n          value: \"4096\"\n        -
+    name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n
+    \     - name: calico-config-windows\n        configMap:\n          name: calico-config-windows\n
+    \     - name: calico-static-rules\n        configMap:\n          name: calico-static-rules\n
+    \     # Used to install CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path:
+    /opt/cni/bin\n      - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
     \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
 kind: ConfigMap
 metadata:

--- a/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap-windows.yaml
+++ b/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap-windows.yaml
@@ -30,8 +30,8 @@
 
       # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
       # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-      ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
-      ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
+      ctr.exe -n k8s.io images pull ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:v1.23.1-calico-hostprocess
+      ctr.exe -n k8s.io images tag ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:v1.23.1-calico-hostprocess "ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
       kubeadm.exe version -o=short
       kubectl.exe version --client=true --short=true

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/kubeadm-bootstrap-windows.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/kubeadm-bootstrap-windows.yaml
@@ -18,8 +18,8 @@
 
       # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
       # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-      ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
-      ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
+      ctr.exe -n k8s.io images pull ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:v1.23.1-calico-hostprocess
+      ctr.exe -n k8s.io images tag ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:v1.23.1-calico-hostprocess "ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
       kubeadm.exe version -o=short
       kubectl.exe version --client=true --short=true

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -427,7 +427,7 @@ data:
     \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
     kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
     true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
+    true\n      containers:\n      - image: ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
     kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
@@ -4798,7 +4798,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.22.1-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: ghcr.io/kubernetes-sigs/sig-windows/calico-install:v3.22.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -4817,7 +4817,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.22.1-hostprocess\n
+    \     - name: calico-node-startup\n        image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -4828,21 +4828,21 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.22.1-hostprocess\n        args:
-    [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
-    Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
-    \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n
-    \       - name: calico-static-rules\n          mountPath: /calico/static-rules.json\n
-    \         subPath: static-rules.json\n        env:\n        - name: POD_NAME\n
-    \         valueFrom:\n            fieldRef:\n              apiVersion: v1\n              fieldPath:
-    metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: metadata.namespace\n        -
-    name: VXLAN_VNI\n          value: \"4096\"\n        - name: KUBECONFIG\n          value:
-    \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n      - name: calico-config-windows\n
-    \       configMap:\n          name: calico-config-windows\n      - name: calico-static-rules\n
-    \       configMap:\n          name: calico-static-rules\n      # Used to install
-    CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
-    \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
+    \       image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess\n
+    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n
+    \       imagePullPolicy: Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n
+    \       volumeMounts:\n        - name: calico-config-windows\n          mountPath:
+    /etc/kube-calico-windows/\n        - name: calico-static-rules\n          mountPath:
+    /calico/static-rules.json\n          subPath: static-rules.json\n        env:\n
+    \       - name: POD_NAME\n          valueFrom:\n            fieldRef:\n              apiVersion:
+    v1\n              fieldPath: metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n
+    \           fieldRef:\n              apiVersion: v1\n              fieldPath:
+    metadata.namespace\n        - name: VXLAN_VNI\n          value: \"4096\"\n        -
+    name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n
+    \     - name: calico-config-windows\n        configMap:\n          name: calico-config-windows\n
+    \     - name: calico-static-rules\n        configMap:\n          name: calico-static-rules\n
+    \     # Used to install CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path:
+    /opt/cni/bin\n      - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
     \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
 kind: ConfigMap
 metadata:

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -412,8 +412,8 @@ spec:
 
           # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
           # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-          ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
-          ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
+          ctr.exe -n k8s.io images pull ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:v1.23.1-calico-hostprocess
+          ctr.exe -n k8s.io images tag ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:v1.23.1-calico-hostprocess "ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
           kubeadm.exe version -o=short
           kubectl.exe version --client=true --short=true
@@ -522,7 +522,7 @@ data:
     \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
     kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
     true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
+    true\n      containers:\n      - image: ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
     kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
@@ -4893,7 +4893,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.22.1-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: ghcr.io/kubernetes-sigs/sig-windows/calico-install:v3.22.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -4912,7 +4912,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.22.1-hostprocess\n
+    \     - name: calico-node-startup\n        image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -4923,21 +4923,21 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.22.1-hostprocess\n        args:
-    [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
-    Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
-    \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n
-    \       - name: calico-static-rules\n          mountPath: /calico/static-rules.json\n
-    \         subPath: static-rules.json\n        env:\n        - name: POD_NAME\n
-    \         valueFrom:\n            fieldRef:\n              apiVersion: v1\n              fieldPath:
-    metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: metadata.namespace\n        -
-    name: VXLAN_VNI\n          value: \"4096\"\n        - name: KUBECONFIG\n          value:
-    \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n      - name: calico-config-windows\n
-    \       configMap:\n          name: calico-config-windows\n      - name: calico-static-rules\n
-    \       configMap:\n          name: calico-static-rules\n      # Used to install
-    CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
-    \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
+    \       image: ghcr.io/kubernetes-sigs/sig-windows/calico-node:v3.22.1-hostprocess\n
+    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n
+    \       imagePullPolicy: Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n
+    \       volumeMounts:\n        - name: calico-config-windows\n          mountPath:
+    /etc/kube-calico-windows/\n        - name: calico-static-rules\n          mountPath:
+    /calico/static-rules.json\n          subPath: static-rules.json\n        env:\n
+    \       - name: POD_NAME\n          valueFrom:\n            fieldRef:\n              apiVersion:
+    v1\n              fieldPath: metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n
+    \           fieldRef:\n              apiVersion: v1\n              fieldPath:
+    metadata.namespace\n        - name: VXLAN_VNI\n          value: \"4096\"\n        -
+    name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n
+    \     - name: calico-config-windows\n        configMap:\n          name: calico-config-windows\n
+    \     - name: calico-static-rules\n        configMap:\n          name: calico-static-rules\n
+    \     # Used to install CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path:
+    /opt/cni/bin\n      - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
     \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
 kind: ConfigMap
 metadata:

--- a/templates/test/dev/custom-builds/patches/kubeadm-bootstrap-windows.yaml
+++ b/templates/test/dev/custom-builds/patches/kubeadm-bootstrap-windows.yaml
@@ -25,8 +25,8 @@
 
       # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
       # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-      ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
-      ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
+      ctr.exe -n k8s.io images pull ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:v1.23.1-calico-hostprocess
+      ctr.exe -n k8s.io images tag ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:v1.23.1-calico-hostprocess "ghcr.io/kubernetes-sigs/sig-windows/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
       kubeadm.exe version -o=short
       kubectl.exe version --client=true --short=true


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Get Windows container images from ghcr.io instead of docker.io

**Note:** I'm only updating the container images used for provisioning `containerd` clusters because this will reduce the amount of container images we need to backfill in the ghcr.io registries.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2230 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Pull container images from ghcr.io/kubernetes-sigs/sig-windows/ instead of docker.io/sigwindowstools in Windows+containerd templates
```
