### PR TITLE
Remove extra field in windows kube-proxy 

### DIFF
--- a/templates/addons/windows/calico/kube-proxy-windows.yaml
+++ b/templates/addons/windows/calico/kube-proxy-windows.yaml
@@ -53,7 +53,6 @@ spec:
       volumes:
       - configMap:
           name: kube-proxy
-          item:     
         name: kube-proxy
   updateStrategy:
     type: RollingUpdate

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -608,26 +608,65 @@ data:
       namespace: kube-system
     data:
       KUBEPROXY_PATH: "c:/k/kube-proxy.exe"
-  proxy: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  labels:\n    k8s-app:
-    kube-proxy\n  name: kube-proxy-windows\n  namespace: kube-system\nspec:\n  selector:\n
-    \   matchLabels:\n      k8s-app: kube-proxy-windows\n  template:\n    metadata:\n
-    \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
-    kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
-    true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
-    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
-    \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
-    kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: spec.nodeName\n        -
-    name: POD_IP\n          valueFrom:\n            fieldRef:\n              fieldPath:
-    status.podIP\n        - name: KUBEPROXY_PATH\n          valueFrom:\n            configMapKeyRef:\n
-    \             name: windows-kubeproxy-ci\n              key: KUBEPROXY_PATH\n
-    \             optional: true\n        volumeMounts:\n        - mountPath: /var/lib/kube-proxy\n
-    \         name: kube-proxy\n      nodeSelector:\n        kubernetes.io/os: windows\n
-    \     tolerations:\n      - key: CriticalAddonsOnly\n        operator: Exists\n
-    \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
-    kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
-    \   type: RollingUpdate\n"
+  proxy: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: kube-proxy
+      name: kube-proxy-windows
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: kube-proxy-windows
+      template:
+        metadata:
+          labels:
+            k8s-app: kube-proxy-windows
+        spec:
+          serviceAccountName: kube-proxy
+          securityContext:
+            windowsOptions:
+              hostProcess: true
+              runAsUserName: "NT AUTHORITY\\system"
+          hostNetwork: true
+          containers:
+          - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess
+            args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1"]
+            workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/"
+            name: kube-proxy
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: KUBEPROXY_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: windows-kubeproxy-ci
+                  key: KUBEPROXY_PATH
+                  optional: true
+            volumeMounts:
+            - mountPath: /var/lib/kube-proxy
+              name: kube-proxy
+          nodeSelector:
+            kubernetes.io/os: windows
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - operator: Exists
+          volumes:
+          - configMap:
+              name: kube-proxy
+            name: kube-proxy
+      updateStrategy:
+        type: RollingUpdate
   resources: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -608,26 +608,65 @@ data:
       namespace: kube-system
     data:
       KUBEPROXY_PATH: "c:/k/kube-proxy.exe"
-  proxy: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  labels:\n    k8s-app:
-    kube-proxy\n  name: kube-proxy-windows\n  namespace: kube-system\nspec:\n  selector:\n
-    \   matchLabels:\n      k8s-app: kube-proxy-windows\n  template:\n    metadata:\n
-    \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
-    kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
-    true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
-    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
-    \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
-    kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: spec.nodeName\n        -
-    name: POD_IP\n          valueFrom:\n            fieldRef:\n              fieldPath:
-    status.podIP\n        - name: KUBEPROXY_PATH\n          valueFrom:\n            configMapKeyRef:\n
-    \             name: windows-kubeproxy-ci\n              key: KUBEPROXY_PATH\n
-    \             optional: true\n        volumeMounts:\n        - mountPath: /var/lib/kube-proxy\n
-    \         name: kube-proxy\n      nodeSelector:\n        kubernetes.io/os: windows\n
-    \     tolerations:\n      - key: CriticalAddonsOnly\n        operator: Exists\n
-    \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
-    kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
-    \   type: RollingUpdate\n"
+  proxy: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: kube-proxy
+      name: kube-proxy-windows
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: kube-proxy-windows
+      template:
+        metadata:
+          labels:
+            k8s-app: kube-proxy-windows
+        spec:
+          serviceAccountName: kube-proxy
+          securityContext:
+            windowsOptions:
+              hostProcess: true
+              runAsUserName: "NT AUTHORITY\\system"
+          hostNetwork: true
+          containers:
+          - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess
+            args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1"]
+            workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/"
+            name: kube-proxy
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: KUBEPROXY_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: windows-kubeproxy-ci
+                  key: KUBEPROXY_PATH
+                  optional: true
+            volumeMounts:
+            - mountPath: /var/lib/kube-proxy
+              name: kube-proxy
+          nodeSelector:
+            kubernetes.io/os: windows
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - operator: Exists
+          volumes:
+          - configMap:
+              name: kube-proxy
+            name: kube-proxy
+      updateStrategy:
+        type: RollingUpdate
   resources: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
