### PR TITLE
Handle compression at docs.github.com when checking markdown links

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -2,6 +2,13 @@
     "ignorePatterns": [{
         "pattern": "^https://calendar.google.com/calendar"
     }],
+    "httpHeaders": [{
+        "comment": "Workaround as suggested here: https://github.com/tcort/markdown-link-check/issues/201",
+        "urls": ["https://docs.github.com/"],
+        "headers": {
+            "Accept-Encoding": "zstd, br, gzip, deflate"
+        }
+    }],
     "timeout": "5s",
     "retryOn429": true,
     "retryCount": 5,

--- a/docs/book/src/developers/releasing.md
+++ b/docs/book/src/developers/releasing.md
@@ -22,7 +22,7 @@
 - Create tag with git
   - `export RELEASE_TAG=v1.2.3` (the tag of the release to be cut)
   - `git tag -s ${RELEASE_TAG} -m "${RELEASE_TAG}"`
-  - `-s` creates a signed tag, you must have a GPG key [added to your GitHub account](https://docs.github.com/en/enterprise/2.16/user/github/authenticating-to-github/generating-a-new-gpg-key)
+  - `-s` creates a signed tag, you must have a GPG key [added to your GitHub account](https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-new-gpg-key-to-your-github-account)
   - `git push upstream ${RELEASE_TAG}`
 
 This will automatically trigger a [Github Action](https://github.com/kubernetes-sigs/cluster-api-provider-azure/actions) to create a draft release.


### PR DESCRIPTION
**What type of PR is this?**:

/kind documentation

**What this PR does / why we need it**:

The old link (and any links to https://docs.github.com/) raises a 403, which fails our link checker linter.

**Which issue(s) this PR fixes**:

See also gaurav-nelson/github-action-markdown-link-check#136

N/A, but just check any recent PR run to see the failure.

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
