### PR TITLE
Adding Validators for ammp.Spec.OSType and amcp.Name

### DIFF
--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -438,25 +438,26 @@ those can only be set during the creation time.
 
 Following is the list of immutable fields for managed clusters:
 
-| CRD                      | jsonPath                     | Comment                   |
-|--------------------------|------------------------------|---------------------------|
-| AzureManagedControlPlane | .spec.subscriptionID         |                           |
-| AzureManagedControlPlane | .spec.resourceGroupName      |                           |
-| AzureManagedControlPlane | .spec.nodeResourceGroupName  |                           |
-| AzureManagedControlPlane | .spec.location               |                           |
-| AzureManagedControlPlane | .spec.sshPublicKey           |                           |
-| AzureManagedControlPlane | .spec.dnsServiceIP           |                           |
-| AzureManagedControlPlane | .spec.networkPlugin          |                           |
-| AzureManagedControlPlane | .spec.networkPolicy          |                           |
-| AzureManagedControlPlane | .spec.loadBalancerSKU        |                           |
-| AzureManagedControlPlane | .spec.apiServerAccessProfile | except AuthorizedIPRanges |
-| AzureManagedMachinePool  | .spec.sku                    |                           |
-| AzureManagedMachinePool  | .spec.osDiskSizeGB           |                           |
-| AzureManagedMachinePool  | .spec.osDiskType             |                           |
-| AzureManagedMachinePool  | .spec.taints                 |                           |
-| AzureManagedMachinePool  | .spec.availabilityZones      |                           |
-| AzureManagedMachinePool  | .spec.maxPods                |                           |
-| AzureManagedMachinePool  | .spec.osType                 |                           |
+| CRD                       | jsonPath                     | Comment                   |
+|---------------------------|------------------------------|---------------------------|
+| AzureManagedControlPlane  | .name                        |                           |
+| AzureManagedControlPlane  | .spec.subscriptionID         |                           |
+| AzureManagedControlPlane  | .spec.resourceGroupName      |                           |
+| AzureManagedControlPlane  | .spec.nodeResourceGroupName  |                           |
+| AzureManagedControlPlane  | .spec.location               |                           |
+| AzureManagedControlPlane  | .spec.sshPublicKey           |                           |
+| AzureManagedControlPlane  | .spec.dnsServiceIP           |                           |
+| AzureManagedControlPlane  | .spec.networkPlugin          |                           |
+| AzureManagedControlPlane  | .spec.networkPolicy          |                           |
+| AzureManagedControlPlane  | .spec.loadBalancerSKU        |                           |
+| AzureManagedControlPlane  | .spec.apiServerAccessProfile | except AuthorizedIPRanges |
+| AzureManagedMachinePool   | .spec.sku                    |                           |
+| AzureManagedMachinePool   | .spec.osDiskSizeGB           |                           |
+| AzureManagedMachinePool   | .spec.osDiskType             |                           |
+| AzureManagedMachinePool   | .spec.taints                 |                           |
+| AzureManagedMachinePool   | .spec.availabilityZones      |                           |
+| AzureManagedMachinePool   | .spec.maxPods                |                           |
+| AzureManagedMachinePool   | .spec.osType                 |                           |
 
 ## Features
 

