### PR TITLE
Revert "Use setup-envtest instead of fetch_ext_bins"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,6 @@ export GOPROXY
 # Active module mode, as we use go modules to manage dependencies
 export GO111MODULE=on
 
-# Kubebuilder.
-export KUBEBUILDER_ENVTEST_KUBERNETES_VERSION ?= 1.20.2
-export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT ?= 60s
-export KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT ?= 60s
-
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled
 
@@ -125,12 +120,8 @@ KIND_VER := v0.14.0
 KIND_BIN := kind
 KIND :=  $(TOOLS_BIN_DIR)/$(KIND_BIN)-$(KIND_VER)
 
-SETUP_ENVTEST_VER := v0.0.0-20211110210527-619e6b92dab9
-SETUP_ENVTEST_BIN := setup-envtest
-SETUP_ENVTEST := $(abspath $(TOOLS_BIN_DIR)/$(SETUP_ENVTEST_BIN)-$(SETUP_ENVTEST_VER))
-SETUP_ENVTEST_PKG := sigs.k8s.io/controller-runtime/tools/setup-envtest
-
-KUBEBUILDER_ASSETS ?= $(shell $(SETUP_ENVTEST) use --use-env -p path $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))
+KUBE_APISERVER=$(TOOLS_BIN_DIR)/kube-apiserver
+ETCD=$(TOOLS_BIN_DIR)/etcd
 
 # Define Docker related variables. Releases should modify and double check these vars.
 REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
@@ -629,16 +620,23 @@ promote-images: $(KPROMO) ## Promote images.
 ## --------------------------------------
 
 ##@ Testing:
+
 .PHONY: test
 test: generate lint go-test ## Run "generate", "lint" and "go-tests" rules.
 
+envs-test:
+export TEST_ASSET_KUBECTL = $(KUBECTL)
+export TEST_ASSET_KUBE_APISERVER = $(KUBE_APISERVER)
+export TEST_ASSET_ETCD = $(ETCD)
+
 .PHONY: go-test
-go-test: $(SETUP_ENVTEST) ## Run go tests.
-	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./... $(TEST_ARGS)
+go-test: envs-test $(KUBECTL) $(KUBE_APISERVER) $(ETCD) ## Run go tests.
+	echo $(TEST_ASSET_KUBECTL)
+	go test ./...
 
 .PHONY: test-cover
-test-cover: $(SETUP_ENVTEST) ## Run tests with code coverage and code generate reports.
-	$(MAKE) test TEST_ARGS="$(TEST_ARGS) -coverprofile=coverage.out"
+test-cover: envs-test $(KUBECTL) $(KUBE_APISERVER) $(ETCD) ## Run tests with code coverage and code generate reports.
+	go test -v -coverprofile=coverage.out ./...
 	go tool cover -func=coverage.out -o coverage.txt
 	go tool cover -html=coverage.out -o coverage.html
 
@@ -680,6 +678,9 @@ ifneq ($(WIN_REPO_URL), )
 	curl --retry $(CURL_RETRIES) $(WIN_REPO_URL) -o $(KUBETEST_REPO_LIST_PATH)/custom-repo-list.yaml
 endif
 	$(MAKE) test-conformance CONFORMANCE_E2E_ARGS="-kubetest.config-file=$(KUBETEST_WINDOWS_CONF_PATH) -kubetest.repo-list-path=$(KUBETEST_REPO_LIST_PATH) $(E2E_ARGS)"
+
+$(KUBE_APISERVER) $(ETCD): ## Install test asset kubectl, kube-apiserver, etcd.
+	source ./scripts/fetch_ext_bins.sh && fetch_tools
 
 ## --------------------------------------
 ## Tilt / Kind
@@ -725,7 +726,6 @@ kubectl: $(KUBECTL) ## Build a local copy of kubectl.
 helm: $(HELM) ## Build a local copy of helm.
 yq: $(YQ) ## Build a local copy of yq.
 kind: $(KIND) ## Build a local copy of kind.
