### PR TITLE
Fix Inbound NAT rule port allocation

### DIFF
--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -206,7 +206,7 @@ func (m *MachineScope) PublicIPSpecs() []azure.ResourceSpecGetter {
 }
 
 // InboundNatSpecs returns the inbound NAT specs.
-func (m *MachineScope) InboundNatSpecs(portsInUse map[int32]struct{}) []azure.ResourceSpecGetter {
+func (m *MachineScope) InboundNatSpecs() []azure.ResourceSpecGetter {
 	// The existing inbound NAT rules are needed in order to find an available SSH port for each new inbound NAT rule.
 	if m.Role() == infrav1.ControlPlane {
 		spec := &inboundnatrules.InboundNatSpec{
@@ -214,7 +214,6 @@ func (m *MachineScope) InboundNatSpecs(portsInUse map[int32]struct{}) []azure.Re
 			ResourceGroup:             m.ResourceGroup(),
 			LoadBalancerName:          m.APIServerLBName(),
 			FrontendIPConfigurationID: nil,
-			PortsInUse:                portsInUse,
 		}
 		if frontEndIPs := m.APIServerLB().FrontendIPs; len(frontEndIPs) > 0 {
 			ipConfig := frontEndIPs[0].Name

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -404,7 +404,6 @@ func TestMachineScope_InboundNatSpecs(t *testing.T) {
 					LoadBalancerName:          "foo-loadbalancer",
 					ResourceGroup:             "my-rg",
 					FrontendIPConfigurationID: to.StringPtr(azure.FrontendIPConfigID("123", "my-rg", "foo-loadbalancer", "foo-frontend-ip")),
-					PortsInUse:                make(map[int32]struct{}),
 				},
 			},
 		},
@@ -413,7 +412,7 @@ func TestMachineScope_InboundNatSpecs(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := tt.machineScope.InboundNatSpecs(make(map[int32]struct{})); !reflect.DeepEqual(got, tt.want) {
+			if got := tt.machineScope.InboundNatSpecs(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("InboundNatSpecs() = %s, want %s", specArrayToString(got), specArrayToString(tt.want))
 			}
 		})

--- a/azure/services/inboundnatrules/mock_inboundnatrules/inboundnatrules_mock.go
+++ b/azure/services/inboundnatrules/mock_inboundnatrules/inboundnatrules_mock.go
@@ -248,17 +248,17 @@ func (mr *MockInboundNatScopeMockRecorder) HashKey() *gomock.Call {
 }
 
 // InboundNatSpecs mocks base method.
-func (m *MockInboundNatScope) InboundNatSpecs(arg0 map[int32]struct{}) []azure.ResourceSpecGetter {
+func (m *MockInboundNatScope) InboundNatSpecs() []azure.ResourceSpecGetter {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InboundNatSpecs", arg0)
+	ret := m.ctrl.Call(m, "InboundNatSpecs")
 	ret0, _ := ret[0].([]azure.ResourceSpecGetter)
 	return ret0
 }
 
 // InboundNatSpecs indicates an expected call of InboundNatSpecs.
-func (mr *MockInboundNatScopeMockRecorder) InboundNatSpecs(arg0 interface{}) *gomock.Call {
+func (mr *MockInboundNatScopeMockRecorder) InboundNatSpecs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InboundNatSpecs", reflect.TypeOf((*MockInboundNatScope)(nil).InboundNatSpecs), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InboundNatSpecs", reflect.TypeOf((*MockInboundNatScope)(nil).InboundNatSpecs))
 }
 
 // Location mocks base method.

--- a/azure/services/inboundnatrules/spec_test.go
+++ b/azure/services/inboundnatrules/spec_test.go
@@ -67,7 +67,7 @@ func TestGetAvailablePort(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			res, err := getAvailablePort(tc.portsInput)
+			res, err := getAvailableSSHFrontendPort(tc.portsInput)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This fixes a TODO for inbound NAT rule reconciliation where collisions might happen. Also stops doing unnecessary `List` calls for every AzureMachine, even if there are no inbound nat rules to reconcile (eg. worker machines).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2492 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix Inbound NAT rule port allocation
```
