### PR TITLE
Reuse logic in ci scripts

### DIFF
--- a/hack/create-dev-cluster.sh
+++ b/hack/create-dev-cluster.sh
@@ -17,6 +17,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+# shellcheck source=hack/util.sh
+source "${REPO_ROOT}/hack/util.sh"
+
 # Verify the required Environment Variables are present.
 : "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
 : "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"
@@ -56,16 +60,7 @@ export CLUSTER_IDENTITY_NAME=${CLUSTER_IDENTITY_NAME:="cluster-identity"}
 export AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE="default"
 
 # Generate SSH key.
-SSH_KEY_FILE=${SSH_KEY_FILE:-""}
-if [ -z "$SSH_KEY_FILE" ]; then
-    SSH_KEY_FILE=.sshkey
-    rm -f "${SSH_KEY_FILE}" 2>/dev/null
-    ssh-keygen -t rsa -b 2048 -f "${SSH_KEY_FILE}" -N '' 1>/dev/null
-    echo "Machine SSH key generated in ${SSH_KEY_FILE}"
-fi
-
-AZURE_SSH_PUBLIC_KEY_B64=$(base64 "${SSH_KEY_FILE}.pub" | tr -d '\r\n')
-export AZURE_SSH_PUBLIC_KEY_B64
+capz::util::generate_ssh_key
 
 echo "================ DOCKER BUILD ==============="
 PULL_POLICY=IfNotPresent make modules docker-build

--- a/hack/create-dev-cluster.sh
+++ b/hack/create-dev-cluster.sh
@@ -22,10 +22,7 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${REPO_ROOT}/hack/util.sh"
 
 # Verify the required Environment Variables are present.
-: "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
-: "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"
-: "${AZURE_CLIENT_ID:?Environment variable empty or not defined.}"
-: "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
+capz::util::ensure_azure_envs
 
 make envsubst
 

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -38,3 +38,9 @@ capz::util::should_build_kubernetes() {
     fi
     echo "false"
 }
+
+# all test regions must support AvailabilityZones
+capz::util::get_random_region() {
+    local REGIONS=("eastus" "eastus2" "northeurope" "uksouth" "westeurope" "westus2")
+    echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
+}

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -44,3 +44,20 @@ capz::util::get_random_region() {
     local REGIONS=("eastus" "eastus2" "northeurope" "uksouth" "westeurope" "westus2")
     echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
 }
+
+capz::util::generate_ssh_key() {
+    # Generate SSH key.
+    AZURE_SSH_PUBLIC_KEY_FILE=${AZURE_SSH_PUBLIC_KEY_FILE:-""}
+    if [ -z "${AZURE_SSH_PUBLIC_KEY_FILE}" ]; then
+        echo "generating sshkey for e2e"
+        SSH_KEY_FILE=.sshkey
+        rm -f "${SSH_KEY_FILE}" 2>/dev/null
+        ssh-keygen -t rsa -b 2048 -f "${SSH_KEY_FILE}" -N '' 1>/dev/null
+        AZURE_SSH_PUBLIC_KEY_FILE="${SSH_KEY_FILE}.pub"
+    fi
+    AZURE_SSH_PUBLIC_KEY_B64=$(base64 "${AZURE_SSH_PUBLIC_KEY_FILE}" | tr -d '\r\n')
+    export AZURE_SSH_PUBLIC_KEY_B64
+    # Windows sets the public key via cloudbase-init which take the raw text as input
+    AZURE_SSH_PUBLIC_KEY=$(tr -d '\r\n' < "${AZURE_SSH_PUBLIC_KEY_FILE}")
+    export AZURE_SSH_PUBLIC_KEY
+}

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -61,3 +61,10 @@ capz::util::generate_ssh_key() {
     AZURE_SSH_PUBLIC_KEY=$(tr -d '\r\n' < "${AZURE_SSH_PUBLIC_KEY_FILE}")
     export AZURE_SSH_PUBLIC_KEY
 }
+
+capz::util::ensure_azure_envs() {
+    : "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
+    : "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"
+    : "${AZURE_CLIENT_ID:?Environment variable empty or not defined.}"
+    : "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
+}

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -42,10 +42,7 @@ source "${REPO_ROOT}/hack/parse-prow-creds.sh"
 source "${REPO_ROOT}/hack/util.sh"
 
 # Verify the required Environment Variables are present.
