### PR TITLE
Serialize unit test to prevent flaky failures

### DIFF
--- a/exp/api/v1beta1/azuremachinepool_test.go
+++ b/exp/api/v1beta1/azuremachinepool_test.go
@@ -134,7 +134,7 @@ func TestAzureMachinePool_Validate(t *testing.T) {
 	for _, c := range cases {
 		c := c
 		t.Run(c.Name, func(t *testing.T) {
-			t.Parallel()
+			// Don't add t.Parallel() here or the test will fail.
 			// NOTE: AzureMachinePool is behind MachinePool feature gate flag; the web hook
 			// must prevent creating new objects in case the feature flag is disabled.
 			defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, capifeature.MachinePool, true)()


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test


**What this PR does / why we need it**:

The parallelized test `TestAzureMachinePool_Validate` calls [`SetFeatureGateDuringTest`](https://github.com/kubernetes/component-base/blob/master/featuregate/testing/feature_gate.go#L32) which doesn't appear to be goroutine-safe. Removing `t.Parallel()` makes it reliable and does not affect the time the test takes to run.

**Which issue(s) this PR fixes**:

Fixes #2391

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
