### PR TITLE
ci: support external-cloud-provider plus latest k8s releases

### DIFF
--- a/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
@@ -1,0 +1,5644 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    ccm: external
+    cni: calico
+    containerd-logger: enabled
+    csi-proxy: enabled
+    metrics-server: enabled
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
+    creationTimestamp: ${TIMESTAMP}
+    jobName: ${JOB_NAME}
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureClusterIdentity
+    name: ${CLUSTER_IDENTITY_NAME}
+  location: ${AZURE_LOCATION}
+  networkSpec:
+    subnets:
+    - name: control-plane-subnet
+      role: control-plane
+    - name: node-subnet
+      natGateway:
+        name: node-natgateway
+      role: node
+    vnet:
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
+  subscriptionID: ${AZURE_SUBSCRIPTION_ID}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
+          cloud-config: /etc/kubernetes/azure.json
+          cloud-provider: external
+          feature-gates: ${K8S_FEATURE_GATES:-""}
+        extraVolumes:
+        - hostPath: /etc/kubernetes/azure.json
+          mountPath: /etc/kubernetes/azure.json
+          name: cloud-config
+          readOnly: true
+        timeoutForControlPlane: 20m
+      controllerManager:
+        extraArgs:
+          allocate-node-cidrs: "false"
+          cloud-config: /etc/kubernetes/azure.json
+          cloud-provider: external
+          cluster-name: ${CLUSTER_NAME}
+          feature-gates: HPAContainerMetrics=true
+          v: "4"
+        extraVolumes:
+        - hostPath: /etc/kubernetes/azure.json
+          mountPath: /etc/kubernetes/azure.json
+          name: cloud-config
+          readOnly: true
+      etcd:
+        local:
+          dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
+      kubernetesVersion: ci/${CI_VERSION}
+    diskSetup:
+      filesystems:
+      - device: /dev/disk/azure/scsi1/lun0
+        extraOpts:
+        - -E
+        - lazy_itable_init=1,lazy_journal_init=1
+        filesystem: ext4
+        label: etcd_disk
+      - device: ephemeral0.1
+        filesystem: ext4
+        label: ephemeral0
+        replaceFS: ntfs
+      partitions:
+      - device: /dev/disk/azure/scsi1/lun0
+        layout: true
+        overwrite: false
+        tableType: gpt
+    files:
+    - contentFrom:
+        secret:
+          key: control-plane-azure.json
+          name: ${CLUSTER_NAME}-control-plane-azure-json
+      owner: root:root
+      path: /etc/kubernetes/azure.json
+      permissions: "0644"
+    - content: |
+        #!/bin/bash
+
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+
+        # This test installs release packages or binaries that are a result of the CI and release builds.
+        # It runs '... --version' commands to verify that the binaries are correctly installed
+        # and finally uninstalls the packages.
+        # For the release packages it tests all versions in the support skew.
+        LINE_SEPARATOR="*************************************************"
+        echo "$$LINE_SEPARATOR"
+        CI_VERSION=${CI_VERSION}
+        if [[ "$${CI_VERSION}" != "" ]]; then
+          CI_DIR=/tmp/k8s-ci
+          mkdir -p $$CI_DIR
+          declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
+          declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+          CONTAINER_EXT="tar"
+          echo "* testing CI version $$CI_VERSION"
+          # Check for semver
+          if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            CI_URL="https://storage.googleapis.com/k8s-release-dev/ci/$${CI_VERSION}/bin/linux/amd64"
+            VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
+            DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
+            curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+            echo 'deb https://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list
+            apt-get update
+            # replace . with \.
+            VERSION_REGEX="${VERSION_WITHOUT_PREFIX//./\\.}"
+            PACKAGE_VERSION="$(apt-cache madison kubelet|grep $${VERSION_REGEX}- | head -n1 | cut -d '|' -f 2 | tr -d '[:space:]')"
+            for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+              echo "* installing package: $$CI_PACKAGE $${PACKAGE_VERSION}"
+              DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
+            done
+          else
+              CI_URL="https://storage.googleapis.com/k8s-release-dev/ci/$${CI_VERSION}/bin/linux/amd64"
+            fi
+            for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+              echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
+              wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
+              chmod +x "$$CI_DIR/$$CI_PACKAGE"
+              mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
+            done
+            systemctl restart kubelet
+          fi
+          for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
+            echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
+            wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"
+            $${SUDO} ctr -n k8s.io images import "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
+            $${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" k8s.gcr.io/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
+            $${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
+          done
+        fi
+        echo "* checking binary versions"
+        echo "ctr version: " $(ctr version)
+        echo "kubeadm version: " $(kubeadm version -o=short)
+        echo "kubectl version: " $(kubectl version --client=true --short=true)
+        echo "kubelet version: " $(kubelet --version)
+        echo "$$LINE_SEPARATOR"
+      owner: root:root
+      path: /tmp/kubeadm-bootstrap.sh
+      permissions: "0744"
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          azure-container-registry-config: /etc/kubernetes/azure.json
+          cloud-config: /etc/kubernetes/azure.json
+          cloud-provider: external
+        name: '{{ ds.meta_data["local_hostname"] }}'
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          azure-container-registry-config: /etc/kubernetes/azure.json
+          cloud-config: /etc/kubernetes/azure.json
+          cloud-provider: external
+        name: '{{ ds.meta_data["local_hostname"] }}'
+    mounts:
+    - - LABEL=etcd_disk
+      - /var/lib/etcddisk
+    postKubeadmCommands: []
+    preKubeadmCommands:
+    - bash -c /tmp/kubeadm-bootstrap.sh
+    useExperimentalRetryJoin: true
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: AzureMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      dataDisks:
+      - diskSizeGB: 256
+        lun: 0
+        nameSuffix: etcddisk
+      image:
+        marketplace:
+          offer: capi
+          publisher: cncf-upstream
+          sku: k8s-1dot18dot8-ubuntu-1804
+          version: 2020.08.17
+      osDisk:
+        diskSizeGB: 128
+        osType: Linux
+      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector: {}
+  template:
+    metadata:
+      labels:
+        nodepool: pool1
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-md-0
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureMachineTemplate
+        name: ${CLUSTER_NAME}-md-0
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      image:
+        marketplace:
+          offer: capi
+          publisher: cncf-upstream
+          sku: k8s-1dot18dot8-ubuntu-1804
+          version: 2020.08.17
+      osDisk:
+        diskSizeGB: 128
+        osType: Linux
+      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      vmSize: ${AZURE_NODE_MACHINE_TYPE}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      files:
+      - contentFrom:
+          secret:
+            key: worker-node-azure.json
+            name: ${CLUSTER_NAME}-md-0-azure-json
+        owner: root:root
+        path: /etc/kubernetes/azure.json
+        permissions: "0644"
+      - content: |
+          #!/bin/bash
+
+          set -o nounset
+          set -o pipefail
+          set -o errexit
+          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+
+          # This test installs release packages or binaries that are a result of the CI and release builds.
+          # It runs '... --version' commands to verify that the binaries are correctly installed
+          # and finally uninstalls the packages.
+          # For the release packages it tests all versions in the support skew.
+          LINE_SEPARATOR="*************************************************"
+          echo "$$LINE_SEPARATOR"
+          CI_VERSION=${CI_VERSION}
+          if [[ "$${CI_VERSION}" != "" ]]; then
+            CI_DIR=/tmp/k8s-ci
+            mkdir -p $$CI_DIR
+            declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
+            declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+            CONTAINER_EXT="tar"
+            echo "* testing CI version $$CI_VERSION"
+            # Check for semver
+            if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              CI_URL="https://storage.googleapis.com/k8s-release-dev/ci/$${CI_VERSION}/bin/linux/amd64"
+              VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
+              DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
+              curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+              echo 'deb https://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list
+              apt-get update
+              # replace . with \.
+              VERSION_REGEX="${VERSION_WITHOUT_PREFIX//./\\.}"
+              PACKAGE_VERSION="$(apt-cache madison kubelet|grep $${VERSION_REGEX}- | head -n1 | cut -d '|' -f 2 | tr -d '[:space:]')"
+              for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+                echo "* installing package: $$CI_PACKAGE $${PACKAGE_VERSION}"
+                DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
+              done
+            else
+                CI_URL="https://storage.googleapis.com/k8s-release-dev/ci/$${CI_VERSION}/bin/linux/amd64"
+              fi
+              for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+                echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
+                wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
+                chmod +x "$$CI_DIR/$$CI_PACKAGE"
+                mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
+              done
+              systemctl restart kubelet
+            fi
+            for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
+              echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
+              wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"
+              $${SUDO} ctr -n k8s.io images import "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
+              $${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" k8s.gcr.io/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
+              $${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
+            done
+          fi
+          echo "* checking binary versions"
+          echo "ctr version: " $(ctr version)
+          echo "kubeadm version: " $(kubeadm version -o=short)
+          echo "kubectl version: " $(kubectl version --client=true --short=true)
+          echo "kubelet version: " $(kubelet --version)
+          echo "$$LINE_SEPARATOR"
+        owner: root:root
+        path: /tmp/kubeadm-bootstrap.sh
+        permissions: "0744"
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            azure-container-registry-config: /etc/kubernetes/azure.json
+            cloud-config: /etc/kubernetes/azure.json
+            cloud-provider: external
+          name: '{{ ds.meta_data["local_hostname"] }}'
+      preKubeadmCommands:
+      - bash -c /tmp/kubeadm-bootstrap.sh
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-win
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
+  selector: {}
+  template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-md-win
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureMachineTemplate
+        name: ${CLUSTER_NAME}-md-win
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  annotations:
+    runtime: containerd
+  name: ${CLUSTER_NAME}-md-win
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations:
+        runtime: containerd
+        windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
+    spec:
+      image:
+        marketplace:
+          offer: capi-windows
+          publisher: cncf-upstream
+          sku: k8s-1dot23dot3-windows-2019-containerd
+          version: latest
+      osDisk:
+        diskSizeGB: 128
+        managedDisk:
+          storageAccountType: Premium_LRS
+        osType: Windows
+      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      vmSize: ${AZURE_NODE_MACHINE_TYPE}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-win
+  namespace: default
+spec:
+  template:
+    spec:
+      files:
+      - contentFrom:
+          secret:
+            key: worker-node-azure.json
+            name: ${CLUSTER_NAME}-md-win-azure-json
+        owner: root:root
+        path: c:/k/azure.json
+        permissions: "0644"
+      - content: |-
+          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
+          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico-ipam.exe
+        path: C:/defender-exclude-calico.ps1
+        permissions: "0744"
+      - content: |
+          # /tmp is assumed created and required for upstream e2e tests to pass
+          New-Item -ItemType Directory -Force -Path C:\tmp\
+        path: C:/create-temp-folder.ps1
+        permissions: "0744"
+      - content: |
+          $ErrorActionPreference = 'Stop'
+
+          Stop-Service kubelet -Force
+
+          $$CI_VERSION="${CI_VERSION}"
+          if($$CI_VERSION -ne "")
+          {
+            $$binaries=@("kubeadm", "kubectl", "kubelet", "kube-proxy")
+            $$ci_url="https://storage.googleapis.com/k8s-release-dev/ci/$$CI_VERSION/bin/windows/amd64"
+            foreach ( $$binary in $$binaries )
+            {
+              echo "downloading binary: $$ci_url/$$binary.exe"
+              curl.exe --retry 10 --retry-delay 5 "$$ci_url/$$binary.exe" --output "c:/k/$$binary.exe"
+            }
+          }
+
+          $$CONTAINERD_URL="${WINDOWS_CONTAINERD_URL}"
+          if($$CONTAINERD_URL -ne ""){
+            Stop-Service containerd -Force
+            echo "downloading containerd: $$CONTAINERD_URL"
+            curl.exe --retry 10 --retry-delay 5 -L "$$CONTAINERD_URL" --output "c:/k/containerd.tar.gz"
+            tar.exe -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
+
+            Start-Service containerd
+          }
+
+          # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
+          # that is applied at at this stage (windows-kubeproxy-ci.yaml)
+          ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
+          ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
+
+          kubeadm.exe version -o=short
+          kubectl.exe version --client=true --short=true
+          kubelet.exe --version
+          kube-proxy.exe --version
+          containerd.exe --version
+          containerd-shim-runhcs-v1.exe --version
+        path: C:/replace-ci-binaries.ps1
+        permissions: "0744"
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: npipe:////./pipe/containerd-containerd
+          kubeletExtraArgs:
+            azure-container-registry-config: c:/k/azure.json
+            cloud-config: c:/k/azure.json
+            cloud-provider: azure
+            feature-gates: WindowsHostProcessContainers=true
+            v: "2"
+            windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
+          name: '{{ ds.meta_data["local_hostname"] }}'
+      postKubeadmCommands:
+      - nssm set kubelet start SERVICE_AUTO_START
+      - powershell C:/defender-exclude-calico.ps1
+      preKubeadmCommands:
+      - powershell C:/create-temp-folder.ps1
+      - powershell C:/replace-ci-binaries.ps1
+      users:
+      - groups: Administrators
+        name: capi
+        sshAuthorizedKeys:
+        - ${AZURE_SSH_PUBLIC_KEY:=""}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-0
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      nodepool: pool1
+  unhealthyConditions:
+  - status: "True"
+    timeout: 30s
+    type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: ${CLUSTER_NAME}-calico
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: ${CLUSTER_NAME}-calico
+  resources:
+  - kind: ConfigMap
+    name: cni-${CLUSTER_NAME}-calico
+  strategy: ApplyOnce
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureClusterIdentity
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  name: ${CLUSTER_IDENTITY_NAME}
+  namespace: default
+spec:
+  allowedNamespaces: {}
+  clientID: ${AZURE_CLIENT_ID}
+  clientSecret:
+    name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
+    namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
+  tenantID: ${AZURE_TENANT_ID}
+  type: ServicePrincipal
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: csi-proxy
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      csi-proxy: enabled
+  resources:
+  - kind: ConfigMap
+    name: csi-proxy-addon
+  strategy: ApplyOnce
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: containerd-logger-${CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      containerd-logger: enabled
+  resources:
+  - kind: ConfigMap
+    name: containerd-logger-${CLUSTER_NAME}
+  strategy: ApplyOnce
+---
+apiVersion: v1
+data:
+  kube-proxy-patch: |-
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: windows-kubeproxy-ci
+      namespace: kube-system
+    data:
+      KUBEPROXY_PATH: "c:/k/kube-proxy.exe"
+  proxy: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  labels:\n    k8s-app:
+    kube-proxy\n  name: kube-proxy-windows\n  namespace: kube-system\nspec:\n  selector:\n
+    \   matchLabels:\n      k8s-app: kube-proxy-windows\n  template:\n    metadata:\n
+    \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
+    kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
+    true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
+    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
+    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
+    \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
+    kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
+    \             apiVersion: v1\n              fieldPath: spec.nodeName\n        -
+    name: POD_IP\n          valueFrom:\n            fieldRef:\n              fieldPath:
+    status.podIP\n        - name: KUBEPROXY_PATH\n          valueFrom:\n            configMapKeyRef:\n
+    \             name: windows-kubeproxy-ci\n              key: KUBEPROXY_PATH\n
+    \             optional: true\n        volumeMounts:\n        - mountPath: /var/lib/kube-proxy\n
+    \         name: kube-proxy\n      nodeSelector:\n        kubernetes.io/os: windows\n
+    \     tolerations:\n      - key: CriticalAddonsOnly\n        operator: Exists\n
+    \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
+    kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
+    \   type: RollingUpdate\n"
+  resources: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgpconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPConfiguration
+        listKind: BGPConfigurationList
+        plural: bgpconfigurations
+        singular: bgpconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: BGPConfiguration contains the configuration for any BGP routing.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPConfigurationSpec contains the values of the BGP configuration.
+                properties:
+                  asNumber:
+                    description: 'ASNumber is the default AS number used by a node. [Default:
+                      64512]'
+                    format: int32
+                    type: integer
+                  bindMode:
+                    description: BindMode indicates whether to listen for BGP connections
+                      on all addresses (None) or only on the node's canonical IP address
+                      Node.Spec.BGP.IPvXAddress (NodeIP). Default behaviour is to listen
+                      for BGP connections on all addresses.
+                    type: string
+                  communities:
+                    description: Communities is a list of BGP community values and their
+                      arbitrary names for tagging routes.
+                    items:
+                      description: Community contains standard or large community value
+                        and its name.
+                      properties:
+                        name:
+                          description: Name given to community value.
+                          type: string
+                        value:
+                          description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                            For standard community use `aa:nn` format, where `aa` and
+                            `nn` are 16 bit number. For large community use `aa:nn:mm`
+                            format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                            `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                          pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                          type: string
+                      type: object
+                    type: array
+                  listenPort:
+                    description: ListenPort is the port where BGP protocol should listen.
+                      Defaults to 179
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: INFO]'
+                    type: string
+                  nodeMeshMaxRestartTime:
+                    description: Time to allow for software restart for node-to-mesh peerings.  When
+                      specified, this is configured as the graceful restart timeout.  When
+                      not specified, the BIRD default of 120s is used. This field can
+                      only be set on the default BGPConfiguration instance and requires
+                      that NodeMesh is enabled
+                    type: string
+                  nodeMeshPassword:
+                    description: Optional BGP password for full node-to-mesh peerings.
+                      This field can only be set on the default BGPConfiguration instance
+                      and requires that NodeMesh is enabled
+                    properties:
+                      secretKeyRef:
+                        description: Selects a key of a secret in the node pod's namespace.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be
+                              a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be
+                              defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  nodeToNodeMeshEnabled:
+                    description: 'NodeToNodeMeshEnabled sets whether full node to node
+                      BGP mesh is enabled. [Default: true]'
+                    type: boolean
+                  prefixAdvertisements:
+                    description: PrefixAdvertisements contains per-prefix advertisement
+                      configuration.
+                    items:
+                      description: PrefixAdvertisement configures advertisement properties
+                        for the specified CIDR.
+                      properties:
+                        cidr:
+                          description: CIDR for which properties should be advertised.
+                          type: string
+                        communities:
+                          description: Communities can be list of either community names
+                            already defined in `Specs.Communities` or community value
+                            of format `aa:nn` or `aa:nn:mm`. For standard community use
+                            `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                            large community use `aa:nn:mm` format, where `aa`, `nn` and
+                            `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                            `mm` are per-AS identifier.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  serviceClusterIPs:
+                    description: ServiceClusterIPs are the CIDR blocks from which service
+                      cluster IPs are allocated. If specified, Calico will advertise these
+                      blocks, as well as any cluster IPs within them.
+                    items:
+                      description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                        CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceExternalIPs:
+                    description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                      Service External IPs. Kubernetes Service ExternalIPs will only be
+                      advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceExternalIPBlock represents a single allowed
+                        External IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                  serviceLoadBalancerIPs:
+                    description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                      Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                      IPs will only be advertised if they are within one of these blocks.
+                    items:
+                      description: ServiceLoadBalancerIPBlock represents a single allowed
+                        LoadBalancer IP CIDR block.
+                      properties:
+                        cidr:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgppeers.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BGPPeer
+        listKind: BGPPeerList
+        plural: bgppeers
+        singular: bgppeer
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BGPPeerSpec contains the specification for a BGPPeer resource.
+                properties:
+                  asNumber:
+                    description: The AS Number of the peer.
+                    format: int32
+                    type: integer
+                  keepOriginalNextHop:
+                    description: Option to keep the original nexthop field when routes
+                      are sent to a BGP Peer. Setting "true" configures the selected BGP
+                      Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                      in the specific branch of the Node on "bird.cfg".
+                    type: boolean
+                  maxRestartTime:
+                    description: Time to allow for software restart.  When specified,
+                      this is configured as the graceful restart timeout.  When not specified,
+                      the BIRD default of 120s is used.
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance that
+                      is targeted by this peer. If this is not set, and no nodeSelector
+                      is specified, then this BGP peer selects all nodes in the cluster.
+                    type: string
+                  nodeSelector:
+                    description: Selector for the nodes that should have this peering.  When
+                      this is set, the Node field must be empty.
+                    type: string
+                  numAllowedLocalASNumbers:
+                    description: Maximum number of local AS numbers that are allowed in
+                      the AS path for received routes. This removes BGP loop prevention
+                      and should only be used if absolutely necesssary.
+                    format: int32
+                    type: integer
+                  password:
+                    description: Optional BGP password for the peerings generated by this
+                      BGPPeer resource.
+                    properties:
+                      secretKeyRef:
+                        description: Selects a key of a secret in the node pod's namespace.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be
+                              a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be
+                              defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  peerIP:
+                    description: The IP address of the peer followed by an optional port
+                      number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                      or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                      and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                      set in BGPConfiguration, then we use that port to peer.
+                    type: string
+                  peerSelector:
+                    description: Selector for the remote nodes to peer with.  When this
+                      is set, the PeerIP and ASNumber fields must be empty.  For each
+                      peering between the local node and selected remote nodes, we configure
+                      an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                      and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                      remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                      or the global default if that is not set.
+                    type: string
+                  sourceAddress:
+                    description: Specifies whether and how to configure a source address
+                      for the peerings generated by this BGPPeer resource.  Default value
+                      "UseNodeIP" means to configure the node IP as the source address.  "None"
+                      means not to configure a source address.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: blockaffinities.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: BlockAffinity
+        listKind: BlockAffinityList
+        plural: blockaffinities
+        singular: blockaffinity
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: BlockAffinitySpec contains the specification for a BlockAffinity
+                  resource.
+                properties:
+                  cidr:
+                    type: string
+                  deleted:
+                    description: Deleted indicates that this block affinity is being deleted.
+                      This field is a string for compatibility with older releases that
+                      mistakenly treat this field as a string.
+                    type: string
+                  node:
+                    type: string
+                  state:
+                    type: string
+                required:
+                - cidr
+                - deleted
+                - node
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        controller-gen.kubebuilder.io/version: (devel)
+      creationTimestamp: null
+      name: caliconodestatuses.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: CalicoNodeStatus
+        listKind: CalicoNodeStatusList
+        plural: caliconodestatuses
+        singular: caliconodestatus
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: CalicoNodeStatusSpec contains the specification for a CalicoNodeStatus
+                  resource.
+                properties:
+                  classes:
+                    description: Classes declares the types of information to monitor
+                      for this calico/node, and allows for selective status reporting
+                      about certain subsets of information.
+                    items:
+                      type: string
+                    type: array
+                  node:
+                    description: The node name identifies the Calico node instance for
+                      node status.
+                    type: string
+                  updatePeriodSeconds:
+                    description: UpdatePeriodSeconds is the period at which CalicoNodeStatus
+                      should be updated. Set to 0 to disable CalicoNodeStatus refresh.
+                      Maximum update period is one day.
+                    format: int32
+                    type: integer
+                type: object
+              status:
+                description: CalicoNodeStatusStatus defines the observed state of CalicoNodeStatus.
+                  No validation needed for status since it is updated by Calico.
+                properties:
+                  agent:
+                    description: Agent holds agent status on the node.
+                    properties:
+                      birdV4:
+                        description: BIRDV4 represents the latest observed status of bird4.
+                        properties:
+                          lastBootTime:
+                            description: LastBootTime holds the value of lastBootTime
+                              from bird.ctl output.
+                            type: string
+                          lastReconfigurationTime:
+                            description: LastReconfigurationTime holds the value of lastReconfigTime
+                              from bird.ctl output.
+                            type: string
+                          routerID:
+                            description: Router ID used by bird.
+                            type: string
+                          state:
+                            description: The state of the BGP Daemon.
+                            type: string
+                          version:
+                            description: Version of the BGP daemon
+                            type: string
+                        type: object
+                      birdV6:
+                        description: BIRDV6 represents the latest observed status of bird6.
+                        properties:
+                          lastBootTime:
+                            description: LastBootTime holds the value of lastBootTime
+                              from bird.ctl output.
+                            type: string
+                          lastReconfigurationTime:
+                            description: LastReconfigurationTime holds the value of lastReconfigTime
+                              from bird.ctl output.
+                            type: string
+                          routerID:
+                            description: Router ID used by bird.
+                            type: string
+                          state:
+                            description: The state of the BGP Daemon.
+                            type: string
+                          version:
+                            description: Version of the BGP daemon
+                            type: string
+                        type: object
+                    type: object
+                  bgp:
+                    description: BGP holds node BGP status.
+                    properties:
+                      numberEstablishedV4:
+                        description: The total number of IPv4 established bgp sessions.
+                        type: integer
+                      numberEstablishedV6:
+                        description: The total number of IPv6 established bgp sessions.
+                        type: integer
+                      numberNotEstablishedV4:
+                        description: The total number of IPv4 non-established bgp sessions.
+                        type: integer
+                      numberNotEstablishedV6:
+                        description: The total number of IPv6 non-established bgp sessions.
+                        type: integer
+                      peersV4:
+                        description: PeersV4 represents IPv4 BGP peers status on the node.
+                        items:
+                          description: CalicoNodePeer contains the status of BGP peers
+                            on the node.
+                          properties:
+                            peerIP:
+                              description: IP address of the peer whose condition we are
+                                reporting.
+                              type: string
+                            since:
+                              description: Since the state or reason last changed.
+                              type: string
+                            state:
+                              description: State is the BGP session state.
+                              type: string
+                            type:
+                              description: Type indicates whether this peer is configured
+                                via the node-to-node mesh, or via en explicit global or
+                                per-node BGPPeer object.
+                              type: string
+                          type: object
+                        type: array
+                      peersV6:
+                        description: PeersV6 represents IPv6 BGP peers status on the node.
+                        items:
+                          description: CalicoNodePeer contains the status of BGP peers
+                            on the node.
+                          properties:
+                            peerIP:
+                              description: IP address of the peer whose condition we are
+                                reporting.
+                              type: string
+                            since:
+                              description: Since the state or reason last changed.
+                              type: string
+                            state:
+                              description: State is the BGP session state.
+                              type: string
+                            type:
+                              description: Type indicates whether this peer is configured
+                                via the node-to-node mesh, or via en explicit global or
+                                per-node BGPPeer object.
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                    - numberEstablishedV4
+                    - numberEstablishedV6
+                    - numberNotEstablishedV4
+                    - numberNotEstablishedV6
+                    type: object
+                  lastUpdated:
+                    description: LastUpdated is a timestamp representing the server time
+                      when CalicoNodeStatus object last updated. It is represented in
+                      RFC3339 form and is in UTC.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  routes:
+                    description: Routes reports routes known to the Calico BGP daemon
+                      on the node.
+                    properties:
+                      routesV4:
+                        description: RoutesV4 represents IPv4 routes on the node.
+                        items:
+                          description: CalicoNodeRoute contains the status of BGP routes
+                            on the node.
+                          properties:
+                            destination:
+                              description: Destination of the route.
+                              type: string
+                            gateway:
+                              description: Gateway for the destination.
+                              type: string
+                            interface:
+                              description: Interface for the destination
+                              type: string
+                            learnedFrom:
+                              description: LearnedFrom contains information regarding
+                                where this route originated.
+                              properties:
+                                peerIP:
+                                  description: If sourceType is NodeMesh or BGPPeer, IP
+                                    address of the router that sent us this route.
+                                  type: string
+                                sourceType:
+                                  description: Type of the source where a route is learned
+                                    from.
+                                  type: string
+                              type: object
+                            type:
+                              description: Type indicates if the route is being used for
+                                forwarding or not.
+                              type: string
+                          type: object
+                        type: array
+                      routesV6:
+                        description: RoutesV6 represents IPv6 routes on the node.
+                        items:
+                          description: CalicoNodeRoute contains the status of BGP routes
+                            on the node.
+                          properties:
+                            destination:
+                              description: Destination of the route.
+                              type: string
+                            gateway:
+                              description: Gateway for the destination.
+                              type: string
+                            interface:
+                              description: Interface for the destination
+                              type: string
+                            learnedFrom:
+                              description: LearnedFrom contains information regarding
+                                where this route originated.
+                              properties:
+                                peerIP:
+                                  description: If sourceType is NodeMesh or BGPPeer, IP
+                                    address of the router that sent us this route.
+                                  type: string
+                                sourceType:
+                                  description: Type of the source where a route is learned
+                                    from.
+                                  type: string
+                              type: object
+                            type:
+                              description: Type indicates if the route is being used for
+                                forwarding or not.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: clusterinformations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: ClusterInformation
+        listKind: ClusterInformationList
+        plural: clusterinformations
+        singular: clusterinformation
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterInformation contains the cluster specific information.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterInformationSpec contains the values of describing
+                  the cluster.
+                properties:
+                  calicoVersion:
+                    description: CalicoVersion is the version of Calico that the cluster
+                      is running
+                    type: string
+                  clusterGUID:
+                    description: ClusterGUID is the GUID of the cluster
+                    type: string
+                  clusterType:
+                    description: ClusterType describes the type of the cluster
+                    type: string
+                  datastoreReady:
+                    description: DatastoreReady is used during significant datastore migrations
+                      to signal to components such as Felix that it should wait before
+                      accessing the datastore.
+                    type: boolean
+                  variant:
+                    description: Variant declares which variant of Calico should be active.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: felixconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: FelixConfiguration
+        listKind: FelixConfigurationList
+        plural: felixconfigurations
+        singular: felixconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: Felix Configuration contains the configuration for Felix.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: FelixConfigurationSpec contains the values of the Felix configuration.
+                properties:
+                  allowIPIPPacketsFromWorkloads:
+                    description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop IPIP encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  allowVXLANPacketsFromWorkloads:
+                    description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                      will add a rule to drop VXLAN encapsulated traffic from workloads
+                      [Default: false]'
+                    type: boolean
+                  awsSrcDstCheck:
+                    description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                      value must be one of "DoNothing", "Enable" or "Disable". [Default:
+                      DoNothing]'
+                    enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                    type: string
+                  bpfConnectTimeLoadBalancingEnabled:
+                    description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                      controls whether Felix installs the connection-time load balancer.  The
+                      connect-time load balancer is required for the host to be able to
+                      reach Kubernetes services and it improves the performance of pod-to-service
+                      connections.  The only reason to disable it is for debugging purposes.  [Default:
+                      true]'
+                    type: boolean
+                  bpfDataIfacePattern:
+                    description: BPFDataIfacePattern is a regular expression that controls
+                      which interfaces Felix should attach BPF programs to in order to
+                      catch traffic to/from the network.  This needs to match the interfaces
+                      that Calico workload traffic flows over as well as any interfaces
+                      that handle incoming traffic to nodeports and services from outside
+                      the cluster.  It should not match the workload interfaces (usually
+                      named cali...).
+                    type: string
+                  bpfDisableUnprivileged:
+                    description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                      sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                      users cannot access Calico''s BPF maps and cannot insert their own
+                      BPF programs to interfere with Calico''s. [Default: true]'
+                    type: boolean
+                  bpfEnabled:
+                    description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                      [Default: false]'
+                    type: boolean
+                  bpfEnforceRPF:
+                    description: 'BPFEnforceRPF enforce strict RPF on all interfaces with
+                      BPF programs regardless of what is the per-interfaces or global
+                      setting. Possible values are Disabled or Strict. [Default: Strict]'
+                    type: string
+                  bpfExtToServiceConnmark:
+                    description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit
+                      mark that is set on connections from an external client to a local
+                      service. This mark allows us to control how packets of that connection
+                      are routed within the host and how is routing intepreted by RPF
+                      check. [Default: 0]'
+                    type: integer
+                  bpfExternalServiceMode:
+                    description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                      from outside the cluster to services (node ports and cluster IPs)
+                      are forwarded to remote workloads.  If set to "Tunnel" then both
+                      request and response traffic is tunneled to the remote node.  If
+                      set to "DSR", the request traffic is tunneled but the response traffic
+                      is sent directly from the remote node.  In "DSR" mode, the remote
+                      node appears to use the IP of the ingress node; this requires a
+                      permissive L2 network.  [Default: Tunnel]'
+                    type: string
+                  bpfKubeProxyEndpointSlicesEnabled:
+                    description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                      whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                    type: boolean
+                  bpfKubeProxyIptablesCleanupEnabled:
+                    description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                      mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                      iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                      true]'
+                    type: boolean
+                  bpfKubeProxyMinSyncPeriod:
+                    description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                      minimum time between updates to the dataplane for Felix''s embedded
+                      kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                      reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                    type: string
+                  bpfLogLevel:
+                    description: 'BPFLogLevel controls the log level of the BPF programs
+                      when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                      logs are emitted to the BPF trace pipe, accessible with the command
+                      `tc exec bpf debug`. [Default: Off].'
+                    type: string
+                  bpfMapSizeConntrack:
+                    description: 'BPFMapSizeConntrack sets the size for the conntrack
+                      map.  This map must be large enough to hold an entry for each active
+                      connection.  Warning: changing the size of the conntrack map can
+                      cause disruption.'
+                    type: integer
+                  bpfMapSizeIPSets:
+                    description: BPFMapSizeIPSets sets the size for ipsets map.  The IP
+                      sets map must be large enough to hold an entry for each endpoint
+                      matched by every selector in the source/destination matches in network
+                      policy.  Selectors such as "all()" can result in large numbers of
+                      entries (one entry per endpoint in that case).
+                    type: integer
+                  bpfMapSizeNATAffinity:
+                    type: integer
+                  bpfMapSizeNATBackend:
+                    description: BPFMapSizeNATBackend sets the size for nat back end map.
+                      This is the total number of endpoints. This is mostly more than
+                      the size of the number of services.
+                    type: integer
+                  bpfMapSizeNATFrontend:
+                    description: BPFMapSizeNATFrontend sets the size for nat front end
+                      map. FrontendMap should be large enough to hold an entry for each
+                      nodeport, external IP and each port in each service.
+                    type: integer
+                  bpfMapSizeRoute:
+                    description: BPFMapSizeRoute sets the size for the routes map.  The
+                      routes map should be large enough to hold one entry per workload
+                      and a handful of entries per host (enough to cover its own IPs and
+                      tunnel IPs).
+                    type: integer
+                  bpfPSNATPorts:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'BPFPSNATPorts sets the range from which we randomly
+                      pick a port if there is a source port collision. This should be
+                      within the ephemeral range as defined by RFC 6056 (1024–65535) and
+                      preferably outside the  ephemeral ranges used by common operating
+                      systems. Linux uses 32768–60999, while others mostly use the IANA
+                      defined range 49152–65535. It is not necessarily a problem if this
+                      range overlaps with the operating systems. Both ends of the range
+                      are inclusive. [Default: 20000:29999]'
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  chainInsertMode:
+                    description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                      top-level iptables chains by inserting a rule at the top of the
+                      chain or by appending a rule at the bottom. insert is the safe default
+                      since it prevents Calico''s rules from being bypassed. If you switch
+                      to append mode, be sure that the other rules in the chains signal
+                      acceptance by falling through to the Calico rules, otherwise the
+                      Calico policy will be bypassed. [Default: insert]'
+                    type: string
+                  dataplaneDriver:
+                    description: DataplaneDriver filename of the external dataplane driver
+                      to use.  Only used if UseInternalDataplaneDriver is set to false.
+                    type: string
+                  dataplaneWatchdogTimeout:
+                    description: 'DataplaneWatchdogTimeout is the readiness/liveness timeout
+                      used for Felix''s (internal) dataplane driver. Increase this value
+                      if you experience spurious non-ready or non-live events when Felix
+                      is under heavy load. Decrease the value to get felix to report non-live
+                      or non-ready more quickly. [Default: 90s]'
+                    type: string
+                  debugDisableLogDropping:
+                    type: boolean
+                  debugMemoryProfilePath:
+                    type: string
+                  debugSimulateCalcGraphHangAfter:
+                    type: string
+                  debugSimulateDataplaneHangAfter:
+                    type: string
+                  defaultEndpointToHostAction:
+                    description: 'DefaultEndpointToHostAction controls what happens to
+                      traffic that goes from a workload endpoint to the host itself (after
+                      the traffic hits the endpoint egress policy). By default Calico
+                      blocks traffic from workload endpoints to the host itself with an
+                      iptables "DROP" action. If you want to allow some or all traffic
+                      from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                      RETURN if you have your own rules in the iptables "INPUT" chain;
+                      Calico will insert its rules at the top of that chain, then "RETURN"
+                      packets to the "INPUT" chain once it has completed processing workload
+                      endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                      from workloads after processing workload endpoint egress policy.
+                      [Default: Drop]'
+                    type: string
+                  deviceRouteProtocol:
+                    description: This defines the route protocol added to programmed device
+                      routes, by default this will be RTPROT_BOOT when left blank.
+                    type: integer
+                  deviceRouteSourceAddress:
+                    description: This is the IPv4 source address to use on programmed
+                      device routes. By default the source address is left blank, leaving
+                      the kernel to choose the source address used.
+                    type: string
+                  deviceRouteSourceAddressIPv6:
+                    description: This is the IPv6 source address to use on programmed
+                      device routes. By default the source address is left blank, leaving
+                      the kernel to choose the source address used.
+                    type: string
+                  disableConntrackInvalidCheck:
+                    type: boolean
+                  endpointReportingDelay:
+                    type: string
+                  endpointReportingEnabled:
+                    type: boolean
+                  externalNodesList:
+                    description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                      which may source tunnel traffic and have the tunneled traffic be
+                      accepted at calico nodes.
+                    items:
+                      type: string
+                    type: array
+                  failsafeInboundHostPorts:
+                    description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow incoming traffic to host endpoints
+                      on irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all inbound host ports, use the value
+                      none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                      udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  failsafeOutboundHostPorts:
+                    description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                      and CIDRs that Felix will allow outgoing traffic from host endpoints
+                      to irrespective of the security policy. This is useful to avoid
+                      accidentally cutting off a host with incorrect configuration. For
+                      back-compatibility, if the protocol is not specified, it defaults
+                      to "tcp". If a CIDR is not specified, it will allow traffic from
+                      all addresses. To disable all outbound host ports, use the value
+                      none. The default value opens etcd''s standard ports to ensure that
+                      Felix does not get cut off from etcd as well as allowing DHCP and
+                      DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                      tcp:6667, udp:53, udp:67]'
+                    items:
+                      description: ProtoPort is combination of protocol, port, and CIDR.
+                        Protocol and port must be specified.
+                      properties:
+                        net:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  featureDetectOverride:
+                    description: FeatureDetectOverride is used to override the feature
+                      detection. Values are specified in a comma separated list with no
+                      spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                      "true" or "false" will force the feature, empty or omitted values
+                      are auto-detected.
+                    type: string
+                  floatingIPs:
+                    default: Disabled
+                    description: FloatingIPs configures whether or not Felix will program
+                      floating IP addresses.
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
+                  genericXDPEnabled:
+                    description: 'GenericXDPEnabled enables Generic XDP so network cards
+                      that don''t support XDP offload or driver modes can use XDP. This
+                      is not recommended since it doesn''t provide better performance
+                      than iptables. [Default: false]'
+                    type: boolean
+                  healthEnabled:
+                    type: boolean
+                  healthHost:
+                    type: string
+                  healthPort:
+                    type: integer
+                  interfaceExclude:
+                    description: 'InterfaceExclude is a comma-separated list of interfaces
+                      that Felix should exclude when monitoring for host endpoints. The
+                      default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                      interface, which is used internally by kube-proxy. If you want to
+                      exclude multiple interface names using a single value, the list
+                      supports regular expressions. For regular expressions you must wrap
+                      the value with ''/''. For example having values ''/^kube/,veth1''
+                      will exclude all interfaces that begin with ''kube'' and also the
+                      interface ''veth1''. [Default: kube-ipvs0]'
+                    type: string
+                  interfacePrefix:
+                    description: 'InterfacePrefix is the interface name prefix that identifies
+                      workload endpoints and so distinguishes them from host endpoint
+                      interfaces. Note: in environments other than bare metal, the orchestrators
+                      configure this appropriately. For example our Kubernetes and Docker
+                      integrations set the ''cali'' value, and our OpenStack integration
+                      sets the ''tap'' value. [Default: cali]'
+                    type: string
+                  interfaceRefreshInterval:
+                    description: InterfaceRefreshInterval is the period at which Felix
+                      rescans local interfaces to verify their state. The rescan can be
+                      disabled by setting the interval to 0.
+                    type: string
+                  ipipEnabled:
+                    description: 'IPIPEnabled overrides whether Felix should configure
+                      an IPIP interface on the host. Optional as Felix determines this
+                      based on the existing IP pools. [Default: nil (unset)]'
+                    type: boolean
+                  ipipMTU:
+                    description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                      Configuring MTU [Default: 1440]'
+                    type: integer
+                  ipsetsRefreshInterval:
+                    description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                      all iptables state to ensure that no other process has accidentally
+                      broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                      90s]'
+                    type: string
+                  iptablesBackend:
+                    description: IptablesBackend specifies which backend of iptables will
+                      be used. The default is legacy.
+                    type: string
+                  iptablesFilterAllowAction:
+                    type: string
+                  iptablesLockFilePath:
+                    description: 'IptablesLockFilePath is the location of the iptables
+                      lock file. You may need to change this if the lock file is not in
+                      its standard location (for example if you have mapped it into Felix''s
+                      container at a different path). [Default: /run/xtables.lock]'
+                    type: string
+                  iptablesLockProbeInterval:
+                    description: 'IptablesLockProbeInterval is the time that Felix will
+                      wait between attempts to acquire the iptables lock if it is not
+                      available. Lower values make Felix more responsive when the lock
+                      is contended, but use more CPU. [Default: 50ms]'
+                    type: string
+                  iptablesLockTimeout:
+                    description: 'IptablesLockTimeout is the time that Felix will wait
+                      for the iptables lock, or 0, to disable. To use this feature, Felix
+                      must share the iptables lock file with all other processes that
+                      also take the lock. When running Felix inside a container, this
+                      requires the /run directory of the host to be mounted into the calico/node
+                      or calico/felix container. [Default: 0s disabled]'
+                    type: string
+                  iptablesMangleAllowAction:
+                    type: string
+                  iptablesMarkMask:
+                    description: 'IptablesMarkMask is the mask that Felix selects its
+                      IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                      at least 8 bits set, none of which clash with any other mark bits
+                      in use on the system. [Default: 0xff000000]'
+                    format: int32
+                    type: integer
+                  iptablesNATOutgoingInterfaceFilter:
+                    type: string
+                  iptablesPostWriteCheckInterval:
+                    description: 'IptablesPostWriteCheckInterval is the period after Felix
+                      has done a write to the dataplane that it schedules an extra read
+                      back in order to check the write was not clobbered by another process.
+                      This should only occur if another application on the system doesn''t
+                      respect the iptables lock. [Default: 1s]'
+                    type: string
+                  iptablesRefreshInterval:
+                    description: 'IptablesRefreshInterval is the period at which Felix
+                      re-checks the IP sets in the dataplane to ensure that no other process
+                      has accidentally broken Calico''s rules. Set to 0 to disable IP
+                      sets refresh. Note: the default for this value is lower than the
+                      other refresh intervals as a workaround for a Linux kernel bug that
+                      was fixed in kernel version 4.11. If you are using v4.11 or greater
+                      you may want to set this to, a higher value to reduce Felix CPU
+                      usage. [Default: 10s]'
+                    type: string
+                  ipv6Support:
+                    description: IPv6Support controls whether Felix enables support for
+                      IPv6 (if supported by the in-use dataplane).
+                    type: boolean
+                  kubeNodePortRanges:
+                    description: 'KubeNodePortRanges holds list of port ranges used for
+                      service node ports. Only used if felix detects kube-proxy running
+                      in ipvs mode. Felix uses these ranges to separate host and workload
+                      traffic. [Default: 30000:32767].'
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  logDebugFilenameRegex:
+                    description: LogDebugFilenameRegex controls which source code files
+                      have their Debug log output included in the logs. Only logs from
+                      files with names that match the given regular expression are included.  The
+                      filter only applies to Debug level logs.
+                    type: string
+                  logFilePath:
+                    description: 'LogFilePath is the full path to the Felix log. Set to
+                      none to disable file logging. [Default: /var/log/calico/felix.log]'
+                    type: string
+                  logPrefix:
+                    description: 'LogPrefix is the log prefix that Felix uses when rendering
+                      LOG rules. [Default: calico-packet]'
+                    type: string
+                  logSeverityFile:
+                    description: 'LogSeverityFile is the log severity above which logs
+                      are sent to the log file. [Default: Info]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  logSeveritySys:
+                    description: 'LogSeveritySys is the log severity above which logs
+                      are sent to the syslog. Set to None for no logging to syslog. [Default:
+                      Info]'
+                    type: string
+                  maxIpsetSize:
+                    type: integer
+                  metadataAddr:
+                    description: 'MetadataAddr is the IP address or domain name of the
+                      server that can answer VM queries for cloud-init metadata. In OpenStack,
+                      this corresponds to the machine running nova-api (or in Ubuntu,
+                      nova-api-metadata). A value of none (case insensitive) means that
+                      Felix should not set up any NAT rule for the metadata path. [Default:
+                      127.0.0.1]'
+                    type: string
+                  metadataPort:
+                    description: 'MetadataPort is the port of the metadata server. This,
+                      combined with global.MetadataAddr (if not ''None''), is used to
+                      set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                      In most cases this should not need to be changed [Default: 8775].'
+                    type: integer
+                  mtuIfacePattern:
+                    description: MTUIfacePattern is a regular expression that controls
+                      which interfaces Felix should scan in order to calculate the host's
+                      MTU. This should not match workload interfaces (usually named cali...).
+                    type: string
+                  natOutgoingAddress:
+                    description: NATOutgoingAddress specifies an address to use when performing
+                      source NAT for traffic in a natOutgoing pool that is leaving the
+                      network. By default the address used is an address on the interface
+                      the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                    type: string
+                  natPortRange:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NATPortRange specifies the range of ports that is used
+                      for port mapping when doing outgoing NAT. When unset the default
+                      behavior of the network stack is used.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  netlinkTimeout:
+                    type: string
+                  openstackRegion:
+                    description: 'OpenstackRegion is the name of the region that a particular
+                      Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                      this must be configured somehow for each Felix (here in the datamodel,
+                      or in felix.cfg or the environment on each compute node), and must
+                      match the [calico] openstack_region value configured in neutron.conf
+                      on each node. [Default: Empty]'
+                    type: string
+                  policySyncPathPrefix:
+                    description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                      policy changes to external services, like Application layer policy.
+                      [Default: Empty]'
+                    type: string
+                  prometheusGoMetricsEnabled:
+                    description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusMetricsEnabled:
+                    description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                      server in Felix if set to true. [Default: false]'
+                    type: boolean
+                  prometheusMetricsHost:
+                    description: 'PrometheusMetricsHost is the host that the Prometheus
+                      metrics server should bind to. [Default: empty]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. [Default: 9091]'
+                    type: integer
+                  prometheusProcessMetricsEnabled:
+                    description: 'PrometheusProcessMetricsEnabled disables process metrics
+                      collection, which the Prometheus client does by default, when set
+                      to false. This reduces the number of metrics reported, reducing
+                      Prometheus load. [Default: true]'
+                    type: boolean
+                  prometheusWireGuardMetricsEnabled:
+                    description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                      metrics collection, which the Prometheus client does by default,
+                      when set to false. This reduces the number of metrics reported,
+                      reducing Prometheus load. [Default: true]'
+                    type: boolean
+                  removeExternalRoutes:
+                    description: Whether or not to remove device routes that have not
+                      been programmed by Felix. Disabling this will allow external applications
+                      to also add device routes. This is enabled by default which means
+                      we will remove externally added routes.
+                    type: boolean
+                  reportingInterval:
+                    description: 'ReportingInterval is the interval at which Felix reports
+                      its status into the datastore or 0 to disable. Must be non-zero
+                      in OpenStack deployments. [Default: 30s]'
+                    type: string
+                  reportingTTL:
+                    description: 'ReportingTTL is the time-to-live setting for process-wide
+                      status reports. [Default: 90s]'
+                    type: string
+                  routeRefreshInterval:
+                    description: 'RouteRefreshInterval is the period at which Felix re-checks
+                      the routes in the dataplane to ensure that no other process has
+                      accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                      [Default: 90s]'
+                    type: string
+                  routeSource:
+                    description: 'RouteSource configures where Felix gets its routing
+                      information. - WorkloadIPs: use workload endpoints to construct
+                      routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                    type: string
+                  routeTableRange:
+                    description: Deprecated in favor of RouteTableRanges. Calico programs
+                      additional Linux route tables for various purposes. RouteTableRange
+                      specifies the indices of the route tables that Calico should use.
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                    - max
+                    - min
+                    type: object
+                  routeTableRanges:
+                    description: Calico programs additional Linux route tables for various
+                      purposes. RouteTableRanges specifies a set of table index ranges
+                      that Calico should use. Deprecates`RouteTableRange`, overrides `RouteTableRange`.
+                    items:
+                      properties:
+                        max:
+                          type: integer
+                        min:
+                          type: integer
+                      required:
+                      - max
+                      - min
+                      type: object
+                    type: array
+                  serviceLoopPrevention:
+                    description: 'When service IP advertisement is enabled, prevent routing
+                      loops to service IPs that are not in use, by dropping or rejecting
+                      packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                      in which case such routing loops continue to be allowed. [Default:
+                      Drop]'
+                    type: string
+                  sidecarAccelerationEnabled:
+                    description: 'SidecarAccelerationEnabled enables experimental sidecar
+                      acceleration [Default: false]'
+                    type: boolean
+                  usageReportingEnabled:
+                    description: 'UsageReportingEnabled reports anonymous Calico version
+                      number and cluster size to projectcalico.org. Logs warnings returned
+                      by the usage server. For example, if a significant security vulnerability
+                      has been discovered in the version of Calico being used. [Default:
+                      true]'
+                    type: boolean
+                  usageReportingInitialDelay:
+                    description: 'UsageReportingInitialDelay controls the minimum delay
+                      before Felix makes a report. [Default: 300s]'
+                    type: string
+                  usageReportingInterval:
+                    description: 'UsageReportingInterval controls the interval at which
+                      Felix makes reports. [Default: 86400s]'
+                    type: string
+                  useInternalDataplaneDriver:
+                    description: UseInternalDataplaneDriver, if true, Felix will use its
+                      internal dataplane programming logic.  If false, it will launch
+                      an external dataplane driver and communicate with it over protobuf.
+                    type: boolean
+                  vxlanEnabled:
+                    description: 'VXLANEnabled overrides whether Felix should create the
+                      VXLAN tunnel device for VXLAN networking. Optional as Felix determines
+                      this based on the existing IP pools. [Default: nil (unset)]'
+                    type: boolean
+                  vxlanMTU:
+                    description: 'VXLANMTU is the MTU to set on the IPv4 VXLAN tunnel
+                      device. See Configuring MTU [Default: 1410]'
+                    type: integer
+                  vxlanMTUV6:
+                    description: 'VXLANMTUV6 is the MTU to set on the IPv6 VXLAN tunnel
+                      device. See Configuring MTU [Default: 1390]'
+                    type: integer
+                  vxlanPort:
+                    type: integer
+                  vxlanVNI:
+                    type: integer
+                  wireguardEnabled:
+                    description: 'WireguardEnabled controls whether Wireguard is enabled.
+                      [Default: false]'
+                    type: boolean
+                  wireguardHostEncryptionEnabled:
+                    description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                      host-to-host encryption is enabled. [Default: false]'
+                    type: boolean
+                  wireguardInterfaceName:
+                    description: 'WireguardInterfaceName specifies the name to use for
+                      the Wireguard interface. [Default: wg.calico]'
+                    type: string
+                  wireguardKeepAlive:
+                    description: 'WireguardKeepAlive controls Wireguard PersistentKeepalive
+                      option. Set 0 to disable. [Default: 0]'
+                    type: string
+                  wireguardListeningPort:
+                    description: 'WireguardListeningPort controls the listening port used
+                      by Wireguard. [Default: 51820]'
+                    type: integer
+                  wireguardMTU:
+                    description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                      See Configuring MTU [Default: 1420]'
+                    type: integer
+                  wireguardRoutingRulePriority:
+                    description: 'WireguardRoutingRulePriority controls the priority value
+                      to use for the Wireguard routing rule. [Default: 99]'
+                    type: integer
+                  workloadSourceSpoofing:
+                    description: WorkloadSourceSpoofing controls whether pods can use
+                      the allowedSourcePrefixes annotation to send traffic with a source
+                      IP address that is not theirs. This is disabled by default. When
+                      set to "Any", pods can request any prefix.
+                    type: string
+                  xdpEnabled:
+                    description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                      incoming deny rules. [Default: true]'
+                    type: boolean
+                  xdpRefreshInterval:
+                    description: 'XDPRefreshInterval is the period at which Felix re-checks
+                      all XDP state to ensure that no other process has accidentally broken
+                      Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                      refresh. [Default: 90s]'
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkPolicy
+        listKind: GlobalNetworkPolicyList
+        plural: globalnetworkpolicies
+        singular: globalnetworkpolicy
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  applyOnForward:
+                    description: ApplyOnForward indicates to apply the rules in this policy
+                      on forward traffic.
+                    type: boolean
+                  doNotTrack:
+                    description: DoNotTrack indicates whether packets matched by the rules
+                      in this policy should go through the data plane's connection tracking,
+                      such as Linux conntrack.  If True, the rules in this policy are
+                      applied before any data plane connection tracking, and packets allowed
+                      by this policy are marked as not to be tracked.
+                    type: boolean
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                                can only be specified with Services on ingress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                                can only be specified with Services on ingress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                                can only be specified with Services on ingress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                                can only be specified with Services on ingress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    description: NamespaceSelector is an optional field for an expression
+                      used to select a pod based on namespaces.
+                    type: string
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  preDNAT:
+                    description: PreDNAT indicates to apply the rules in this policy before
+                      any DNAT.
+                    type: boolean
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress rules are present in the policy.  The
+                      default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                      (including the case where there are   also no Ingress rules) \n
+                      - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                      rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                      both Ingress and Egress rules. \n When the policy is read back again,
+                      Types will always be one of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: GlobalNetworkSet
+        listKind: GlobalNetworkSetList
+        plural: globalnetworksets
+        singular: globalnetworkset
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+              that share labels to allow rules to refer to them via selectors.  The labels
+              of GlobalNetworkSet are not namespaced.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: hostendpoints.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: HostEndpoint
+        listKind: HostEndpointList
+        plural: hostendpoints
+        singular: hostendpoint
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: HostEndpointSpec contains the specification for a HostEndpoint
+                  resource.
+                properties:
+                  expectedIPs:
+                    description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                      If \"InterfaceName\" is not present, Calico will look for an interface
+                      matching any of the IPs in the list and apply policy to that. Note:
+                      \tWhen using the selector match criteria in an ingress or egress
+                      security Policy \tor Profile, Calico converts the selector into
+                      a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                      is used for that purpose. (If only the interface \tname is specified,
+                      Calico does not learn the IPs of the interface for use in match
+                      \tcriteria.)"
+                    items:
+                      type: string
+                    type: array
+                  interfaceName:
+                    description: "Either \"*\", or the name of a specific Linux interface
+                      to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                      governs all traffic to, from or through the default network namespace
+                      of the host named by the \"Node\" field; entering and leaving that
+                      namespace via any interface, including those from/to non-host-networked
+                      local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                      only governs traffic that enters or leaves the host through the
+                      specific interface named by InterfaceName, or - when InterfaceName
+                      is empty - through the specific interface that has one of the IPs
+                      in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                      one expected IP must be specified.  Only external interfaces (such
+                      as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                      to protect traffic through a specific local workload interface.
+                      \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                      initially just pre-DNAT policy.  Please check Calico documentation
+                      for the latest position."
+                    type: string
+                  node:
+                    description: The node name identifying the Calico node instance.
+                    type: string
+                  ports:
+                    description: Ports contains the endpoint's named ports, which may
+                      be referenced in security policy rules.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          type: integer
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - protocol
+                      type: object
+                    type: array
+                  profiles:
+                    description: A list of identifiers of security Profile objects that
+                      apply to this endpoint. Each profile is applied in the order that
+                      they appear in this list.  Profile rules are applied after the selector-based
+                      security policy.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamblocks.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMBlock
+        listKind: IPAMBlockList
+        plural: ipamblocks
+        singular: ipamblock
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMBlockSpec contains the specification for an IPAMBlock
+                  resource.
+                properties:
+                  affinity:
+                    description: Affinity of the block, if this block has one. If set,
+                      it will be of the form "host:<hostname>". If not set, this block
+                      is not affine to a host.
+                    type: string
+                  allocations:
+                    description: Array of allocations in-use within this block. nil entries
+                      mean the allocation is free. For non-nil entries at index i, the
+                      index is the ordinal of the allocation within this block and the
+                      value is the index of the associated attributes in the Attributes
+                      array.
+                    items:
+                      nullable: true
+                      type: integer
+                    type: array
+                  attributes:
+                    description: Attributes is an array of arbitrary metadata associated
+                      with allocations in the block. To find attributes for a given allocation,
+                      use the value of the allocation's entry in the Allocations array
+                      as the index of the element in this array.
+                    items:
+                      properties:
+                        handle_id:
+                          type: string
+                        secondary:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    type: array
+                  cidr:
+                    description: The block's CIDR.
+                    type: string
+                  deleted:
+                    description: Deleted is an internal boolean used to workaround a limitation
+                      in the Kubernetes API whereby deletion will not return a conflict
+                      error if the block has been updated. It should not be set manually.
+                    type: boolean
+                  sequenceNumber:
+                    default: 0
+                    description: We store a sequence number that is updated each time
+                      the block is written. Each allocation will also store the sequence
+                      number of the block at the time of its creation. When releasing
+                      an IP, passing the sequence number associated with the allocation
+                      allows us to protect against a race condition and ensure the IP
+                      hasn't been released and re-allocated since the release request.
+                    format: int64
+                    type: integer
+                  sequenceNumberForAllocation:
+                    additionalProperties:
+                      format: int64
+                      type: integer
+                    description: Map of allocated ordinal within the block to sequence
+                      number of the block at the time of allocation. Kubernetes does not
+                      allow numerical keys for maps, so the key is cast to a string.
+                    type: object
+                  strictAffinity:
+                    description: StrictAffinity on the IPAMBlock is deprecated and no
+                      longer used by the code. Use IPAMConfig StrictAffinity instead.
+                    type: boolean
+                  unallocated:
+                    description: Unallocated is an ordered list of allocations which are
+                      free in the block.
+                    items:
+                      type: integer
+                    type: array
+                required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamconfigs.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMConfig
+        listKind: IPAMConfigList
+        plural: ipamconfigs
+        singular: ipamconfig
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMConfigSpec contains the specification for an IPAMConfig
+                  resource.
+                properties:
+                  autoAllocateBlocks:
+                    type: boolean
+                  maxBlocksPerHost:
+                    description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                      that can be affine to each host.
+                    type: integer
+                  strictAffinity:
+                    type: boolean
+                required:
+                - autoAllocateBlocks
+                - strictAffinity
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamhandles.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPAMHandle
+        listKind: IPAMHandleList
+        plural: ipamhandles
+        singular: ipamhandle
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPAMHandleSpec contains the specification for an IPAMHandle
+                  resource.
+                properties:
+                  block:
+                    additionalProperties:
+                      type: integer
+                    type: object
+                  deleted:
+                    type: boolean
+                  handleID:
+                    type: string
+                required:
+                - block
+                - handleID
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ippools.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPPool
+        listKind: IPPoolList
+        plural: ippools
+        singular: ippool
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPPoolSpec contains the specification for an IPPool resource.
+                properties:
+                  allowedUses:
+                    description: AllowedUse controls what the IP pool will be used for.  If
+                      not specified or empty, defaults to ["Tunnel", "Workload"] for back-compatibility
+                    items:
+                      type: string
+                    type: array
+                  blockSize:
+                    description: The block size to use for IP address assignments from
+                      this pool. Defaults to 26 for IPv4 and 122 for IPv6.
+                    type: integer
+                  cidr:
+                    description: The pool CIDR.
+                    type: string
+                  disableBGPExport:
+                    description: 'Disable exporting routes from this IP Pool''s CIDR over
+                      BGP. [Default: false]'
+                    type: boolean
+                  disabled:
+                    description: When disabled is true, Calico IPAM will not assign addresses
+                      from this pool.
+                    type: boolean
+                  ipip:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    properties:
+                      enabled:
+                        description: When enabled is true, ipip tunneling will be used
+                          to deliver packets to destinations within this pool.
+                        type: boolean
+                      mode:
+                        description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                          mode of "always" will also use IPIP tunneling for routing to
+                          destination IP addresses within this pool.  A mode of "cross-subnet"
+                          will only use IPIP tunneling when the destination node is on
+                          a different subnet to the originating node.  The default value
+                          (if not specified) is "always".
+                        type: string
+                    type: object
+                  ipipMode:
+                    description: Contains configuration for IPIP tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                      is disabled).
+                    type: string
+                  nat-outgoing:
+                    description: 'Deprecated: this field is only used for APIv1 backwards
+                      compatibility. Setting this field is not allowed, this field is
+                      for internal use only.'
+                    type: boolean
+                  natOutgoing:
+                    description: When nat-outgoing is true, packets sent from Calico networked
+                      containers in this pool to destinations outside of this pool will
+                      be masqueraded.
+                    type: boolean
+                  nodeSelector:
+                    description: Allows IPPool to allocate for a specific node by label
+                      selector.
+                    type: string
+                  vxlanMode:
+                    description: Contains configuration for VXLAN tunneling for this pool.
+                      If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                      tunneling is disabled).
+                    type: string
+                required:
+                - cidr
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        controller-gen.kubebuilder.io/version: (devel)
+      creationTimestamp: null
+      name: ipreservations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: IPReservation
+        listKind: IPReservationList
+        plural: ipreservations
+        singular: ipreservation
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: IPReservationSpec contains the specification for an IPReservation
+                  resource.
+                properties:
+                  reservedCIDRs:
+                    description: ReservedCIDRs is a list of CIDRs and/or IP addresses
+                      that Calico IPAM will exclude from new allocations.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubecontrollersconfigurations.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: KubeControllersConfiguration
+        listKind: KubeControllersConfigurationList
+        plural: kubecontrollersconfigurations
+        singular: kubecontrollersconfiguration
+      scope: Cluster
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeControllersConfigurationSpec contains the values of the
+                  Kubernetes controllers configuration.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host endpoints.
+                              Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation of
+                                  host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          leakGracePeriod:
+                            description: 'LeakGracePeriod is the period used by the controller
+                              to determine if an IP address has been leaked. Set to 0
+                              to disable IP garbage collection. [Default: 15m]'
+                            type: string
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform reconciliation
+                              with the Calico datastore. [Default: 5m]'
+                            type: string
+                        type: object
+                    type: object
+                  debugProfilePort:
+                    description: DebugProfilePort configures the port to serve memory
+                      and cpu profiles on. If not specified, profiling is disabled.
+                    format: int32
+                    type: integer
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which logs
+                      are sent to the stdout. [Default: Info]'
+                    type: string
+                  prometheusMetricsPort:
+                    description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                      metrics server should bind to. Set to 0 to disable. [Default: 9094]'
+                    type: integer
+                required:
+                - controllers
+                type: object
+              status:
+                description: KubeControllersConfigurationStatus represents the status
+                  of the configuration. It's useful for admins to be able to see the actual
+                  config that was applied, which can be modified by environment variables
+                  on the kube-controllers process.
+                properties:
+                  environmentVars:
+                    additionalProperties:
+                      type: string
+                    description: EnvironmentVars contains the environment variables on
+                      the kube-controllers that influenced the RunningConfig.
+                    type: object
+                  runningConfig:
+                    description: RunningConfig contains the effective config that is running
+                      in the kube-controllers pod, after merging the API resource with
+                      any environment variables.
+                    properties:
+                      controllers:
+                        description: Controllers enables and configures individual Kubernetes
+                          controllers
+                        properties:
+                          namespace:
+                            description: Namespace enables and configures the namespace
+                              controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          node:
+                            description: Node enables and configures the node controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              hostEndpoint:
+                                description: HostEndpoint controls syncing nodes to host
+                                  endpoints. Disabled by default, set to nil to disable.
+                                properties:
+                                  autoCreate:
+                                    description: 'AutoCreate enables automatic creation
+                                      of host endpoints for every node. [Default: Disabled]'
+                                    type: string
+                                type: object
+                              leakGracePeriod:
+                                description: 'LeakGracePeriod is the period used by the
+                                  controller to determine if an IP address has been leaked.
+                                  Set to 0 to disable IP garbage collection. [Default:
+                                  15m]'
+                                type: string
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                              syncLabels:
+                                description: 'SyncLabels controls whether to copy Kubernetes
+                                  node labels to Calico nodes. [Default: Enabled]'
+                                type: string
+                            type: object
+                          policy:
+                            description: Policy enables and configures the policy controller.
+                              Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          serviceAccount:
+                            description: ServiceAccount enables and configures the service
+                              account controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                          workloadEndpoint:
+                            description: WorkloadEndpoint enables and configures the workload
+                              endpoint controller. Enabled by default, set to nil to disable.
+                            properties:
+                              reconcilerPeriod:
+                                description: 'ReconcilerPeriod is the period to perform
+                                  reconciliation with the Calico datastore. [Default:
+                                  5m]'
+                                type: string
+                            type: object
+                        type: object
+                      debugProfilePort:
+                        description: DebugProfilePort configures the port to serve memory
+                          and cpu profiles on. If not specified, profiling is disabled.
+                        format: int32
+                        type: integer
+                      etcdV3CompactionPeriod:
+                        description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                          compaction requests. Set to 0 to disable. [Default: 10m]'
+                        type: string
+                      healthChecks:
+                        description: 'HealthChecks enables or disables support for health
+                          checks [Default: Enabled]'
+                        type: string
+                      logSeverityScreen:
+                        description: 'LogSeverityScreen is the log severity above which
+                          logs are sent to the stdout. [Default: Info]'
+                        type: string
+                      prometheusMetricsPort:
+                        description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                          metrics server should bind to. Set to 0 to disable. [Default:
+                          9094]'
+                        type: integer
+                    required:
+                    - controllers
+                    type: object
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networkpolicies.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkPolicy
+        listKind: NetworkPolicyList
+        plural: networkpolicies
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  egress:
+                    description: The ordered set of egress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                                can only be specified with Services on ingress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                                can only be specified with Services on ingress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: The ordered set of ingress rules.  Each rule contains
+                      a set of packet match criteria and a corresponding action to apply.
+                    items:
+                      description: "A Rule encapsulates a set of match criteria and an
+                        action.  Both selector-based security Policy and security Profiles
+                        reference rules - separated out as a list of rules for both ingress
+                        and egress packet matching. \n Each positive match criteria has
+                        a negated version, prefixed with \"Not\". All the match criteria
+                        within a rule must be satisfied for a packet to match. A single
+                        rule can contain the positive and negative version of a match
+                        and both must be satisfied for the rule to match."
+                      properties:
+                        action:
+                          type: string
+                        destination:
+                          description: Destination contains the match criteria that apply
+                            to destination entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                                can only be specified with Services on ingress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                        http:
+                          description: HTTP contains match criteria that apply to HTTP
+                            requests.
+                          properties:
+                            methods:
+                              description: Methods is an optional field that restricts
+                                the rule to apply only to HTTP requests that use one of
+                                the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                                methods are OR'd together.
+                              items:
+                                type: string
+                              type: array
+                            paths:
+                              description: 'Paths is an optional field that restricts
+                                the rule to apply to HTTP requests that use one of the
+                                listed HTTP Paths. Multiple paths are OR''d together.
+                                e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                                ONLY specify either a `exact` or a `prefix` match. The
+                                validator will check for it.'
+                              items:
+                                description: 'HTTPPath specifies an HTTP path to match.
+                                  It may be either of the form: exact: <path>: which matches
+                                  the path exactly or prefix: <path-prefix>: which matches
+                                  the path prefix'
+                                properties:
+                                  exact:
+                                    type: string
+                                  prefix:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        icmp:
+                          description: ICMP is an optional field that restricts the rule
+                            to apply to a specific type and code of ICMP traffic.  This
+                            should only be specified if the Protocol field is set to "ICMP"
+                            or "ICMPv6".
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        ipVersion:
+                          description: IPVersion is an optional field that restricts the
+                            rule to only match a specific IP version.
+                          type: integer
+                        metadata:
+                          description: Metadata contains additional information for this
+                            rule
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a set of key value pairs that
+                                give extra information about the rule
+                              type: object
+                          type: object
+                        notICMP:
+                          description: NotICMP is the negated version of the ICMP field.
+                          properties:
+                            code:
+                              description: Match on a specific ICMP code.  If specified,
+                                the Type value must also be specified. This is a technical
+                                limitation imposed by the kernel's iptables firewall,
+                                which Calico uses to enforce the rule.
+                              type: integer
+                            type:
+                              description: Match on a specific ICMP type.  For example
+                                a value of 8 refers to ICMP Echo Request (i.e. pings).
+                              type: integer
+                          type: object
+                        notProtocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: NotProtocol is the negated version of the Protocol
+                            field.
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: "Protocol is an optional field that restricts the
+                            rule to only apply to traffic of a specific IP protocol. Required
+                            if any of the EntityRules contain Ports (because ports only
+                            apply to certain protocols). \n Must be one of these string
+                            values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                            \"UDPLite\" or an integer in the range 1-255."
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        source:
+                          description: Source contains the match criteria that apply to
+                            source entity.
+                          properties:
+                            namespaceSelector:
+                              description: "NamespaceSelector is an optional field that
+                                contains a selector expression. Only traffic that originates
+                                from (or terminates at) endpoints within the selected
+                                namespaces will be matched. When both NamespaceSelector
+                                and another selector are defined on the same rule, then
+                                only workload endpoints that are matched by both selectors
+                                will be selected by the rule. \n For NetworkPolicy, an
+                                empty NamespaceSelector implies that the Selector is limited
+                                to selecting only workload endpoints in the same namespace
+                                as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                                NamespaceSelector implies that the Selector is limited
+                                to selecting only GlobalNetworkSet or HostEndpoint. \n
+                                For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                                the Selector applies to workload endpoints across all
+                                namespaces."
+                              type: string
+                            nets:
+                              description: Nets is an optional field that restricts the
+                                rule to only apply to traffic that originates from (or
+                                terminates at) IP addresses in any of the given subnets.
+                              items:
+                                type: string
+                              type: array
+                            notNets:
+                              description: NotNets is the negated version of the Nets
+                                field.
+                              items:
+                                type: string
+                              type: array
+                            notPorts:
+                              description: NotPorts is the negated version of the Ports
+                                field. Since only some protocols have ports, if any ports
+                                are specified it requires the Protocol match in the Rule
+                                to be set to "TCP" or "UDP".
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            notSelector:
+                              description: NotSelector is the negated version of the Selector
+                                field.  See Selector field for subtleties with negated
+                                selectors.
+                              type: string
+                            ports:
+                              description: "Ports is an optional field that restricts
+                                the rule to only apply to traffic that has a source (destination)
+                                port that matches one of these ranges/values. This value
+                                is a list of integers or strings that represent ranges
+                                of ports. \n Since only some protocols have ports, if
+                                any ports are specified it requires the Protocol match
+                                in the Rule to be set to \"TCP\" or \"UDP\"."
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^.*
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            selector:
+                              description: "Selector is an optional field that contains
+                                a selector expression (see Policy for sample syntax).
+                                \ Only traffic that originates from (terminates at) endpoints
+                                matching the selector will be matched. \n Note that: in
+                                addition to the negated version of the Selector (see NotSelector
+                                below), the selector expression syntax itself supports
+                                negation.  The two types of negation are subtly different.
+                                One negates the set of matched endpoints, the other negates
+                                the whole match: \n \tSelector = \"!has(my_label)\" matches
+                                packets that are from other Calico-controlled \tendpoints
+                                that do not have the label \"my_label\". \n \tNotSelector
+                                = \"has(my_label)\" matches packets that are not from
+                                Calico-controlled \tendpoints that do have the label \"my_label\".
+                                \n The effect is that the latter will accept packets from
+                                non-Calico sources whereas the former is limited to packets
+                                from Calico-controlled endpoints."
+                              type: string
+                            serviceAccounts:
+                              description: ServiceAccounts is an optional field that restricts
+                                the rule to only apply to traffic that originates from
+                                (or terminates at) a pod running as a matching service
+                                account.
+                              properties:
+                                names:
+                                  description: Names is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account whose name is in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: Selector is an optional field that restricts
+                                    the rule to only apply to traffic that originates
+                                    from (or terminates at) a pod running as a service
+                                    account that matches the given label selector. If
+                                    both Names and Selector are specified then they are
+                                    AND'ed.
+                                  type: string
+                              type: object
+                            services:
+                              description: "Services is an optional field that contains
+                                options for matching Kubernetes Services. If specified,
+                                only traffic that originates from or terminates at endpoints
+                                within the selected service(s) will be matched, and only
+                                to/from each endpoint's port. \n Services cannot be specified
+                                on the same rule as Selector, NotSelector, NamespaceSelector,
+                                Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                                can only be specified with Services on ingress rules."
+                              properties:
+                                name:
+                                  description: Name specifies the name of a Kubernetes
+                                    Service to match.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies the namespace of the
+                                    given Service. If left empty, the rule will match
+                                    within this policy's namespace.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  order:
+                    description: Order is an optional field that specifies the order in
+                      which the policy is applied. Policies with higher "order" are applied
+                      after those with lower order.  If the order is omitted, it may be
+                      considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                      with identical order will be applied in alphanumerical order based
+                      on the Policy "Name".
+                    type: number
+                  selector:
+                    description: "The selector is an expression used to pick pick out
+                      the endpoints that the policy should be applied to. \n Selector
+                      expressions follow this syntax: \n \tlabel == \"string_literal\"
+                      \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                      \  ->  not equal; also matches if label is not present \tlabel in
+                      { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                      one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                      ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                      \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                      -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                      || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                      or the empty selector -> matches all endpoints. \n Label names are
+                      allowed to contain alphanumerics, -, _ and /. String literals are
+                      more permissive but they do not support escape characters. \n Examples
+                      (with made-up labels): \n \ttype == \"webserver\" && deployment
+                      == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                      \"dev\" \t! has(label_name)"
+                    type: string
+                  serviceAccountSelector:
+                    description: ServiceAccountSelector is an optional field for an expression
+                      used to select a pod based on service accounts.
+                    type: string
+                  types:
+                    description: "Types indicates whether this policy applies to ingress,
+                      or to egress, or to both.  When not explicitly specified (and so
+                      the value on creation is empty or nil), Calico defaults Types according
+                      to what Ingress and Egress are present in the policy.  The default
+                      is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                      the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                      ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                      PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                      \n When the policy is read back again, Types will always be one
+                      of these values, never empty or nil."
+                    items:
+                      description: PolicyType enumerates the possible values of the PolicySpec
+                        Types field.
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networksets.crd.projectcalico.org
+    spec:
+      group: crd.projectcalico.org
+      names:
+        kind: NetworkSet
+        listKind: NetworkSetList
+        plural: networksets
+        singular: networkset
+      scope: Namespaced
+      versions:
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: NetworkSetSpec contains the specification for a NetworkSet
+                  resource.
+                properties:
+                  nets:
+                    description: The list of IP networks that belong to this set.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-kube-controllers
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ipreservations
+      verbs:
+      - list
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - hostendpoints
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - clusterinformations
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - kubecontrollersconfigurations
+      verbs:
+      - get
+      - create
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: calico-node
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - namespaces
+      verbs:
+      - get
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - watch
+      - list
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - patch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipreservations
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      - caliconodestatuses
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - caliconodestatuses
+      verbs:
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - bgpconfigurations
+      - bgppeers
+      verbs:
+      - create
+      - update
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - ipamconfigs
+      verbs:
+      - get
+    - apiGroups:
+      - crd.projectcalico.org
+      resources:
+      - blockaffinities
+      verbs:
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - daemonsets
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-kube-controllers
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      calico_backend: vxlan
+      cni_network_config: |-
+        {
+          "name": "k8s-pod-network",
+          "cniVersion": "0.3.1",
+          "plugins": [
+            {
+              "type": "calico",
+              "log_level": "info",
+              "log_file_path": "/var/log/calico/cni/cni.log",
+              "datastore_type": "kubernetes",
+              "nodename": "__KUBERNETES_NODE_NAME__",
+              "mtu": __CNI_MTU__,
+              "ipam": {
+                  "type": "calico-ipam"
+              },
+              "policy": {
+                  "type": "k8s"
+              },
+              "kubernetes": {
+                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              }
+            },
+            {
+              "type": "portmap",
+              "snat": true,
+              "capabilities": {"portMappings": true}
+            },
+            {
+              "type": "bandwidth",
+              "capabilities": {"bandwidth": true}
+            }
+          ]
+        }
+      typha_service_name: none
+      veth_mtu: "1350"
+    kind: ConfigMap
+    metadata:
+      name: calico-config
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-kube-controllers
+          name: calico-kube-controllers
+          namespace: kube-system
+        spec:
+          containers:
+          - env:
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            image: docker.io/calico/kube-controllers:v3.23.0
+            livenessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -l
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-kube-controllers
+            readinessProbe:
+              exec:
+                command:
+                - /usr/bin/check-status
+                - -r
+              periodSeconds: 10
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: calico-kube-controllers
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+    ---
+    apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+      name: calico-kube-controllers
+      namespace: kube-system
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: calico-node
+      name: calico-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+        spec:
+          containers:
+          - env:
+            - name: FELIX_FEATUREDETECTOVERRIDE
+              value: ChecksumOffloadBroken=true
+            - name: CALICO_IPV4POOL_VXLAN
+              value: Always
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            - name: CLUSTER_TYPE
+              value: k8s,bgp
+            - name: IP
+              value: autodetect
+            - name: CALICO_IPV4POOL_IPIP
+              value: Never
+            - name: CALICO_IPV6POOL_VXLAN
+              value: CrossSubnet
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: FELIX_WIREGUARDMTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: ACCEPT
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/node:v3.23.0
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -shutdown
+            livenessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-live
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: calico-node
+            readinessProbe:
+              exec:
+                command:
+                - /bin/calico-node
+                - -felix-ready
+              periodSeconds: 10
+              timeoutSeconds: 10
+            resources:
+              requests:
+                cpu: 250m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /var/run/nodeagent
+              name: policysync
+            - mountPath: /sys/fs/
+              mountPropagation: Bidirectional
+              name: sysfs
+            - mountPath: /var/log/calico/cni
+              name: cni-log-dir
+              readOnly: true
+          hostNetwork: true
+          initContainers:
+          - command:
+            - /opt/cni/bin/calico-ipam
+            - -upgrade
+            env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  key: calico_backend
+                  name: calico-config
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.23.0
+            name: upgrade-ipam
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          - command:
+            - /opt/cni/bin/install
+            env:
+            - name: CNI_CONF_NAME
+              value: 10-calico.conflist
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  key: cni_network_config
+                  name: calico-config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  key: veth_mtu
+                  name: calico-config
+            - name: SLEEP
+              value: "false"
+            envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+            image: docker.io/calico/cni:v3.23.0
+            name: install-cni
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: calico-node
+          terminationGracePeriodSeconds: 0
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /lib/modules
+            name: lib-modules
+          - hostPath:
+              path: /var/run/calico
+            name: var-run-calico
+          - hostPath:
+              path: /var/lib/calico
+            name: var-lib-calico
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+          - hostPath:
+              path: /sys/fs/
+              type: DirectoryOrCreate
+            name: sysfs
+          - hostPath:
+              path: /opt/cni/bin
+            name: cni-bin-dir
+          - hostPath:
+              path: /etc/cni/net.d
+            name: cni-net-dir
+          - hostPath:
+              path: /var/log/calico/cni
+            name: cni-log-dir
+          - hostPath:
+              path: /var/lib/cni/networks
+            name: host-local-net-dir
+          - hostPath:
+              path: /var/run/nodeagent
+              type: DirectoryOrCreate
+            name: policysync
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
+  windows-cni: "# strictAffinity required for windows\napiVersion: crd.projectcalico.org/v1\nkind:
+    IPAMConfig\nmetadata:\n  name: default\nspec:\n  autoAllocateBlocks: true\n  strictAffinity:
+    true\n---\nkind: ConfigMap\napiVersion: v1\nmetadata:\n  name: calico-static-rules\n
+    \ namespace: kube-system\n  labels:\n    tier: node\n    app: calico\ndata:\n
+    \ static-rules.json: |\n    {\n      \"Provider\": \"azure\",\n      \"Version\":
+    \"0.1\",\n      \"Rules\": [\n        {\n          \"Name\": \"EndpointPolicy\",\n
+    \         \"Rule\": {\n              \"Id\": \"wireserver\",\n              \"Type\":
+    \"ACL\",\n              \"Protocol\": 6,\n              \"Action\": \"Block\",\n
+    \             \"Direction\": \"Out\",\n              \"RemoteAddresses\": \"168.63.129.16/32\",\n
+    \             \"RemotePorts\": \"80\",\n              \"Priority\": 200,\n              \"RuleType\":
+    \"Switch\"\n            }\n          }\n      ]\n    } \n---\nkind: ConfigMap\napiVersion:
+    v1\nmetadata:\n  name: calico-config-windows\n  namespace: kube-system\n  labels:\n
+    \   tier: node\n    app: calico\ndata:\n  veth_mtu: \"1350\"\n  \n  cni_network_config:
+    |\n    {\n      \"name\": \"Calico\",\n      \"cniVersion\": \"0.3.1\",\n      \"plugins\":
+    [\n        {\n          \"windows_use_single_network\": true,\n          \"type\":
+    \"calico\",\n          \"mode\": \"vxlan\",\n          \"nodename\": \"__KUBERNETES_NODE_NAME__\",\n
+    \         \"nodename_file_optional\": true,\n          \"log_file_path\": \"c:/cni.log\",\n
+    \         \"log_level\": \"debug\",\n\n          \"vxlan_mac_prefix\": \"0E-2A\",\n
+    \         \"vxlan_vni\": 4096,\n          \"mtu\": __CNI_MTU__,\n          \"policy\":
+    {\n            \"type\": \"k8s\"\n          },\n\n          \"log_level\": \"info\",\n\n
+    \         \"capabilities\": {\"dns\": true},\n          \"DNS\":  {\n            \"Search\":
+    \ [\n              \"svc.cluster.local\"\n            ]\n          },\n\n          \"datastore_type\":
+    \"kubernetes\",\n\n          \"kubernetes\": {\n            \"kubeconfig\": \"__KUBECONFIG_FILEPATH__\"\n
+    \         },\n\n          \"ipam\": {\n            \"type\": \"calico-ipam\",\n
+    \           \"subnet\": \"usePodCidr\"\n          },\n\n          \"policies\":
+    \ [\n            {\n              \"Name\":  \"EndpointPolicy\",\n              \"Value\":
+    \ {\n                \"Type\":  \"OutBoundNAT\",\n                \"ExceptionList\":
+    \ [\n                  \"__K8S_SERVICE_CIDR__\"\n                ]\n              }\n
+    \           },\n            {\n              \"Name\":  \"EndpointPolicy\",\n
+    \             \"Value\":  {\n                \"Type\":  \"SDNROUTE\",\n                \"DestinationPrefix\":
+    \ \"__K8S_SERVICE_CIDR__\",\n                \"NeedEncap\":  true\n              }\n
+    \           }\n          ]\n        }\n      ]\n\n    }\n---\napiVersion: apps/v1\nkind:
+    DaemonSet\nmetadata:\n  name: calico-node-windows\n  labels:\n    tier: node\n
+    \   app: calico\n  namespace: kube-system\nspec:\n  selector:\n    matchLabels:\n
+    \     app: calico\n  template:\n    metadata:\n      labels:\n        tier: node\n
+    \       app: calico\n    spec:\n      affinity:\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n
+    \           nodeSelectorTerms:\n              - matchExpressions:\n                  -
+    key: kubernetes.io/os\n                    operator: In\n                    values:\n
+    \                     - windows\n                  - key: kubernetes.io/arch\n
+    \                   operator: In\n                    values:\n                      -
+    amd64\n      securityContext:\n        windowsOptions:\n          hostProcess:
+    true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
+    true\n      serviceAccountName: calico-node\n      tolerations:\n      - operator:
+    Exists\n        effect: NoSchedule\n        # Mark the pod as a critical add-on
+    for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
+    \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
+    This container installs the CNI binaries\n        # and CNI network config file
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.23.0-hostprocess\n
+    \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
+    \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
+    config file to create.\n            - name: CNI_CONF_NAME\n              value:
+    \"10-calico.conflist\"\n            # The CNI network config to install on each
+    node.\n            - name: CNI_NETWORK_CONFIG\n              valueFrom:\n                configMapKeyRef:\n
+    \                 name: calico-config-windows\n                  key: cni_network_config\n
+    \           # Set the hostname based on the k8s node name.\n            - name:
+    KUBERNETES_NODE_NAME\n              valueFrom:\n                fieldRef:\n                  fieldPath:
+    spec.nodeName\n            # CNI MTU Config variable\n            - name: CNI_MTU\n
+    \             valueFrom:\n                configMapKeyRef:\n                  name:
+    calico-config-windows\n                  key: veth_mtu\n            # Prevents
+    the container from sleeping forever.\n            - name: SLEEP\n              value:
+    \"false\"\n            - name: K8S_SERVICE_CIDR\n              value: \"10.96.0.0/12\"\n
+    \         volumeMounts:\n            - mountPath: /host/opt/cni/bin\n              name:
+    cni-bin-dir\n            - mountPath: /host/etc/cni/net.d\n              name:
+    cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
+    \         securityContext:\n            windowsOptions:\n              hostProcess:
+    true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.23.0-hostprocess\n
+    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
+    \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
+    Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
+    /etc/kube-calico-windows/\n        env:\n        - name: POD_NAME\n          valueFrom:\n
+    \           fieldRef:\n              apiVersion: v1\n              fieldPath:
+    metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n            fieldRef:\n
+    \             apiVersion: v1\n              fieldPath: metadata.namespace\n        -
+    name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
+    \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
+    \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
+    \       image: sigwindowstools/calico-node:v3.23.0-hostprocess\n        args:
+    [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
+    Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
+    \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n
+    \       - name: calico-static-rules\n          mountPath: /calico/static-rules.json\n
+    \         subPath: static-rules.json\n        env:\n        - name: POD_NAME\n
+    \         valueFrom:\n            fieldRef:\n              apiVersion: v1\n              fieldPath:
+    metadata.name\n        - name: POD_NAMESPACE\n          valueFrom:\n            fieldRef:\n
+    \             apiVersion: v1\n              fieldPath: metadata.namespace\n        -
+    name: VXLAN_VNI\n          value: \"4096\"\n        - name: KUBECONFIG\n          value:
+    \"C:/etc/cni/net.d/calico-kubeconfig\"\n      volumes:\n      - name: calico-config-windows\n
+    \       configMap:\n          name: calico-config-windows\n      - name: calico-static-rules\n
+    \       configMap:\n          name: calico-static-rules\n      # Used to install
+    CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
+    \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
+    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
+kind: ConfigMap
+metadata:
+  annotations:
+    note: generated
+  labels:
+    type: generated
+  name: cni-${CLUSTER_NAME}-calico
+  namespace: default
+---
+apiVersion: v1
+data:
+  csi-proxy: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: csi-proxy
+      name: csi-proxy
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: csi-proxy
+      template:
+        metadata:
+          labels:
+            k8s-app: csi-proxy
+        spec:
+          nodeSelector:
+            "kubernetes.io/os": windows
+          securityContext:
+            windowsOptions:
+              hostProcess: true
+              runAsUserName: "NT AUTHORITY\\SYSTEM"
+          hostNetwork: true
+          containers:
+            - name: csi-proxy
+              image: ghcr.io/kubernetes-sigs/sig-windows/csi-proxy:v1.0.2
+kind: ConfigMap
+metadata:
+  annotations:
+    note: generated
+  labels:
+    type: generated
+  name: csi-proxy-addon
+  namespace: default
+---
+apiVersion: v1
+data:
+  containerd-windows-logger: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: containerd-logger
+      name: containerd-logger
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: containerd-logger
+      template:
+        metadata:
+          labels:
+            k8s-app: containerd-logger
+        spec:
+          securityContext:
+            windowsOptions:
+              hostProcess: true
+              runAsUserName: "NT AUTHORITY\\system"
+          hostNetwork: true
+          containers:
+          - image: ghcr.io/kubernetes-sigs/sig-windows/eventflow-logger:v0.1.0
+            args: [ "config.json" ]
+            name: containerd-logger
+            imagePullPolicy: Always
+            volumeMounts:
+            - name: containerd-logger-config
+              mountPath: /config.json
+              subPath: config.json
+          nodeSelector:
+            kubernetes.io/os: windows
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - operator: Exists
+          volumes:
+          - configMap:
+              name: containerd-logger-config
+            name: containerd-logger-config
+      updateStrategy:
+        type: RollingUpdate
+    ---
+    kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: containerd-logger-config
+      namespace: kube-system
+    data:
+      config.json: |
+        {
+          "inputs": [
+            {
+              "type": "ETW",
+              "sessionNamePrefix": "containerd",
+              "cleanupOldSessions": true,
+              "reuseExistingSession": true,
+              "providers": [
+                {
+                  "providerName": "Microsoft.Virtualization.RunHCS",
+                  "providerGuid": "0B52781F-B24D-5685-DDF6-69830ED40EC3",
+                  "level": "Verbose"
+                },
+                {
+                  "providerName": "ContainerD",
+                  "providerGuid": "2acb92c0-eb9b-571a-69cf-8f3410f383ad",
+                  "level": "Verbose"
+                }
+              ]
+            }
+          ],
+          "filters": [
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == Stats && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == hcsshim::LayerID && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == hcsshim::NameToGuid && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == containerd.task.v2.Task.Stats && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == containerd.task.v2.Task.State && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == HcsGetProcessProperties && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == HcsGetComputeSystemProperties && hasnoproperty error"
+            }
+          ],
+          "outputs": [
+            {
+              "type": "StdOutput"
+            }
+          ],
+          "schemaVersion": "2016-08-11"
+        }
+kind: ConfigMap
+metadata:
+  annotations:
+    note: generated
+  labels:
+    type: generated
+  name: containerd-logger-${CLUSTER_NAME}
+  namespace: default
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: metrics-server-${CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      metrics-server: enabled
+  resources:
+  - kind: ConfigMap
+    name: metrics-server-${CLUSTER_NAME}
+  strategy: ApplyOnce
+---
+apiVersion: v1
+data:
+  metrics-server: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: metrics-server
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        k8s-app: metrics-server
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        rbac.authorization.k8s.io/aggregate-to-edit: "true"
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+      name: system:aggregated-metrics-reader
+    rules:
+    - apiGroups:
+      - metrics.k8s.io
+      resources:
+      - pods
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: system:metrics-server
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - nodes/stats
+      - namespaces
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: metrics-server-auth-reader
+      namespace: kube-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: extension-apiserver-authentication-reader
+    subjects:
+    - kind: ServiceAccount
+      name: metrics-server
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: metrics-server:system:auth-delegator
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:auth-delegator
+    subjects:
+    - kind: ServiceAccount
+      name: metrics-server
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: system:metrics-server
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:metrics-server
+    subjects:
+    - kind: ServiceAccount
+      name: metrics-server
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: metrics-server
+      namespace: kube-system
+    spec:
+      ports:
+      - name: https
+        port: 443
+        protocol: TCP
+        targetPort: https
+      selector:
+        k8s-app: metrics-server
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: metrics-server
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: metrics-server
+      strategy:
+        rollingUpdate:
+          maxUnavailable: 0
+      template:
+        metadata:
+          labels:
+            k8s-app: metrics-server
+        spec:
+          containers:
+          - args:
+            - --cert-dir=/tmp
+            - --secure-port=4443
+            - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+            - --kubelet-use-node-status-port
+            - --metric-resolution=15s
+            - --kubelet-insecure-tls
+            image: k8s.gcr.io/metrics-server/metrics-server:v0.5.2
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /livez
+                port: https
+                scheme: HTTPS
+              periodSeconds: 10
+            name: metrics-server
+            ports:
+            - containerPort: 4443
+              name: https
+              protocol: TCP
+            readinessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /readyz
+                port: https
+                scheme: HTTPS
+              initialDelaySeconds: 20
+              periodSeconds: 10
+            resources:
+              requests:
+                cpu: 100m
+                memory: 200Mi
+            securityContext:
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 1000
+            volumeMounts:
+            - mountPath: /tmp
+              name: tmp-dir
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: metrics-server
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
+          volumes:
+          - emptyDir: {}
+            name: tmp-dir
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: v1beta1.metrics.k8s.io
+    spec:
+      group: metrics.k8s.io
+      groupPriorityMinimum: 100
+      insecureSkipTLSVerify: true
+      service:
+        name: metrics-server
+        namespace: kube-system
+      version: v1beta1
+      versionPriority: 100
+kind: ConfigMap
+metadata:
+  annotations:
+    note: generated
+  labels:
+    type: generated
+  name: metrics-server-${CLUSTER_NAME}
+  namespace: default

--- a/templates/test/ci/prow-external-cloud-provider-ci-version/kustomization.yaml
+++ b/templates/test/ci/prow-external-cloud-provider-ci-version/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ../prow-ci-version
+patchesStrategicMerge:
+  - ../../../flavors/external-cloud-provider/patches/external-cloud-provider.yaml


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR adds a new `external-cloud-provider-ci-version` prow template to accommodate building out-of-tree cloud-provider-azure clusters running the latest release bits of Kubernetes.

Changes to `ci-entrypoint.sh` should be evaluated for back-compat with existing usage.

After this is merged, we want to cherry-pick into release-1.3 ASAP.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
