### PR TITLE
Standardize more package import aliases

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,6 +72,34 @@ linters-settings:
       # Controller Runtime
       - pkg: sigs.k8s.io/controller-runtime
         alias: ctrl
+      # CAPI
+      - pkg: sigs.k8s.io/cluster-api/api/v1alpha3
+        alias: clusterv1alpha3
+      - pkg: sigs.k8s.io/cluster-api/api/v1alpha4
+        alias: clusterv1alpha4
+      - pkg: sigs.k8s.io/cluster-api/api/v1beta1
+        alias: clusterv1
+      # CAPI exp
+      - pkg: sigs.k8s.io/cluster-api/exp/api/v1alpha3
+        alias: expv1alpha3
+      - pkg: sigs.k8s.io/cluster-api/exp/api/v1alpha4
+        alias: expv1alpha4
+      - pkg: sigs.k8s.io/cluster-api/exp/api/v1beta1
+        alias: expv1
+      # CAPZ
+      - pkg: sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3
+        alias: infrav1alpha3
+      - pkg: sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4
+        alias: infrav1alpha4
+      - pkg: sigs.k8s.io/cluster-api-provider-azure/api/v1beta1
+        alias: infrav1
+      # CAPZ exp
+      - pkg: sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3
+        alias: infrav1alpha3exp
+      - pkg: sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha4
+        alias: infrav1alpha4exp
+      - pkg: sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1
+        alias: infrav1exp
   godot:
     #   declarations - for top level declaration comments (default);
     #   toplevel     - for top level comments;