@@ -612,26 +612,65 @@ data:
       namespace: kube-system
     data:
       KUBEPROXY_PATH: "c:/k/kube-proxy.exe"
-  proxy: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  labels:\n    k8s-app:
-    kube-proxy\n  name: kube-proxy-windows\n  namespace: kube-system\nspec:\n  selector:\n
-    \   matchLabels:\n      k8s-app: kube-proxy-windows\n  template:\n    metadata:\n
-    \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
-    kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
-    true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
-    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
-    \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
-    kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: spec.nodeName\n        -
-    name: POD_IP\n          valueFrom:\n            fieldRef:\n              fieldPath:
-    status.podIP\n        - name: KUBEPROXY_PATH\n          valueFrom:\n            configMapKeyRef:\n
-    \             name: windows-kubeproxy-ci\n              key: KUBEPROXY_PATH\n
-    \             optional: true\n        volumeMounts:\n        - mountPath: /var/lib/kube-proxy\n
-    \         name: kube-proxy\n      nodeSelector:\n        kubernetes.io/os: windows\n
-    \     tolerations:\n      - key: CriticalAddonsOnly\n        operator: Exists\n
-    \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
-    kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
-    \   type: RollingUpdate\n"
+  proxy: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: kube-proxy
+      name: kube-proxy-windows
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: kube-proxy-windows
+      template:
+        metadata:
+          labels:
+            k8s-app: kube-proxy-windows
+        spec:
+          serviceAccountName: kube-proxy
+          securityContext:
+            windowsOptions:
+              hostProcess: true
+              runAsUserName: "NT AUTHORITY\\system"
+          hostNetwork: true
+          containers:
+          - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess
+            args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1"]
+            workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/"
+            name: kube-proxy
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: KUBEPROXY_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: windows-kubeproxy-ci
+                  key: KUBEPROXY_PATH
+                  optional: true
+            volumeMounts:
+            - mountPath: /var/lib/kube-proxy
+              name: kube-proxy
+          nodeSelector:
+            kubernetes.io/os: windows
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - operator: Exists
+          volumes:
+          - configMap:
+              name: kube-proxy
+            name: kube-proxy
+      updateStrategy:
+        type: RollingUpdate
   resources: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -528,26 +528,65 @@ data:
       namespace: kube-system
     data:
       KUBEPROXY_PATH: "c:/k/kube-proxy.exe"
-  proxy: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  labels:\n    k8s-app:
-    kube-proxy\n  name: kube-proxy-windows\n  namespace: kube-system\nspec:\n  selector:\n
-    \   matchLabels:\n      k8s-app: kube-proxy-windows\n  template:\n    metadata:\n
-    \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
-    kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
-    true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
-    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
-    \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
-    kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: spec.nodeName\n        -
-    name: POD_IP\n          valueFrom:\n            fieldRef:\n              fieldPath:
-    status.podIP\n        - name: KUBEPROXY_PATH\n          valueFrom:\n            configMapKeyRef:\n
-    \             name: windows-kubeproxy-ci\n              key: KUBEPROXY_PATH\n
-    \             optional: true\n        volumeMounts:\n        - mountPath: /var/lib/kube-proxy\n
-    \         name: kube-proxy\n      nodeSelector:\n        kubernetes.io/os: windows\n
-    \     tolerations:\n      - key: CriticalAddonsOnly\n        operator: Exists\n
-    \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
-    kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
-    \   type: RollingUpdate\n"
+  proxy: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: kube-proxy
+      name: kube-proxy-windows
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: kube-proxy-windows
+      template:
+        metadata:
+          labels:
+            k8s-app: kube-proxy-windows
+        spec:
+          serviceAccountName: kube-proxy
+          securityContext:
+            windowsOptions:
+              hostProcess: true
+              runAsUserName: "NT AUTHORITY\\system"
+          hostNetwork: true
+          containers:
+          - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess
+            args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1"]
+            workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/"
+            name: kube-proxy
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: KUBEPROXY_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: windows-kubeproxy-ci
+                  key: KUBEPROXY_PATH
+                  optional: true
+            volumeMounts:
+            - mountPath: /var/lib/kube-proxy
+              name: kube-proxy
+          nodeSelector:
+            kubernetes.io/os: windows
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - operator: Exists
+          volumes:
+          - configMap:
+              name: kube-proxy
+            name: kube-proxy
+      updateStrategy:
+        type: RollingUpdate
   resources: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -331,26 +331,65 @@ spec:
 ---
 apiVersion: v1
 data:
