### PR TITLE
Clarify where to get help with CAPZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,14 @@ Check out the [Cluster API Quick Start][quickstart] to create your first Kuberne
 
 See the [flavors documentation][flavors_doc] to know which cluster templates are provided by CAPZ.
 
+
+## Getting Help
+
+If you need help with CAPZ, please visit the [#cluster-api-azure][slack] channel on Slack, open a [GitHub issue](#github-issues), or join us at [Office Hours](#office-hours).
+
 ------
 
-## Support Policy
+## Compatibility
 
 ### Cluster API Versions
 
@@ -89,7 +94,7 @@ developers.
 
 Office hours are hosted on a zoom video chat every other Thursday
 at 08:00 (PT) / 11:00 (ET) / 16:00 (UTC),
-and are published on the [Kubernetes community meetings calendar][gcal].
+and are published on the [Kubernetes community meetings calendar][gcal]. Please add your questions or ideas to [the agenda][capz_agenda].
 
 ### Other ways to communicate with the contributors
 
@@ -134,3 +139,4 @@ We also use the issue tracker to track features. If you have an idea for a featu
 [cluster_api]: https://github.com/kubernetes-sigs/cluster-api
 [quickstart]: https://cluster-api.sigs.k8s.io/user/quick-start.html
 [flavors_doc]: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/templates/flavors/README.md
+[capz_agenda]: http://bit.ly/k8s-capz-agenda

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,24 @@
+# Support
+
+## How to get help
+
+If you have questions about using this project or need help, please:
+
+  - Consult the [Cluster API Provider Azure Book][docs]
+  - Ask in the [#cluster-api-azure][slack] Slack channel
+  - Join us for bi-weekly [office hours][office-hours]
+
+## How to create issues
+
+This project uses GitHub Issues to track bugs and feature requests. Please search the [existing issues][github-issues] before creating a new one to avoid duplication.
+
+The project maintainers will respond to the best of their abilities.
+
+## Support Policy
+
+Support for this project is limited to the resources listed above.
+
+[docs]: https://capz.sigs.k8s.io/
+[github-issues]: https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues
+[office-hours]: http://bit.ly/k8s-capz-agenda
+[slack]: https://kubernetes.slack.com/messages/CEX9HENG7


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Clarifies where to get help with Cluster API Provider for Azure. Specifically, this change tries to prioritize the [#cluster-api-provider-azure](https://kubernetes.slack.com/messages/CEX9HENG7) Slack channel, where maintainers are active.

**Which issue(s) this PR fixes**:

Fixes #2517 

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Clarify where to get help with CAPZ
```
