### PR TITLE
Fix outbound LB Public IP names to use webhook default

### DIFF
--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -326,6 +326,9 @@ func TestPublicIPSpecs(t *testing.T) {
 						},
 					},
 					NetworkSpec: infrav1.NetworkSpec{
+						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
+							FrontendIPsCount: to.Int32Ptr(0),
+						},
 						APIServerLB: infrav1.LoadBalancerSpec{
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 								Type: infrav1.Internal,
@@ -368,7 +371,15 @@ func TestPublicIPSpecs(t *testing.T) {
 					},
 					NetworkSpec: infrav1.NetworkSpec{
 						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
-							FrontendIPsCount:      to.Int32Ptr(1),
+							FrontendIPsCount: to.Int32Ptr(1),
+							FrontendIPs: []infrav1.FrontendIP{
+								{
+									Name: "my-frontend-ip",
+									PublicIP: &infrav1.PublicIPSpec{
+										Name: "pip-my-cluster-controlplane-outbound",
+									},
+								},
+							},
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{},
 						},
 						APIServerLB: infrav1.LoadBalancerSpec{
@@ -427,7 +438,27 @@ func TestPublicIPSpecs(t *testing.T) {
 					},
 					NetworkSpec: infrav1.NetworkSpec{
 						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
-							FrontendIPsCount:      to.Int32Ptr(3),
+							FrontendIPsCount: to.Int32Ptr(3),
+							FrontendIPs: []infrav1.FrontendIP{
+								{
+									Name: "my-frontend-ip-1",
+									PublicIP: &infrav1.PublicIPSpec{
+										Name: "pip-my-cluster-controlplane-outbound-1",
+									},
+								},
+								{
+									Name: "my-frontend-ip-2",
+									PublicIP: &infrav1.PublicIPSpec{
+										Name: "pip-my-cluster-controlplane-outbound-2",
+									},
+								},
+								{
+									Name: "my-frontend-ip-3",
+									PublicIP: &infrav1.PublicIPSpec{
+										Name: "pip-my-cluster-controlplane-outbound-3",
+									},
+								},
+							},
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{},
 						},
 						APIServerLB: infrav1.LoadBalancerSpec{
@@ -743,7 +774,7 @@ func TestPublicIPSpecs(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			if got := clusterScope.PublicIPSpecs(); !reflect.DeepEqual(got, tc.expectedPublicIPSpec) {
-				t.Errorf("PublicIPSpecs() diff between expected result and actual result: %s", cmp.Diff(tc.expectedPublicIPSpec, got))
+				t.Errorf("PublicIPSpecs() diff between expected result and actual result (%v): %s", got, cmp.Diff(tc.expectedPublicIPSpec, got))
 			}
 		})
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Node outbound LB was regenerating public IP names (using the Cluster name) in the controller instead of reusing the value of the IP name in the API (defaulted by the webhook using the AzureCluster name, not the Cluster name). This also caused some logic duplication as we were generating names in two places. This fixes the bug and simplifies the code.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2441 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix outbound LB Public IP names to use webhook default
```