-  proxy: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  labels:\n    k8s-app:
-    kube-proxy\n  name: kube-proxy-windows\n  namespace: kube-system\nspec:\n  selector:\n
-    \   matchLabels:\n      k8s-app: kube-proxy-windows\n  template:\n    metadata:\n
-    \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
-    kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
-    true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
-    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
-    \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
-    kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: spec.nodeName\n        -
-    name: POD_IP\n          valueFrom:\n            fieldRef:\n              fieldPath:
-    status.podIP\n        - name: KUBEPROXY_PATH\n          valueFrom:\n            configMapKeyRef:\n
-    \             name: windows-kubeproxy-ci\n              key: KUBEPROXY_PATH\n
-    \             optional: true\n        volumeMounts:\n        - mountPath: /var/lib/kube-proxy\n
-    \         name: kube-proxy\n      nodeSelector:\n        kubernetes.io/os: windows\n
-    \     tolerations:\n      - key: CriticalAddonsOnly\n        operator: Exists\n
-    \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
-    kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
-    \   type: RollingUpdate\n"
+  proxy: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: kube-proxy
+      name: kube-proxy-windows
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: kube-proxy-windows
+      template:
+        metadata:
+          labels:
+            k8s-app: kube-proxy-windows
+        spec:
+          serviceAccountName: kube-proxy
+          securityContext:
+            windowsOptions:
+              hostProcess: true
+              runAsUserName: "NT AUTHORITY\\system"
+          hostNetwork: true
+          containers:
+          - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess
+            args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1"]
+            workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/"
+            name: kube-proxy
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: KUBEPROXY_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: windows-kubeproxy-ci
+                  key: KUBEPROXY_PATH
+                  optional: true
+            volumeMounts:
+            - mountPath: /var/lib/kube-proxy
+              name: kube-proxy
+          nodeSelector:
+            kubernetes.io/os: windows
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - operator: Exists
+          volumes:
+          - configMap:
+              name: kube-proxy
+            name: kube-proxy
+      updateStrategy:
+        type: RollingUpdate
   resources: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition

--- a/templates/test/ci/cluster-template-prow-topology.yaml
+++ b/templates/test/ci/cluster-template-prow-topology.yaml
@@ -80,26 +80,65 @@ spec:
 ---
 apiVersion: v1
 data:
-  proxy: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  labels:\n    k8s-app:
-    kube-proxy\n  name: kube-proxy-windows\n  namespace: kube-system\nspec:\n  selector:\n
-    \   matchLabels:\n      k8s-app: kube-proxy-windows\n  template:\n    metadata:\n
-    \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
-    kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
-    true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
-    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
-    \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
-    kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: spec.nodeName\n        -
-    name: POD_IP\n          valueFrom:\n            fieldRef:\n              fieldPath:
-    status.podIP\n        - name: KUBEPROXY_PATH\n          valueFrom:\n            configMapKeyRef:\n
-    \             name: windows-kubeproxy-ci\n              key: KUBEPROXY_PATH\n
-    \             optional: true\n        volumeMounts:\n        - mountPath: /var/lib/kube-proxy\n
-    \         name: kube-proxy\n      nodeSelector:\n        kubernetes.io/os: windows\n
-    \     tolerations:\n      - key: CriticalAddonsOnly\n        operator: Exists\n
-    \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
-    kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
-    \   type: RollingUpdate\n"
+  proxy: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: kube-proxy
+      name: kube-proxy-windows
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: kube-proxy-windows
+      template:
+        metadata:
+          labels:
+            k8s-app: kube-proxy-windows
+        spec:
+          serviceAccountName: kube-proxy
+          securityContext:
+            windowsOptions:
+              hostProcess: true
+              runAsUserName: "NT AUTHORITY\\system"
+          hostNetwork: true
+          containers:
+          - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess
+            args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1"]
+            workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/"
+            name: kube-proxy
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: KUBEPROXY_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: windows-kubeproxy-ci
+                  key: KUBEPROXY_PATH
+                  optional: true
+            volumeMounts:
+            - mountPath: /var/lib/kube-proxy
+              name: kube-proxy
+          nodeSelector:
+            kubernetes.io/os: windows
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - operator: Exists
+          volumes:
+          - configMap:
+              name: kube-proxy
+            name: kube-proxy
+      updateStrategy:
+        type: RollingUpdate
   resources: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -409,26 +409,65 @@ spec:
 ---
 apiVersion: v1
 data:
