### PR TITLE
Use user kubeconfig instead of admin kubeconfig

### DIFF
--- a/azure/services/managedclusters/client.go
+++ b/azure/services/managedclusters/client.go
@@ -60,12 +60,12 @@ func (ac *AzureClient) Get(ctx context.Context, resourceGroupName, name string) 
 	return ac.managedclusters.Get(ctx, resourceGroupName, name)
 }
 
-// GetCredentials fetches the admin kubeconfig for a managed cluster.
+// GetCredentials fetches a user kubeconfig for a managed cluster.
 func (ac *AzureClient) GetCredentials(ctx context.Context, resourceGroupName, name string) ([]byte, error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "managedclusters.AzureClient.GetCredentials")
 	defer done()
 
-	credentialList, err := ac.managedclusters.ListClusterAdminCredentials(ctx, resourceGroupName, name, "")
+	credentialList, err := ac.managedclusters.ListClusterUserCredentials(ctx, resourceGroupName, name, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->
/kind feature

**What this PR does / why we need it**:
Uses user kubeconfig instead of admin kubeconfig to access the target cluster. It is needed because the admin kubeconfig contains a 2year cert that cannot be revoked.

Related to https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2129

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

One issue with this PR is that CAPI controller logs into the API server of the cluster to get details of the nodes ([reconcileNodeRefs](https://github.com/kubernetes-sigs/cluster-api/blob/af33e43d891e3af3787e86bceabce6b8e052c984/exp/controllers/machinepool_controller_noderef.go#L48)). The change to user kubeconfig breaks this flow.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

