### PR TITLE
Adding *.sh eol=lf to make working in WSL Easier

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Specify generated cluster templates as generated files
 **/cluster-template-*.yaml linguist-generated
+
+*.sh text eol=lf


### PR DESCRIPTION
**What type of PR is this?**
Utility PR to help WSL developers with autocrlf turned on. For anyone that wants to apply this PR after it's merged you can pull in the change and run the following for git to switch all *.sh files to LF.

```
git rm --cached -r .
git reset --hard
```

/kind feature


**What this PR does / why we need it**:
Adds a .gitattribute for *.sh to force LF so when you run make commands in WSL the shell scripts will run without having to convert them by hand.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/shrug
_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
