### PR TITLE
Update deprecated annotation to `kubectl.kubernetes.io/default-container`

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -17,7 +17,7 @@ spec:
         control-plane: capz-controller-manager
         aadpodidbinding: capz-controller-aadpodidentity-selector
       annotations:
-        kubectl.kubernetes.io/default-logs-container: manager
+        kubectl.kubernetes.io/default-container: manager
     spec:
       containers:
         - args:


### PR DESCRIPTION
…ner`

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Update deprecated annotation to fix warning in logs:

```
Using deprecated annotation `kubectl.kubernetes.io/default-logs-container` in pod/capz-controller-manager-786b678866-2j2w6. Please use `kubectl.kubernetes.io/default-container` instead
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
