### PR TITLE
Make sure to use resolved k8s versions on parallel e2e nodes

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -104,6 +104,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	dec := gob.NewDecoder(buf)
 	Expect(dec.Decode(&e2eConfig)).To(Succeed())
 
+	// we unset Kubernetes version variables to make sure we use the ones resolved from the first Ginkgo ParallelNode in the e2e config.
+	os.Unsetenv(capi_e2e.KubernetesVersion)
+	os.Unsetenv(capi_e2e.KubernetesVersionUpgradeFrom)
+	os.Unsetenv(capi_e2e.KubernetesVersionUpgradeTo)
+
 	kubeconfigPath := parts[3]
 	bootstrapClusterProxy = NewAzureClusterProxy("bootstrap", kubeconfigPath, framework.WithMachineLogCollector(AzureLogCollector{}))
 })


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Since clusterctl will get config variables from the OS environment, we need to make sure that we are getting the right version set in the config on parallel nodes where that env variable was not overwritten. Unset the environment variables for k8s versions to make sure we use the ones in the config.

fixes https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#capi-periodic-upgrade-main-1-23-1-24

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
