### PR TITLE
Fix Cluster labels in OOT cloud provider templates

### DIFF
--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    ccm: external
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/templates/flavors/external-cloud-provider/patches/external-cloud-provider.yaml
+++ b/templates/flavors/external-cloud-provider/patches/external-cloud-provider.yaml
@@ -1,12 +1,4 @@
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: Cluster
-metadata:
-  name: ${CLUSTER_NAME}
-  labels:
-    cni: "calico"
-    ccm: "external"
----
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
@@ -2,8 +2,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    ccm: external
-    cni: calico
+    cni: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
     csi-proxy: enabled
     metrics-server: enabled

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    ccm: external
     cni: ${CLUSTER_NAME}-calico
   name: ${CLUSTER_NAME}
   namespace: default


### PR DESCRIPTION
Co-Authored-By: Mark Rossetti <18291632+marosset@users.noreply.github.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: The ClusterResourceSets for external cloud-provider (CCM) were removed as part of #2209. This PR removes the leftover cluster labels that are no longer needed to match Clusters. It also fixes a bug where the calico CNI label was being overwritten by the external cloud provider patch, causing Calico not to get installed, on the external cloud provider CI version template.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2341 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix Cluster labels in OOT cloud provider templates
```
