### PR TITLE
suppress cloud-init wget download progress output

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -155,7 +155,7 @@ spec:
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
-              wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
+              wget "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
               chmod +x "$$CI_DIR/$$CI_PACKAGE"
               mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
             done
@@ -328,7 +328,7 @@ spec:
               fi
               for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
                 echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
-                wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
+                wget "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
                 chmod +x "$$CI_DIR/$$CI_PACKAGE"
                 mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
               done

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -155,7 +155,7 @@ spec:
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
-              wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
+              wget "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
               chmod +x "$$CI_DIR/$$CI_PACKAGE"
               mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
             done
@@ -328,7 +328,7 @@ spec:
               fi
               for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
                 echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
-                wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
+                wget "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
                 chmod +x "$$CI_DIR/$$CI_PACKAGE"
                 mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
               done

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
@@ -156,7 +156,7 @@ spec:
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
-              wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
+              wget "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
               chmod +x "$$CI_DIR/$$CI_PACKAGE"
               mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
             done
@@ -329,7 +329,7 @@ spec:
               fi
               for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
                 echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
-                wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
+                wget "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
                 chmod +x "$$CI_DIR/$$CI_PACKAGE"
                 mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
               done

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -153,7 +153,7 @@ spec:
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
-              wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
+              wget "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
               chmod +x "$$CI_DIR/$$CI_PACKAGE"
               mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
             done
@@ -321,7 +321,7 @@ spec:
           fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
-            wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
+            wget "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
             chmod +x "$$CI_DIR/$$CI_PACKAGE"
             mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
           done

--- a/templates/test/ci/patches/control-plane-kubeadm-boostrap-ci-version.yaml
+++ b/templates/test/ci/patches/control-plane-kubeadm-boostrap-ci-version.yaml
@@ -43,7 +43,7 @@
           fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
-            wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
+            wget "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
             chmod +x "$$CI_DIR/$$CI_PACKAGE"
             mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
           done

--- a/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap.yaml
+++ b/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap.yaml
@@ -8,7 +8,7 @@
       set -o pipefail
       set -o errexit
       [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-      
+
       # This test installs release packages or binaries that are a result of the CI and release builds.
       # It runs '... --version' commands to verify that the binaries are correctly installed
       # and finally uninstalls the packages.
@@ -43,7 +43,7 @@
           fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
-            wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
+            wget "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
             chmod +x "$$CI_DIR/$$CI_PACKAGE"
             mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
           done

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -51,7 +51,7 @@ spec:
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
-              wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
+              wget "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
               chmod +x "$$CI_DIR/$$CI_PACKAGE"
               mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
             done


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

In order to better troubleshoot CI failures for custom-built k8s bits, this PR modifies the wget command used by our `preKubeadmCommand' so that we only return basic output. E.g.:

```
$ wget https://storage.googleapis.com/k8s-release-dev/ci/v1.25.0-alpha.1.29+19c8a2127177b4/bin/linux/amd64/kubectl -nv -O ./kubectl
2022-06-17 14:55:47 URL:https://storage.googleapis.com/k8s-release-dev/ci/v1.25.0-alpha.1.29+19c8a2127177b4/bin/linux/amd64/kubectl [44089344/44089344] -> "./kubectl" [1]
$ wget https://storage.googleapis.com/k8s-release-dev/ci/v1.25.0-alpha.1.29+19c8a2127177b4/bin/linux/amd64/kubectlbogon -nv -O ./kubectl
https://storage.googleapis.com/k8s-release-dev/ci/v1.25.0-alpha.1.29+19c8a2127177b4/bin/linux/amd64/kubectlbogon:
2022-06-17 14:55:54 ERROR 404: Not Found.
```

Compare to the current log output we persist to `/var/log/cloud-init-output.log`:

```
[2022-06-17 11:32:41] --2022-06-17 11:32:41--  https://storage.googleapis.com/k8s-release-dev/ci/v1.25.0-alpha.1.29+19c8a2127177b4/bin/linux/amd64/kubectl
[2022-06-17 11:32:41] Resolving storage.googleapis.com (storage.googleapis.com)... 172.217.16.240, 142.250.200.16, 142.250.200.48, ...
[2022-06-17 11:32:41] Connecting to storage.googleapis.com (storage.googleapis.com)|172.217.16.240|:443... connected.
[2022-06-17 11:32:42] HTTP request sent, awaiting response... 200 OK
[2022-06-17 11:32:42] Length: 44089344 (42M) [application/octet-stream]
[2022-06-17 11:32:42] Saving to: ‘/tmp/k8s-ci/kubectl’
[2022-06-17 11:32:42] 
[2022-06-17 11:32:42]      0K .......... .......... .......... .......... ..........  0% 12.2M 3s
[2022-06-17 11:32:42]     50K .......... .......... .......... .......... ..........  0% 20.6M 3s
[2022-06-17 11:32:42]    100K .......... .......... .......... .......... ..........  0% 21.1M 2s
....  0% 47.2M 2s
[2022-06-17 11:32:42]    200K .......... .......... .......... .......... ..........  0% 36.9M 2s
[2022-06-17 11:32:42]    250K .......... .......... .......... .......... ..........  0% 12.2M 2s
[2022-06-17 11:32:42]    300K .......... .......... .......... .......... ..........  0% 54.8M 2s
[2022-06-17 11:32:42]    350K .......... .......... .......... .......... ..........  0% 60.2M 2s
[2022-06-17 11:32:42]    400K .......... .......... .......... .......... ..........  1% 58.8M 2s
[2022-06-17 11:32:42]    450K .......... .......... .......... .......... ..........  1% 49.7M 2s
[2022-06-17 11:32:42]    500K .......... .......... .......... .......... ..........  1% 48.5M 2s
[2022-06-17 11:32:42]    550K .......... .......... .......... .......... ..........  1% 58.4M 1s
[2022-06-17 11:32:42]    600K .......... .......... .......... .......... ..........  1% 56.0M 1s
[2022-06-17 11:32:42]    650K .......... .......... .......... .......... ..........  1% 56.2M 1s
[2022-06-17 11:32:42]    700K .......... .......... .......... .......... ..........  1% 53.4M 1s
...
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