--- a/exp/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/exp/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -88,6 +88,14 @@ func (m *AzureManagedControlPlane) ValidateUpdate(oldRaw runtime.Object, client 
 	var allErrs field.ErrorList
 	old := oldRaw.(*AzureManagedControlPlane)
 
+	if m.Name != old.Name {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("Name"),
+				m.Name,
+				"field is immutable"))
+	}
+
 	if m.Spec.SubscriptionID != old.Spec.SubscriptionID {
 		allErrs = append(allErrs,
 			field.Invalid(
@@ -251,6 +259,7 @@ func (m *AzureManagedControlPlane) ValidateDelete(_ client.Client) error {
 // Validate the Azure Machine Pool and return an aggregate error.
 func (m *AzureManagedControlPlane) Validate(cli client.Client) error {
 	validators := []func(client client.Client) error{
+		m.validateName,
 		m.validateVersion,
 		m.validateDNSServiceIP,
 		m.validateSSHKey,
@@ -460,4 +469,14 @@ func (m *AzureManagedControlPlane) validateAPIServerAccessProfileUpdate(old *Azu
 	}
 
 	return allErrs
+}
+
+func (m *AzureManagedControlPlane) validateName(_ client.Client) error {
+	if lName := strings.ToLower(m.Name); strings.Contains(lName, "microsoft") ||
+		strings.Contains(lName, "windows") {
+		return field.Invalid(field.NewPath("Name"), m.Name,
+			"cluster name is invalid because 'MICROSOFT' and 'WINDOWS' can't be used as either a whole word or a substring in the name")
+	}
+
+	return nil
 }

--- a/exp/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/exp/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -300,6 +300,36 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 			wantErr:  true,
 			errorLen: 1,
 		},
+		{
+			name: "invalid name with microsoft",
+			amcp: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "microsoft-cluster",
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					SSHPublicKey: generateSSHPublicKey(true),
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					Version:      "v1.23.5",
+				},
+			},
+			wantErr:  true,
+			errorLen: 1,
+		},
+		{
+			name: "invalid name with windows",
+			amcp: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a-windows-cluster",
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					SSHPublicKey: generateSSHPublicKey(true),
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					Version:      "v1.23.5",
+				},
+			},
+			wantErr:  true,
+			errorLen: 1,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -721,6 +751,31 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "AzureManagedControlPlane Name is mutable",
+			oldAMCP: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					Version:      "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-test-cluster",
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					Version:      "v1.18.0",
+					APIServerAccessProfile: &APIServerAccessProfile{
+						AuthorizedIPRanges: []string{"192.168.0.1/32"},
+					},
+				},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tc := range tests {

--- a/exp/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/exp/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -76,6 +76,25 @@ func (m *AzureManagedMachinePool) ValidateUpdate(oldRaw runtime.Object, client c
 	old := oldRaw.(*AzureManagedMachinePool)
 	var allErrs field.ErrorList
 
+	if old.Spec.OSType != nil {
+		// Prevent OSType modification if it was already set to some value
+		if m.Spec.OSType == nil {
+			// unsetting the field is not allowed
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("Spec", "OSType"),
+					m.Spec.OSType,
+					"field is immutable, unsetting is not allowed"))
+		} else if *m.Spec.OSType != *old.Spec.OSType {
+			// changing the field is not allowed
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("Spec", "OSType"),
+					*m.Spec.OSType,
+					"field is immutable"))
+		}
+	}
+
 	if m.Spec.SKU != old.Spec.SKU {
 		allErrs = append(allErrs,
 			field.Invalid(

--- a/exp/api/v1beta1/azuremanagedmachinepool_webhook_test.go
+++ b/exp/api/v1beta1/azuremanagedmachinepool_webhook_test.go
@@ -99,6 +99,26 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Cannot change OSType of the agentpool",
+			new: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					OSType:       to.StringPtr("Linux"),
+					Mode:         "System",
+					SKU:          "StandardD2S_V3",
+					OSDiskSizeGB: to.Int32Ptr(512),
+				},
+			},
+			old: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					OSType:       to.StringPtr("Windows"),
+					Mode:         "System",
+					SKU:          "StandardD2S_V4",
+					OSDiskSizeGB: to.Int32Ptr(512),
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "Cannot change OSDiskSizeGB of the agentpool",
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
* Adds immutable checks for ammp.Spec.OSType, previously added OSType field was marked as immutable in docs etc. but the validator to confirm the update didn't let you change it was never added.
* The azuremanagedcontrolplane name is also immutable as AKS doesn't let you change a cluster name after it is created. Added a validator to bubble up errors if you try. In addition there is this nuance to Azure ` managed cluster name is invalid because 'MICROSOFT' and 'WINDOWS' can't be used as either a whole word or a substring in the name..` which I added a new validator for to help bubble up errors before they hit the Azure API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
try and make a cluster with `microsoft` or `windows` in the title, try and change the name of the cluster or the ammp ostype and you should see validation errors

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add validators for ammp.Spec.OSType and amcp.Name
```
