### PR TITLE
Check for nil infra ref in azurejson controllers

### DIFF
--- a/controllers/azurejson_machine_controller.go
+++ b/controllers/azurejson_machine_controller.go
@@ -147,6 +147,10 @@ func (r *AzureJSONMachineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	_, kind := infrav1.GroupVersion.WithKind("AzureCluster").ToAPIVersionAndKind()
 
 	// only look at azure clusters
+	if cluster.Spec.InfrastructureRef == nil {
+		log.Info("infra ref is nil")
+		return ctrl.Result{}, nil
+	}
 	if cluster.Spec.InfrastructureRef.Kind != kind {
 		log.WithValues("kind", cluster.Spec.InfrastructureRef.Kind).Info("infra ref was not an AzureCluster")
 		return ctrl.Result{}, nil

--- a/controllers/azurejson_machine_controller_test.go
+++ b/controllers/azurejson_machine_controller_test.go
@@ -169,6 +169,40 @@ func TestAzureJSONMachineReconciler(t *testing.T) {
 			fail: true,
 			err:  "azureclusters.infrastructure.cluster.x-k8s.io \"my-azure-cluster\" not found",
 		},
+		"infra ref is nil": {
+			objects: []runtime.Object{
+				&clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-cluster",
+					},
+					Spec: clusterv1.ClusterSpec{
+						InfrastructureRef: nil,
+					},
+				},
+				azureCluster,
+				azureMachine,
+			},
+			fail: false,
+		},
+		"infra ref is not an azure cluster": {
+			objects: []runtime.Object{
+				&clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-cluster",
+					},
+					Spec: clusterv1.ClusterSpec{
+						InfrastructureRef: &corev1.ObjectReference{
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+							Kind:       "FooCluster",
+							Name:       "my-foo-cluster",
+						},
+					},
+				},
+				azureCluster,
+				azureMachine,
+			},
+			fail: false,
+		},
 	}
 
 	os.Setenv(auth.ClientID, "fooClient")

--- a/controllers/azurejson_machinepool_controller.go
+++ b/controllers/azurejson_machinepool_controller.go
@@ -115,6 +115,10 @@ func (r *AzureJSONMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl
 	_, kind := infrav1.GroupVersion.WithKind("AzureCluster").ToAPIVersionAndKind()
 
 	// only look at azure clusters
+	if cluster.Spec.InfrastructureRef == nil {
+		log.Info("infra ref is nil")
+		return ctrl.Result{}, nil
+	}
 	if cluster.Spec.InfrastructureRef.Kind != kind {
 		log.WithValues("kind", cluster.Spec.InfrastructureRef.Kind).Info("infra ref was not an AzureCluster")
 		return ctrl.Result{}, nil

--- a/controllers/azurejson_machinepool_controller_test.go
+++ b/controllers/azurejson_machinepool_controller_test.go
@@ -139,6 +139,42 @@ func TestAzureJSONPoolReconciler(t *testing.T) {
 			fail: true,
 			err:  "azureclusters.infrastructure.cluster.x-k8s.io \"my-azure-cluster\" not found",
 		},
+		"infra ref is nil": {
+			objects: []runtime.Object{
+				&clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-cluster",
+					},
+					Spec: clusterv1.ClusterSpec{
+						InfrastructureRef: nil,
+					},
+				},
+				azureCluster,
+				machinePool,
+				azureMachinePool,
+			},
+			fail: false,
+		},
+		"infra ref is not an azure cluster": {
+			objects: []runtime.Object{
+				&clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-cluster",
+					},
+					Spec: clusterv1.ClusterSpec{
+						InfrastructureRef: &corev1.ObjectReference{
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+							Kind:       "FooCluster",
+							Name:       "my-foo-cluster",
+						},
+					},
+				},
+				azureCluster,
+				machinePool,
+				azureMachinePool,
+			},
+			fail: false,
+		},
 	}
 
 	os.Setenv(auth.ClientID, "fooClient")

--- a/controllers/azurejson_machinetemplate_controller.go
+++ b/controllers/azurejson_machinetemplate_controller.go
@@ -106,6 +106,10 @@ func (r *AzureJSONTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// only look at azure clusters
+	if cluster.Spec.InfrastructureRef == nil {
+		log.Info("infra ref is nil")
+		return ctrl.Result{}, nil
+	}
 	if cluster.Spec.InfrastructureRef.Kind != "AzureCluster" {
 		log.WithValues("kind", cluster.Spec.InfrastructureRef.Kind).Info("infra ref was not an AzureCluster")
 		return ctrl.Result{}, nil

--- a/controllers/azurejson_machinetemplate_controller_test.go
+++ b/controllers/azurejson_machinetemplate_controller_test.go
@@ -104,6 +104,40 @@ func TestAzureJSONTemplateReconciler(t *testing.T) {
 			fail: true,
 			err:  "azureclusters.infrastructure.cluster.x-k8s.io \"my-azure-cluster\" not found",
 		},
+		"infra ref is nil": {
+			objects: []runtime.Object{
+				&clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-cluster",
+					},
+					Spec: clusterv1.ClusterSpec{
+						InfrastructureRef: nil,
+					},
+				},
+				azureCluster,
+				azureMachineTemplate,
+			},
+			fail: false,
+		},
+		"infra ref is not an azure cluster": {
+			objects: []runtime.Object{
+				&clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-cluster",
+					},
+					Spec: clusterv1.ClusterSpec{
+						InfrastructureRef: &corev1.ObjectReference{
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+							Kind:       "FooCluster",
+							Name:       "my-foo-cluster",
+						},
+					},
+				},
+				azureCluster,
+				azureMachineTemplate,
+			},
+			fail: false,
+		},
 	}
 
 	os.Setenv(auth.ClientID, "fooClient")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Fix a nil pointer error observed in https://storage.googleapis.com/kubernetes-jenkins/logs/periodic-cluster-api-provider-azure-e2e-full-main/1549613668864364544/artifacts/clusters/bootstrap/controllers/capz-controller-manager/capz-controller-manager-65c9d7b84d-mz2j2/manager.log and https://storage.googleapis.com/kubernetes-jenkins/logs/periodic-cluster-api-provider-azure-e2e-full-main/1549794864755904512/artifacts/clusters/bootstrap/controllers/capz-controller-manager/capz-controller-manager-75fc64f756-mhfkn/manager.log

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Not 100% sure if this is a new bug or if it started being visible in e2e logs because of changes to parallelism.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Check for infra ref nil pointer in azurejson controllers
```
