### PR TITLE
fix: Updating azure_logcollector.go to reflect containerd runtime on Windows

### DIFF
--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -238,11 +238,11 @@ func windowsK8sLogs(execToPathFn func(outputFileName string, command string, arg
 			"Get-WinEvent", "-LogName Microsoft-Windows-Hyper-V-Compute-Operational | Select-Object -Property TimeCreated, Id, LevelDisplayName, Message | Sort-Object TimeCreated | Format-Table -Wrap -Autosize",
 		),
 		execToPathFn(
-			"containers.log",
+			"containerd-containers.log",
 			"ctr.exe", "-n k8s.io containers list",
 		),
 		execToPathFn(
-			"hcsshim-taskss.log",
+			"containerd-tasks.log",
 			"ctr.exe", "-n k8s.io tasks list",
 		),
 		execToPathFn(

--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -238,12 +238,12 @@ func windowsK8sLogs(execToPathFn func(outputFileName string, command string, arg
 			"Get-WinEvent", "-LogName Microsoft-Windows-Hyper-V-Compute-Operational | Select-Object -Property TimeCreated, Id, LevelDisplayName, Message | Sort-Object TimeCreated | Format-Table -Wrap -Autosize",
 		),
 		execToPathFn(
-			"docker.log",
-			"get-eventlog", "-LogName Application -Source Docker | Select-Object Index, TimeGenerated, EntryType, Message | Sort-Object Index | Format-Table -Wrap -Autosize",
+			"containers.log",
+			"ctr.exe", "-n k8s.io containers list",
 		),
 		execToPathFn(
-			"containers.log",
-			"docker", "ps -a",
+			"hcsshim-taskss.log",
+			"ctr.exe", "-n k8s.io tasks list",
 		),
 		execToPathFn(
 			"containers-hcs.log",


### PR DESCRIPTION


Signed-off-by: Mark Rossetti <marosset@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change

/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR updates log collection for Windows nodes to gather logs assuming containerd is the container runtime, not docke.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