-: "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
-: "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"
-: "${AZURE_CLIENT_ID:?Environment variable empty or not defined.}"
-: "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
+capz::util::ensure_azure_envs
 
 export LOCAL_ONLY=${LOCAL_ONLY:-"true"}
 

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -47,12 +47,6 @@ source "${REPO_ROOT}/hack/util.sh"
 : "${AZURE_CLIENT_ID:?Environment variable empty or not defined.}"
 : "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
 
-# all test regions must support AvailabilityZones
-get_random_region() {
-    local REGIONS=("eastus" "eastus2" "northeurope" "uksouth" "westeurope" "westus2")
-    echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
-}
-
 export LOCAL_ONLY=${LOCAL_ONLY:-"true"}
 
 if [[ "${LOCAL_ONLY}" == "true" ]]; then
@@ -71,7 +65,7 @@ defaultTag=$(date -u '+%Y%m%d%H%M%S')
 export TAG="${defaultTag:-dev}"
 export GINKGO_NODES=1
 
-export AZURE_LOCATION="${AZURE_LOCATION:-$(get_random_region)}"
+export AZURE_LOCATION="${AZURE_LOCATION:-$(capz::util::get_random_region)}"
 export AZURE_CONTROL_PLANE_MACHINE_TYPE="${AZURE_CONTROL_PLANE_MACHINE_TYPE:-"Standard_D2s_v3"}"
 export AZURE_NODE_MACHINE_TYPE="${AZURE_NODE_MACHINE_TYPE:-"Standard_D2s_v3"}"
 export WINDOWS="${WINDOWS:-false}"

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -71,19 +71,7 @@ export AZURE_NODE_MACHINE_TYPE="${AZURE_NODE_MACHINE_TYPE:-"Standard_D2s_v3"}"
 export WINDOWS="${WINDOWS:-false}"
 
 # Generate SSH key.
