### PR TITLE
Check configmap existence before creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,10 +268,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) ## Create a management clust
 	kubectl wait --for=condition=Available --timeout=5m -n capi-kubeadm-control-plane-system deployment -l cluster.x-k8s.io/provider=control-plane-kubeadm
 
 	# apply CNI ClusterResourceSets
-	kubectl create configmap calico-addon --from-file=templates/addons/calico.yaml
-	kubectl create configmap calico-ipv6-addon --from-file=templates/addons/calico-ipv6.yaml
-	kubectl create configmap calico-dual-stack-addon --from-file=templates/addons/calico-dual-stack.yaml
-	kubectl create configmap calico-windows-addon --from-file=templates/addons/windows/calico
+	source ./scripts/ci-configmap.sh
 
 	kubectl apply -f templates/addons/calico-resource-set.yaml
 

--- a/scripts/ci-configmap.sh
+++ b/scripts/ci-configmap.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+CM_NAMES=("calico-addon" "calico-ipv6-addon" "calico-dual-stack-addon" "calico-windows-addon")
+CM_FILES=("calico.yaml" "calico-ipv6.yaml" "calico-dual-stack.yaml" "windows/calico")
+for i in "${!CM_NAMES[@]}"; do
+	kubectl create configmap "${CM_NAMES[i]}" --from-file="${REPO_ROOT}/templates/addons/${CM_FILES[i]}" --dry-run -o yaml | kubectl apply -f -
+done


### PR DESCRIPTION
Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Check configmap existence before creation

Otherwise:
```
# apply CNI ClusterResourceSets
kubectl create configmap calico-addon --from-file=templates/addons/calico.yaml
error: failed to create configmap: configmaps "calico-addon" already exists
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
