### PR TITLE
Wait calico pod to be ready before installing windows CNMs

### DIFF
--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -181,6 +181,10 @@ timeout --foreground 1800 bash -c wait_for_nodes
 
 # install cloud-provider-azure components, if using out-of-tree
 if [[ -n "${TEST_CCM:-}" ]]; then
+    if [[ -n "${TEST_WINDOWS:-}" ]]; then
+        # "app=calico" is the label only for calico-node-windows pods
+        "${KUBECTL}" wait --for=condition=Ready pod -l app=calico -n kube-system --timeout=10m
+    fi
     echo "Installing cloud-provider-azure components via helm"
     "${HELM}" install --repo https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo cloud-provider-azure --generate-name \
 --set infra.clusterName="${CLUSTER_NAME}" \
@@ -191,6 +195,8 @@ if [[ -n "${TEST_CCM:-}" ]]; then
 --set-string cloudControllerManager.imageTag="${IMAGE_TAG}" \
 --set-string cloudNodeManager.imageTag="${IMAGE_TAG}" \
 --set cloudControllerManager.replicas="${CCM_COUNT}"
+    echo "Waiting for all kube-system pods to be ready"
+    "${KUBECTL}" wait --for=condition=Ready pod -n kube-system --all --timeout=10m
 fi
 
 if [[ "${#}" -gt 0 ]]; then


### PR DESCRIPTION
Signed-off-by: Lan Lou [t-lanlou@microsoft.com](mailto:t-lanlou@microsoft.com)
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Because windows image for calico is big, it takes some time for calico pods to be ready. If windows CNMs are installed when calico pods are not ready, there may exist some unstable factors. 
By doing this way, installing windows CNM will be smoother, which is verified several local tests.

![image](https://user-images.githubusercontent.com/62441979/181486065-20fd7589-6fda-48b1-a9b9-ef4da18e6cc8.png)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
