### PR TITLE
update windows osversion in ci-build-azure-ccm.sh

### DIFF
--- a/scripts/ci-build-azure-ccm.sh
+++ b/scripts/ci-build-azure-ccm.sh
@@ -34,6 +34,8 @@ source "${REPO_ROOT}/hack/parse-prow-creds.sh"
 export CCM_IMAGE_NAME=azure-cloud-controller-manager
 # cloud node manager image
 export CNM_IMAGE_NAME=azure-cloud-node-manager
+# cloud node manager windows image version
+export WINDOWS_IMAGE_VERSION=1809
 declare -a IMAGES=("${CCM_IMAGE_NAME}" "${CNM_IMAGE_NAME}")
 
 setup() {
@@ -43,15 +45,25 @@ setup() {
     export IMAGE_REGISTRY=${REGISTRY}
     pushd "${AZURE_CLOUD_PROVIDER_ROOT}" && IMAGE_TAG=$(git rev-parse --short=7 HEAD) && export IMAGE_TAG && popd
     echo "Image Tag is ${IMAGE_TAG}"
+
+    if [[ -n "${WINDOWS_SERVER_VERSION:-}" ]]; then
+        if [[ "${WINDOWS_SERVER_VERSION}" == "windows-2019" ]]; then
+            export WINDOWS_IMAGE_VERSION="1809"
+        elif [[ "${WINDOWS_SERVER_VERSION}" == "windows-2022" ]]; then
+            export WINDOWS_IMAGE_VERSION="ltsc2022"
+        else
+            echo "Windows version not supported: ${WINDOWS_SERVER_VERSION}"
+        fi
+    fi
 }
 
 main() {
-    if [[ "$(can_reuse_artifacts)" == "false" ]]; then
+    if [[ "$(can_reuse_artifacts)" =~ "false" ]]; then
         echo "Build Linux Azure amd64 cloud controller manager"
         make -C "${AZURE_CLOUD_PROVIDER_ROOT}" build-ccm-image-amd64 push-ccm-image-amd64
         if [[ -n "${TEST_WINDOWS:-}" ]]; then
-            echo "Building Linux amd64 and Windows ltsc2022 amd64 cloud node managers"
-            make -C "${AZURE_CLOUD_PROVIDER_ROOT}" build-node-image-linux-amd64 push-node-image-linux-amd64 push-node-image-windows-ltsc2022-amd64 manifest-node-manager-image-windows-ltsc2022-amd64
+            echo "Building Linux amd64 and Windows ${WINDOWS_IMAGE_VERSION} amd64 cloud node managers"
+            make -C "${AZURE_CLOUD_PROVIDER_ROOT}" build-node-image-linux-amd64 push-node-image-linux-amd64 push-node-image-windows-"${WINDOWS_IMAGE_VERSION}"-amd64 manifest-node-manager-image-windows-"${WINDOWS_IMAGE_VERSION}"-amd64
         else
             echo "Building Linux amd64 cloud node manager"
             make -C "${AZURE_CLOUD_PROVIDER_ROOT}" build-node-image-linux-amd64 push-node-image-linux-push-name-amd64
@@ -67,6 +79,12 @@ can_reuse_artifacts() {
         fi
     done
 
+    if [[ -n "${TEST_WINDOWS:-}" ]]; then
+        if ! docker manifest inspect "${REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG}" | grep -q "\"os.version\": \"${WINDOWS_IMAGE_VERSION}\""; then
+            echo "false" && return
+        fi
+    fi
+    
     echo "true"
 }
 


### PR DESCRIPTION
Signed-off-by: Lan Lou [t-lanlou@microsoft.com](mailto:t-lanlou@microsoft.com)
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
If windows VMs need "1809" os version, the image can't be pulled successfully. We can specify os version via env "WINDOWS_SERVER_VERSION".

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
