### PR TITLE
Add MHC as mitigation against cloudbase init bug on Windows prow jobs

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -378,6 +378,9 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   selector: {}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -523,6 +526,26 @@ spec:
   - status: "True"
     timeout: 30s
     type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -379,8 +379,7 @@ spec:
   selector: {}
   template:
     metadata:
-      labels:
-        windows-healthcheck: "true"
+      labels: {}
     spec:
       bootstrap:
         configRef:

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -378,6 +378,9 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   selector: {}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -523,6 +526,26 @@ spec:
   - status: "True"
     timeout: 30s
     type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -230,6 +230,9 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   selector: {}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -328,6 +331,26 @@ spec:
   - status: "True"
     timeout: 30s
     type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/patches/mhc-windows.yaml
+++ b/templates/test/ci/patches/mhc-windows.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-win"
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        "windows-healthcheck": "true"

--- a/templates/test/ci/prow-ci-version-windows-containerd-2022/kustomization.yaml
+++ b/templates/test/ci/prow-ci-version-windows-containerd-2022/kustomization.yaml
@@ -5,3 +5,11 @@ resources:
   - ../prow-ci-version
 patchesStrategicMerge:
   - patches/windows-image-update.yaml
+patches:
+- target:
+    group: cluster.x-k8s.io
+    version: v1beta1
+    kind: MachineDeployment
+    name: .*-md-win
+    namespace: default
+  path: patches/drop-mhc.yaml

--- a/templates/test/ci/prow-ci-version-windows-containerd-2022/patches/drop-mhc.yaml
+++ b/templates/test/ci/prow-ci-version-windows-containerd-2022/patches/drop-mhc.yaml
@@ -1,0 +1,4 @@
+# not including in WS 2022 image so we can test cloudbase-init patch with this image
+# https://github.com/cloudbase/cloudbase-init/issues/94#issuecomment-1115930324
+- op: remove
+  path: "/spec/template/metadata/labels/windows-healthcheck"

--- a/templates/test/ci/prow/kustomization.yaml
+++ b/templates/test/ci/prow/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../../flavors/default/machine-deployment.yaml
   - ../../../flavors/windows-containerd/machine-deployment-windows.yaml
   - mhc.yaml
+  - mhc-windows.yaml
   - cni-resource-set.yaml
   - ../../../azure-cluster-identity
   - ../../../addons/windows/csi-proxy/csi-proxy-resource-set.yaml
@@ -13,6 +14,7 @@ resources:
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/mhc.yaml
+  - ../patches/mhc-windows.yaml
   - ../patches/cluster-cni.yaml
   - ../patches/controller-manager.yaml
   - ../patches/machine-deployment-worker-counts.yaml

--- a/templates/test/ci/prow/mhc-windows.yaml
+++ b/templates/test/ci/prow/mhc-windows.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-mhc-windows"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      "windows-healthcheck": "true"
+  nodeStartupTimeout: 10m
+  unhealthyConditions:
+    - type: Ready
+      status: "false"
+      timeout: 300s
+    - type: Ready
+      status: Unknown
+      timeout: 300s

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -321,6 +321,9 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   selector: {}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -461,6 +464,26 @@ spec:
   - status: "True"
     timeout: 30s
     type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -217,7 +217,7 @@ intervals:
   default/wait-cluster: ["20m", "10s"]
   default/wait-private-cluster: ["30m", "10s"]
   default/wait-control-plane: ["20m", "10s"]
-  default/wait-worker-nodes: ["20m", "10s"]
+  default/wait-worker-nodes: ["25m", "10s"]
   default/wait-delete-cluster: ["30m", "10s"]
   default/wait-machine-upgrade: ["60m", "10s"]
   default/wait-machine-remediation: ["30m", "10s"]


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
/kind flake

This adds a machine 
<!--
Add one of the following kinds:
/kind feature

/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test

-->

**What this PR does / why we need it**:
We identified a [bug in cloudbase-init](https://github.com/cloudbase/cloudbase-init/issues/94) on Azure that is causing timeouts in [Windows nodes coming online](https://github.com/kubernetes/kubernetes/issues/109444). In conformance tests it looks like:

```
{ Failure /home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/test/e2e/conformance_test.go:103
Timed out after 1200.001s.
Expected
    <int>: 0
to equal
    <int>: 2
```

This adds machine health checks that will timeout on a node when it gets into this state during provisioning.  I've bumped the timeout when waiting for nodes a bit to make sure the nodes comes online with in the correct time.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/kubernetes/kubernetes/issues/109444

**Special notes for your reviewer**:
This may also the timeouts we are seeing in the tests that are flaking with https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2256

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
