### PR TITLE
Stop setting image repo list for Windows test passes for K8s v1.25+

### DIFF
--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -203,10 +203,11 @@ var _ = Describe("Conformance Tests", func() {
 			err = node.TaintNode(workloadProxy.GetClientSet(), options, noScheduleTaint)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Windows requires a repo-list because some images are not in k8s gcr
+			// Windows requires a repo-list when running e2e tests against K8s versions prior to v1.25
+			// because some test images published to the k8s gcr do not have Windows flavors.
 			repoList, err = resolveKubetestRepoListPath(kubernetesVersion, kubetestRepoListPath)
 			Expect(err).NotTo(HaveOccurred())
-			fmt.Fprintf(GinkgoWriter, "INFO: Using repo-list %s for version %s\n", repoList, kubernetesVersion)
+			fmt.Fprintf(GinkgoWriter, "INFO: Using repo-list '%s' for version '%s'\n", repoList, kubernetesVersion)
 		}
 
 		ginkgoNodes, err := strconv.Atoi(e2eConfig.GetVariable("CONFORMANCE_NODES"))


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Starting with K8s v1.25 we should no longer be setting specifying a repo list for Windows e2e test passes because all of the test images now container windows flavors. 

Prior to v1.24 the etcd test image was needed for Windows tests but did not container a Windows flavor so an alternate image was hosted at k8sprow.azurecr.io

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I tried to structure this PR in such a way that custom image repo lists could still be used for v1.25+ clusters.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Stop setting repo-list for K8s v1.25+ Windows conformance test passes
```
