### PR TITLE
Fix parsing error for CCM tag

### DIFF
--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -185,8 +185,8 @@ if [[ -n "${TEST_CCM:-}" ]]; then
 --set cloudNodeManager.imageRepository="${IMAGE_REGISTRY}" \
 --set cloudControllerManager.imageName="${CCM_IMAGE_NAME}" \
 --set cloudNodeManager.imageName="${CNM_IMAGE_NAME}" \
---set cloudControllerManager.imageTag="${IMAGE_TAG}" \
---set cloudNodeManager.imageTag="${IMAGE_TAG}" \
+--set-string cloudControllerManager.imageTag="${IMAGE_TAG}" \
+--set-string cloudNodeManager.imageTag="${IMAGE_TAG}" \
 --set cloudControllerManager.replicas="${CCM_COUNT}"
 fi
 


### PR DESCRIPTION
If CCM tag is numerical, helm will parse it incorrectly.
https://github.com/helm/helm/issues/1707#issuecomment-810371666

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Fix parsing error for CCM tag. If CCM tag is numerical, helm will parse it incorrectly.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix parsing error for CCM tag. If CCM tag is numerical, helm will parse it incorrectly.
```
