### PR TITLE
Add Name and owner tags to NGWs

### DIFF
--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -267,9 +267,11 @@ func (s *ClusterScope) NatGatewaySpecs() []azure.ResourceSpecGetter {
 					ResourceGroup:  s.ResourceGroup(),
 					SubscriptionID: s.SubscriptionID(),
 					Location:       s.Location(),
+					ClusterName:    s.ClusterName(),
 					NatGatewayIP: infrav1.PublicIPSpec{
 						Name: subnet.NatGateway.NatGatewayIP.Name,
 					},
+					AdditionalTags: s.AdditionalTags(),
 				})
 			}
 		}

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -685,6 +685,11 @@ func TestNatGatewaySpecs(t *testing.T) {
 		{
 			name: "returns specified node NAT gateway if present",
 			clusterScope: ClusterScope{
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-cluster",
+					},
+				},
 				AzureClients: AzureClients{
 					EnvironmentSettings: auth.EnvironmentSettings{
 						Values: map[string]string{
@@ -728,15 +733,22 @@ func TestNatGatewaySpecs(t *testing.T) {
 					ResourceGroup:  "my-rg",
 					Location:       "centralIndia",
 					SubscriptionID: "123",
+					ClusterName:    "my-cluster",
 					NatGatewayIP: infrav1.PublicIPSpec{
 						Name: "44.78.67.90",
 					},
+					AdditionalTags: make(infrav1.Tags),
 				},
 			},
 		},
 		{
 			name: "returns specified node NAT gateway if present and ignores duplicate",
 			clusterScope: ClusterScope{
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-cluster",
+					},
+				},
 				AzureClients: AzureClients{
 					EnvironmentSettings: auth.EnvironmentSettings{
 						Values: map[string]string{
@@ -798,15 +810,22 @@ func TestNatGatewaySpecs(t *testing.T) {
 					ResourceGroup:  "my-rg",
 					Location:       "centralIndia",
 					SubscriptionID: "123",
+					ClusterName:    "my-cluster",
 					NatGatewayIP: infrav1.PublicIPSpec{
 						Name: "44.78.67.90",
 					},
+					AdditionalTags: make(infrav1.Tags),
 				},
 			},
 		},
 		{
 			name: "returns specified node NAT gateway if present and ignores control plane nat gateway",
 			clusterScope: ClusterScope{
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-cluster",
+					},
+				},
 				AzureClients: AzureClients{
 					EnvironmentSettings: auth.EnvironmentSettings{
 						Values: map[string]string{
@@ -867,9 +886,11 @@ func TestNatGatewaySpecs(t *testing.T) {
 					ResourceGroup:  "my-rg",
 					Location:       "centralIndia",
 					SubscriptionID: "123",
+					ClusterName:    "my-cluster",
 					NatGatewayIP: infrav1.PublicIPSpec{
 						Name: "44.78.67.90",
 					},
+					AdditionalTags: make(infrav1.Tags),
 				},
 			},
 		},

--- a/azure/services/natgateways/natgateways_test.go
+++ b/azure/services/natgateways/natgateways_test.go
@@ -45,6 +45,7 @@ var (
 		ResourceGroup:  "my-rg",
 		SubscriptionID: "my-sub",
 		Location:       "westus",
+		ClusterName:    "my-cluster",
 		NatGatewayIP:   infrav1.PublicIPSpec{Name: "pip-node-subnet"},
 	}
 	natGateway1 = network.NatGateway{

--- a/azure/services/natgateways/spec.go
+++ b/azure/services/natgateways/spec.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 )
 
 // NatGatewaySpec defines the specification for a NAT gateway.
@@ -32,6 +33,8 @@ type NatGatewaySpec struct {
 	SubscriptionID string
 	Location       string
 	NatGatewayIP   infrav1.PublicIPSpec
+	ClusterName    string
+	AdditionalTags infrav1.Tags
 }
 
 // ResourceName returns the name of the NAT gateway.
@@ -74,6 +77,12 @@ func (s *NatGatewaySpec) Parameters(existing interface{}) (params interface{}, e
 				},
 			},
 		},
+		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
+			ClusterName: s.ClusterName,
+			Lifecycle:   infrav1.ResourceLifecycleOwned,
+			Name:        to.StringPtr(s.Name),
+			Additional:  s.AdditionalTags,
+		})),
 	}
 
 	return natGatewayToCreate, nil


### PR DESCRIPTION
What type of PR is this?
Add Name and owner tags to NGWs created by CAPZ

/kind feature

What this PR does / why we need it:
Adds Name tag and sigs.k8s.io_cluster-api-provider-azure_cluster_clustername tag

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2369 

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Name and owner tags to NGWs
```