--- a/api/v1alpha3/azurecluster_types.go
+++ b/api/v1alpha3/azurecluster_types.go
@@ -19,7 +19,7 @@ package v1alpha3
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
 const (
@@ -46,7 +46,7 @@ type AzureClusterSpec struct {
 
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
-	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
+	ControlPlaneEndpoint clusterv1alpha3.APIEndpoint `json:"controlPlaneEndpoint"`
 
 	// AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the
 	// ones added by default.
@@ -66,7 +66,7 @@ type AzureClusterStatus struct {
 	// the cluster is more resilient to failure.
 	// See: https://docs.microsoft.com/en-us/azure/availability-zones/az-overview
 	// This list will be used by Cluster API to try and spread the machines across the failure domains.
-	FailureDomains clusterv1.FailureDomains `json:"failureDomains,omitempty"`
+	FailureDomains clusterv1alpha3.FailureDomains `json:"failureDomains,omitempty"`
 
 	// Ready is true when the provider resource is ready.
 	// +optional
@@ -74,7 +74,7 @@ type AzureClusterStatus struct {
 
 	// Conditions defines current service state of the AzureCluster.
 	// +optional
-	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+	Conditions clusterv1alpha3.Conditions `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -106,12 +106,12 @@ type AzureClusterList struct {
 }
 
 // GetConditions returns the list of conditions for an AzureCluster API object.
-func (c *AzureCluster) GetConditions() clusterv1.Conditions {
+func (c *AzureCluster) GetConditions() clusterv1alpha3.Conditions {
 	return c.Status.Conditions
 }
 
 // SetConditions will set the given conditions on an AzureCluster object.
-func (c *AzureCluster) SetConditions(conditions clusterv1.Conditions) {
+func (c *AzureCluster) SetConditions(conditions clusterv1alpha3.Conditions) {
 	c.Status.Conditions = conditions
 }
 

--- a/api/v1alpha3/azureclusteridentity_types.go
+++ b/api/v1alpha3/azureclusteridentity_types.go
@@ -19,7 +19,7 @@ package v1alpha3
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
 // AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity.
@@ -50,7 +50,7 @@ type AzureClusterIdentitySpec struct {
 type AzureClusterIdentityStatus struct {
 	// Conditions defines current service state of the AzureClusterIdentity.
 	// +optional
-	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+	Conditions clusterv1alpha3.Conditions `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -76,12 +76,12 @@ type AzureClusterIdentityList struct {
 }
 
 // GetConditions returns the list of conditions for an AzureClusterIdentity API object.
-func (c *AzureClusterIdentity) GetConditions() clusterv1.Conditions {
+func (c *AzureClusterIdentity) GetConditions() clusterv1alpha3.Conditions {
 	return c.Status.Conditions
 }
 
 // SetConditions will set the given conditions on an AzureClusterIdentity object.
-func (c *AzureClusterIdentity) SetConditions(conditions clusterv1.Conditions) {
+func (c *AzureClusterIdentity) SetConditions(conditions clusterv1alpha3.Conditions) {
 	c.Status.Conditions = conditions
 }
 

--- a/api/v1alpha3/azuremachine_types.go
+++ b/api/v1alpha3/azuremachine_types.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/errors"
 )
 
@@ -176,7 +176,7 @@ type AzureMachineStatus struct {
 
 	// Conditions defines current service state of the AzureMachine.
 	// +optional
-	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+	Conditions clusterv1alpha3.Conditions `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -208,12 +208,12 @@ type AzureMachineList struct {
 }
 
 // GetConditions returns the list of conditions for an AzureMachine API object.
-func (m *AzureMachine) GetConditions() clusterv1.Conditions {
+func (m *AzureMachine) GetConditions() clusterv1alpha3.Conditions {
 	return m.Status.Conditions
 }
 
 // SetConditions will set the given conditions on an AzureMachine object.
-func (m *AzureMachine) SetConditions(conditions clusterv1.Conditions) {
+func (m *AzureMachine) SetConditions(conditions clusterv1alpha3.Conditions) {
 	m.Status.Conditions = conditions
 }
 

--- a/api/v1alpha3/conditions_consts.go
+++ b/api/v1alpha3/conditions_consts.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package v1alpha3
 
-import clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+import clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 // AzureCluster Conditions and Reasons.
 const (
@@ -33,7 +33,7 @@ const (
 // AzureMachine Conditions and Reasons.
 const (
 	// VMRunningCondition reports on current status of the Azure VM.
-	VMRunningCondition clusterv1.ConditionType = "VMRunning"
+	VMRunningCondition clusterv1alpha3.ConditionType = "VMRunning"
 	// VMNCreatingReason used when the vm creation is in progress.
 	VMNCreatingReason = "VMCreating"
 	// VMNUpdatingReason used when the vm updating is in progress.

--- a/api/v1alpha4/azurecluster_types.go
+++ b/api/v1alpha4/azurecluster_types.go
@@ -19,7 +19,7 @@ package v1alpha4
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
 const (
@@ -46,7 +46,7 @@ type AzureClusterSpec struct {
 
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
-	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
+	ControlPlaneEndpoint clusterv1alpha4.APIEndpoint `json:"controlPlaneEndpoint"`
 
 	// AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the
 	// ones added by default.
@@ -87,7 +87,7 @@ type AzureClusterStatus struct {
 	// the cluster is more resilient to failure.
 	// See: https://docs.microsoft.com/en-us/azure/availability-zones/az-overview
 	// This list will be used by Cluster API to try and spread the machines across the failure domains.
-	FailureDomains clusterv1.FailureDomains `json:"failureDomains,omitempty"`
+	FailureDomains clusterv1alpha4.FailureDomains `json:"failureDomains,omitempty"`
 
 	// Ready is true when the provider resource is ready.
 	// +optional
@@ -95,7 +95,7 @@ type AzureClusterStatus struct {
 
 	// Conditions defines current service state of the AzureCluster.
 	// +optional
-	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+	Conditions clusterv1alpha4.Conditions `json:"conditions,omitempty"`
 
 	// LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the
 	// next reconciliation loop.
@@ -134,12 +134,12 @@ type AzureClusterList struct {
 }
 
 // GetConditions returns the list of conditions for an AzureCluster API object.
-func (c *AzureCluster) GetConditions() clusterv1.Conditions {
+func (c *AzureCluster) GetConditions() clusterv1alpha4.Conditions {
 	return c.Status.Conditions
 }
 
 // SetConditions will set the given conditions on an AzureCluster object.
-func (c *AzureCluster) SetConditions(conditions clusterv1.Conditions) {
+func (c *AzureCluster) SetConditions(conditions clusterv1alpha4.Conditions) {
 	c.Status.Conditions = conditions
 }
 

--- a/api/v1alpha4/azureclusteridentity_types.go
+++ b/api/v1alpha4/azureclusteridentity_types.go
@@ -19,7 +19,7 @@ package v1alpha4
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
 // AllowedNamespaces defines the namespaces the clusters are allowed to use the identity from
@@ -70,7 +70,7 @@ type AzureClusterIdentitySpec struct {
 type AzureClusterIdentityStatus struct {
 	// Conditions defines current service state of the AzureClusterIdentity.
 	// +optional
-	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+	Conditions clusterv1alpha4.Conditions `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -96,12 +96,12 @@ type AzureClusterIdentityList struct {
 }
 
 // GetConditions returns the list of conditions for an AzureClusterIdentity API object.
-func (c *AzureClusterIdentity) GetConditions() clusterv1.Conditions {
+func (c *AzureClusterIdentity) GetConditions() clusterv1alpha4.Conditions {
 	return c.Status.Conditions
 }
 
 // SetConditions will set the given conditions on an AzureClusterIdentity object.
-func (c *AzureClusterIdentity) SetConditions(conditions clusterv1.Conditions) {
+func (c *AzureClusterIdentity) SetConditions(conditions clusterv1alpha4.Conditions) {
 	c.Status.Conditions = conditions
 }
 

--- a/api/v1alpha4/azuremachine_types.go
+++ b/api/v1alpha4/azuremachine_types.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/errors"
 )
 
@@ -174,7 +174,7 @@ type AzureMachineStatus struct {
 
 	// Conditions defines current service state of the AzureMachine.
 	// +optional
-	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+	Conditions clusterv1alpha4.Conditions `json:"conditions,omitempty"`
 
 	// LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the
 	// next reconciliation loop.
@@ -211,12 +211,12 @@ type AzureMachineList struct {
 }
 
 // GetConditions returns the list of conditions for an AzureMachine API object.
-func (m *AzureMachine) GetConditions() clusterv1.Conditions {
+func (m *AzureMachine) GetConditions() clusterv1alpha4.Conditions {
 	return m.Status.Conditions
 }
 
 // SetConditions will set the given conditions on an AzureMachine object.
-func (m *AzureMachine) SetConditions(conditions clusterv1.Conditions) {
+func (m *AzureMachine) SetConditions(conditions clusterv1alpha4.Conditions) {
 	m.Status.Conditions = conditions
 }
 

--- a/api/v1alpha4/conditions_consts.go
+++ b/api/v1alpha4/conditions_consts.go
@@ -16,12 +16,12 @@ limitations under the License.
 
 package v1alpha4
 
-import clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+import clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 
 // AzureCluster Conditions and Reasons.
 const (
 	// NetworkInfrastructureReadyCondition reports of current status of cluster infrastructure.
-	NetworkInfrastructureReadyCondition clusterv1.ConditionType = "NetworkInfrastructureReady"
+	NetworkInfrastructureReadyCondition clusterv1alpha4.ConditionType = "NetworkInfrastructureReady"
 	// NamespaceNotAllowedByIdentity used to indicate cluster in a namespace not allowed by identity.
 	NamespaceNotAllowedByIdentity = "NamespaceNotAllowedByIdentity"
 )
@@ -29,7 +29,7 @@ const (
 // AzureMachine Conditions and Reasons.
 const (
 	// VMRunningCondition reports on current status of the Azure VM.
-	VMRunningCondition clusterv1.ConditionType = "VMRunning"
+	VMRunningCondition clusterv1alpha4.ConditionType = "VMRunning"
 	// VMCreatingReason used when the vm creation is in progress.
 	VMCreatingReason = "VMCreating"
 	// VMUpdatingReason used when the vm updating is in progress.
@@ -53,7 +53,7 @@ const (
 // AzureMachinePool Conditions and Reasons.
 const (
 	// ScaleSetRunningCondition reports on current status of the Azure Scale Set.
-	ScaleSetRunningCondition clusterv1.ConditionType = "ScaleSetRunning"
+	ScaleSetRunningCondition clusterv1alpha4.ConditionType = "ScaleSetRunning"
 	// ScaleSetCreatingReason used when the scale set creation is in progress.
 	ScaleSetCreatingReason = "ScaleSetCreating"
 	// ScaleSetUpdatingReason used when the scale set updating is in progress.
@@ -64,14 +64,14 @@ const (
 	ScaleSetProvisionFailedReason = "ScaleSetProvisionFailed"
 
 	// ScaleSetDesiredReplicasCondition reports on the scaling state of the machine pool.
-	ScaleSetDesiredReplicasCondition clusterv1.ConditionType = "ScaleSetDesiredReplicas"
+	ScaleSetDesiredReplicasCondition clusterv1alpha4.ConditionType = "ScaleSetDesiredReplicas"
 	// ScaleSetScaleUpReason describes the machine pool scaling up.
 	ScaleSetScaleUpReason = "ScaleSetScalingUp"
 	// ScaleSetScaleDownReason describes the machine pool scaling down.
 	ScaleSetScaleDownReason = "ScaleSetScalingDown"
 
 	// ScaleSetModelUpdatedCondition reports on the model state of the pool.
-	ScaleSetModelUpdatedCondition clusterv1.ConditionType = "ScaleSetModelUpdated"
+	ScaleSetModelUpdatedCondition clusterv1alpha4.ConditionType = "ScaleSetModelUpdated"
 	// ScaleSetModelOutOfDateReason describes the machine pool model being out of date.
 	ScaleSetModelOutOfDateReason = "ScaleSetModelOutOfDate"
 )
@@ -79,31 +79,31 @@ const (
 // Azure Services Conditions and Reasons.
 const (
 	// ResourceGroupReadyCondition means the resource group exists and is ready to be used.
-	ResourceGroupReadyCondition clusterv1.ConditionType = "ResourceGroupReady"
+	ResourceGroupReadyCondition clusterv1alpha4.ConditionType = "ResourceGroupReady"
 	// VNetReadyCondition means the virtual network exists and is ready to be used.
-	VNetReadyCondition clusterv1.ConditionType = "VNetReady"
+	VNetReadyCondition clusterv1alpha4.ConditionType = "VNetReady"
 	// SecurityGroupsReadyCondition means the security groups exist and are ready to be used.
-	SecurityGroupsReadyCondition clusterv1.ConditionType = "SecurityGroupsReady"
+	SecurityGroupsReadyCondition clusterv1alpha4.ConditionType = "SecurityGroupsReady"
 	// RouteTablesReadyCondition means the route tables exist and are ready to be used.
-	RouteTablesReadyCondition clusterv1.ConditionType = "RouteTablesReady"
+	RouteTablesReadyCondition clusterv1alpha4.ConditionType = "RouteTablesReady"
 	// PublicIPsReadyCondition means the public IPs exist and are ready to be used.
-	PublicIPsReadyCondition clusterv1.ConditionType = "PublicIPsReady"
+	PublicIPsReadyCondition clusterv1alpha4.ConditionType = "PublicIPsReady"
 	// NATGatewaysReadyCondition means the NAT gateways exist and are ready to be used.
-	NATGatewaysReadyCondition clusterv1.ConditionType = "NATGatewaysReady"
+	NATGatewaysReadyCondition clusterv1alpha4.ConditionType = "NATGatewaysReady"
 	// SubnetsReadyCondition means the subnets exist and are ready to be used.
-	SubnetsReadyCondition clusterv1.ConditionType = "SubnetsReady"
+	SubnetsReadyCondition clusterv1alpha4.ConditionType = "SubnetsReady"
 	// LoadBalancersReadyCondition means the load balancers exist and are ready to be used.
-	LoadBalancersReadyCondition clusterv1.ConditionType = "LoadBalancersReady"
+	LoadBalancersReadyCondition clusterv1alpha4.ConditionType = "LoadBalancersReady"
 	// PrivateDNSReadyCondition means the private DNS exists and is ready to be used.
-	PrivateDNSReadyCondition clusterv1.ConditionType = "PrivateDNSReady"
+	PrivateDNSReadyCondition clusterv1alpha4.ConditionType = "PrivateDNSReady"
 	// BastionHostReadyCondition means the bastion host exists and is ready to be used.
-	BastionHostReadyCondition clusterv1.ConditionType = "BastionHostReady"
+	BastionHostReadyCondition clusterv1alpha4.ConditionType = "BastionHostReady"
 	// InboundNATRulesReadyCondition means the inbound NAT rules exist and are ready to be used.
-	InboundNATRulesReadyCondition clusterv1.ConditionType = "InboundNATRulesReady"
+	InboundNATRulesReadyCondition clusterv1alpha4.ConditionType = "InboundNATRulesReady"
 	// AvailabilitySetReadyCondition means the availability set exists and is ready to be used.
-	AvailabilitySetReadyCondition clusterv1.ConditionType = "AvailabilitySetReady"
+	AvailabilitySetReadyCondition clusterv1alpha4.ConditionType = "AvailabilitySetReady"
 	// RoleAssignmentReadyCondition means the role assignment exists and is ready to be used.
-	RoleAssignmentReadyCondition clusterv1.ConditionType = "RoleAssignmentReady"
+	RoleAssignmentReadyCondition clusterv1alpha4.ConditionType = "RoleAssignmentReady"
 
 	// CreatingReason means the resource is being created.
 	CreatingReason = "Creating"

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -40,7 +40,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	capierrors "sigs.k8s.io/cluster-api/errors"
-	capiv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,7 +56,7 @@ type (
 	// MachinePoolScopeParams defines the input parameters used to create a new MachinePoolScope.
 	MachinePoolScopeParams struct {
 		Client           client.Client
-		MachinePool      *capiv1exp.MachinePool
+		MachinePool      *expv1.MachinePool
 		AzureMachinePool *infrav1exp.AzureMachinePool
 		ClusterScope     azure.ClusterScoper
 	}
@@ -65,7 +65,7 @@ type (
 	MachinePoolScope struct {
 		azure.ClusterScoper
 		AzureMachinePool *infrav1exp.AzureMachinePool
-		MachinePool      *capiv1exp.MachinePool
+		MachinePool      *expv1.MachinePool
 		client           client.Client
 		patchHelper      *patch.Helper
 		vmssState        *azure.VMSS

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/scalesets"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -165,7 +165,7 @@ func TestMachinePoolScope_SetBootstrapConditions(t *testing.T) {
 func TestMachinePoolScope_MaxSurge(t *testing.T) {
 	cases := []struct {
 		Name   string
-		Setup  func(mp *clusterv1exp.MachinePool, amp *infrav1exp.AzureMachinePool)
+		Setup  func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool)
 		Verify func(g *WithT, surge int, err error)
 	}{
 		{
@@ -177,7 +177,7 @@ func TestMachinePoolScope_MaxSurge(t *testing.T) {
 		},
 		{
 			Name: "default surge should be 1 regardless of replica count with no surger",
-			Setup: func(mp *clusterv1exp.MachinePool, amp *infrav1exp.AzureMachinePool) {
+			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool) {
 				mp.Spec.Replicas = to.Int32Ptr(3)
 			},
 			Verify: func(g *WithT, surge int, err error) {
@@ -187,7 +187,7 @@ func TestMachinePoolScope_MaxSurge(t *testing.T) {
 		},
 		{
 			Name: "default surge should be 2 as specified by the surger",
-			Setup: func(mp *clusterv1exp.MachinePool, amp *infrav1exp.AzureMachinePool) {
+			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool) {
 				mp.Spec.Replicas = to.Int32Ptr(3)
 				two := intstr.FromInt(2)
 				amp.Spec.Strategy = infrav1exp.AzureMachinePoolDeploymentStrategy{
@@ -204,7 +204,7 @@ func TestMachinePoolScope_MaxSurge(t *testing.T) {
 		},
 		{
 			Name: "default surge should be 2 (50%) of the desired replicas",
-			Setup: func(mp *clusterv1exp.MachinePool, amp *infrav1exp.AzureMachinePool) {
+			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool) {
 				mp.Spec.Replicas = to.Int32Ptr(4)
 				fiftyPercent := intstr.FromString("50%")
 				amp.Spec.Strategy = infrav1exp.AzureMachinePoolDeploymentStrategy{
@@ -234,12 +234,12 @@ func TestMachinePoolScope_MaxSurge(t *testing.T) {
 							{
 								Name:       "mp1",
 								Kind:       "MachinePool",
-								APIVersion: clusterv1exp.GroupVersion.String(),
+								APIVersion: expv1.GroupVersion.String(),
 							},
 						},
 					},
 				}
-				mp = &clusterv1exp.MachinePool{
+				mp = &expv1.MachinePool{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mp1",
 						Namespace: "default",
@@ -274,7 +274,7 @@ func TestMachinePoolScope_SaveVMImageToStatus(t *testing.T) {
 					{
 						Name:       "mp1",
 						Kind:       "MachinePool",
-						APIVersion: clusterv1exp.GroupVersion.String(),
+						APIVersion: expv1.GroupVersion.String(),
 					},
 				},
 			},
@@ -312,12 +312,12 @@ func TestMachinePoolScope_GetVMImage(t *testing.T) {
 
 	cases := []struct {
 		Name   string
-		Setup  func(mp *clusterv1exp.MachinePool, amp *infrav1exp.AzureMachinePool)
+		Setup  func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool)
 		Verify func(g *WithT, amp *infrav1exp.AzureMachinePool, vmImage *infrav1.Image, err error)
 	}{
 		{
 			Name: "should set and default the image if no image is specified for the AzureMachinePool",
-			Setup: func(mp *clusterv1exp.MachinePool, amp *infrav1exp.AzureMachinePool) {
+			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool) {
 				mp.Spec.Template.Spec.Version = to.StringPtr("v1.19.11")
 			},
 			Verify: func(g *WithT, amp *infrav1exp.AzureMachinePool, vmImage *infrav1.Image, err error) {
@@ -339,7 +339,7 @@ func TestMachinePoolScope_GetVMImage(t *testing.T) {
 		},
 		{
 			Name: "should not default or set the image on the AzureMachinePool if it already exists",
-			Setup: func(mp *clusterv1exp.MachinePool, amp *infrav1exp.AzureMachinePool) {
+			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool) {
 				mp.Spec.Template.Spec.Version = to.StringPtr("v1.19.11")
 				amp.Spec.Template.Image = &infrav1.Image{
 					Marketplace: &infrav1.AzureMarketplaceImage{
@@ -385,12 +385,12 @@ func TestMachinePoolScope_GetVMImage(t *testing.T) {
 							{
 								Name:       "mp1",
 								Kind:       "MachinePool",
-								APIVersion: clusterv1exp.GroupVersion.String(),
+								APIVersion: expv1.GroupVersion.String(),
 							},
 						},
 					},
 				}
-				mp = &clusterv1exp.MachinePool{
+				mp = &expv1.MachinePool{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mp1",
 						Namespace: "default",
@@ -417,12 +417,12 @@ func TestMachinePoolScope_GetVMImage(t *testing.T) {
 func TestMachinePoolScope_NeedsRequeue(t *testing.T) {
 	cases := []struct {
 		Name   string
-		Setup  func(mp *clusterv1exp.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS)
+		Setup  func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS)
 		Verify func(g *WithT, requeue bool)
 	}{
 		{
 			Name: "should requeue if the machine is not in succeeded state",
-			Setup: func(mp *clusterv1exp.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
+			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
 				creating := infrav1.Creating
 				mp.Spec.Replicas = to.Int32Ptr(0)
 				amp.Status.ProvisioningState = &creating
@@ -433,7 +433,7 @@ func TestMachinePoolScope_NeedsRequeue(t *testing.T) {
 		},
 		{
 			Name: "should not requeue if the machine is in succeeded state",
-			Setup: func(mp *clusterv1exp.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
+			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
 				succeeded := infrav1.Succeeded
 				mp.Spec.Replicas = to.Int32Ptr(0)
 				amp.Status.ProvisioningState = &succeeded
@@ -444,7 +444,7 @@ func TestMachinePoolScope_NeedsRequeue(t *testing.T) {
 		},
 		{
 			Name: "should requeue if the machine is in succeeded state but desired replica count does not match",
-			Setup: func(mp *clusterv1exp.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
+			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
 				succeeded := infrav1.Succeeded
 				mp.Spec.Replicas = to.Int32Ptr(1)
 				amp.Status.ProvisioningState = &succeeded
@@ -455,7 +455,7 @@ func TestMachinePoolScope_NeedsRequeue(t *testing.T) {
 		},
 		{
 			Name: "should not requeue if the machine is in succeeded state but desired replica count does match",
-			Setup: func(mp *clusterv1exp.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
+			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
 				succeeded := infrav1.Succeeded
 				mp.Spec.Replicas = to.Int32Ptr(1)
 				amp.Status.ProvisioningState = &succeeded
@@ -471,7 +471,7 @@ func TestMachinePoolScope_NeedsRequeue(t *testing.T) {
 		},
 		{
 			Name: "should requeue if an instance VM image does not match the VM image of the VMSS",
-			Setup: func(mp *clusterv1exp.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
+			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
 				succeeded := infrav1.Succeeded
 				mp.Spec.Replicas = to.Int32Ptr(1)
 				amp.Status.ProvisioningState = &succeeded
@@ -505,12 +505,12 @@ func TestMachinePoolScope_NeedsRequeue(t *testing.T) {
 							{
 								Name:       "mp1",
 								Kind:       "MachinePool",
-								APIVersion: clusterv1exp.GroupVersion.String(),
+								APIVersion: expv1.GroupVersion.String(),
 							},
 						},
 					},
 				}
-				mp = &clusterv1exp.MachinePool{
+				mp = &expv1.MachinePool{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mp1",
 						Namespace: "default",
@@ -618,7 +618,7 @@ func TestMachinePoolScope_updateReplicasAndProviderIDs(t *testing.T) {
 							{
 								Name:       "mp1",
 								Kind:       "MachinePool",
-								APIVersion: clusterv1exp.GroupVersion.String(),
+								APIVersion: expv1.GroupVersion.String(),
 							},
 						},
 					},
@@ -649,7 +649,7 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 		{
 			name: "If OS type is Linux and cloud is AzurePublicCloud, it returns ExtensionSpec",
 			machinePoolScope: MachinePoolScope{
-				MachinePool: &clusterv1exp.MachinePool{},
+				MachinePool: &expv1.MachinePool{},
 				AzureMachinePool: &infrav1exp.AzureMachinePool{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "machinepool-name",
@@ -695,7 +695,7 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 		{
 			name: "If OS type is Linux and cloud is not AzurePublicCloud, it returns empty",
 			machinePoolScope: MachinePoolScope{
-				MachinePool: &clusterv1exp.MachinePool{},
+				MachinePool: &expv1.MachinePool{},
 				AzureMachinePool: &infrav1exp.AzureMachinePool{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "machinepool-name",
@@ -728,7 +728,7 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 		{
 			name: "If OS type is Windows and cloud is AzurePublicCloud, it returns ExtensionSpec",
 			machinePoolScope: MachinePoolScope{
-				MachinePool: &clusterv1exp.MachinePool{},
+				MachinePool: &expv1.MachinePool{},
 				AzureMachinePool: &infrav1exp.AzureMachinePool{
 					ObjectMeta: metav1.ObjectMeta{
 						// Note: machine pool names longer than 9 characters get truncated. See MachinePoolScope::Name() for more details.
@@ -776,7 +776,7 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 		{
 			name: "If OS type is Windows and cloud is not AzurePublicCloud, it returns empty",
 			machinePoolScope: MachinePoolScope{
-				MachinePool: &clusterv1exp.MachinePool{},
+				MachinePool: &expv1.MachinePool{},
 				AzureMachinePool: &infrav1exp.AzureMachinePool{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "machinepool-name",
@@ -809,7 +809,7 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 		{
 			name: "If OS type is not Linux or Windows and cloud is AzurePublicCloud, it returns empty",
 			machinePoolScope: MachinePoolScope{
-				MachinePool: &clusterv1exp.MachinePool{},
+				MachinePool: &expv1.MachinePool{},
 				AzureMachinePool: &infrav1exp.AzureMachinePool{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "machinepool-name",
@@ -842,7 +842,7 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 		{
 			name: "If OS type is not Windows or Linux and cloud is not AzurePublicCloud, it returns empty",
 			machinePoolScope: MachinePoolScope{
-				MachinePool: &clusterv1exp.MachinePool{},
+				MachinePool: &expv1.MachinePool{},
 				AzureMachinePool: &infrav1exp.AzureMachinePool{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "machinepool-name",

--- a/azure/scope/machinepoolmachine.go
+++ b/azure/scope/machinepoolmachine.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	capierrors "sigs.k8s.io/cluster-api/errors"
-	capiv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,7 +66,7 @@ type (
 		AzureMachinePoolMachine *infrav1exp.AzureMachinePoolMachine
 		Client                  client.Client
 		ClusterScope            azure.ClusterScoper
-		MachinePool             *capiv1exp.MachinePool
+		MachinePool             *expv1.MachinePool
 
 		// workloadNodeGetter is only used for testing purposes and provides a way for mocking requests to the workload cluster
 		workloadNodeGetter nodeGetter
@@ -77,7 +77,7 @@ type (
 		azure.ClusterScoper
 		AzureMachinePoolMachine *infrav1exp.AzureMachinePoolMachine
 		AzureMachinePool        *infrav1exp.AzureMachinePool
-		MachinePool             *capiv1exp.MachinePool
+		MachinePool             *expv1.MachinePool
 		MachinePoolScope        *MachinePoolScope
 		client                  client.Client
 		patchHelper             *patch.Helper

--- a/azure/scope/machinepoolmachine_test.go
+++ b/azure/scope/machinepoolmachine_test.go
@@ -30,10 +30,10 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
 	mock_scope "sigs.k8s.io/cluster-api-provider-azure/azure/scope/mocks"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	gomock2 "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	capiv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -44,8 +44,8 @@ const (
 
 func TestNewMachinePoolMachineScope(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = capiv1exp.AddToScheme(scheme)
-	_ = infrav1.AddToScheme(scheme)
+	_ = expv1.AddToScheme(scheme)
+	_ = infrav1exp.AddToScheme(scheme)
 
 	cases := []struct {
 		Name  string
@@ -63,18 +63,18 @@ func TestNewMachinePoolMachineScope(t *testing.T) {
 						},
 					},
 				},
-				MachinePool:             new(capiv1exp.MachinePool),
-				AzureMachinePool:        new(infrav1.AzureMachinePool),
-				AzureMachinePoolMachine: new(infrav1.AzureMachinePoolMachine),
+				MachinePool:             new(expv1.MachinePool),
+				AzureMachinePool:        new(infrav1exp.AzureMachinePool),
+				AzureMachinePoolMachine: new(infrav1exp.AzureMachinePoolMachine),
 			},
 		},
 		{
 			Name: "no client",
 			Input: MachinePoolMachineScopeParams{
 				ClusterScope:            new(ClusterScope),
-				MachinePool:             new(capiv1exp.MachinePool),
-				AzureMachinePool:        new(infrav1.AzureMachinePool),
-				AzureMachinePoolMachine: new(infrav1.AzureMachinePoolMachine),
+				MachinePool:             new(expv1.MachinePool),
+				AzureMachinePool:        new(infrav1exp.AzureMachinePool),
+				AzureMachinePoolMachine: new(infrav1exp.AzureMachinePoolMachine),
 			},
 			Err: "client is required when creating a MachinePoolScope",
 		},
@@ -82,9 +82,9 @@ func TestNewMachinePoolMachineScope(t *testing.T) {
 			Name: "no ClusterScope",
 			Input: MachinePoolMachineScopeParams{
 				Client:                  fake.NewClientBuilder().WithScheme(scheme).Build(),
-				MachinePool:             new(capiv1exp.MachinePool),
-				AzureMachinePool:        new(infrav1.AzureMachinePool),
-				AzureMachinePoolMachine: new(infrav1.AzureMachinePoolMachine),
+				MachinePool:             new(expv1.MachinePool),
+				AzureMachinePool:        new(infrav1exp.AzureMachinePool),
+				AzureMachinePoolMachine: new(infrav1exp.AzureMachinePoolMachine),
 			},
 			Err: "cluster scope is required when creating a MachinePoolScope",
 		},
@@ -93,8 +93,8 @@ func TestNewMachinePoolMachineScope(t *testing.T) {
 			Input: MachinePoolMachineScopeParams{
 				Client:                  fake.NewClientBuilder().WithScheme(scheme).Build(),
 				ClusterScope:            new(ClusterScope),
-				AzureMachinePool:        new(infrav1.AzureMachinePool),
-				AzureMachinePoolMachine: new(infrav1.AzureMachinePoolMachine),
+				AzureMachinePool:        new(infrav1exp.AzureMachinePool),
+				AzureMachinePoolMachine: new(infrav1exp.AzureMachinePoolMachine),
 			},
 			Err: "machine pool is required when creating a MachinePoolScope",
 		},
@@ -103,8 +103,8 @@ func TestNewMachinePoolMachineScope(t *testing.T) {
 			Input: MachinePoolMachineScopeParams{
 				Client:                  fake.NewClientBuilder().WithScheme(scheme).Build(),
 				ClusterScope:            new(ClusterScope),
-				MachinePool:             new(capiv1exp.MachinePool),
-				AzureMachinePoolMachine: new(infrav1.AzureMachinePoolMachine),
+				MachinePool:             new(expv1.MachinePool),
+				AzureMachinePoolMachine: new(infrav1exp.AzureMachinePoolMachine),
 			},
 			Err: "azure machine pool is required when creating a MachinePoolScope",
 		},
@@ -113,8 +113,8 @@ func TestNewMachinePoolMachineScope(t *testing.T) {
 			Input: MachinePoolMachineScopeParams{
 				Client:           fake.NewClientBuilder().WithScheme(scheme).Build(),
 				ClusterScope:     new(ClusterScope),
-				MachinePool:      new(capiv1exp.MachinePool),
-				AzureMachinePool: new(infrav1.AzureMachinePool),
+				MachinePool:      new(expv1.MachinePool),
+				AzureMachinePool: new(infrav1exp.AzureMachinePool),
 			},
 			Err: "azure machine pool machine is required when creating a MachinePoolScope",
 		},
@@ -136,8 +136,8 @@ func TestNewMachinePoolMachineScope(t *testing.T) {
 
 func TestMachineScope_UpdateNodeStatus(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = capiv1exp.AddToScheme(scheme)
-	_ = infrav1.AddToScheme(scheme)
+	_ = expv1.AddToScheme(scheme)
+	_ = infrav1exp.AddToScheme(scheme)
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -151,13 +151,13 @@ func TestMachineScope_UpdateNodeStatus(t *testing.T) {
 
 	cases := []struct {
 		Name   string
-		Setup  func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1.AzureMachinePoolMachine) (*azure.VMSSVM, *infrav1.AzureMachinePoolMachine)
+		Setup  func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1exp.AzureMachinePoolMachine) (*azure.VMSSVM, *infrav1exp.AzureMachinePoolMachine)
 		Verify func(g *WithT, scope *MachinePoolMachineScope)
 		Err    string
 	}{
 		{
 			Name: "should set kubernetes version, ready, and node reference upon finding the node",
-			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1.AzureMachinePoolMachine) (*azure.VMSSVM, *infrav1.AzureMachinePoolMachine) {
+			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1exp.AzureMachinePoolMachine) (*azure.VMSSVM, *infrav1exp.AzureMachinePoolMachine) {
 				mockNodeGetter.EXPECT().GetNodeByProviderID(gomock2.AContext(), FakeProviderID).Return(getReadyNode(), nil)
 				return nil, ampm
 			},
@@ -172,7 +172,7 @@ func TestMachineScope_UpdateNodeStatus(t *testing.T) {
 		},
 		{
 			Name: "should not mark AMPM ready if node is not ready",
-			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1.AzureMachinePoolMachine) (*azure.VMSSVM, *infrav1.AzureMachinePoolMachine) {
+			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1exp.AzureMachinePoolMachine) (*azure.VMSSVM, *infrav1exp.AzureMachinePoolMachine) {
 				mockNodeGetter.EXPECT().GetNodeByProviderID(gomock2.AContext(), FakeProviderID).Return(getNotReadyNode(), nil)
 				return nil, ampm
 			},
@@ -187,7 +187,7 @@ func TestMachineScope_UpdateNodeStatus(t *testing.T) {
 		},
 		{
 			Name: "fails fetching the node",
-			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1.AzureMachinePoolMachine) (*azure.VMSSVM, *infrav1.AzureMachinePoolMachine) {
+			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1exp.AzureMachinePoolMachine) (*azure.VMSSVM, *infrav1exp.AzureMachinePoolMachine) {
 				mockNodeGetter.EXPECT().GetNodeByProviderID(gomock2.AContext(), FakeProviderID).Return(nil, errors.New("boom"))
 				return nil, ampm
 			},
@@ -195,7 +195,7 @@ func TestMachineScope_UpdateNodeStatus(t *testing.T) {
 		},
 		{
 			Name: "node is not found by providerID without error",
-			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1.AzureMachinePoolMachine) (*azure.VMSSVM, *infrav1.AzureMachinePoolMachine) {
+			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1exp.AzureMachinePoolMachine) (*azure.VMSSVM, *infrav1exp.AzureMachinePoolMachine) {
 				mockNodeGetter.EXPECT().GetNodeByProviderID(gomock2.AContext(), FakeProviderID).Return(nil, nil)
 				return nil, ampm
 			},
@@ -205,7 +205,7 @@ func TestMachineScope_UpdateNodeStatus(t *testing.T) {
 		},
 		{
 			Name: "node is found by ObjectReference",
-			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1.AzureMachinePoolMachine) (*azure.VMSSVM, *infrav1.AzureMachinePoolMachine) {
+			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1exp.AzureMachinePoolMachine) (*azure.VMSSVM, *infrav1exp.AzureMachinePoolMachine) {
 				nodeRef := corev1.ObjectReference{
 					Name: "node1",
 				}
@@ -233,8 +233,8 @@ func TestMachineScope_UpdateNodeStatus(t *testing.T) {
 				params     = MachinePoolMachineScopeParams{
 					Client:       fake.NewClientBuilder().WithScheme(scheme).Build(),
 					ClusterScope: clusterScope,
-					MachinePool: &capiv1exp.MachinePool{
-						Spec: capiv1exp.MachinePoolSpec{
+					MachinePool: &expv1.MachinePool{
+						Spec: expv1.MachinePoolSpec{
 							Template: clusterv1.MachineTemplateSpec{
 								Spec: clusterv1.MachineSpec{
 									Version: to.StringPtr("v1.19.11"),
@@ -242,14 +242,14 @@ func TestMachineScope_UpdateNodeStatus(t *testing.T) {
 							},
 						},
 					},
-					AzureMachinePool: new(infrav1.AzureMachinePool),
+					AzureMachinePool: new(infrav1exp.AzureMachinePool),
 				}
 			)
 
 			defer controller.Finish()
 
-			instance, ampm := c.Setup(mockClient, &infrav1.AzureMachinePoolMachine{
-				Spec: infrav1.AzureMachinePoolMachineSpec{
+			instance, ampm := c.Setup(mockClient, &infrav1exp.AzureMachinePoolMachine{
+				Spec: infrav1exp.AzureMachinePoolMachineSpec{
 					ProviderID: FakeProviderID,
 				},
 			})
@@ -276,8 +276,8 @@ func TestMachineScope_UpdateNodeStatus(t *testing.T) {
 
 func TestMachinePoolMachineScope_CordonAndDrain(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = capiv1exp.AddToScheme(scheme)
-	_ = infrav1.AddToScheme(scheme)
+	_ = expv1.AddToScheme(scheme)
+	_ = infrav1exp.AddToScheme(scheme)
 
 	var (
 		clusterScope = ClusterScope{
@@ -291,19 +291,19 @@ func TestMachinePoolMachineScope_CordonAndDrain(t *testing.T) {
 
 	cases := []struct {
 		Name  string
-		Setup func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1.AzureMachinePoolMachine) *infrav1.AzureMachinePoolMachine
+		Setup func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1exp.AzureMachinePoolMachine) *infrav1exp.AzureMachinePoolMachine
 		Err   string
 	}{
 		{
 			Name: "should skip cordon and drain if the node does not exist with provider ID",
-			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1.AzureMachinePoolMachine) *infrav1.AzureMachinePoolMachine {
+			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1exp.AzureMachinePoolMachine) *infrav1exp.AzureMachinePoolMachine {
 				mockNodeGetter.EXPECT().GetNodeByProviderID(gomock2.AContext(), FakeProviderID).Return(nil, nil)
 				return ampm
 			},
 		},
 		{
 			Name: "should skip cordon and drain if the node does not exist with node reference",
-			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1.AzureMachinePoolMachine) *infrav1.AzureMachinePoolMachine {
+			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1exp.AzureMachinePoolMachine) *infrav1exp.AzureMachinePoolMachine {
 				nodeRef := corev1.ObjectReference{
 					Name: "node1",
 				}
@@ -314,7 +314,7 @@ func TestMachinePoolMachineScope_CordonAndDrain(t *testing.T) {
 		},
 		{
 			Name: "if GetNodeByProviderID fails with an error, an error will be returned",
-			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1.AzureMachinePoolMachine) *infrav1.AzureMachinePoolMachine {
+			Setup: func(mockNodeGetter *mock_scope.MocknodeGetter, ampm *infrav1exp.AzureMachinePoolMachine) *infrav1exp.AzureMachinePoolMachine {
 				mockNodeGetter.EXPECT().GetNodeByProviderID(gomock2.AContext(), FakeProviderID).Return(nil, errors.New("boom"))
 				return ampm
 			},
@@ -331,8 +331,8 @@ func TestMachinePoolMachineScope_CordonAndDrain(t *testing.T) {
 				params     = MachinePoolMachineScopeParams{
 					Client:       fake.NewClientBuilder().WithScheme(scheme).Build(),
 					ClusterScope: &clusterScope,
-					MachinePool: &capiv1exp.MachinePool{
-						Spec: capiv1exp.MachinePoolSpec{
+					MachinePool: &expv1.MachinePool{
+						Spec: expv1.MachinePoolSpec{
 							Template: clusterv1.MachineTemplateSpec{
 								Spec: clusterv1.MachineSpec{
 									Version: to.StringPtr("v1.19.11"),
@@ -340,14 +340,14 @@ func TestMachinePoolMachineScope_CordonAndDrain(t *testing.T) {
 							},
 						},
 					},
-					AzureMachinePool: new(infrav1.AzureMachinePool),
+					AzureMachinePool: new(infrav1exp.AzureMachinePool),
 				}
 			)
 
 			defer controller.Finish()
 
-			ampm := c.Setup(mockClient, &infrav1.AzureMachinePoolMachine{
-				Spec: infrav1.AzureMachinePoolMachineSpec{
+			ampm := c.Setup(mockClient, &infrav1exp.AzureMachinePoolMachine{
+				Spec: infrav1exp.AzureMachinePoolMachineSpec{
 					ProviderID: FakeProviderID,
 				},
 			})

--- a/azure/scope/managedcontrolplane_test.go
+++ b/azure/scope/managedcontrolplane_test.go
@@ -27,16 +27,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/managedclusters"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	capiv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestManagedControlPlaneScope_PoolVersion(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = capiv1exp.AddToScheme(scheme)
-	_ = infrav1.AddToScheme(scheme)
+	_ = expv1.AddToScheme(scheme)
+	_ = infrav1exp.AddToScheme(scheme)
 
 	cases := []struct {
 		Name     string
@@ -56,19 +56,19 @@ func TestManagedControlPlaneScope_PoolVersion(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
 				},
 				ManagedMachinePools: []ManagedMachinePool{
 					{
 						MachinePool:      getMachinePool("pool0"),
-						InfraMachinePool: getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+						InfraMachinePool: getAzureMachinePool("pool0", infrav1exp.NodePoolModeSystem),
 					},
 				},
 			},
@@ -95,12 +95,12 @@ func TestManagedControlPlaneScope_PoolVersion(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						Version:        "v1.22.0",
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
@@ -108,7 +108,7 @@ func TestManagedControlPlaneScope_PoolVersion(t *testing.T) {
 				ManagedMachinePools: []ManagedMachinePool{
 					{
 						MachinePool:      getMachinePoolWithVersion("pool0", "v1.21.1"),
-						InfraMachinePool: getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+						InfraMachinePool: getAzureMachinePool("pool0", infrav1exp.NodePoolModeSystem),
 					},
 				},
 			},
@@ -136,12 +136,12 @@ func TestManagedControlPlaneScope_PoolVersion(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						Version:        "v1.20.1",
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
@@ -149,7 +149,7 @@ func TestManagedControlPlaneScope_PoolVersion(t *testing.T) {
 				ManagedMachinePools: []ManagedMachinePool{
 					{
 						MachinePool:      getMachinePoolWithVersion("pool0", "v1.21.1"),
-						InfraMachinePool: getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+						InfraMachinePool: getAzureMachinePool("pool0", infrav1exp.NodePoolModeSystem),
 					},
 				},
 			},
@@ -177,8 +177,8 @@ func TestManagedControlPlaneScope_PoolVersion(t *testing.T) {
 
 func TestManagedControlPlaneScope_AddonProfiles(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = capiv1exp.AddToScheme(scheme)
-	_ = infrav1.AddToScheme(scheme)
+	_ = expv1.AddToScheme(scheme)
+	_ = infrav1exp.AddToScheme(scheme)
 
 	cases := []struct {
 		Name     string
@@ -197,19 +197,19 @@ func TestManagedControlPlaneScope_AddonProfiles(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
 				},
 				ManagedMachinePools: []ManagedMachinePool{
 					{
 						MachinePool:      getMachinePool("pool0"),
-						InfraMachinePool: getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+						InfraMachinePool: getAzureMachinePool("pool0", infrav1exp.NodePoolModeSystem),
 					},
 				},
 			},
@@ -227,14 +227,14 @@ func TestManagedControlPlaneScope_AddonProfiles(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
-						AddonProfiles: []infrav1.AddonProfile{
+						AddonProfiles: []infrav1exp.AddonProfile{
 							{Name: "addon1", Config: nil, Enabled: false},
 							{Name: "addon2", Config: map[string]string{"k1": "v1", "k2": "v2"}, Enabled: true},
 						},
@@ -243,7 +243,7 @@ func TestManagedControlPlaneScope_AddonProfiles(t *testing.T) {
 				ManagedMachinePools: []ManagedMachinePool{
 					{
 						MachinePool:      getMachinePool("pool0"),
-						InfraMachinePool: getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+						InfraMachinePool: getAzureMachinePool("pool0", infrav1exp.NodePoolModeSystem),
 					},
 				},
 			},
@@ -270,8 +270,8 @@ func TestManagedControlPlaneScope_AddonProfiles(t *testing.T) {
 
 func TestManagedControlPlaneScope_OSType(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = capiv1exp.AddToScheme(scheme)
-	_ = infrav1.AddToScheme(scheme)
+	_ = expv1.AddToScheme(scheme)
+	_ = infrav1exp.AddToScheme(scheme)
 
 	cases := []struct {
 		Name     string
@@ -291,12 +291,12 @@ func TestManagedControlPlaneScope_OSType(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						Version:        "v1.20.1",
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
@@ -304,7 +304,7 @@ func TestManagedControlPlaneScope_OSType(t *testing.T) {
 				ManagedMachinePools: []ManagedMachinePool{
 					{
 						MachinePool:      getMachinePool("pool0"),
-						InfraMachinePool: getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+						InfraMachinePool: getAzureMachinePool("pool0", infrav1exp.NodePoolModeSystem),
 					},
 					{
 						MachinePool:      getMachinePool("pool1"),
@@ -357,12 +357,12 @@ func TestManagedControlPlaneScope_OSType(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						Version:        "v1.20.1",
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},

--- a/azure/scope/managedmachinepool.go
+++ b/azure/scope/managedmachinepool.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/futures"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,7 +47,7 @@ type ManagedMachinePoolScopeParams struct {
 
 type ManagedMachinePool struct {
 	InfraMachinePool *infrav1exp.AzureManagedMachinePool
-	MachinePool      *clusterv1exp.MachinePool
+	MachinePool      *expv1.MachinePool
 }
 
 // NewManagedMachinePoolScope creates a new Scope from the supplied parameters.
@@ -87,7 +87,7 @@ type ManagedMachinePoolScope struct {
 
 	azure.ManagedClusterScoper
 	Cluster          *clusterv1.Cluster
-	MachinePool      *clusterv1exp.MachinePool
+	MachinePool      *expv1.MachinePool
 	ControlPlane     *infrav1exp.AzureManagedControlPlane
 	InfraMachinePool *infrav1exp.AzureManagedMachinePool
 }
@@ -126,7 +126,7 @@ func (s *ManagedMachinePoolScope) AgentPoolSpec() azure.AgentPoolSpec {
 }
 
 func buildAgentPoolSpec(managedControlPlane *infrav1exp.AzureManagedControlPlane,
-	machinePool *clusterv1exp.MachinePool,
+	machinePool *expv1.MachinePool,
 	managedMachinePool *infrav1exp.AzureManagedMachinePool) azure.AgentPoolSpec {
 	var normalizedVersion *string
 	if machinePool.Spec.Template.Spec.Version != nil {

--- a/azure/scope/managedmachinepool_test.go
+++ b/azure/scope/managedmachinepool_test.go
@@ -26,16 +26,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	capiv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestManagedMachinePoolScope_Autoscaling(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = capiv1exp.AddToScheme(scheme)
-	_ = infrav1.AddToScheme(scheme)
+	_ = expv1.AddToScheme(scheme)
+	_ = infrav1exp.AddToScheme(scheme)
 
 	cases := []struct {
 		Name     string
@@ -51,18 +51,18 @@ func TestManagedMachinePoolScope_Autoscaling(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
 				},
 				ManagedMachinePool: ManagedMachinePool{
 					MachinePool:      getMachinePool("pool0"),
-					InfraMachinePool: getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+					InfraMachinePool: getAzureMachinePool("pool0", infrav1exp.NodePoolModeSystem),
 				},
 			},
 			Expected: azure.AgentPoolSpec{
@@ -84,12 +84,12 @@ func TestManagedMachinePoolScope_Autoscaling(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
 				},
@@ -128,8 +128,8 @@ func TestManagedMachinePoolScope_Autoscaling(t *testing.T) {
 
 func TestManagedMachinePoolScope_NodeLabels(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = capiv1exp.AddToScheme(scheme)
-	_ = infrav1.AddToScheme(scheme)
+	_ = expv1.AddToScheme(scheme)
+	_ = infrav1exp.AddToScheme(scheme)
 
 	cases := []struct {
 		Name     string
@@ -145,18 +145,18 @@ func TestManagedMachinePoolScope_NodeLabels(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
 				},
 				ManagedMachinePool: ManagedMachinePool{
 					MachinePool:      getMachinePool("pool0"),
-					InfraMachinePool: getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+					InfraMachinePool: getAzureMachinePool("pool0", infrav1exp.NodePoolModeSystem),
 				},
 			},
 			Expected: azure.AgentPoolSpec{
@@ -178,12 +178,12 @@ func TestManagedMachinePoolScope_NodeLabels(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
 				},
@@ -224,8 +224,8 @@ func TestManagedMachinePoolScope_NodeLabels(t *testing.T) {
 
 func TestManagedMachinePoolScope_MaxPods(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = capiv1exp.AddToScheme(scheme)
-	_ = infrav1.AddToScheme(scheme)
+	_ = expv1.AddToScheme(scheme)
+	_ = infrav1exp.AddToScheme(scheme)
 
 	cases := []struct {
 		Name     string
@@ -241,18 +241,18 @@ func TestManagedMachinePoolScope_MaxPods(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
 				},
 				ManagedMachinePool: ManagedMachinePool{
 					MachinePool:      getMachinePool("pool0"),
-					InfraMachinePool: getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+					InfraMachinePool: getAzureMachinePool("pool0", infrav1exp.NodePoolModeSystem),
 				},
 			},
 			Expected: azure.AgentPoolSpec{
@@ -273,12 +273,12 @@ func TestManagedMachinePoolScope_MaxPods(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
 				},
@@ -315,8 +315,8 @@ func TestManagedMachinePoolScope_MaxPods(t *testing.T) {
 
 func TestManagedMachinePoolScope_Taints(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = capiv1exp.AddToScheme(scheme)
-	_ = infrav1.AddToScheme(scheme)
+	_ = expv1.AddToScheme(scheme)
+	_ = infrav1exp.AddToScheme(scheme)
 
 	cases := []struct {
 		Name     string
@@ -332,18 +332,18 @@ func TestManagedMachinePoolScope_Taints(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
 				},
 				ManagedMachinePool: ManagedMachinePool{
 					MachinePool:      getMachinePool("pool0"),
-					InfraMachinePool: getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+					InfraMachinePool: getAzureMachinePool("pool0", infrav1exp.NodePoolModeSystem),
 				},
 			},
 			Expected: azure.AgentPoolSpec{
@@ -365,19 +365,19 @@ func TestManagedMachinePoolScope_Taints(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
 				},
 				ManagedMachinePool: ManagedMachinePool{
 					MachinePool: getMachinePool("pool1"),
-					InfraMachinePool: getAzureMachinePoolWithTaints("pool1", infrav1.Taints{
-						infrav1.Taint{
+					InfraMachinePool: getAzureMachinePoolWithTaints("pool1", infrav1exp.Taints{
+						infrav1exp.Taint{
 							Key:    "key1",
 							Value:  "value1",
 							Effect: "NoSchedule",
@@ -413,8 +413,8 @@ func TestManagedMachinePoolScope_Taints(t *testing.T) {
 
 func TestManagedMachinePoolScope_OSDiskType(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = capiv1exp.AddToScheme(scheme)
-	_ = infrav1.AddToScheme(scheme)
+	_ = expv1.AddToScheme(scheme)
+	_ = infrav1exp.AddToScheme(scheme)
 
 	cases := []struct {
 		Name     string
@@ -430,18 +430,18 @@ func TestManagedMachinePoolScope_OSDiskType(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
 				},
 				ManagedMachinePool: ManagedMachinePool{
 					MachinePool:      getMachinePool("pool0"),
-					InfraMachinePool: getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+					InfraMachinePool: getAzureMachinePool("pool0", infrav1exp.NodePoolModeSystem),
 				},
 			},
 			Expected: azure.AgentPoolSpec{
@@ -462,12 +462,12 @@ func TestManagedMachinePoolScope_OSDiskType(t *testing.T) {
 						Namespace: "default",
 					},
 				},
-				ControlPlane: &infrav1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
 						Namespace: "default",
 					},
-					Spec: infrav1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					},
 				},
@@ -502,8 +502,8 @@ func TestManagedMachinePoolScope_OSDiskType(t *testing.T) {
 	}
 }
 
-func getAzureMachinePool(name string, mode infrav1.NodePoolMode) *infrav1.AzureManagedMachinePool {
-	return &infrav1.AzureManagedMachinePool{
+func getAzureMachinePool(name string, mode infrav1exp.NodePoolMode) *infrav1exp.AzureManagedMachinePool {
+	return &infrav1exp.AzureManagedMachinePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "default",
@@ -518,7 +518,7 @@ func getAzureMachinePool(name string, mode infrav1.NodePoolMode) *infrav1.AzureM
 				},
 			},
 		},
-		Spec: infrav1.AzureManagedMachinePoolSpec{
+		Spec: infrav1exp.AzureManagedMachinePoolSpec{
 			Mode: string(mode),
 			SKU:  "Standard_D2s_v3",
 			Name: to.StringPtr(name),
@@ -526,41 +526,41 @@ func getAzureMachinePool(name string, mode infrav1.NodePoolMode) *infrav1.AzureM
 	}
 }
 
-func getAzureMachinePoolWithScaling(name string, min, max int32) *infrav1.AzureManagedMachinePool {
-	managedPool := getAzureMachinePool(name, infrav1.NodePoolModeUser)
-	managedPool.Spec.Scaling = &infrav1.ManagedMachinePoolScaling{
+func getAzureMachinePoolWithScaling(name string, min, max int32) *infrav1exp.AzureManagedMachinePool {
+	managedPool := getAzureMachinePool(name, infrav1exp.NodePoolModeUser)
+	managedPool.Spec.Scaling = &infrav1exp.ManagedMachinePoolScaling{
 		MinSize: to.Int32Ptr(min),
 		MaxSize: to.Int32Ptr(max),
 	}
 	return managedPool
 }
 
-func getAzureMachinePoolWithMaxPods(name string, maxPods int32) *infrav1.AzureManagedMachinePool {
-	managedPool := getAzureMachinePool(name, infrav1.NodePoolModeSystem)
+func getAzureMachinePoolWithMaxPods(name string, maxPods int32) *infrav1exp.AzureManagedMachinePool {
+	managedPool := getAzureMachinePool(name, infrav1exp.NodePoolModeSystem)
 	managedPool.Spec.MaxPods = to.Int32Ptr(maxPods)
 	return managedPool
 }
 
-func getAzureMachinePoolWithTaints(name string, taints infrav1.Taints) *infrav1.AzureManagedMachinePool {
-	managedPool := getAzureMachinePool(name, infrav1.NodePoolModeUser)
+func getAzureMachinePoolWithTaints(name string, taints infrav1exp.Taints) *infrav1exp.AzureManagedMachinePool {
+	managedPool := getAzureMachinePool(name, infrav1exp.NodePoolModeUser)
 	managedPool.Spec.Taints = taints
 	return managedPool
 }
 
-func getAzureMachinePoolWithOsDiskType(name string, osDiskType string) *infrav1.AzureManagedMachinePool {
-	managedPool := getAzureMachinePool(name, infrav1.NodePoolModeUser)
+func getAzureMachinePoolWithOsDiskType(name string, osDiskType string) *infrav1exp.AzureManagedMachinePool {
+	managedPool := getAzureMachinePool(name, infrav1exp.NodePoolModeUser)
 	managedPool.Spec.OsDiskType = to.StringPtr(osDiskType)
 	return managedPool
 }
 
-func getAzureMachinePoolWithLabels(name string, nodeLabels map[string]string) *infrav1.AzureManagedMachinePool {
-	managedPool := getAzureMachinePool(name, infrav1.NodePoolModeSystem)
+func getAzureMachinePoolWithLabels(name string, nodeLabels map[string]string) *infrav1exp.AzureManagedMachinePool {
+	managedPool := getAzureMachinePool(name, infrav1exp.NodePoolModeSystem)
 	managedPool.Spec.NodeLabels = nodeLabels
 	return managedPool
 }
 
-func getMachinePool(name string) *capiv1exp.MachinePool {
-	return &capiv1exp.MachinePool{
+func getMachinePool(name string) *expv1.MachinePool {
+	return &expv1.MachinePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "default",
@@ -568,25 +568,25 @@ func getMachinePool(name string) *capiv1exp.MachinePool {
 				clusterv1.ClusterLabelName: "cluster1",
 			},
 		},
-		Spec: capiv1exp.MachinePoolSpec{
+		Spec: expv1.MachinePoolSpec{
 			ClusterName: "cluster1",
 		},
 	}
 }
 
-func getLinuxAzureMachinePool(name string) *infrav1.AzureManagedMachinePool {
-	managedPool := getAzureMachinePool(name, infrav1.NodePoolModeUser)
+func getLinuxAzureMachinePool(name string) *infrav1exp.AzureManagedMachinePool {
+	managedPool := getAzureMachinePool(name, infrav1exp.NodePoolModeUser)
 	managedPool.Spec.OSType = to.StringPtr(azure.LinuxOS)
 	return managedPool
 }
 
-func getWindowsAzureMachinePool(name string) *infrav1.AzureManagedMachinePool {
-	managedPool := getAzureMachinePool(name, infrav1.NodePoolModeUser)
+func getWindowsAzureMachinePool(name string) *infrav1exp.AzureManagedMachinePool {
+	managedPool := getAzureMachinePool(name, infrav1exp.NodePoolModeUser)
 	managedPool.Spec.OSType = to.StringPtr(azure.WindowsOS)
 	return managedPool
 }
 
-func getMachinePoolWithVersion(name, version string) *capiv1exp.MachinePool {
+func getMachinePoolWithVersion(name, version string) *expv1.MachinePool {
 	machine := getMachinePool(name)
 	machine.Spec.Template.Spec.Version = to.StringPtr(version)
 	return machine

--- a/azure/services/agentpools/agentpools.go
+++ b/azure/services/agentpools/agentpools.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-05-01/containerservice"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	infrav1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 	"sigs.k8s.io/cluster-api-provider-azure/util/maps"
@@ -96,7 +96,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		}
 	} else {
 		ps := *existingPool.ManagedClusterAgentPoolProfileProperties.ProvisioningState
-		if ps != string(infrav1alpha4.Canceled) && ps != string(infrav1alpha4.Failed) && ps != string(infrav1alpha4.Succeeded) {
+		if ps != string(infrav1.Canceled) && ps != string(infrav1.Failed) && ps != string(infrav1.Succeeded) {
 			msg := fmt.Sprintf("Unable to update existing agent pool in non terminal state. Agent pool must be in one of the following provisioning states: canceled, failed, or succeeded. Actual state: %s", ps)
 			log.V(2).Info(msg)
 			return azure.WithTransientError(errors.New(msg), 20*time.Second)

--- a/azure/services/agentpools/agentpools_test.go
+++ b/azure/services/agentpools/agentpools_test.go
@@ -30,10 +30,10 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/agentpools/mock_agentpools"
-	infraexpv1 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
-	capiexp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 )
 
 func TestReconcile(t *testing.T) {
@@ -92,20 +92,20 @@ func TestReconcile(t *testing.T) {
 
 				agentpoolsMock := mock_agentpools.NewMockClient(mockCtrl)
 				machinePoolScope := &scope.ManagedMachinePoolScope{
-					ControlPlane: &infraexpv1.AzureManagedControlPlane{
+					ControlPlane: &infrav1exp.AzureManagedControlPlane{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: tc.agentpoolSpec.Cluster,
 						},
-						Spec: infraexpv1.AzureManagedControlPlaneSpec{
+						Spec: infrav1exp.AzureManagedControlPlaneSpec{
 							ResourceGroupName: tc.agentpoolSpec.ResourceGroup,
 						},
 					},
-					MachinePool: &capiexp.MachinePool{},
-					InfraMachinePool: &infraexpv1.AzureManagedMachinePool{
+					MachinePool: &expv1.MachinePool{},
+					InfraMachinePool: &infrav1exp.AzureManagedMachinePool{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: tc.agentpoolSpec.Name,
 						},
-						Spec: infraexpv1.AzureManagedMachinePoolSpec{
+						Spec: infrav1exp.AzureManagedMachinePoolSpec{
 							Name: &tc.agentpoolSpec.Name,
 						},
 					},
@@ -277,29 +277,29 @@ func TestReconcile(t *testing.T) {
 
 			agentpoolsMock := mock_agentpools.NewMockClient(mockCtrl)
 			machinePoolScope := &scope.ManagedMachinePoolScope{
-				ControlPlane: &infraexpv1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: tc.agentPoolsSpec.Cluster,
 					},
-					Spec: infraexpv1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						ResourceGroupName: tc.agentPoolsSpec.ResourceGroup,
 					},
 				},
-				MachinePool: &capiexp.MachinePool{
-					Spec: capiexp.MachinePoolSpec{
+				MachinePool: &expv1.MachinePool{
+					Spec: expv1.MachinePoolSpec{
 						Replicas: &replicas,
-						Template: capi.MachineTemplateSpec{
-							Spec: capi.MachineSpec{
+						Template: clusterv1.MachineTemplateSpec{
+							Spec: clusterv1.MachineSpec{
 								Version: tc.agentPoolsSpec.Version,
 							},
 						},
 					},
 				},
-				InfraMachinePool: &infraexpv1.AzureManagedMachinePool{
+				InfraMachinePool: &infrav1exp.AzureManagedMachinePool{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: tc.agentPoolsSpec.Name,
 					},
-					Spec: infraexpv1.AzureManagedMachinePoolSpec{
+					Spec: infrav1exp.AzureManagedMachinePoolSpec{
 						Name:         &tc.agentPoolsSpec.Name,
 						SKU:          tc.agentPoolsSpec.SKU,
 						OSDiskSizeGB: &osDiskSizeGB,
@@ -384,20 +384,20 @@ func TestDeleteAgentPools(t *testing.T) {
 
 			agentPoolsMock := mock_agentpools.NewMockClient(mockCtrl)
 			machinePoolScope := &scope.ManagedMachinePoolScope{
-				ControlPlane: &infraexpv1.AzureManagedControlPlane{
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: tc.agentPoolsSpec.Cluster,
 					},
-					Spec: infraexpv1.AzureManagedControlPlaneSpec{
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
 						ResourceGroupName: tc.agentPoolsSpec.ResourceGroup,
 					},
 				},
-				MachinePool: &capiexp.MachinePool{},
-				InfraMachinePool: &infraexpv1.AzureManagedMachinePool{
+				MachinePool: &expv1.MachinePool{},
+				InfraMachinePool: &infrav1exp.AzureManagedMachinePool{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: tc.agentPoolsSpec.Name,
 					},
-					Spec: infraexpv1.AzureManagedMachinePoolSpec{
+					Spec: infrav1exp.AzureManagedMachinePoolSpec{
 						Name: &tc.agentPoolsSpec.Name,
 					},
 				},

--- a/azure/services/natgateways/natgateways_test.go
+++ b/azure/services/natgateways/natgateways_test.go
@@ -32,11 +32,11 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/natgateways/mock_natgateways"
 	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
 func init() {
-	_ = clusterv1.AddToScheme(scheme.Scheme)
+	_ = clusterv1alpha3.AddToScheme(scheme.Scheme)
 }
 
 var (

--- a/azure/services/scalesetvms/scalesetvms_test.go
+++ b/azure/services/scalesetvms/scalesetvms_test.go
@@ -38,7 +38,7 @@ import (
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	gomock2 "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -80,7 +80,7 @@ func TestNewService(t *testing.T) {
 
 	mpms, err := scope.NewMachinePoolMachineScope(scope.MachinePoolMachineScopeParams{
 		Client:                  client,
-		MachinePool:             new(clusterv1exp.MachinePool),
+		MachinePool:             new(expv1.MachinePool),
 		AzureMachinePool:        new(infrav1exp.AzureMachinePool),
 		AzureMachinePoolMachine: new(infrav1exp.AzureMachinePoolMachine),
 		ClusterScope:            s,

--- a/controllers/azureidentity_controller.go
+++ b/controllers/azureidentity_controller.go
@@ -27,7 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
-	infraexpv1 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/system"
@@ -70,10 +70,10 @@ func (r *AzureIdentityReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		return errors.Wrap(err, "error creating controller")
 	}
 
-	// Add a watch on infraexpv1.AzureManagedControlPlane if aks is enabled.
+	// Add a watch on infrav1exp.AzureManagedControlPlane if aks is enabled.
 	if feature.Gates.Enabled(feature.AKS) {
 		if err = c.Watch(
-			&source.Kind{Type: &infraexpv1.AzureManagedControlPlane{}},
+			&source.Kind{Type: &infrav1exp.AzureManagedControlPlane{}},
 			&handler.EnqueueRequestForObject{},
 			predicates.ResourceNotPausedAndHasFilterLabel(log, r.WatchFilterValue),
 		); err != nil {
@@ -122,7 +122,7 @@ func (r *AzureIdentityReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err != nil && apierrors.IsNotFound(err) {
 		if feature.Gates.Enabled(feature.AKS) {
 			// Fetch the AzureManagedControlPlane instance
-			azureManagedControlPlane := &infraexpv1.AzureManagedControlPlane{}
+			azureManagedControlPlane := &infrav1exp.AzureManagedControlPlane{}
 			identityOwner = azureManagedControlPlane
 			err = r.Get(ctx, req.NamespacedName, azureManagedControlPlane)
 			if err != nil && apierrors.IsNotFound(err) {
@@ -172,8 +172,8 @@ func (r *AzureIdentityReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 					return ctrl.Result{}, errors.Wrap(err, "failed to get AzureCluster")
 				}
 			}
-		case infraexpv1.AzureManagedControlPlane:
-			azManagedControlPlane := &infraexpv1.AzureManagedControlPlane{}
+		case infrav1exp.AzureManagedControlPlane:
+			azManagedControlPlane := &infrav1exp.AzureManagedControlPlane{}
 			if err := r.Get(ctx, key, azManagedControlPlane); err != nil {
 				if apierrors.IsNotFound(err) {
 					bindingsToDelete = append(bindingsToDelete, b)

--- a/controllers/azurejson_machine_controller_test.go
+++ b/controllers/azurejson_machine_controller_test.go
@@ -30,9 +30,9 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
-	infraexpv1 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterexpv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -243,8 +243,8 @@ func newScheme() (*runtime.Scheme, error) {
 		clientgoscheme.AddToScheme,
 		infrav1.AddToScheme,
 		clusterv1.AddToScheme,
-		infraexpv1.AddToScheme,
-		clusterexpv1.AddToScheme,
+		infrav1exp.AddToScheme,
+		expv1.AddToScheme,
 	}
 	for _, fn := range schemeFn {
 		fn := fn

--- a/controllers/azurejson_machinepool_controller.go
+++ b/controllers/azurejson_machinepool_controller.go
@@ -30,7 +30,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/identities"
-	expv1 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	"sigs.k8s.io/cluster-api/util"
@@ -58,7 +58,7 @@ func (r *AzureJSONMachinePoolReconciler) SetupWithManager(ctx context.Context, m
 
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
-		For(&expv1.AzureMachinePool{}).
+		For(&infrav1exp.AzureMachinePool{}).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(log, r.WatchFilterValue)).
 		Owns(&corev1.Secret{}).
 		Complete(r)
@@ -81,7 +81,7 @@ func (r *AzureJSONMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl
 	log = log.WithValues("namespace", req.Namespace, "azureMachinePool", req.Name)
 
 	// Fetch the AzureMachine instance
-	azureMachinePool := &expv1.AzureMachinePool{}
+	azureMachinePool := &infrav1exp.AzureMachinePool{}
 	err := r.Get(ctx, req.NamespacedName, azureMachinePool)
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/controllers/azurejson_machinepool_controller_test.go
+++ b/controllers/azurejson_machinepool_controller_test.go
@@ -29,9 +29,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
-	infraexpv1 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterexpv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -83,7 +83,7 @@ func TestAzureJSONPoolReconciler(t *testing.T) {
 		},
 	}
 
-	machinePool := &clusterexpv1.MachinePool{
+	machinePool := &expv1.MachinePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-machine-pool",
 			Labels: map[string]string{
@@ -99,7 +99,7 @@ func TestAzureJSONPoolReconciler(t *testing.T) {
 		},
 	}
 
-	azureMachinePool := &infraexpv1.AzureMachinePool{
+	azureMachinePool := &infrav1exp.AzureMachinePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-azure-machine-pool",
 			OwnerReferences: []metav1.OwnerReference{

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -40,7 +40,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	capiv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -497,7 +497,7 @@ func reconcileAzureSecret(ctx context.Context, kubeclient client.Client, owner m
 }
 
 // GetOwnerMachinePool returns the MachinePool object owning the current resource.
-func GetOwnerMachinePool(ctx context.Context, c client.Client, obj metav1.ObjectMeta) (*capiv1exp.MachinePool, error) {
+func GetOwnerMachinePool(ctx context.Context, c client.Client, obj metav1.ObjectMeta) (*expv1.MachinePool, error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.GetOwnerMachinePool")
 	defer done()
 
@@ -510,7 +510,7 @@ func GetOwnerMachinePool(ctx context.Context, c client.Client, obj metav1.Object
 			return nil, errors.WithStack(err)
 		}
 
-		if gv.Group == capiv1exp.GroupVersion.Group {
+		if gv.Group == expv1.GroupVersion.Group {
 			return GetMachinePoolByName(ctx, c, obj.Namespace, ref.Name)
 		}
 	}
@@ -540,11 +540,11 @@ func GetOwnerAzureMachinePool(ctx context.Context, c client.Client, obj metav1.O
 }
 
 // GetMachinePoolByName finds and return a MachinePool object using the specified params.
-func GetMachinePoolByName(ctx context.Context, c client.Client, namespace, name string) (*capiv1exp.MachinePool, error) {
+func GetMachinePoolByName(ctx context.Context, c client.Client, namespace, name string) (*expv1.MachinePool, error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.GetMachinePoolByName")
 	defer done()
 
-	m := &capiv1exp.MachinePool{}
+	m := &expv1.MachinePool{}
 	key := client.ObjectKey{Name: name, Namespace: namespace}
 	if err := c.Get(ctx, key, m); err != nil {
 		return nil, err

--- a/exp/api/v1alpha3/azuremachinepool_types.go
+++ b/exp/api/v1alpha3/azuremachinepool_types.go
@@ -18,8 +18,8 @@ package v1alpha3
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	infrav1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/errors"
 )
 
@@ -35,14 +35,14 @@ type (
 		// which is based on Ubuntu.
 		// +kubebuilder:validation:nullable
 		// +optional
-		Image *infrav1.Image `json:"image,omitempty"`
+		Image *infrav1alpha3.Image `json:"image,omitempty"`
 
 		// OSDisk contains the operating system disk information for a Virtual Machine
-		OSDisk infrav1.OSDisk `json:"osDisk"`
+		OSDisk infrav1alpha3.OSDisk `json:"osDisk"`
 
 		// DataDisks specifies the list of data disks to be created for a Virtual Machine
 		// +optional
-		DataDisks []infrav1.DataDisk `json:"dataDisks,omitempty"`
+		DataDisks []infrav1alpha3.DataDisk `json:"dataDisks,omitempty"`
 
 		// SSHPublicKey is the SSH public key string base64 encoded to add to a Virtual Machine
 		SSHPublicKey string `json:"sshPublicKey"`
@@ -60,11 +60,11 @@ type (
 
 		// SecurityProfile specifies the Security profile settings for a virtual machine.
 		// +optional
-		SecurityProfile *infrav1.SecurityProfile `json:"securityProfile,omitempty"`
+		SecurityProfile *infrav1alpha3.SecurityProfile `json:"securityProfile,omitempty"`
 
 		// SpotVMOptions allows the ability to specify the Machine should use a Spot VM
 		// +optional
-		SpotVMOptions *infrav1.SpotVMOptions `json:"spotVMOptions,omitempty"`
+		SpotVMOptions *infrav1alpha3.SpotVMOptions `json:"spotVMOptions,omitempty"`
 	}
 
 	// AzureMachinePoolSpec defines the desired state of AzureMachinePool.
@@ -79,7 +79,7 @@ type (
 		// Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the
 		// AzureMachine's value takes precedence.
 		// +optional
-		AdditionalTags infrav1.Tags `json:"additionalTags,omitempty"`
+		AdditionalTags infrav1alpha3.Tags `json:"additionalTags,omitempty"`
 
 		// ProviderID is the identification ID of the Virtual Machine Scale Set
 		// +optional
@@ -97,14 +97,14 @@ type (
 		// and assigned to the VM
 		// +kubebuilder:default=None
 		// +optional
-		Identity infrav1.VMIdentity `json:"identity,omitempty"`
+		Identity infrav1alpha3.VMIdentity `json:"identity,omitempty"`
 
 		// UserAssignedIdentities is a list of standalone Azure identities provided by the user
 		// The lifecycle of a user-assigned identity is managed separately from the lifecycle of
 		// the AzureMachinePool.
 		// See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli
 		// +optional
-		UserAssignedIdentities []infrav1.UserAssignedIdentity `json:"userAssignedIdentities,omitempty"`
+		UserAssignedIdentities []infrav1alpha3.UserAssignedIdentity `json:"userAssignedIdentities,omitempty"`
 
 		// RoleAssignmentName is the name of the role assignment to create for a system assigned identity. It can be any valid GUID.
 		// If not specified, a random GUID will be generated.
@@ -132,7 +132,7 @@ type (
 
 		// ProvisioningState is the provisioning state of the Azure virtual machine.
 		// +optional
-		ProvisioningState *infrav1.VMState `json:"provisioningState,omitempty"`
+		ProvisioningState *infrav1alpha3.VMState `json:"provisioningState,omitempty"`
 
 		// FailureReason will be set in the event that there is a terminal problem
 		// reconciling the MachinePool and will contain a succinct value suitable
@@ -174,12 +174,12 @@ type (
 
 		// Conditions defines current service state of the AzureMachinePool.
 		// +optional
-		Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+		Conditions clusterv1alpha3.Conditions `json:"conditions,omitempty"`
 
 		// LongRunningOperationState saves the state for an Azure long running operations so it can be continued on the
 		// next reconciliation loop.
 		// +optional
-		LongRunningOperationState *infrav1.Future `json:"longRunningOperationState,omitempty"`
+		LongRunningOperationState *infrav1alpha3.Future `json:"longRunningOperationState,omitempty"`
 	}
 
 	// AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS.
@@ -190,7 +190,7 @@ type (
 
 		// ProvisioningState is the provisioning state of the Azure virtual machine instance.
 		// +optional
-		ProvisioningState *infrav1.VMState `json:"provisioningState"`
+		ProvisioningState *infrav1alpha3.VMState `json:"provisioningState"`
 
 		// ProviderID is the provider identification of the VMSS Instance
 		// +optional
@@ -241,12 +241,12 @@ type (
 )
 
 // GetConditions returns the list of conditions for an AzureMachinePool API object.
-func (amp *AzureMachinePool) GetConditions() clusterv1.Conditions {
+func (amp *AzureMachinePool) GetConditions() clusterv1alpha3.Conditions {
 	return amp.Status.Conditions
 }
 
 // SetConditions will set the given conditions on an AzureMachinePool object.
-func (amp *AzureMachinePool) SetConditions(conditions clusterv1.Conditions) {
+func (amp *AzureMachinePool) SetConditions(conditions clusterv1alpha3.Conditions) {
 	amp.Status.Conditions = conditions
 }
 

--- a/exp/api/v1alpha3/azuremanagedcluster_types.go
+++ b/exp/api/v1alpha3/azuremanagedcluster_types.go
@@ -18,14 +18,14 @@ package v1alpha3
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
 // AzureManagedClusterSpec defines the desired state of AzureManagedCluster.
 type AzureManagedClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
-	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
+	ControlPlaneEndpoint clusterv1alpha3.APIEndpoint `json:"controlPlaneEndpoint"`
 }
 
 // AzureManagedClusterStatus defines the observed state of AzureManagedCluster.

--- a/exp/api/v1alpha3/azuremanagedcontrolplane_types.go
+++ b/exp/api/v1alpha3/azuremanagedcontrolplane_types.go
@@ -18,8 +18,8 @@ package v1alpha3
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	infrav1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
 // AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane.
@@ -47,12 +47,12 @@ type AzureManagedControlPlaneSpec struct {
 
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
-	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
+	ControlPlaneEndpoint clusterv1alpha3.APIEndpoint `json:"controlPlaneEndpoint"`
 
 	// AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the
 	// ones added by default.
 	// +optional
-	AdditionalTags infrav1.Tags `json:"additionalTags,omitempty"`
+	AdditionalTags infrav1alpha3.Tags `json:"additionalTags,omitempty"`
 
 	// NetworkPlugin used for building Kubernetes network.
 	// +kubebuilder:validation:Enum=azure;kubenet

--- a/exp/api/v1alpha4/azuremachinepool_types.go
+++ b/exp/api/v1alpha4/azuremachinepool_types.go
@@ -19,8 +19,8 @@ package v1alpha4
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	infrav1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
+	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/errors"
 )
 
@@ -53,14 +53,14 @@ type (
 		// which is based on Ubuntu.
 		// +kubebuilder:validation:nullable
 		// +optional
-		Image *infrav1.Image `json:"image,omitempty"`
+		Image *infrav1alpha4.Image `json:"image,omitempty"`
 
 		// OSDisk contains the operating system disk information for a Virtual Machine
-		OSDisk infrav1.OSDisk `json:"osDisk"`
+		OSDisk infrav1alpha4.OSDisk `json:"osDisk"`
 
 		// DataDisks specifies the list of data disks to be created for a Virtual Machine
 		// +optional
-		DataDisks []infrav1.DataDisk `json:"dataDisks,omitempty"`
+		DataDisks []infrav1alpha4.DataDisk `json:"dataDisks,omitempty"`
 
 		// SSHPublicKey is the SSH public key string base64 encoded to add to a Virtual Machine
 		SSHPublicKey string `json:"sshPublicKey"`
@@ -78,11 +78,11 @@ type (
 
 		// SecurityProfile specifies the Security profile settings for a virtual machine.
 		// +optional
-		SecurityProfile *infrav1.SecurityProfile `json:"securityProfile,omitempty"`
+		SecurityProfile *infrav1alpha4.SecurityProfile `json:"securityProfile,omitempty"`
 
 		// SpotVMOptions allows the ability to specify the Machine should use a Spot VM
 		// +optional
-		SpotVMOptions *infrav1.SpotVMOptions `json:"spotVMOptions,omitempty"`
+		SpotVMOptions *infrav1alpha4.SpotVMOptions `json:"spotVMOptions,omitempty"`
 
 		// SubnetName selects the Subnet where the VMSS will be placed
 		// +optional
@@ -101,7 +101,7 @@ type (
 		// Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the
 		// AzureMachine's value takes precedence.
 		// +optional
-		AdditionalTags infrav1.Tags `json:"additionalTags,omitempty"`
+		AdditionalTags infrav1alpha4.Tags `json:"additionalTags,omitempty"`
 
 		// ProviderID is the identification ID of the Virtual Machine Scale Set
 		// +optional
@@ -119,14 +119,14 @@ type (
 		// and assigned to the VM
 		// +kubebuilder:default=None
 		// +optional
-		Identity infrav1.VMIdentity `json:"identity,omitempty"`
+		Identity infrav1alpha4.VMIdentity `json:"identity,omitempty"`
 
 		// UserAssignedIdentities is a list of standalone Azure identities provided by the user
 		// The lifecycle of a user-assigned identity is managed separately from the lifecycle of
 		// the AzureMachinePool.
 		// See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli
 		// +optional
-		UserAssignedIdentities []infrav1.UserAssignedIdentity `json:"userAssignedIdentities,omitempty"`
+		UserAssignedIdentities []infrav1alpha4.UserAssignedIdentity `json:"userAssignedIdentities,omitempty"`
 
 		// RoleAssignmentName is the name of the role assignment to create for a system assigned identity. It can be any valid GUID.
 		// If not specified, a random GUID will be generated.
@@ -229,7 +229,7 @@ type (
 		// Image is the current image used in the AzureMachinePool. When the spec image is nil, this image is populated
 		// with the details of the defaulted Azure Marketplace "capi" offer.
 		// +optional
-		Image *infrav1.Image `json:"image,omitempty"`
+		Image *infrav1alpha4.Image `json:"image,omitempty"`
 
 		// Version is the Kubernetes version for the current VMSS model
 		// +optional
@@ -237,7 +237,7 @@ type (
 
 		// ProvisioningState is the provisioning state of the Azure virtual machine.
 		// +optional
-		ProvisioningState *infrav1.ProvisioningState `json:"provisioningState,omitempty"`
+		ProvisioningState *infrav1alpha4.ProvisioningState `json:"provisioningState,omitempty"`
 
 		// FailureReason will be set in the event that there is a terminal problem
 		// reconciling the MachinePool and will contain a succinct value suitable
@@ -279,12 +279,12 @@ type (
 
 		// Conditions defines current service state of the AzureMachinePool.
 		// +optional
-		Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+		Conditions clusterv1alpha4.Conditions `json:"conditions,omitempty"`
 
 		// LongRunningOperationStates saves the state for Azure long-running operations so they can be continued on the
 		// next reconciliation loop.
 		// +optional
-		LongRunningOperationStates infrav1.Futures `json:"longRunningOperationStates,omitempty"`
+		LongRunningOperationStates infrav1alpha4.Futures `json:"longRunningOperationStates,omitempty"`
 	}
 
 	// AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS.
@@ -295,7 +295,7 @@ type (
 
 		// ProvisioningState is the provisioning state of the Azure virtual machine instance.
 		// +optional
-		ProvisioningState *infrav1.ProvisioningState `json:"provisioningState"`
+		ProvisioningState *infrav1alpha4.ProvisioningState `json:"provisioningState"`
 
 		// ProviderID is the provider identification of the VMSS Instance
 		// +optional
@@ -346,22 +346,22 @@ type (
 )
 
 // GetConditions returns the list of conditions for an AzureMachinePool API object.
-func (amp *AzureMachinePool) GetConditions() clusterv1.Conditions {
+func (amp *AzureMachinePool) GetConditions() clusterv1alpha4.Conditions {
 	return amp.Status.Conditions
 }
 
 // SetConditions will set the given conditions on an AzureMachinePool object.
-func (amp *AzureMachinePool) SetConditions(conditions clusterv1.Conditions) {
+func (amp *AzureMachinePool) SetConditions(conditions clusterv1alpha4.Conditions) {
 	amp.Status.Conditions = conditions
 }
 
 // GetFutures returns the list of long running operation states for an AzureMachinePool API object.
-func (amp *AzureMachinePool) GetFutures() infrav1.Futures {
+func (amp *AzureMachinePool) GetFutures() infrav1alpha4.Futures {
 	return amp.Status.LongRunningOperationStates
 }
 
 // SetFutures will set the given long running operation states on an AzureMachinePool object.
-func (amp *AzureMachinePool) SetFutures(futures infrav1.Futures) {
+func (amp *AzureMachinePool) SetFutures(futures infrav1alpha4.Futures) {
 	amp.Status.LongRunningOperationStates = futures
 }
 

--- a/exp/api/v1alpha4/azuremachinepoolmachine_types.go
+++ b/exp/api/v1alpha4/azuremachinepoolmachine_types.go
@@ -19,8 +19,8 @@ package v1alpha4
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	infrav1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
+	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/errors"
 )
 
@@ -52,7 +52,7 @@ type (
 
 		// ProvisioningState is the provisioning state of the Azure virtual machine instance.
 		// +optional
-		ProvisioningState *infrav1.ProvisioningState `json:"provisioningState"`
+		ProvisioningState *infrav1alpha4.ProvisioningState `json:"provisioningState"`
 
 		// InstanceName is the name of the Machine Instance within the VMSS
 		// +optional
@@ -80,12 +80,12 @@ type (
 
 		// Conditions defines current service state of the AzureMachinePool.
 		// +optional
-		Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+		Conditions clusterv1alpha4.Conditions `json:"conditions,omitempty"`
 
 		// LongRunningOperationStates saves the state for Azure long running operations so they can be continued on the
 		// next reconciliation loop.
 		// +optional
-		LongRunningOperationStates infrav1.Futures `json:"longRunningOperationStates,omitempty"`
+		LongRunningOperationStates infrav1alpha4.Futures `json:"longRunningOperationStates,omitempty"`
 
 		// LatestModelApplied indicates the instance is running the most up-to-date VMSS model. A VMSS model describes
 		// the image version the VM is running. If the instance is not running the latest model, it means the instance
@@ -126,22 +126,22 @@ type (
 )
 
 // GetConditions returns the list of conditions for an AzureMachinePool API object.
-func (ampm *AzureMachinePoolMachine) GetConditions() clusterv1.Conditions {
+func (ampm *AzureMachinePoolMachine) GetConditions() clusterv1alpha4.Conditions {
 	return ampm.Status.Conditions
 }
 
 // SetConditions will set the given conditions on an AzureMachinePool object.
-func (ampm *AzureMachinePoolMachine) SetConditions(conditions clusterv1.Conditions) {
+func (ampm *AzureMachinePoolMachine) SetConditions(conditions clusterv1alpha4.Conditions) {
 	ampm.Status.Conditions = conditions
 }
 
 // GetFutures returns the list of long running operation states for an AzureMachinePoolMachine API object.
-func (ampm *AzureMachinePoolMachine) GetFutures() infrav1.Futures {
+func (ampm *AzureMachinePoolMachine) GetFutures() infrav1alpha4.Futures {
 	return ampm.Status.LongRunningOperationStates
 }
 
 // SetFutures will set the given long running operation states on an AzureMachinePoolMachine object.
-func (ampm *AzureMachinePoolMachine) SetFutures(futures infrav1.Futures) {
+func (ampm *AzureMachinePoolMachine) SetFutures(futures infrav1alpha4.Futures) {
 	ampm.Status.LongRunningOperationStates = futures
 }
 

--- a/exp/api/v1alpha4/azuremanagedcluster_types.go
+++ b/exp/api/v1alpha4/azuremanagedcluster_types.go
@@ -18,14 +18,14 @@ package v1alpha4
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
 // AzureManagedClusterSpec defines the desired state of AzureManagedCluster.
 type AzureManagedClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
-	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
+	ControlPlaneEndpoint clusterv1alpha4.APIEndpoint `json:"controlPlaneEndpoint"`
 }
 
 // AzureManagedClusterStatus defines the observed state of AzureManagedCluster.

--- a/exp/api/v1alpha4/azuremanagedcontrolplane_types.go
+++ b/exp/api/v1alpha4/azuremanagedcontrolplane_types.go
@@ -19,8 +19,8 @@ package v1alpha4
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	infrav1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
+	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
 const (
@@ -57,12 +57,12 @@ type AzureManagedControlPlaneSpec struct {
 
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
-	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
+	ControlPlaneEndpoint clusterv1alpha4.APIEndpoint `json:"controlPlaneEndpoint"`
 
 	// AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the
 	// ones added by default.
 	// +optional
-	AdditionalTags infrav1.Tags `json:"additionalTags,omitempty"`
+	AdditionalTags infrav1alpha4.Tags `json:"additionalTags,omitempty"`
 
 	// NetworkPlugin used for building Kubernetes network.
 	// +kubebuilder:validation:Enum=azure;kubenet
@@ -199,7 +199,7 @@ type AzureManagedControlPlaneStatus struct {
 	// LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the
 	// next reconciliation loop.
 	// +optional
-	LongRunningOperationStates infrav1.Futures `json:"longRunningOperationStates,omitempty"`
+	LongRunningOperationStates infrav1alpha4.Futures `json:"longRunningOperationStates,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -225,12 +225,12 @@ type AzureManagedControlPlaneList struct {
 }
 
 // GetFutures returns the list of long running operation states for an AzureManagedControlPlane API object.
-func (m *AzureManagedControlPlane) GetFutures() infrav1.Futures {
+func (m *AzureManagedControlPlane) GetFutures() infrav1alpha4.Futures {
 	return m.Status.LongRunningOperationStates
 }
 
 // SetFutures will set the given long running operation states on an AzureManagedControlPlane object.
-func (m *AzureManagedControlPlane) SetFutures(futures infrav1.Futures) {
+func (m *AzureManagedControlPlane) SetFutures(futures infrav1alpha4.Futures) {
 	m.Status.LongRunningOperationStates = futures
 }
 

--- a/exp/api/v1beta1/azuremachinepool_test.go
+++ b/exp/api/v1beta1/azuremachinepool_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onsi/gomega"
 	utilfeature "k8s.io/component-base/featuregate/testing"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
-	exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	capifeature "sigs.k8s.io/cluster-api/feature"
 )
@@ -31,13 +31,13 @@ import (
 func TestAzureMachinePool_Validate(t *testing.T) {
 	cases := []struct {
 		Name    string
-		Factory func(g *gomega.GomegaWithT) *exp.AzureMachinePool
+		Factory func(g *gomega.GomegaWithT) *infrav1exp.AzureMachinePool
 		Expect  func(g *gomega.GomegaWithT, actual error)
 	}{
 		{
 			Name: "HasNoImage",
-			Factory: func(_ *gomega.GomegaWithT) *exp.AzureMachinePool {
-				return new(exp.AzureMachinePool)
+			Factory: func(_ *gomega.GomegaWithT) *infrav1exp.AzureMachinePool {
+				return new(infrav1exp.AzureMachinePool)
 			},
 			Expect: func(g *gomega.GomegaWithT, actual error) {
 				g.Expect(actual).NotTo(gomega.HaveOccurred())
@@ -45,10 +45,10 @@ func TestAzureMachinePool_Validate(t *testing.T) {
 		},
 		{
 			Name: "HasValidImage",
-			Factory: func(_ *gomega.GomegaWithT) *exp.AzureMachinePool {
-				return &exp.AzureMachinePool{
-					Spec: exp.AzureMachinePoolSpec{
-						Template: exp.AzureMachinePoolMachineTemplate{
+			Factory: func(_ *gomega.GomegaWithT) *infrav1exp.AzureMachinePool {
+				return &infrav1exp.AzureMachinePool{
+					Spec: infrav1exp.AzureMachinePoolSpec{
+						Template: infrav1exp.AzureMachinePoolMachineTemplate{
 							Image: &infrav1.Image{
 								SharedGallery: &infrav1.AzureSharedGalleryImage{
 									SubscriptionID: "foo",
@@ -68,10 +68,10 @@ func TestAzureMachinePool_Validate(t *testing.T) {
 		},
 		{
 			Name: "HasInvalidImage",
-			Factory: func(_ *gomega.GomegaWithT) *exp.AzureMachinePool {
-				return &exp.AzureMachinePool{
-					Spec: exp.AzureMachinePoolSpec{
-						Template: exp.AzureMachinePoolMachineTemplate{
+			Factory: func(_ *gomega.GomegaWithT) *infrav1exp.AzureMachinePool {
+				return &infrav1exp.AzureMachinePool{
+					Spec: infrav1exp.AzureMachinePoolSpec{
+						Template: infrav1exp.AzureMachinePoolMachineTemplate{
 							Image: new(infrav1.Image),
 						},
 					},
@@ -84,10 +84,10 @@ func TestAzureMachinePool_Validate(t *testing.T) {
 		},
 		{
 			Name: "HasValidTerminateNotificationTimeout",
-			Factory: func(_ *gomega.GomegaWithT) *exp.AzureMachinePool {
-				return &exp.AzureMachinePool{
-					Spec: exp.AzureMachinePoolSpec{
-						Template: exp.AzureMachinePoolMachineTemplate{
+			Factory: func(_ *gomega.GomegaWithT) *infrav1exp.AzureMachinePool {
+				return &infrav1exp.AzureMachinePool{
+					Spec: infrav1exp.AzureMachinePoolSpec{
+						Template: infrav1exp.AzureMachinePoolMachineTemplate{
 							TerminateNotificationTimeout: to.IntPtr(7),
 						},
 					},
@@ -99,10 +99,10 @@ func TestAzureMachinePool_Validate(t *testing.T) {
 		},
 		{
 			Name: "HasInvalidMaximumTerminateNotificationTimeout",
-			Factory: func(_ *gomega.GomegaWithT) *exp.AzureMachinePool {
-				return &exp.AzureMachinePool{
-					Spec: exp.AzureMachinePoolSpec{
-						Template: exp.AzureMachinePoolMachineTemplate{
+			Factory: func(_ *gomega.GomegaWithT) *infrav1exp.AzureMachinePool {
+				return &infrav1exp.AzureMachinePool{
+					Spec: infrav1exp.AzureMachinePoolSpec{
+						Template: infrav1exp.AzureMachinePoolMachineTemplate{
 							TerminateNotificationTimeout: to.IntPtr(20),
 						},
 					},
@@ -115,10 +115,10 @@ func TestAzureMachinePool_Validate(t *testing.T) {
 		},
 		{
 			Name: "HasInvalidMinimumTerminateNotificationTimeout",
-			Factory: func(_ *gomega.GomegaWithT) *exp.AzureMachinePool {
-				return &exp.AzureMachinePool{
-					Spec: exp.AzureMachinePoolSpec{
-						Template: exp.AzureMachinePoolMachineTemplate{
+			Factory: func(_ *gomega.GomegaWithT) *infrav1exp.AzureMachinePool {
+				return &infrav1exp.AzureMachinePool{
+					Spec: infrav1exp.AzureMachinePoolSpec{
+						Template: infrav1exp.AzureMachinePoolMachineTemplate{
 							TerminateNotificationTimeout: to.IntPtr(3),
 						},
 					},

--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	capiv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/predicates"
@@ -105,7 +105,7 @@ func (ampr *AzureMachinePoolReconciler) SetupWithManager(ctx context.Context, mg
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(log, ampr.WatchFilterValue)).
 		// watch for changes in CAPI MachinePool resources
 		Watches(
-			&source.Kind{Type: &capiv1exp.MachinePool{}},
+			&source.Kind{Type: &expv1.MachinePool{}},
 			handler.EnqueueRequestsFromMapFunc(MachinePoolToInfrastructureMapFunc(infrav1exp.GroupVersion.WithKind("AzureMachinePool"), log)),
 		).
 		// watch for changes in AzureCluster resources
@@ -265,7 +265,7 @@ func (ampr *AzureMachinePoolReconciler) reconcileNormal(ctx context.Context, mac
 	}
 
 	// If the AzureMachine doesn't have our finalizer, add it.
-	controllerutil.AddFinalizer(machinePoolScope.AzureMachinePool, capiv1exp.MachinePoolFinalizer)
+	controllerutil.AddFinalizer(machinePoolScope.AzureMachinePool, expv1.MachinePoolFinalizer)
 	// Register the finalizer immediately to avoid orphaning Azure resources on delete
 	if err := machinePoolScope.PatchObject(ctx); err != nil {
 		return reconcile.Result{}, err
@@ -351,6 +351,6 @@ func (ampr *AzureMachinePoolReconciler) reconcileDelete(ctx context.Context, mac
 
 	// Delete succeeded, remove finalizer
 	log.V(4).Info("removing finalizer for AzureMachinePool")
-	controllerutil.RemoveFinalizer(machinePoolScope.AzureMachinePool, capiv1exp.MachinePoolFinalizer)
+	controllerutil.RemoveFinalizer(machinePoolScope.AzureMachinePool, expv1.MachinePoolFinalizer)
 	return reconcile.Result{}, nil
 }

--- a/exp/controllers/azuremachinepool_controller_unit_test.go
+++ b/exp/controllers/azuremachinepool_controller_unit_test.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 )
 
 func Test_newAzureMachinePoolService(t *testing.T) {
@@ -75,7 +75,7 @@ func newScheme(g *GomegaWithT) *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	for _, f := range []func(*runtime.Scheme) error{
 		clusterv1.AddToScheme,
-		clusterv1exp.AddToScheme,
+		expv1.AddToScheme,
 		infrav1.AddToScheme,
 		infrav1exp.AddToScheme,
 	} {
@@ -84,8 +84,8 @@ func newScheme(g *GomegaWithT) *runtime.Scheme {
 	return scheme
 }
 
-func newMachinePool(clusterName, poolName string) *clusterv1exp.MachinePool {
-	return &clusterv1exp.MachinePool{
+func newMachinePool(clusterName, poolName string) *expv1.MachinePool {
+	return &expv1.MachinePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				clusterv1.ClusterLabelName: clusterName,
@@ -93,7 +93,7 @@ func newMachinePool(clusterName, poolName string) *clusterv1exp.MachinePool {
 			Name:      poolName,
 			Namespace: "default",
 		},
-		Spec: clusterv1exp.MachinePoolSpec{
+		Spec: expv1.MachinePoolSpec{
 			Replicas: to.Int32Ptr(2),
 		},
 	}
@@ -111,7 +111,7 @@ func newAzureMachinePool(clusterName, poolName string) *infrav1exp.AzureMachineP
 	}
 }
 
-func newMachinePoolWithInfrastructureRef(clusterName, poolName string) *clusterv1exp.MachinePool {
+func newMachinePoolWithInfrastructureRef(clusterName, poolName string) *expv1.MachinePool {
 	m := newMachinePool(clusterName, poolName)
 	m.Spec.Template.Spec.InfrastructureRef = corev1.ObjectReference{
 		Kind:       "AzureMachinePool",
@@ -122,7 +122,7 @@ func newMachinePoolWithInfrastructureRef(clusterName, poolName string) *clusterv
 	return m
 }
 
-func newManagedMachinePoolWithInfrastructureRef(clusterName, poolName string) *clusterv1exp.MachinePool {
+func newManagedMachinePoolWithInfrastructureRef(clusterName, poolName string) *expv1.MachinePool {
 	m := newMachinePool(clusterName, poolName)
 	m.Spec.Template.Spec.InfrastructureRef = corev1.ObjectReference{
 		Kind:       "AzureManagedMachinePool",

--- a/exp/controllers/azuremachinepool_reconciler_test.go
+++ b/exp/controllers/azuremachinepool_reconciler_test.go
@@ -32,7 +32,7 @@ import (
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	capiv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 )
 
 func TestAzureMachinePoolServiceReconcile(t *testing.T) {
@@ -80,7 +80,7 @@ func TestAzureMachinePoolServiceReconcile(t *testing.T) {
 						AzureCluster: &infrav1.AzureCluster{},
 						Cluster:      &clusterv1.Cluster{},
 					},
-					MachinePool: &capiv1exp.MachinePool{},
+					MachinePool: &expv1.MachinePool{},
 					AzureMachinePool: &infrav1exp.AzureMachinePool{
 						Spec: infrav1exp.AzureMachinePoolSpec{
 							Template: infrav1exp.AzureMachinePoolMachineTemplate{
@@ -153,7 +153,7 @@ func TestAzureMachinePoolServiceDelete(t *testing.T) {
 						AzureCluster: &infrav1.AzureCluster{},
 						Cluster:      &clusterv1.Cluster{},
 					},
-					MachinePool:      &capiv1exp.MachinePool{},
+					MachinePool:      &expv1.MachinePool{},
 					AzureMachinePool: &infrav1exp.AzureMachinePool{},
 				},
 				services: []azure.ServiceReconciler{

--- a/exp/controllers/azuremachinepoolmachine_controller_test.go
+++ b/exp/controllers/azuremachinepoolmachine_controller_test.go
@@ -36,7 +36,7 @@ import (
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	gomock2 "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -89,7 +89,7 @@ func TestAzureMachinePoolMachineReconciler_Reconcile(t *testing.T) {
 					s := runtime.NewScheme()
 					for _, addTo := range []func(s *runtime.Scheme) error{
 						clusterv1.AddToScheme,
-						clusterv1exp.AddToScheme,
+						expv1.AddToScheme,
 						infrav1.AddToScheme,
 						infrav1exp.AddToScheme,
 					} {
@@ -118,7 +118,7 @@ func TestAzureMachinePoolMachineReconciler_Reconcile(t *testing.T) {
 	}
 }
 
-func getAReadyMachinePoolMachineCluster() (*clusterv1.Cluster, *infrav1.AzureCluster, *clusterv1exp.MachinePool, *infrav1exp.AzureMachinePool, *infrav1exp.AzureMachinePoolMachine) {
+func getAReadyMachinePoolMachineCluster() (*clusterv1.Cluster, *infrav1.AzureCluster, *expv1.MachinePool, *infrav1exp.AzureMachinePool, *infrav1exp.AzureMachinePoolMachine) {
 	azCluster := &infrav1.AzureCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "azCluster1",
@@ -146,7 +146,7 @@ func getAReadyMachinePoolMachineCluster() (*clusterv1.Cluster, *infrav1.AzureClu
 		},
 	}
 
-	mp := &clusterv1exp.MachinePool{
+	mp := &expv1.MachinePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mp1",
 			Namespace: "default",
@@ -164,7 +164,7 @@ func getAReadyMachinePoolMachineCluster() (*clusterv1.Cluster, *infrav1.AzureClu
 				{
 					Name:       mp.Name,
 					Kind:       "MachinePool",
-					APIVersion: clusterv1exp.GroupVersion.String(),
+					APIVersion: expv1.GroupVersion.String(),
 				},
 			},
 		},

--- a/exp/controllers/azuremanagedcontrolplane_controller.go
+++ b/exp/controllers/azuremanagedcontrolplane_controller.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	capiexputil "sigs.k8s.io/cluster-api/exp/util"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
@@ -89,7 +89,7 @@ func (amcpr *AzureManagedControlPlaneReconciler) SetupWithManager(ctx context.Co
 		).
 		// watch MachinePool resources
 		Watches(
-			&source.Kind{Type: &clusterv1exp.MachinePool{}},
+			&source.Kind{Type: &expv1.MachinePool{}},
 			handler.EnqueueRequestsFromMapFunc(azureManagedMachinePoolMapper),
 		).
 		Build(r)

--- a/exp/controllers/azuremanagedmachinepool_controller.go
+++ b/exp/controllers/azuremanagedmachinepool_controller.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/predicates"
@@ -96,7 +96,7 @@ func (ammpr *AzureManagedMachinePoolReconciler) SetupWithManager(ctx context.Con
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(log, ammpr.WatchFilterValue)).
 		// watch for changes in CAPI MachinePool resources
 		Watches(
-			&source.Kind{Type: &clusterv1exp.MachinePool{}},
+			&source.Kind{Type: &expv1.MachinePool{}},
 			handler.EnqueueRequestsFromMapFunc(MachinePoolToInfrastructureMapFunc(infrav1exp.GroupVersion.WithKind("AzureManagedMachinePool"), log)),
 		).
 		// watch for changes in AzureManagedControlPlanes

--- a/exp/controllers/helpers.go
+++ b/exp/controllers/helpers.go
@@ -32,7 +32,7 @@ import (
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,7 +76,7 @@ func AzureClusterToAzureMachinePoolsMapper(ctx context.Context, c client.Client,
 			return nil
 		}
 
-		machineList := &clusterv1exp.MachinePoolList{}
+		machineList := &expv1.MachinePoolList{}
 		machineList.SetGroupVersionKind(gvk)
 		// list all of the requested objects within the cluster namespace with the cluster name label
 		if err := c.List(ctx, machineList, client.InNamespace(azCluster.Namespace), client.MatchingLabels{clusterv1.ClusterLabelName: clusterName}); err != nil {
@@ -173,7 +173,7 @@ func AzureManagedClusterToAzureManagedMachinePoolsMapper(ctx context.Context, c 
 			return nil
 		}
 
-		machineList := &clusterv1exp.MachinePoolList{}
+		machineList := &expv1.MachinePoolList{}
 		machineList.SetGroupVersionKind(gvk)
 		// list all of the requested objects within the cluster namespace with the cluster name label
 		if err := c.List(ctx, machineList, client.InNamespace(azCluster.Namespace), client.MatchingLabels{clusterv1.ClusterLabelName: clusterName}); err != nil {
@@ -226,7 +226,7 @@ func AzureManagedControlPlaneToAzureManagedMachinePoolsMapper(ctx context.Contex
 			return nil
 		}
 
-		machineList := &clusterv1exp.MachinePoolList{}
+		machineList := &expv1.MachinePoolList{}
 		machineList.SetGroupVersionKind(gvk)
 		// list all of the requested objects within the cluster namespace with the cluster name label
 		if err := c.List(ctx, machineList, client.InNamespace(azControlPlane.Namespace), client.MatchingLabels{clusterv1.ClusterLabelName: clusterName}); err != nil {
@@ -350,7 +350,7 @@ func MachinePoolToAzureManagedControlPlaneMapFunc(ctx context.Context, c client.
 		ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultMappingTimeout)
 		defer cancel()
 
-		machinePool, ok := o.(*clusterv1exp.MachinePool)
+		machinePool, ok := o.(*expv1.MachinePool)
 		if !ok {
 			log.Info("expected a MachinePool, got wrong type", "type", fmt.Sprintf("%T", o))
 			return nil
@@ -448,7 +448,7 @@ func MachinePoolToAzureManagedControlPlaneMapFunc(ctx context.Context, c client.
 // MachinePool events and returns reconciliation requests for an infrastructure provider object.
 func MachinePoolToInfrastructureMapFunc(gvk schema.GroupVersionKind, log logr.Logger) handler.MapFunc {
 	return func(o client.Object) []reconcile.Request {
-		m, ok := o.(*clusterv1exp.MachinePool)
+		m, ok := o.(*expv1.MachinePool)
 		if !ok {
 			log.V(4).Info("attempt to map incorrect type", "type", fmt.Sprintf("%T", o))
 			return nil

--- a/exp/controllers/helpers_test.go
+++ b/exp/controllers/helpers_test.go
@@ -33,7 +33,7 @@ import (
 	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
 	"sigs.k8s.io/cluster-api-provider-azure/internal/test/mock_log"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -722,7 +722,7 @@ func newAzureManagedControlPlane(cpName string) *infrav1exp.AzureManagedControlP
 	}
 }
 
-func newManagedMachinePoolInfraReference(clusterName, poolName string) *clusterv1exp.MachinePool {
+func newManagedMachinePoolInfraReference(clusterName, poolName string) *expv1.MachinePool {
 	m := newMachinePool(clusterName, poolName)
 	m.Spec.ClusterName = clusterName
 	m.Spec.Template.Spec.InfrastructureRef = corev1.ObjectReference{

--- a/internal/test/env/env.go
+++ b/internal/test/env/env.go
@@ -42,7 +42,7 @@ import (
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/internal/test/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -59,7 +59,7 @@ func init() {
 	// Calculate the scheme.
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
-	utilruntime.Must(clusterv1exp.AddToScheme(scheme))
+	utilruntime.Must(expv1.AddToScheme(scheme))
 	utilruntime.Must(infrav1.AddToScheme(scheme))
 	utilruntime.Must(infrav1exp.AddToScheme(scheme))
 	utilruntime.Must(infrav1alpha3.AddToScheme(scheme))

--- a/main.go
+++ b/main.go
@@ -38,11 +38,11 @@ import (
 	"k8s.io/klog/v2/klogr"
 	infrav1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	infrav1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
-	infrav1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/controllers"
 	infrav1alpha3exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	infrav1alpha4exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha4"
-	infrav1beta1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	infrav1controllersexp "sigs.k8s.io/cluster-api-provider-azure/exp/controllers"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	"sigs.k8s.io/cluster-api-provider-azure/pkg/coalescing"
@@ -50,10 +50,10 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 	"sigs.k8s.io/cluster-api-provider-azure/version"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
-	clusterv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1alpha4"
-	clusterv1beta1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	expv1alpha4 "sigs.k8s.io/cluster-api/exp/api/v1alpha4"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	capifeature "sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -72,14 +72,14 @@ func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = infrav1alpha3.AddToScheme(scheme)
 	_ = infrav1alpha4.AddToScheme(scheme)
-	_ = infrav1beta1.AddToScheme(scheme)
+	_ = infrav1.AddToScheme(scheme)
 	_ = infrav1alpha3exp.AddToScheme(scheme)
 	_ = infrav1alpha4exp.AddToScheme(scheme)
-	_ = infrav1beta1exp.AddToScheme(scheme)
+	_ = infrav1exp.AddToScheme(scheme)
+	_ = clusterv1alpha4.AddToScheme(scheme)
+	_ = expv1alpha4.AddToScheme(scheme)
 	_ = clusterv1.AddToScheme(scheme)
-	_ = clusterv1exp.AddToScheme(scheme)
-	_ = clusterv1beta1.AddToScheme(scheme)
-	_ = clusterv1beta1exp.AddToScheme(scheme)
+	_ = expv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 
 	// Add aadpodidentity v1 to the scheme.
@@ -172,7 +172,7 @@ func InitFlags(fs *pflag.FlagSet) {
 		&watchFilterValue,
 		"watch-filter",
 		"",
-		fmt.Sprintf("Label value that the controller watches to reconcile cluster-api objects. Label key is always %s. If unspecified, the controller watches for all cluster-api objects.", clusterv1.WatchLabel),
+		fmt.Sprintf("Label value that the controller watches to reconcile cluster-api objects. Label key is always %s. If unspecified, the controller watches for all cluster-api objects.", clusterv1alpha4.WatchLabel),
 	)
 
 	fs.StringVar(
@@ -472,45 +472,45 @@ func registerControllers(ctx context.Context, mgr manager.Manager) {
 }
 
 func registerWebhooks(mgr manager.Manager) {
-	if err := (&infrav1beta1.AzureCluster{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1.AzureCluster{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AzureCluster")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1beta1.AzureClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1.AzureClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AzureClusterTemplate")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1beta1.AzureMachine{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1.AzureMachine{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AzureMachine")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1beta1.AzureMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1.AzureMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AzureMachineTemplate")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1beta1.AzureClusterIdentity{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1.AzureClusterIdentity{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AzureClusterIdentity")
 		os.Exit(1)
 	}
 	// NOTE: AzureMachinePool is behind MachinePool feature gate flag; the webhook
 	// is going to prevent creating or updating new objects in case the feature flag is disabled
-	if err := (&infrav1beta1exp.AzureMachinePool{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1exp.AzureMachinePool{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AzureMachinePool")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1beta1exp.AzureMachinePoolMachine{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1exp.AzureMachinePoolMachine{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AzureMachinePoolMachine")
 		os.Exit(1)
 	}
 
 	// NOTE: AzureManagedCluster is behind AKS feature gate flag; the webhook
 	// is going to prevent creating or updating new objects in case the feature flag is disabled
-	if err := (&infrav1beta1exp.AzureManagedCluster{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1exp.AzureManagedCluster{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedCluster")
 		os.Exit(1)
 	}
@@ -518,16 +518,16 @@ func registerWebhooks(mgr manager.Manager) {
 	if feature.Gates.Enabled(feature.AKS) {
 		hookServer := mgr.GetWebhookServer()
 		hookServer.Register("/mutate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedmachinepool", webhook.NewMutatingWebhook(
-			&infrav1beta1exp.AzureManagedMachinePool{}, mgr.GetClient(),
+			&infrav1exp.AzureManagedMachinePool{}, mgr.GetClient(),
 		))
 		hookServer.Register("/validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedmachinepool", webhook.NewValidatingWebhook(
-			&infrav1beta1exp.AzureManagedMachinePool{}, mgr.GetClient(),
+			&infrav1exp.AzureManagedMachinePool{}, mgr.GetClient(),
 		))
 		hookServer.Register("/mutate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcontrolplane", webhook.NewMutatingWebhook(
-			&infrav1beta1exp.AzureManagedControlPlane{}, mgr.GetClient(),
+			&infrav1exp.AzureManagedControlPlane{}, mgr.GetClient(),
 		))
 		hookServer.Register("/validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcontrolplane", webhook.NewValidatingWebhook(
-			&infrav1beta1exp.AzureManagedControlPlane{}, mgr.GetClient(),
+			&infrav1exp.AzureManagedControlPlane{}, mgr.GetClient(),
 		))
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Standardizes several popular import aliases by adding them to the `importas` linter configuration. This is an area of code where creativity is ultimately unhelpful. The CAPI sections were copied from [CAPI's golangci config](https://github.com/kubernetes-sigs/cluster-api/blob/main/.golangci.yml#L59).

**Which issue(s) this PR fixes**:

Refs #2289

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
