### PR TITLE
Simplify use of tar in scripts for compatibility

### DIFF
--- a/hack/observability/jaeger/fetch-jaeger-resources.sh
+++ b/hack/observability/jaeger/fetch-jaeger-resources.sh
@@ -22,6 +22,8 @@ CHART_RELEASE=${CHART_RELEASE:-0.1.5}
 JAEGER_ROOT=$(dirname "${BASH_SOURCE[0]}")
 CHART_ROOT=$JAEGER_ROOT/chart
 
-rm -rf "${CHART_ROOT:?}/"*
+rm -rf "$CHART_ROOT"
+# "tar" has no POSIX standard, so use only basic options and test with both BSD and GNU.
 wget -qO- https://github.com/hansehe/jaeger-all-in-one/raw/master/helm/charts/jaeger-all-in-one-"$CHART_RELEASE".tgz \
-    | tar xvz -C "$JAEGER_ROOT" -s /^jaeger-all-in-one/chart/ -
+    | tar xvz -C "$JAEGER_ROOT"
+mv "$JAEGER_ROOT"/jaeger-all-in-one "$CHART_ROOT"

--- a/hack/observability/opentelemetry/fetch-otel-resources.sh
+++ b/hack/observability/opentelemetry/fetch-otel-resources.sh
@@ -23,6 +23,8 @@ OTEL_ROOT=$(dirname "${BASH_SOURCE[0]}")
 CHART_ROOT=$OTEL_ROOT/chart
 
 rm -rf "$CHART_ROOT"
+# "tar" has no POSIX standard, so use only basic options and test with both BSD and GNU.
 wget -qO- https://github.com/open-telemetry/opentelemetry-helm-charts/releases/download/opentelemetry-collector-"$CHART_RELEASE"/opentelemetry-collector-"$CHART_RELEASE".tgz \
-  | tar xvz -C "$OTEL_ROOT" -s /^opentelemetry-collector/chart/ -
+  | tar xvz -C "$OTEL_ROOT"
+mv "$OTEL_ROOT"/opentelemetry-collector "$CHART_ROOT"
 wget -q https://raw.githubusercontent.com/open-telemetry/opentelemetry-helm-charts/main/LICENSE -P "$CHART_ROOT"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

In two resource update scripts, we use the `-s <pattern>` argument to `tar`. This is not supported on all versions of `tar`, but it can be replaced with a manual renaming of the target directory.

**Which issue(s) this PR fixes**:

Fixes #2255

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
