### PR TITLE
don’t explicitly delete subnet, routetable, nsg

### DIFF
--- a/azure/services/subnets/subnets.go
+++ b/azure/services/subnets/subnets.go
@@ -102,46 +102,21 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	return resultErr
 }
 
-// Delete deletes the subnet with the provided name.
+// Delete takes no action.
+// We don't need to explicitly delete a subnet;
+// We can rely upon the Virtual Network to delete its subnet(s).
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, log, done := tele.StartSpanWithLogger(ctx, "subnets.Service.Delete")
+	_, log, done := tele.StartSpanWithLogger(ctx, "subnets.Service.Delete")
 	defer done()
 
-	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
-	defer cancel()
-
-	if managed, err := s.IsManaged(ctx); err == nil && !managed {
-		log.V(4).Info("Skipping subnets deletion in custom vnet mode")
-		return nil
-	} else if err != nil {
-		return errors.Wrap(err, "failed to check if subnets are managed")
-	}
-
-	specs := s.Scope.SubnetSpecs()
-	if len(specs) == 0 {
-		return nil
-	}
-
-	// We go through the list of SubnetSpecs to delete each one, independently of the result of the previous one.
-	// If multiple errors occur, we return the most pressing one.
-	//  Order of precedence (highest -> lowest) is: error that is not an operationNotDoneError (i.e. error deleting) -> operationNotDoneError (i.e. deleting in progress) -> no error (i.e. deleted)
-	var result error
-	for _, subnetSpec := range specs {
-		if err := s.DeleteResource(ctx, subnetSpec, serviceName); err != nil {
-			if !azure.IsOperationNotDoneError(err) || result == nil {
-				result = err
-			}
-		}
-	}
-
-	s.Scope.UpdateDeleteStatus(infrav1.SubnetsReadyCondition, serviceName, result)
-	return result
+	log.V(4).Info("Subnet will be deleted when its parent Virtual Network is deleted")
+	return nil
 }
 
-// IsManaged returns true if the route tables' lifecycles are managed.
+// IsManaged always returns false for subnets.
+// This is semantically imprecise, as we aren't actually able to determine
+// whether or not a subnet was created by capz or if it existed previously,
+// but we must implement `IsManaged` given the ServiceReconciler type constraints.
 func (s *Service) IsManaged(ctx context.Context) (bool, error) {
-	_, _, done := tele.StartSpanWithLogger(ctx, "subnets.Service.IsManaged")
-	defer done()
-
-	return s.Scope.IsVnetManaged(), nil
+	return false, nil
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind bug

**What this PR does / why we need it**:

This PR changes the subnet `Delete` implementation so that it is a no-op. There are a couple reasons why this is an attractive idea:

1. A subnet, properly speaking, are a dependent/child/sub- resource of a Virtual Network. Whenever we delete a Virtual Network, we will always delete any subnets it contains.
2. Subnets don't support resource tags, which means that we can't positively identify whether or not a subnet resource is "owned" by capz (and should thus be deleted by a capz controller when its relevant capz CRD resource is deleted) after it is created. Thus we aren't able to properly, conditionally delete a subnet _only if it is owned by capz_.

Unfortunately there are a couple undesirable side-effects of this change:

1. Making a resource `Delete` operation a static no-op in practice is hacky
2. Because subnet like all service resources fulfills the type `azure.ServiceReconciler`, we need to implement `IsManaged()`, which as stated above we don't actually know, and in fact with this change we actually aren't going to invoke. It seems like the least hacky way to do this is to always return `false`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2484

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