-setup-envtest: $(SETUP_ENVTEST) ## Build a local copy of setup-envtest.
 
 $(CONVERSION_VERIFIER): go.mod
 	cd $(TOOLS_DIR); go build -tags=tools -o $@ sigs.k8s.io/cluster-api/hack/tools/conversion-verifier
@@ -799,9 +799,3 @@ $(YQ_BIN): $(YQ) ## Building yq from the tools folder.
 
 .PHONY: $(KIND_BIN)
 $(KIND_BIN): $(KIND)
-
-.PHONY: $(SETUP_ENVTEST_BIN)
-$(SETUP_ENVTEST_BIN): $(SETUP_ENVTEST) ## Build a local copy of setup-envtest.
-
-$(SETUP_ENVTEST): # Build setup-envtest from tools folder.
-	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(SETUP_ENVTEST_PKG) $(SETUP_ENVTEST_BIN) $(SETUP_ENVTEST_VER)

--- a/scripts/fetch_ext_bins.sh
+++ b/scripts/fetch_ext_bins.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Enable tracing in this script off by setting the TRACE variable in your
+# environment to any value:
+#
+# $ TRACE=1 test.sh
+TRACE=${TRACE:-""}
+if [[ -n "${TRACE}" ]]; then
+  set -x
+fi
+
+k8s_version=1.20.2
+goarch=amd64
+goos="unknown"
+
+if [[ "${OSTYPE}" == "linux"* ]]; then
+  goos="linux"
+elif [[ "${OSTYPE}" == "darwin"* ]]; then
+  goos="darwin"
+fi
+
+if [[ "$goos" == "unknown" ]]; then
+  echo "OS '$OSTYPE' not supported. Aborting." >&2
+  exit 1
+fi
+
+# Turn colors in this script off by setting the NO_COLOR variable in your
+# environment to any value:
+#
+# $ NO_COLOR=1 test.sh
+NO_COLOR=${NO_COLOR:-""}
+if [[ -z "${NO_COLOR}" ]]; then
+  header=$'\e[1;33m'
+  reset=$'\e[0m'
+else
+  header=''
+  reset=''
+fi
+
+function header_text {
+  echo "$header$*$reset"
+}
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+tools_bin=${REPO_ROOT}/hack/tools/bin
+tmp_root=/tmp
+kb_root_dir=${tmp_root}/kubebuilder
+
+# Skip fetching and untaring the tools by setting the SKIP_FETCH_TOOLS variable
+# in your environment to any value:
+#
+# $ SKIP_FETCH_TOOLS=1 ./fetch_ext_bins.sh
+#
+# If you skip fetching tools, this script will use the tools already on your
+# machine, but rebuild the kubebuilder and kubebuilder-bin binaries.
+SKIP_FETCH_TOOLS=${SKIP_FETCH_TOOLS:-""}
+
+# fetch k8s API gen tools and make it available under kb_root_dir/bin.
+function fetch_tools {
+  if [[ -n "$SKIP_FETCH_TOOLS" ]]; then
+    return 0
+  fi
+
+  header_text "fetching tools"
+  kb_tools_archive_name="kubebuilder-tools-${k8s_version}-${goos}-${goarch}.tar.gz"
+  kb_tools_download_url="https://storage.googleapis.com/kubebuilder-tools/${kb_tools_archive_name}"
+
+  kb_tools_archive_path="${tmp_root}/${kb_tools_archive_name}"
+  if [[ ! -f ${kb_tools_archive_path} ]]; then
+    curl -fsL ${kb_tools_download_url} -o "${kb_tools_archive_path}"
+  fi
+  tar -zvxf "${kb_tools_archive_path}" -C "${tmp_root}/"
+
+  mkdir -p "${tools_bin}"
+  mv "${kb_root_dir}"/bin/* "${tools_bin}"
+  rm -f "${tools_bin}"/bin/kubectl
+}


### PR DESCRIPTION
Reverts kubernetes-sigs/cluster-api-provider-azure#2374

> This will need to be reverted now. As I noted above, this doesn’t work as-is on Apple Silicon. I apologize—I should have put a hold on it but assumed comments were read. I don’t see that anyone has tested it successfully on an M1.

https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2374#issuecomment-1175595483

cc @evanfreed @mboersma 