-AZURE_SSH_PUBLIC_KEY_FILE=${AZURE_SSH_PUBLIC_KEY_FILE:-""}
-if [ -z "${AZURE_SSH_PUBLIC_KEY_FILE}" ]; then
-    SSH_KEY_FILE=.sshkey
-    rm -f "${SSH_KEY_FILE}" 2>/dev/null
-    ssh-keygen -t rsa -b 2048 -f "${SSH_KEY_FILE}" -N '' 1>/dev/null
-    AZURE_SSH_PUBLIC_KEY_FILE="${SSH_KEY_FILE}.pub"
-fi
-AZURE_SSH_PUBLIC_KEY_B64=$(base64 "${AZURE_SSH_PUBLIC_KEY_FILE}" | tr -d '\r\n')
-export AZURE_SSH_PUBLIC_KEY_B64
-
-# Windows sets the public key via cloudbase-init which take the raw text as input
-AZURE_SSH_PUBLIC_KEY=$(< "${AZURE_SSH_PUBLIC_KEY_FILE}" tr -d '\r\n')
-export AZURE_SSH_PUBLIC_KEY
+capz::util::generate_ssh_key
 
 cleanup() {
     "${REPO_ROOT}/hack/log/redact.sh" || true

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -40,10 +40,7 @@ source "${REPO_ROOT}/hack/parse-prow-creds.sh"
 source "${REPO_ROOT}/hack/util.sh"
 
 # Verify the required Environment Variables are present.
-: "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
-: "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"
-: "${AZURE_CLIENT_ID:?Environment variable empty or not defined.}"
-: "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
+capz::util::ensure_azure_envs
 
 export LOCAL_ONLY=${LOCAL_ONLY:-"true"}
 

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -36,18 +36,14 @@ source "${REPO_ROOT}/hack/ensure-kind.sh"
 source "${REPO_ROOT}/hack/ensure-tags.sh"
 # shellcheck source=hack/parse-prow-creds.sh
 source "${REPO_ROOT}/hack/parse-prow-creds.sh"
+# shellcheck source=hack/util.sh
+source "${REPO_ROOT}/hack/util.sh"
 
 # Verify the required Environment Variables are present.
 : "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
 : "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"
 : "${AZURE_CLIENT_ID:?Environment variable empty or not defined.}"
 : "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
-
-# all test regions must support AvailabilityZones
-get_random_region() {
-    local REGIONS=("eastus" "eastus2" "northeurope" "uksouth" "westeurope" "westus2")
-    echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
-}
 
 export LOCAL_ONLY=${LOCAL_ONLY:-"true"}
 
@@ -62,7 +58,7 @@ defaultTag=$(date -u '+%Y%m%d%H%M%S')
 export TAG="${defaultTag:-dev}"
 export GINKGO_NODES=3
 
-export AZURE_LOCATION="${AZURE_LOCATION:-$(get_random_region)}"
+export AZURE_LOCATION="${AZURE_LOCATION:-$(capz::util::get_random_region)}"
 export AZURE_CONTROL_PLANE_MACHINE_TYPE="${AZURE_CONTROL_PLANE_MACHINE_TYPE:-"Standard_D2s_v3"}"
 export AZURE_NODE_MACHINE_TYPE="${AZURE_NODE_MACHINE_TYPE:-"Standard_D2s_v3"}"
 export KIND_EXPERIMENTAL_DOCKER_NETWORK="bridge"

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -63,20 +63,7 @@ export AZURE_CONTROL_PLANE_MACHINE_TYPE="${AZURE_CONTROL_PLANE_MACHINE_TYPE:-"St
 export AZURE_NODE_MACHINE_TYPE="${AZURE_NODE_MACHINE_TYPE:-"Standard_D2s_v3"}"
 export KIND_EXPERIMENTAL_DOCKER_NETWORK="bridge"
 
-# Generate SSH key.
-AZURE_SSH_PUBLIC_KEY_FILE=${AZURE_SSH_PUBLIC_KEY_FILE:-""}
-if [ -z "${AZURE_SSH_PUBLIC_KEY_FILE}" ]; then
-    echo "generating sshkey for e2e"
-    SSH_KEY_FILE=.sshkey
-    rm -f "${SSH_KEY_FILE}" 2>/dev/null
-    ssh-keygen -t rsa -b 2048 -f "${SSH_KEY_FILE}" -N '' 1>/dev/null
-    AZURE_SSH_PUBLIC_KEY_FILE="${SSH_KEY_FILE}.pub"
-fi
-AZURE_SSH_PUBLIC_KEY_B64=$(base64 "${AZURE_SSH_PUBLIC_KEY_FILE}" | tr -d '\r\n')
-export AZURE_SSH_PUBLIC_KEY_B64
-# Windows sets the public key via cloudbase-init which take the raw text as input
-AZURE_SSH_PUBLIC_KEY=$(tr -d '\r\n' < "${AZURE_SSH_PUBLIC_KEY_FILE}")
-export AZURE_SSH_PUBLIC_KEY
+capz::util::generate_ssh_key
 
 cleanup() {
     "${REPO_ROOT}/hack/log/redact.sh" || true

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -44,12 +44,6 @@ source "${REPO_ROOT}/hack/parse-prow-creds.sh"
 # shellcheck source=hack/util.sh
 source "${REPO_ROOT}/hack/util.sh"
 
-# all test regions must support AvailabilityZones
-get_random_region() {
-    local REGIONS=("eastus" "eastus2" "northeurope" "uksouth" "westeurope" "westus2")
-    echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
-}
-
 setup() {
     # setup REGISTRY for custom images.
     : "${REGISTRY:?Environment variable empty or not defined.}"
@@ -67,7 +61,7 @@ setup() {
 
     export CLUSTER_NAME="${CLUSTER_NAME:-capz-$(head /dev/urandom | LC_ALL=C tr -dc a-z0-9 | head -c 6 ; echo '')}"
     export AZURE_RESOURCE_GROUP="${CLUSTER_NAME}"
-    export AZURE_LOCATION="${AZURE_LOCATION:-$(get_random_region)}"
+    export AZURE_LOCATION="${AZURE_LOCATION:-$(capz::util::get_random_region)}"
     # Need a cluster with at least 2 nodes
     export CONTROL_PLANE_MACHINE_COUNT="${CONTROL_PLANE_MACHINE_COUNT:-1}"
     export WORKER_MACHINE_COUNT="${WORKER_MACHINE_COUNT:-2}"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change

/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

We have a lot of logic that is same across our CI scripts.  Some of it was shared but not all of it.  This consolidates so of the logic.  Most of this logic is used to ensure that PROW and related templates are set up properly.

An example of how this helps consistency would be our `ci-entrypoint.sh`:  the [docs ](https://capz.sigs.k8s.io/developers/development.html#running-custom-test-suites-on-capz-clusters) say `AZURE_SSH_PUBLIC_KEY_FILE` is used but the logic wasn't actually using it.  As well as wasn't setting the correct keys for windows: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/2a9b44c7c24758eec051abd01c64da32c8144c3e/hack/create-dev-cluster.sh#L59-L65

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Each change is in a separate commit, which makes for easier reviewing

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
