### PR TITLE
ci: shorter node pool names in AKS templates

### DIFF
--- a/templates/cluster-template-aks.yaml
+++ b/templates/cluster-template-aks.yaml
@@ -42,7 +42,7 @@ metadata:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: agentpool0
+  name: pool0
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
@@ -56,13 +56,13 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: agentpool0
+        name: pool0
       version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: agentpool0
+  name: pool0
   namespace: default
 spec:
   mode: System
@@ -72,7 +72,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: agentpool1
+  name: pool1
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
@@ -86,13 +86,13 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: agentpool1
+        name: pool1
       version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: agentpool1
+  name: pool1
   namespace: default
 spec:
   mode: User

--- a/templates/flavors/aks/cluster-template.yaml
+++ b/templates/flavors/aks/cluster-template.yaml
@@ -48,7 +48,7 @@ metadata:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: "agentpool0"
+  name: "pool0"
 spec:
   clusterName: "${CLUSTER_NAME}"
   replicas: ${WORKER_MACHINE_COUNT}
@@ -61,7 +61,7 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: "agentpool0"
+        name: "pool0"
       version: "${KUBERNETES_VERSION}"
 ---
 # The Azure-specific machine pool implementation drives the configuration of the
@@ -69,7 +69,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: "agentpool0"
+  name: "pool0"
 spec:
   mode: System
   osDiskSizeGB: 30
@@ -79,7 +79,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: "agentpool1"
+  name: "pool1"
 spec:
   clusterName: "${CLUSTER_NAME}"
   replicas: ${WORKER_MACHINE_COUNT}
@@ -92,14 +92,14 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: "agentpool1"
+        name: "pool1"
       version: "${KUBERNETES_VERSION}"
 ---
 # The infrastructure backing the second pool will use the same VM sku, but a larger OS disk.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: "agentpool1"
+  name: "pool1"
 spec:
   mode: User
   osDiskSizeGB: 40

--- a/templates/test/ci/cluster-template-prow-aks.yaml
+++ b/templates/test/ci/cluster-template-prow-aks.yaml
@@ -49,7 +49,7 @@ metadata:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: agentpool0
+  name: pool0
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
@@ -63,13 +63,13 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: agentpool0
+        name: pool0
       version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: agentpool0
+  name: pool0
   namespace: default
 spec:
   availabilityZones:
@@ -85,7 +85,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: agentpool1
+  name: pool1
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
@@ -99,13 +99,13 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: agentpool1
+        name: pool1
       version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: agentpool1
+  name: pool1
   namespace: default
 spec:
   maxPods: 64
@@ -139,7 +139,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: agentpool2
+  name: pool2
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
@@ -153,13 +153,13 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: agentpool2
+        name: pool2
       version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: agentpool2
+  name: pool2
   namespace: default
 spec:
   mode: User

--- a/templates/test/ci/prow-aks/kustomization.yaml
+++ b/templates/test/ci/prow-aks/kustomization.yaml
@@ -3,10 +3,9 @@ kind: Kustomization
 namespace: default
 resources:
   - ../../../flavors/aks
-  - patches/aks-agentpool2.yaml
+  - patches/aks-pool2.yaml
 patchesStrategicMerge:
   - ../patches/tags-aks.yaml
-  - patches/aks-agentpool0.yaml
-  - patches/aks-agentpool1.yaml
+  - patches/aks-pool0.yaml
+  - patches/aks-pool1.yaml
   - patches/addons.yaml
-

--- a/templates/test/ci/prow-aks/patches/aks-pool0.yaml
+++ b/templates/test/ci/prow-aks/patches/aks-pool0.yaml
@@ -1,7 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: "agentpool0"
+  name: "pool0"
 spec:
   maxPods: 30
   osDiskType: "Managed"

--- a/templates/test/ci/prow-aks/patches/aks-pool1.yaml
+++ b/templates/test/ci/prow-aks/patches/aks-pool1.yaml
@@ -1,7 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: "agentpool1"
+  name: "pool1"
 spec:
   maxPods: 64
   osDiskType: "Ephemeral"

--- a/templates/test/ci/prow-aks/patches/aks-pool2.yaml
+++ b/templates/test/ci/prow-aks/patches/aks-pool2.yaml
@@ -2,7 +2,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: "agentpool2"
+  name: "pool2"
 spec:
   clusterName: "${CLUSTER_NAME}"
   replicas: 1
@@ -15,14 +15,14 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: "agentpool2"
+        name: "pool2"
       version: "${KUBERNETES_VERSION}"
 ---
 # The infrastructure backing the third pool will use the same VM SKU, which is the only required configuration
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: "agentpool2"
+  name: "pool2"
 spec:
   mode: User
   sku: "${AZURE_NODE_MACHINE_TYPE}"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind cleanup

**What this PR does / why we need it**:

In preparation for https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2410 this PR shortens the names we're giving the AKS node pools. This is because AKS restricts Windows pool names to no more than a 6-character string.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
