### PR TITLE
Makefile: put Calico manifest into artifacts directory and cache them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,13 +476,22 @@ generate-addons: fetch-calico-manifests ## Generate metric-server, calico calico
 
 # When updating this, make sure to also update the Windows image version in templates/addons/windows/calico.
 CALICO_VERSION := v3.23.0
+# Where all downloaded Calico manifests are unpacked and stored.
+CALICO_RELEASES := $(ARTIFACTS)/calico
+# Path to manifests directory in a Calico release archive.
+CALICO_RELEASE_MANIFESTS_DIR := release-$(CALICO_VERSION)/manifests
+# Path where Calico manifests are stored which should be used for addons generation.
+CALICO_MANIFESTS_DIR := $(ARTIFACTS)/calico/$(CALICO_RELEASE_MANIFESTS_DIR)
 
 .PHONY: fetch-calico-manifests
-fetch-calico-manifests: ## Get Calico release manifests and unzip them.
+fetch-calico-manifests: $(CALICO_MANIFESTS_DIR) ## Get Calico release manifests and unzip them.
+	cp $(CALICO_MANIFESTS_DIR)/calico-vxlan.yaml $(ADDONS_DIR)/calico
+	cp $(CALICO_MANIFESTS_DIR)/calico-policy-only.yaml $(ADDONS_DIR)/calico-ipv6
+
+$(CALICO_MANIFESTS_DIR):
+	mkdir -p $(ARTIFACTS)/calico
 	@echo "Fetching Calico release manifests from release artifacts, this might take a minute..."
-	wget -qO- https://github.com/projectcalico/calico/releases/download/$(CALICO_VERSION)/release-$(CALICO_VERSION).tgz | tar xz release-$(CALICO_VERSION)/manifests/calico-vxlan.yaml release-$(CALICO_VERSION)/manifests/calico-policy-only.yaml
-	mv release-$(CALICO_VERSION)/manifests/calico-vxlan.yaml $(ADDONS_DIR)/calico
-	mv release-$(CALICO_VERSION)/manifests/calico-policy-only.yaml $(ADDONS_DIR)/calico-ipv6
+	wget -qO- https://github.com/projectcalico/calico/releases/download/$(CALICO_VERSION)/release-$(CALICO_VERSION).tgz | tar xz --directory $(CALICO_RELEASES) $(CALICO_RELEASE_MANIFESTS_DIR)
 
 .PHONY: modules
 modules: ## Runs go mod tidy to ensure proper vendoring.


### PR DESCRIPTION

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Right now running targets like 'generate' or 'generate-flavors' which
are often used when adding new flavors, downloads Calico release
manifests each time and they are 1GB in size, which is slow and
wasteful.

To speed things up and save bandwidth, this commit puts unpacked Calico
manifests in _artifacts directory as a build cache and uses Make file
target feature to only re-download the manifests if the files are
missing, which should only occur on fresh repository clone or when
Calico version changes, which then justifies re-downloading the archive.

To avoid downloading Calico archive multiple times when make targets are
executed in parallel (-j), we unpack entire manifests directory instead
of just desired manifests, which also makes the process simpler overall.

The manifests directory is right now <5MB, which is a lot (it's mostly
whitespace!) but I think acceptable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2449

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```