### PR TITLE
E2E: update resource cleanup to show timestamps

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -146,7 +146,7 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, input cleanupInput) {
 		input.ClusterProxy.CollectWorkloadClusterLogs(ctx, input.Cluster.Namespace, input.Cluster.Name, filepath.Join(input.ArtifactFolder, "clusters", input.Cluster.Name))
 	}
 
-	Byf("Dumping all the Cluster API resources in the %q namespace", input.Namespace.Name)
+	Logf("Dumping all the Cluster API resources in the %q namespace", input.Namespace.Name)
 	// Dump all Cluster API related resources to artifacts before deleting them.
 	framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{
 		Lister:    input.ClusterProxy.GetClient(),
@@ -158,7 +158,7 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, input cleanupInput) {
 		return
 	}
 
-	Byf("Deleting all clusters in the %s namespace", input.Namespace.Name)
+	Logf("Deleting all clusters in the %s namespace", input.Namespace.Name)
 	// While https://github.com/kubernetes-sigs/cluster-api/issues/2955 is addressed in future iterations, there is a chance
 	// that cluster variable is not set even if the cluster exists, so we are calling DeleteAllClustersAndWait
 	// instead of DeleteClusterAndWait
@@ -171,18 +171,18 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, input cleanupInput) {
 		Namespace: input.Namespace.Name,
 	}, input.IntervalsGetter(input.SpecName, deleteTimeoutConfig)...)
 
-	Byf("Deleting namespace used for hosting the %q test spec", input.SpecName)
+	Logf("Deleting namespace used for hosting the %q test spec", input.SpecName)
 	framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{
 		Deleter: input.ClusterProxy.GetClient(),
 		Name:    input.Namespace.Name,
 	})
 
 	if input.AdditionalCleanup != nil {
-		Byf("Running additional cleanup for the %q test spec", input.SpecName)
+		Logf("Running additional cleanup for the %q test spec", input.SpecName)
 		input.AdditionalCleanup()
 	}
 
-	Byf("Checking if any resources are left over in Azure for spec %q", input.SpecName)
+	Logf("Checking if any resources are left over in Azure for spec %q", input.SpecName)
 	ExpectResourceGroupToBe404(ctx)
 }
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Print timestamps during e2e resource cleanup to help debugging when the resource cleanup fails or times out.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
