### PR TITLE
Change all CI templates to use latest reference images

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -216,8 +216,8 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: k8s-1dot18dot8-ubuntu-1804
-          version: 2020.08.17
+          sku: ubuntu-1804-gen1
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -216,8 +216,8 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: k8s-1dot18dot8-ubuntu-1804
-          version: 2020.08.17
+          sku: ubuntu-1804-gen1
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
@@ -217,8 +217,8 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: k8s-1dot18dot8-ubuntu-1804
-          version: 2020.08.17
+          sku: ubuntu-1804-gen1
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -214,8 +214,8 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: k8s-1dot18dot8-ubuntu-1804
-          version: 2020.08.17
+          sku: ubuntu-1804-gen1
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux
@@ -262,8 +262,8 @@ spec:
       marketplace:
         offer: capi
         publisher: cncf-upstream
-        sku: k8s-1dot18dot8-ubuntu-1804
-        version: 2020.08.17
+        sku: ubuntu-1804-gen1
+        version: latest
     osDisk:
       diskSizeGB: 30
       managedDisk:
@@ -406,8 +406,8 @@ spec:
       marketplace:
         offer: capi-windows
         publisher: cncf-upstream
-        sku: k8s-1dot23dot1-windows-2019-containerd
-        version: 2021.12.16
+        sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
+        version: latest
     osDisk:
       diskSizeGB: 30
       managedDisk:

--- a/templates/test/ci/patches/control-plane-image-ci-version.yaml
+++ b/templates/test/ci/patches/control-plane-image-ci-version.yaml
@@ -6,10 +6,10 @@ spec:
   template:
     spec:
       image:
-        # we use the 1.18.8 image as a workaround there is no published marketplace image for k8s CI versions.
-        # 1.18.8 binaries and images will get replaced to the desired version by the script above.
+        # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
+        # latest binaries and images will get replaced to the desired version by the script above.
         marketplace:
           publisher: cncf-upstream
           offer: capi
-          sku: k8s-1dot18dot8-ubuntu-1804
-          version: "2020.08.17"
+          sku: ubuntu-1804-gen1
+          version: latest

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version-windows.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version-windows.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   template:
     image:
-      # we use the 1.23.1 image as a workaround there is no published marketplace image for k8s CI versions.
-      # 1.23.1 binaries and images will get replaced to the desired version by the script in this template.
+      # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
+      # latest binaries and images will get replaced to the desired version by the script in this template.
       marketplace:
         publisher: cncf-upstream
         offer: capi-windows
-        sku: k8s-1dot23dot1-windows-2019-containerd
-        version: "2021.12.16"
+        sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
+        version: latest

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -79,10 +79,10 @@ metadata:
 spec:
   template:
     image:
-      # we use the 1.18.8 image as a workaround there is no published marketplace image for k8s CI versions.
-      # 1.18.8 binaries and images will get replaced to the desired version by the script above.
+      # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
+      # latest binaries and images will get replaced to the desired version by the script above.
       marketplace:
         publisher: cncf-upstream
         offer: capi
-        sku: k8s-1dot18dot8-ubuntu-1804
-        version: "2020.08.17"
+        sku: ubuntu-1804-gen1
+        version: latest

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -208,8 +208,8 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: k8s-1dot18dot8-ubuntu-1804
-          version: 2020.08.17
+          sku: ubuntu-1804-gen1
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux
@@ -256,8 +256,8 @@ spec:
       marketplace:
         offer: capi
         publisher: cncf-upstream
-        sku: k8s-1dot18dot8-ubuntu-1804
-        version: 2020.08.17
+        sku: ubuntu-1804-gen1
+        version: latest
     osDisk:
       diskSizeGB: 30
       managedDisk:

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -210,8 +210,8 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: k8s-1dot18dot8-ubuntu-1804
-          version: 2020.08.17
+          sku: ubuntu-1804-gen1
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux
@@ -256,8 +256,8 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: k8s-1dot18dot8-ubuntu-1804
-          version: 2020.08.17
+          sku: ubuntu-1804-gen1
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux
@@ -355,7 +355,7 @@ spec:
         marketplace:
           offer: capi-windows
           publisher: cncf-upstream