-  proxy: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  labels:\n    k8s-app:
-    kube-proxy\n  name: kube-proxy-windows\n  namespace: kube-system\nspec:\n  selector:\n
-    \   matchLabels:\n      k8s-app: kube-proxy-windows\n  template:\n    metadata:\n
-    \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
-    kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
-    true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
-    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
-    \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
-    kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: spec.nodeName\n        -
-    name: POD_IP\n          valueFrom:\n            fieldRef:\n              fieldPath:
-    status.podIP\n        - name: KUBEPROXY_PATH\n          valueFrom:\n            configMapKeyRef:\n
-    \             name: windows-kubeproxy-ci\n              key: KUBEPROXY_PATH\n
-    \             optional: true\n        volumeMounts:\n        - mountPath: /var/lib/kube-proxy\n
-    \         name: kube-proxy\n      nodeSelector:\n        kubernetes.io/os: windows\n
-    \     tolerations:\n      - key: CriticalAddonsOnly\n        operator: Exists\n
-    \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
-    kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
-    \   type: RollingUpdate\n"
+  proxy: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: kube-proxy
+      name: kube-proxy-windows
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: kube-proxy-windows
+      template:
+        metadata:
+          labels:
+            k8s-app: kube-proxy-windows
+        spec:
+          serviceAccountName: kube-proxy
+          securityContext:
+            windowsOptions:
+              hostProcess: true
+              runAsUserName: "NT AUTHORITY\\system"
+          hostNetwork: true
+          containers:
+          - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess
+            args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1"]
+            workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/"
+            name: kube-proxy
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: KUBEPROXY_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: windows-kubeproxy-ci
+                  key: KUBEPROXY_PATH
+                  optional: true
+            volumeMounts:
+            - mountPath: /var/lib/kube-proxy
+              name: kube-proxy
+          nodeSelector:
+            kubernetes.io/os: windows
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - operator: Exists
+          volumes:
+          - configMap:
+              name: kube-proxy
+            name: kube-proxy
+      updateStrategy:
+        type: RollingUpdate
   resources: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -427,26 +427,65 @@ spec:
 ---
 apiVersion: v1
 data:
-  proxy: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  labels:\n    k8s-app:
-    kube-proxy\n  name: kube-proxy-windows\n  namespace: kube-system\nspec:\n  selector:\n
-    \   matchLabels:\n      k8s-app: kube-proxy-windows\n  template:\n    metadata:\n
-    \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
-    kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
-    true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
-    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
-    \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
-    kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: spec.nodeName\n        -
-    name: POD_IP\n          valueFrom:\n            fieldRef:\n              fieldPath:
-    status.podIP\n        - name: KUBEPROXY_PATH\n          valueFrom:\n            configMapKeyRef:\n
-    \             name: windows-kubeproxy-ci\n              key: KUBEPROXY_PATH\n
-    \             optional: true\n        volumeMounts:\n        - mountPath: /var/lib/kube-proxy\n
-    \         name: kube-proxy\n      nodeSelector:\n        kubernetes.io/os: windows\n
-    \     tolerations:\n      - key: CriticalAddonsOnly\n        operator: Exists\n
-    \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
-    kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
-    \   type: RollingUpdate\n"
+  proxy: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: kube-proxy
+      name: kube-proxy-windows
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: kube-proxy-windows
+      template:
+        metadata:
+          labels:
+            k8s-app: kube-proxy-windows
+        spec:
+          serviceAccountName: kube-proxy
+          securityContext:
+            windowsOptions:
+              hostProcess: true
+              runAsUserName: "NT AUTHORITY\\system"
+          hostNetwork: true
+          containers:
+          - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess
+            args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1"]
+            workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/"
+            name: kube-proxy
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: KUBEPROXY_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: windows-kubeproxy-ci
+                  key: KUBEPROXY_PATH
+                  optional: true
+            volumeMounts:
+            - mountPath: /var/lib/kube-proxy
+              name: kube-proxy
+          nodeSelector:
+            kubernetes.io/os: windows
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - operator: Exists
+          volumes:
+          - configMap:
+              name: kube-proxy
+            name: kube-proxy
+      updateStrategy:
+        type: RollingUpdate
   resources: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -549,26 +549,65 @@ data:
       namespace: kube-system
     data:
       KUBEPROXY_PATH: "c:/k/kube-proxy.exe"
