### PR TITLE
Update subnet CIDRs when reconciling existing vnet

### DIFF
--- a/azure/converters/subnets.go
+++ b/azure/converters/subnets.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package converters
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+func GetSubnetAddresses(subnet network.Subnet) []string {
+	var addresses []string
+	if subnet.SubnetPropertiesFormat != nil && subnet.SubnetPropertiesFormat.AddressPrefix != nil {
+		addresses = []string{to.String(subnet.SubnetPropertiesFormat.AddressPrefix)}
+	} else if subnet.SubnetPropertiesFormat != nil && subnet.SubnetPropertiesFormat.AddressPrefixes != nil {
+		addresses = to.StringSlice(subnet.SubnetPropertiesFormat.AddressPrefixes)
+	}
+	return addresses
+}

--- a/azure/converters/subnets_test.go
+++ b/azure/converters/subnets_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package converters
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/gomega"
+)
+
+func TestGetSubnetAddresses(t *testing.T) {
+	tests := []struct {
+		name   string
+		subnet network.Subnet
+		want   []string
+	}{
+		{
+			name:   "nil properties subnet",
+			subnet: network.Subnet{},
+		},
+		{
+			name: "subnet with single address prefix",
+			subnet: network.Subnet{
+				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+					AddressPrefix: to.StringPtr("test-address-prefix"),
+				},
+			},
+			want: []string{"test-address-prefix"},
+		},
+		{
+			name: "subnet with multiple address prefixes",
+			subnet: network.Subnet{
+				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+					AddressPrefixes: &[]string{"test-address-prefix-1", "test-address-prefix-2"},
+				},
+			},
+			want: []string{"test-address-prefix-1", "test-address-prefix-2"},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+			got := GetSubnetAddresses(tt.subnet)
+			g.Expect(got).To(Equal(tt.want), fmt.Sprintf("got: %v, want: %v", got, tt.want))
+		})
+	}
+}

--- a/azure/services/subnets/subnets.go
+++ b/azure/services/subnets/subnets.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
@@ -89,15 +90,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			if !ok {
 				return errors.Errorf("%T is not a network.Subnet", result)
 			}
-			var addresses []string
-			if subnet.SubnetPropertiesFormat != nil && subnet.SubnetPropertiesFormat.AddressPrefix != nil {
-				addresses = []string{to.String(subnet.SubnetPropertiesFormat.AddressPrefix)}
-			} else if subnet.SubnetPropertiesFormat != nil && subnet.SubnetPropertiesFormat.AddressPrefixes != nil {
-				addresses = to.StringSlice(subnet.SubnetPropertiesFormat.AddressPrefixes)
-			}
-
 			s.Scope.UpdateSubnetID(subnetSpec.ResourceName(), to.String(subnet.ID))
-			s.Scope.UpdateSubnetCIDRs(subnetSpec.ResourceName(), addresses)
+			s.Scope.UpdateSubnetCIDRs(subnetSpec.ResourceName(), converters.GetSubnetAddresses(subnet))
 		}
 	}
 

--- a/azure/services/virtualnetworks/mock_virtualnetworks/virtualnetworks_mock.go
+++ b/azure/services/virtualnetworks/mock_virtualnetworks/virtualnetworks_mock.go
@@ -267,6 +267,18 @@ func (mr *MockVNetScopeMockRecorder) UpdatePutStatus(arg0, arg1, arg2 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePutStatus", reflect.TypeOf((*MockVNetScope)(nil).UpdatePutStatus), arg0, arg1, arg2)
 }
 
+// UpdateSubnetCIDRs mocks base method.
+func (m *MockVNetScope) UpdateSubnetCIDRs(arg0 string, arg1 []string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateSubnetCIDRs", arg0, arg1)
+}
+
+// UpdateSubnetCIDRs indicates an expected call of UpdateSubnetCIDRs.
+func (mr *MockVNetScopeMockRecorder) UpdateSubnetCIDRs(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubnetCIDRs", reflect.TypeOf((*MockVNetScope)(nil).UpdateSubnetCIDRs), arg0, arg1)
+}
+
 // VNetSpec mocks base method.
 func (m *MockVNetScope) VNetSpec() azure.ResourceSpecGetter {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This fixes an edge case scenario where the user specifies an existing BYO vnet along with subnets without specifying CIDR ranges. CAPZ will fill out the details in the controller when doing a GET of the existing vnet/subnet. However, in the case that the controller returns in between those reconciling the vnet and the subnets, which it often does as we reconcile resources async, it will attempt to patch the object with the updated vnet CIDR but the wrong defaulted subnet CIDRs, which results in a validation error similar to: `"validation.azurecluster.infrastructure.cluster.x-k8s.io" denied the request: AzureCluster.infrastructure.cluster.x-k8s.io "efreed-workload1" is invalid: [spec.networkSpec.subnets[0].cidrBlocks: Invalid value: "10.0.0.0/16": subnet CIDR not in vnet address space: [10.22.128.0/22], `.

This updates the reconciler code to update both vnet and subnet CIDR ranges together when an existing VNet with subnets matching the defined subnet names is found.

Thanks @evanfreed for reporting the issue.

slack thread: https://kubernetes.slack.com/archives/CEX9HENG7/p1653600096205839

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update subnet CIDRs when reconciling existing vnet
```
