### PR TITLE
ci: fixing issue where WINDOWS_SERVER_VERSION does not work for cluster-template-prow-ci-version templates

### DIFF
--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -111,6 +111,8 @@ select_cluster_template() {
             export CLUSTER_TEMPLATE="${CLUSTER_TEMPLATE/custom-builds/custom-builds-machine-pool}"
         fi
     fi
+
+    echo "Using cluster template: ${CLUSTER_TEMPLATE}"
 }
 
 create_cluster() {

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -412,7 +412,7 @@ spec:
         marketplace:
           offer: capi-windows
           publisher: cncf-upstream
-          sku: k8s-1dot23dot3-windows-2019-containerd
+          sku: k8s-1dot23dot3-${WINDOWS_SERVER_VERSION:=windows-2019}-containerd
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
@@ -413,7 +413,7 @@ spec:
         marketplace:
           offer: capi-windows
           publisher: cncf-upstream
-          sku: k8s-1dot23dot3-windows-2019-containerd
+          sku: k8s-1dot23dot3-${WINDOWS_SERVER_VERSION:=windows-2019}-containerd
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version-windows.yaml
+++ b/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version-windows.yaml
@@ -11,6 +11,6 @@ spec:
         marketplace:
           publisher: cncf-upstream
           offer: capi-windows
-          sku: k8s-1dot23dot3-windows-2019-containerd
+          sku: k8s-1dot23dot3-${WINDOWS_SERVER_VERSION:=windows-2019}-containerd
           version: "latest"
 


### PR DESCRIPTION


Signed-off-by: Mark Rossetti <marosset@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature

/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Recently several CI jobs that test Windows Server 2022 were switched from using `KUBERNETES_VERSION=v1.23.5` to `KUBERNETES_VERSION=latest-1.23` which caused the cluster template to switch from `cluster-template-prow.yaml` to `cluster-template-prow-ci-version.yaml.

`cluster-template-prow-ci-version.yaml` has a [hard-coded image](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/65beee0ebbb92095832ddb3f6a75bbbae9365040/templates/test/ci/cluster-template-prow-ci-version.yaml#L397-L423) which caused the defaulting logic that uses `WINDOWS_SERVER_VERSION` to not run.

This change allows `cluster-template-prow-ci-version.yaml` templates to provision either Windows Server 2019 or Windows Server 2022 machines if `WINDOWS_SERVER_VERSION` is set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
