### PR TITLE
Switching from strings.Title to cases.Title

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.4.0
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
 	golang.org/x/mod v0.5.1
+	golang.org/x/text v0.3.7
 	helm.sh/helm/v3 v3.8.1
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
@@ -180,7 +181,6 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect

--- a/pkg/record/recorder.go
+++ b/pkg/record/recorder.go
@@ -17,9 +17,10 @@ limitations under the License.
 package record
 
 import (
-	"strings"
 	"sync"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -28,10 +29,12 @@ import (
 var (
 	initOnce        sync.Once
 	defaultRecorder record.EventRecorder
+	eng             cases.Caser
 )
 
 func init() {
 	defaultRecorder = new(record.FakeRecorder)
+	eng = cases.Title(language.English)
 }
 
 // InitFromRecorder initializes the global default recorder. It can only be called once.
@@ -44,20 +47,20 @@ func InitFromRecorder(recorder record.EventRecorder) {
 
 // Event constructs an event from the given information and puts it in the queue for sending.
 func Event(object runtime.Object, reason, message string) {
-	defaultRecorder.Event(object, corev1.EventTypeNormal, strings.Title(reason), message)
+	defaultRecorder.Event(object, corev1.EventTypeNormal, eng.String(reason), message)
 }
 
 // Eventf is just like Event, but with Sprintf for the message field.
 func Eventf(object runtime.Object, reason, message string, args ...interface{}) {
-	defaultRecorder.Eventf(object, corev1.EventTypeNormal, strings.Title(reason), message, args...)
+	defaultRecorder.Eventf(object, corev1.EventTypeNormal, eng.String(reason), message, args...)
 }
 
 // Warn constructs a warning event from the given information and puts it in the queue for sending.
 func Warn(object runtime.Object, reason, message string) {
-	defaultRecorder.Event(object, corev1.EventTypeWarning, strings.Title(reason), message)
+	defaultRecorder.Event(object, corev1.EventTypeWarning, eng.String(reason), message)
 }
 
 // Warnf is just like Warn, but with Sprintf for the message field.
 func Warnf(object runtime.Object, reason, message string, args ...interface{}) {
-	defaultRecorder.Eventf(object, corev1.EventTypeWarning, strings.Title(reason), message, args...)
+	defaultRecorder.Eventf(object, corev1.EventTypeWarning, eng.String(reason), message, args...)
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

There is a new deprecation in go1.18 and if you run a newer version of golangci-lint you'll get the following.

```
// Warn constructs a warning event from the given information and puts it in the queue for sending.
func Warn(object runtime.Object, reason, message string) {
        defaultRecorder.Event(object, corev1.EventTypeWarning, strings.Title(reason), message)
properly. Use golang.org/x/text/cases instead. (staticcheck)
        defaultRecorder.Eventf(object, corev1.EventTypeNormal, strings.Title(reason), message, args...)
                                                               ^
pkg/record/recorder.go:57:57: SA1019: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead. (staticcheck)
        defaultRecorder.Event(object, corev1.EventTypeWarning, strings.Title(reason), message)
                                                               ^
pkg/record/recorder.go:62:58: SA1019: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead. (staticcheck)
        defaultRecorder.Eventf(object, corev1.EventTypeWarning, strings.Title(reason), message, args...)   
```

**What this PR does / why we need it**:
Changes from strings.Title to the cases.Title Caser.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
