### PR TITLE
Add sku version logging

### DIFF
--- a/azure/services/virtualmachineimages/cache.go
+++ b/azure/services/virtualmachineimages/cache.go
@@ -61,7 +61,7 @@ func newCache(auth azure.Authorizer) *Cache {
 	}
 }
 
-// GetCache either creates a new VM images cache or returns an existing one.
+// GetCache either creates a new VM images cache or returns the existing one.
 func GetCache(auth azure.Authorizer) (*Cache, error) {
 	var err error
 	doOnce.Do(func() {

--- a/azure/services/virtualmachineimages/images.go
+++ b/azure/services/virtualmachineimages/images.go
@@ -52,7 +52,7 @@ func (s *Service) GetDefaultUbuntuImage(ctx context.Context, location, k8sVersio
 
 	osVersion := getUbuntuOSVersion(v.Major, v.Minor, v.Patch)
 	publisher, offer := azure.DefaultImagePublisherID, azure.DefaultImageOfferID
-	skuID, version, err := s.getDefaultImageSKUIDAndVersion(
+	skuID, version, err := s.getSKUAndVersion(
 		ctx, location, publisher, offer, k8sVersion, fmt.Sprintf("ubuntu-%s", osVersion))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get default image")
@@ -90,7 +90,7 @@ func (s *Service) GetDefaultWindowsImage(ctx context.Context, location, k8sVersi
 	}
 
 	publisher, offer := azure.DefaultImagePublisherID, azure.DefaultWindowsImageOfferID
-	skuID, version, err := s.getDefaultImageSKUIDAndVersion(
+	skuID, version, err := s.getSKUAndVersion(
 		ctx, location, publisher, offer, k8sVersion, osAndVersion)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get default image")
@@ -115,11 +115,13 @@ func (s *Service) GetDefaultWindowsImage(ctx context.Context, location, k8sVersi
 	return defaultImage, nil
 }
 
-// GetDefaultImageSKUID gets the SKU ID and version of the image to use for the provided version of Kubernetes.
+// getSKUAndVersion gets the SKU ID and version of the image to use for the provided version of Kubernetes.
 // note: osAndVersion is expected to be in the format of {os}-{version} (ex: ubuntu-2004 or windows-2022)
-func (s *Service) getDefaultImageSKUIDAndVersion(ctx context.Context, location, publisher, offer, k8sVersion, osAndVersion string) (string, string, error) {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachineimages.AzureClient.getDefaultImageSKUIDAndVersion")
+func (s *Service) getSKUAndVersion(ctx context.Context, location, publisher, offer, k8sVersion, osAndVersion string) (string, string, error) {
+	ctx, log, done := tele.StartSpanWithLogger(ctx, "virtualmachineimages.Service.getSKUAndVersion")
 	defer done()
+
+	log.Info("Getting VM image SKU and version", "location", location, "publisher", publisher, "offer", offer, "k8sVersion", k8sVersion, "osAndVersion", osAndVersion)
 
 	v, err := semver.ParseTolerant(k8sVersion)
 	if err != nil {
@@ -170,6 +172,8 @@ func (s *Service) getDefaultImageSKUIDAndVersion(ctx context.Context, location, 
 	if version == "" {
 		return "", "", errors.Errorf("no VM image found for publisher \"%s\" offer \"%s\" sku \"%s\" with Kubernetes version \"%s\"", publisher, offer, sku, k8sVersion)
 	}
+
+	log.Info("Found VM image SKU and version", "location", location, "publisher", publisher, "offer", offer, "sku", sku, "version", version)
 
 	return sku, version, nil
 }

--- a/azure/services/virtualmachineimages/images_test.go
+++ b/azure/services/virtualmachineimages/images_test.go
@@ -473,7 +473,7 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 					List(gomock.Any(), location, azure.DefaultImagePublisherID, offer, gomock.Any()).
 					Return(test.versions, nil)
 			}
-			id, version, err := svc.getDefaultImageSKUIDAndVersion(context.TODO(), location, azure.DefaultImagePublisherID,
+			id, version, err := svc.getSKUAndVersion(context.TODO(), location, azure.DefaultImagePublisherID,
 				offer, test.k8sVersion, test.osAndVersion)
 
 			g := NewWithT(t)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Adds some logging that mentions the VM image SKU version, which is now important since it encodes the Kubernetes version for reference images. This also shortens the function name and does some minor cleanup.

**Which issue(s) this PR fixes**:

Refs https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2388#issuecomment-1163356464

**Special notes for your reviewer**:

The output looks like this (newlines added by me to highlight `version`):

```log
controller/azuremachine/controllers.AzureMachineReconciler.reconcileNormal "msg"="Reconciling AzureMachine" "name"="default-18717-control-plane-x58s2" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AzureMachine" "x-ms-correlation-request-id"="6fc79888-c169-4e58-bf10-0eb75963e5a0" 
I0622 21:54:44.587121      38 machine.go:644] controller/azuremachine/scope.MachineScope.GetVMImage "msg"="No image specified for machine, using default Linux Image" "name"="default-18717-control-plane-x58s2" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AzureMachine" "x-ms-correlation-request-id"="6fc79888-c169-4e58-bf10-0eb75963e5a0" "machine"="default-18717-control-plane-x58s2"
I0622 21:54:44.587997      38 images.go:124] controller/azuremachine/virtualmachineimages.Service.getSKUAndVersion "msg"="Getting VM image SKU and version" "name"="default-18717-control-plane-x58s2" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AzureMachine" "x-ms-correlation-request-id"="6fc79888-c169-4e58-bf10-0eb75963e5a0" "k8sVersion"="v1.24.1" "location"="eastus" "offer"="capi" "osAndVersion"="ubuntu-2004" "publisher"="cncf-upstream"
I0622 21:54:44.588751      38 cache.go:117] controller/azuremachine/virtualmachineimages.Cache.Get "msg"="VM images cache miss" "name"="default-18717-control-plane-x58s2" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AzureMachine" "x-ms-correlation-request-id"="6fc79888-c169-4e58-bf10-0eb75963e5a0" "location"="eastus" "offer"="capi" "publisher"="cncf-upstream" "sku"="ubuntu-2004-gen1"
I0622 21:54:45.743926      38 images.go:176] controller/azuremachine/virtualmachineimages.Service.getSKUAndVersion "msg"="Found VM image SKU and version" "name"="default-18717-control-plane-x58s2" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AzureMachine" "x-ms-correlation-request-id"="6fc79888-c169-4e58-bf10-0eb75963e5a0" "location"="eastus" "offer"="capi" "publisher"="cncf-upstream" 
    "sku"="ubuntu-2004-gen1" "version"="124.1.20220601"
I0622 21:55:17.789607      38 images.go:124] controller/azuremachine/virtualmachineimages.Service.getSKUAndVersion "msg"="Getting VM image SKU and version" "name"="default-18717-control-plane-x58s2" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AzureMachine" "x-ms-correlation-request-id"="a83b742c-72a0-4933-9bc5-7cd9cb545a0d" "k8sVersion"="v1.24.1" "location"="eastus" "offer"="capi" "osAndVersion"="ubuntu-2004" "publisher"="cncf-upstream"
I0622 21:55:17.791411      38 cache.go:122] controller/azuremachine/virtualmachineimages.Cache.Get "msg"="VM images cache hit" "name"="default-18717-control-plane-x58s2" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AzureMachine" "x-ms-correlation-request-id"="a83b742c-72a0-4933-9bc5-7cd9cb545a0d" "location"="eastus" "offer"="capi" "publisher"="cncf-upstream" "sku"="ubuntu-2004-gen1"
I0622 21:55:17.791842      38 images.go:176] controller/azuremachine/virtualmachineimages.Service.getSKUAndVersion "msg"="Found VM image SKU and version" "name"="default-18717-control-plane-x58s2" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AzureMachine" "x-ms-correlation-request-id"="a83b742c-72a0-4933-9bc5-7cd9cb545a0d" "location"="eastus" "offer"="capi" "publisher"="cncf-upstream" 
    "sku"="ubuntu-2004-gen1" "version"="124.1.20220601"
```

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
