### PR TITLE
When creating AKS clusters using autoscaler enabled, do not make an update api call to agentpool service based on difference in node count

### DIFF
--- a/azure/const.go
+++ b/azure/const.go
@@ -28,4 +28,8 @@ const (
 	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 	// for annotation formatting rules.
 	RGTagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-azure-last-applied-tags-rg"
+
+	// ReplicasManagedByAutoscalerAnnotation is set to true in the corresponding capi machine pool
+	// when an external autoscaler manages the node count of the associated machine pool.
+	ReplicasManagedByAutoscalerAnnotation = "cluster.x-k8s.io/replicas-managed-by-autoscaler"
 )

--- a/azure/services/agentpools/agentpools.go
+++ b/azure/services/agentpools/agentpools.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-05-01/containerservice"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -43,6 +44,10 @@ type ManagedMachinePoolScope interface {
 	SetAgentPoolProviderIDList([]string)
 	SetAgentPoolReplicas(int32)
 	SetAgentPoolReady(bool)
+	UpdateCAPIMachinePoolReplicas(replicas *int32)
+	UpdateCAPIMachinePoolAnnotations(key, value string)
+	GetCAPIMachinePoolAnnotation(key string) (bool, string)
+	RemoveCAPIMachinePoolAnnotations(key string)
 }
 
 // Service provides operations on Azure resources.
@@ -125,6 +130,25 @@ func (s *Service) Reconcile(ctx context.Context) error {
 				MaxCount:            profile.MaxCount,
 				NodeLabels:          profile.NodeLabels,
 			},
+		}
+
+		// When autoscaling is set, the count of the nodes differ based on the autoscaler and should not depend on the
+		// count present in MachinePool or AzureManagedMachinePool, hence we should not make an update API call based
+		// on difference in count.
+		if to.Bool(profile.EnableAutoScaling) && existingProfile.Count != nil {
+			if ok, _ := s.scope.GetCAPIMachinePoolAnnotation(azure.ReplicasManagedByAutoscalerAnnotation); !ok {
+				s.scope.UpdateCAPIMachinePoolAnnotations(azure.ReplicasManagedByAutoscalerAnnotation, "true")
+			}
+
+			if to.Int32(existingProfile.Count) != to.Int32(normalizedProfile.Count) {
+				s.scope.UpdateCAPIMachinePoolReplicas(existingProfile.Count)
+			}
+			normalizedProfile.Count = existingProfile.Count
+		}
+
+		// set ReplicasManagedByAutoscalerAnnotation to false as it is disabled by the user.
+		if ok, _ := s.scope.GetCAPIMachinePoolAnnotation(azure.ReplicasManagedByAutoscalerAnnotation); !to.Bool(profile.EnableAutoScaling) && ok {
+			s.scope.RemoveCAPIMachinePoolAnnotations(azure.ReplicasManagedByAutoscalerAnnotation)
 		}
 
 		// Diff and check if we require an update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -70,6 +70,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - cluster.x-k8s.io

--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -149,7 +149,7 @@ func (ampr *AzureMachinePoolReconciler) SetupWithManager(ctx context.Context, mg
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=azuremachinepools/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=azuremachinepoolmachines,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=azuremachinepoolmachines/status,verbs=get
-// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools;machinepools/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools;machinepools/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets;,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch

--- a/exp/controllers/azuremanagedmachinepool_controller.go
+++ b/exp/controllers/azuremanagedmachinepool_controller.go
@@ -225,6 +225,9 @@ func (ammpr *AzureManagedMachinePoolReconciler) Reconcile(ctx context.Context, r
 		if err := mcpScope.PatchObject(ctx); err != nil && reterr == nil {
 			reterr = err
 		}
+		if err := mcpScope.PatchCAPIMachinePoolObject(ctx); err != nil && reterr == nil {
+			reterr = err
+		}
 	}()
 
 	// Handle deleted clusters


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Resolves https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2443

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2443

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