-  proxy: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  labels:\n    k8s-app:
-    kube-proxy\n  name: kube-proxy-windows\n  namespace: kube-system\nspec:\n  selector:\n
-    \   matchLabels:\n      k8s-app: kube-proxy-windows\n  template:\n    metadata:\n
-    \     labels:\n        k8s-app: kube-proxy-windows\n    spec:\n      serviceAccountName:
-    kube-proxy\n      securityContext:\n        windowsOptions:\n          hostProcess:
-    true\n          runAsUserName: \"NT AUTHORITY\\\\system\"\n      hostNetwork:
-    true\n      containers:\n      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess\n
-    \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1\"]\n
-    \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/\"\n        name:
-    kube-proxy\n        env:\n        - name: NODE_NAME\n          valueFrom:\n            fieldRef:\n
-    \             apiVersion: v1\n              fieldPath: spec.nodeName\n        -
-    name: POD_IP\n          valueFrom:\n            fieldRef:\n              fieldPath:
-    status.podIP\n        - name: KUBEPROXY_PATH\n          valueFrom:\n            configMapKeyRef:\n
-    \             name: windows-kubeproxy-ci\n              key: KUBEPROXY_PATH\n
-    \             optional: true\n        volumeMounts:\n        - mountPath: /var/lib/kube-proxy\n
-    \         name: kube-proxy\n      nodeSelector:\n        kubernetes.io/os: windows\n
-    \     tolerations:\n      - key: CriticalAddonsOnly\n        operator: Exists\n
-    \     - operator: Exists\n      volumes:\n      - configMap:\n          name:
-    kube-proxy\n          item:     \n        name: kube-proxy\n  updateStrategy:\n
-    \   type: RollingUpdate\n"
+  proxy: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: kube-proxy
+      name: kube-proxy-windows
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: kube-proxy-windows
+      template:
+        metadata:
+          labels:
+            k8s-app: kube-proxy-windows
+        spec:
+          serviceAccountName: kube-proxy
+          securityContext:
+            windowsOptions:
+              hostProcess: true
+              runAsUserName: "NT AUTHORITY\\system"
+          hostNetwork: true
+          containers:
+          - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess
+            args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1"]
+            workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/"
+            name: kube-proxy
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: KUBEPROXY_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: windows-kubeproxy-ci
+                  key: KUBEPROXY_PATH
+                  optional: true
+            volumeMounts:
+            - mountPath: /var/lib/kube-proxy
+              name: kube-proxy
+          nodeSelector:
+            kubernetes.io/os: windows
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - operator: Exists
+          volumes:
+          - configMap:
+              name: kube-proxy
+            name: kube-proxy
+      updateStrategy:
+        type: RollingUpdate
   resources: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
/kind failing-test
<!--
Add one of the following kinds:
/kind feature

/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation

/kind flake
-->

**What this PR does / why we need it**:

If you apply the windows kube-proxy field directly it fails with. Seeing this with the WS2022 test suite: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-capz-master-containerd-windows-2022/1549759884222795776

This extra field also appears to be why the formatting was messed up for these files in the generated yaml.

```
Error from server (BadRequest): error when creating "kube-proxy-windows.yaml": DaemonSet in version "v1" cannot be handled as a DaemonSet: strict decoding error: unknown field "spec.template.spec.volumes[0].configMap.item"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
