### PR TITLE
test: simplify capz provider metadata.yaml

### DIFF
--- a/docs/book/src/developers/releasing.md
+++ b/docs/book/src/developers/releasing.md
@@ -12,6 +12,26 @@
   - Open a PR in https://github.com/kubernetes/test-infra to change this [line](https://github.com/kubernetes/test-infra/blob/25db54eb9d52e08c16b3601726d8f154f8741025/config/prow/plugins.yaml#L344)
     - Example PR: https://github.com/kubernetes/test-infra/pull/16827
 
+## Update test capz provider metadata.yaml (skip for patch releases)
+
+Using that same next release version used to create a new milestone, update the the capz provider [metadata.yaml](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/test/e2e/data/shared/v1beta1_provider/metadata.yaml) that we use to run PR and periodic cluster E2E tests against the main branch templates.
+
+For example, if the latest stable API version of capz that we run E2E tests against is `v1beta`, and we're releasing `v1.4.0`, and our next release version is `v1.5.0`, then we want to ensure that the `metadata.yaml` defines a contract between `1.5` and `v1beta1`:
+
+```yaml
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+releaseSeries:
+  - major: 1
+    minor: 5
+    contract: v1beta1
+```
+
+Additionally, we need to update the `type: InfrastructureProvider` spec in [azure-dev.yaml](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/test/e2e/config/azure-dev.yaml) to express that our intent is to test (using the above example) `1.5`. By convention we use a sentinel patch version "99" to express "any patch version". In this example we want to look for the `type: InfrastructureProvider` with a `name` value of `v1.4.99` and update it to `v1.5.99`:
+
+```
+    - name: v1.5.99 # "vNext"; use manifests from local source files
+```
+
 ## Create a tag
 
 - Prepare the release branch. :warning: Always release from the release branch and not from main!

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -92,7 +92,7 @@ providers:
       replacements:
       - old: "imagePullPolicy: Always"
         new: "imagePullPolicy: IfNotPresent"
-    - name: v1.1.99 # next; use manifest from source files
+    - name: v1.5.99 # "vNext"; use manifests from local source files
       value: "${PWD}/config/default"
       contract: v1beta1
       files:

--- a/test/e2e/data/shared/v1beta1_provider/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1_provider/metadata.yaml
@@ -3,20 +3,10 @@
 # between patch versions.
 #
 # update this file only when a new major or minor version is released
+# in practice this metadata.yaml contract spec is only used to test
+# one capz version at a time against one API version
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 releaseSeries:
-  - major: 0
-    minor: 3
-    contract: v1alpha2
-  - major: 0
-    minor: 4
-    contract: v1alpha3
-  - major: 0
+  - major: 1
     minor: 5
-    contract: v1alpha4
-  - major: 1
-    minor: 0
-    contract: v1beta1
-  - major: 1
-    minor: 1
     contract: v1beta1


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

This PR simplifies the `metadata.yaml` API version contract spec file we maintain for running tests against clusters template in the capz repo. Because our convention at present is to only test one API version (currently `v1beta1`) against an "alias" capz version target that is meant to represent the next release version in the queue, we can make the `metadata.yaml` file much simpler and easier to maintain.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