-          sku: k8s-1dot23dot4-windows-2019-containerd
+          sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/dev/custom-builds-machine-pool/patches/custom-builds.yaml
+++ b/templates/test/dev/custom-builds-machine-pool/patches/custom-builds.yaml
@@ -42,10 +42,10 @@ metadata:
 spec:
   template:
     image:
-      # we use the 1.18.8 image as a workaround there is no published marketplace image for k8s CI versions.
-      # 1.18.8 binaries and images will get replaced to the desired version by the script above.
+      # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
+      # latest binaries and images will get replaced to the desired version by the script above.
       marketplace:
         publisher: cncf-upstream
         offer: capi
-        sku: k8s-1dot18dot8-ubuntu-1804
-        version: "2020.08.17"
+        sku: ubuntu-1804-gen1
+        version: latest

--- a/templates/test/dev/custom-builds/patches/machine-deployment-pr-version-windows.yaml
+++ b/templates/test/dev/custom-builds/patches/machine-deployment-pr-version-windows.yaml
@@ -7,10 +7,10 @@ spec:
   template:
     spec:
       image:
-        # we use the 1.18.19 image as a workaround there is no published marketplace image for k8s CI versions.
-        # 1.18.19 binaries and images will get replaced to the desired version by the script above.
+        # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
+        # latest binaries and images will get replaced to the desired version by the script above.
         marketplace:
           publisher: cncf-upstream
           offer: capi-windows
-          sku: k8s-1dot23dot4-windows-2019-containerd
-          version: "latest"
+          sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
+          version: latest

--- a/templates/test/dev/custom-builds/patches/machine-deployment-pr-version.yaml
+++ b/templates/test/dev/custom-builds/patches/machine-deployment-pr-version.yaml
@@ -6,13 +6,13 @@ spec:
   template:
     spec:
       image:
-        # we use the 1.18.8 image as a workaround there is no published marketplace image for k8s CI versions.
-        # 1.18.8 binaries and images will get replaced to the desired version by the script above.
+        # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
+        # latest binaries and images will get replaced to the desired version by the script above.
         marketplace:
           publisher: cncf-upstream
           offer: capi
-          sku: k8s-1dot18dot8-ubuntu-1804
-          version: "2020.08.17"
+          sku: ubuntu-1804-gen1
+          version: latest
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate
@@ -22,13 +22,13 @@ spec:
   template:
     spec:
       image:
-        # we use the 1.18.8 image as a workaround there is no published marketplace image for k8s CI versions.
-        # 1.18.8 binaries and images will get replaced to the desired version by the script above.
+        # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
+        # latest binaries and images will get replaced to the desired version by the script above.
         marketplace:
           publisher: cncf-upstream
           offer: capi
-          sku: k8s-1dot18dot8-ubuntu-1804
-          version: "2020.08.17"
+          sku: ubuntu-1804-gen1
+          version: latest
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane

--- a/templates/test/dev/patches/control-plane-custom-builds.yaml
+++ b/templates/test/dev/patches/control-plane-custom-builds.yaml
@@ -79,10 +79,10 @@ spec:
   template:
     spec:
       image:
-        # we use the 1.18.8 image as a workaround there is no published marketplace image for k8s CI versions.
-        # 1.18.8 binaries and images will get replaced to the desired version by the script above.
+        # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
+        # latest binaries and images will get replaced to the desired version by the script above.
         marketplace:
           publisher: cncf-upstream
           offer: capi
-          sku: k8s-1dot18dot8-ubuntu-1804
-          version: "2020.08.17"
+          sku: ubuntu-1804-gen1
+          version: latest


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This is a follow up to #2373 to ensure that all CI jobs that use CI k8s versions are using latest images instead of pinning to an old reference image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
