### PR TITLE
AKS: enable isVnetManaged, add caching

### DIFF
--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -56,6 +56,7 @@ type ClusterScopeParams struct {
 	Client       client.Client
 	Cluster      *clusterv1.Cluster
 	AzureCluster *infrav1.AzureCluster
+	Cache        *ClusterCache
 }
 
 // NewClusterScope creates a new Scope from the supplied parameters.
@@ -87,6 +88,10 @@ func NewClusterScope(ctx context.Context, params ClusterScopeParams) (*ClusterSc
 		}
 	}
 
+	if params.Cache == nil {
+		params.Cache = &ClusterCache{}
+	}
+
 	helper, err := patch.NewHelper(params.AzureCluster, params.Client)
 	if err != nil {
 		return nil, errors.Errorf("failed to init patch helper: %v", err)
@@ -98,6 +103,7 @@ func NewClusterScope(ctx context.Context, params ClusterScopeParams) (*ClusterSc
 		Cluster:      params.Cluster,
 		AzureCluster: params.AzureCluster,
 		patchHelper:  helper,
+		cache:        params.Cache,
 	}, nil
 }
 
@@ -105,10 +111,16 @@ func NewClusterScope(ctx context.Context, params ClusterScopeParams) (*ClusterSc
 type ClusterScope struct {
 	Client      client.Client
 	patchHelper *patch.Helper
+	cache       *ClusterCache
 
 	AzureClients
 	Cluster      *clusterv1.Cluster
 	AzureCluster *infrav1.AzureCluster
+}
+
+// ClusterCache stores ClusterCache data locally so we don't have to hit the API multiple times within the same reconcile loop.
+type ClusterCache struct {
+	isVnetManaged *bool
 }
 
 // BaseURI returns the Azure ResourceManagerEndpoint.
@@ -524,7 +536,12 @@ func (s *ClusterScope) Vnet() *infrav1.VnetSpec {
 
 // IsVnetManaged returns true if the vnet is managed.
 func (s *ClusterScope) IsVnetManaged() bool {
-	return s.Vnet().ID == "" || s.Vnet().Tags.HasOwned(s.ClusterName())
+	if s.cache.isVnetManaged != nil {
+		return to.Bool(s.cache.isVnetManaged)
+	}
+	isVnetManaged := s.Vnet().ID == "" || s.Vnet().Tags.HasOwned(s.ClusterName())
+	s.cache.isVnetManaged = to.BoolPtr(isVnetManaged)
+	return isVnetManaged
 }
 
 // IsIPv6Enabled returns true if IPv6 is enabled.

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -793,6 +793,7 @@ func TestRouteTableSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &ClusterCache{},
 			},
 			want: nil,
 		},
@@ -828,6 +829,7 @@ func TestRouteTableSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &ClusterCache{},
 			},
 			want: []azure.ResourceSpecGetter{
 				&routetables.RouteTableSpec{
@@ -875,6 +877,7 @@ func TestNatGatewaySpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &ClusterCache{},
 			},
 			want: nil,
 		},
@@ -922,6 +925,7 @@ func TestNatGatewaySpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &ClusterCache{},
 			},
 			want: []azure.ResourceSpecGetter{
 				&natgateways.NatGatewaySpec{
@@ -999,6 +1003,7 @@ func TestNatGatewaySpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &ClusterCache{},
 			},
 			want: []azure.ResourceSpecGetter{
 				&natgateways.NatGatewaySpec{
@@ -1075,6 +1080,7 @@ func TestNatGatewaySpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &ClusterCache{},
 			},
 			want: []azure.ResourceSpecGetter{
 				&natgateways.NatGatewaySpec{
@@ -1154,6 +1160,7 @@ func TestNSGSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &ClusterCache{},
 			},
 			want: []azure.ResourceSpecGetter{
 				&securitygroups.NSGSpec{
@@ -1199,6 +1206,7 @@ func TestSubnetSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &ClusterCache{},
 			},
 			want: []azure.ResourceSpecGetter{},
 		},
@@ -1260,6 +1268,7 @@ func TestSubnetSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &ClusterCache{},
 			},
 			want: []azure.ResourceSpecGetter{
 				&subnets.SubnetSpec{
@@ -1362,6 +1371,7 @@ func TestSubnetSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &ClusterCache{},
 			},
 			want: []azure.ResourceSpecGetter{
 				&subnets.SubnetSpec{
@@ -1399,6 +1409,122 @@ func TestSubnetSpecs(t *testing.T) {
 			t.Parallel()
 			if got := tt.clusterScope.SubnetSpecs(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("SubnetSpecs() = \n%s, want \n%s", specArrayToString(got), specArrayToString(tt.want))
+			}
+		})
+	}
+}
+
+func TestIsVnetManaged(t *testing.T) {
+	tests := []struct {
+		name         string
+		clusterScope ClusterScope
+		want         bool
+	}{
+		{
+			name: "VNET ID is empty",
+			clusterScope: ClusterScope{
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-cluster",
+					},
+				},
+				AzureCluster: &infrav1.AzureCluster{
+					Spec: infrav1.AzureClusterSpec{
+						NetworkSpec: infrav1.NetworkSpec{
+							Vnet: infrav1.VnetSpec{
+								ID: "",
+							},
+						},
+					},
+				},
+				cache: &ClusterCache{},
+			},
+			want: true,
+		},
+		{
+			name: "Wrong tags",
+			clusterScope: ClusterScope{
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-cluster",
+					},
+				},
+				AzureCluster: &infrav1.AzureCluster{
+					Spec: infrav1.AzureClusterSpec{
+						NetworkSpec: infrav1.NetworkSpec{
+							Vnet: infrav1.VnetSpec{
+								ID: "my-id",
+								VnetClassSpec: infrav1.VnetClassSpec{Tags: map[string]string{
+									"key": "value",
+								}},
+							},
+						},
+					},
+				},
+				cache: &ClusterCache{},
+			},
+			want: false,
+		},
+		{
+			name: "Has owning tags",
+			clusterScope: ClusterScope{
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-cluster",
+					},
+				},
+				AzureCluster: &infrav1.AzureCluster{
+					Spec: infrav1.AzureClusterSpec{
+						NetworkSpec: infrav1.NetworkSpec{
+							Vnet: infrav1.VnetSpec{
+								ID: "my-id",
+								VnetClassSpec: infrav1.VnetClassSpec{Tags: map[string]string{
+									"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": "owned",
+								}},
+							},
+						},
+					},
+				},
+				cache: &ClusterCache{},
+			},
+			want: true,
+		},
+		{
+			name: "Has cached value of false",
+			clusterScope: ClusterScope{
+				AzureCluster: &infrav1.AzureCluster{
+					Spec: infrav1.AzureClusterSpec{},
+				},
+				cache: &ClusterCache{
+					isVnetManaged: to.BoolPtr(false),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Has cached value of true",
+			clusterScope: ClusterScope{
+				AzureCluster: &infrav1.AzureCluster{
+					Spec: infrav1.AzureClusterSpec{},
+				},
+				cache: &ClusterCache{
+					isVnetManaged: to.BoolPtr(true),
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.clusterScope.IsVnetManaged()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IsVnetManaged() = \n%t, want \n%t", got, tt.want)
+			}
+			if to.Bool(tt.clusterScope.cache.isVnetManaged) != got {
+				t.Errorf("IsVnetManaged() = \n%t, cache = \n%t", got, to.Bool(tt.clusterScope.cache.isVnetManaged))
 			}
 		})
 	}
@@ -1510,6 +1636,7 @@ func TestAzureBastionSpec(t *testing.T) {
 						},
 					},
 				},
+				cache: &ClusterCache{},
 			},
 			want: &bastionhosts.AzureBastionSpec{
 				Name:          "fake-azure-bastion-1",

--- a/azure/scope/managedcontrolplane_test.go
+++ b/azure/scope/managedcontrolplane_test.go
@@ -399,3 +399,140 @@ func TestManagedControlPlaneScope_OSType(t *testing.T) {
 		})
 	}
 }
+
+func TestManagedControlPlaneScope_IsVnetManagedCache(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = expv1.AddToScheme(scheme)
+	_ = infrav1exp.AddToScheme(scheme)
+
+	cases := []struct {
+		Name     string
+		Input    ManagedControlPlaneScopeParams
+		Expected bool
+	}{
+		{
+			Name: "no Cache value",
+			Input: ManagedControlPlaneScopeParams{
+				AzureClients: AzureClients{
+					Authorizer: autorest.NullAuthorizer{},
+				},
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster1",
+						Namespace: "default",
+					},
+				},
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster1",
+						Namespace: "default",
+					},
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
+						Version:        "v1.20.1",
+						SubscriptionID: "00000000-0000-0000-0000-000000000000",
+					},
+				},
+				ManagedMachinePools: []ManagedMachinePool{
+					{
+						MachinePool:      getMachinePool("pool0"),
+						InfraMachinePool: getAzureMachinePool("pool0", infrav1exp.NodePoolModeSystem),
+					},
+					{
+						MachinePool:      getMachinePool("pool1"),
+						InfraMachinePool: getLinuxAzureMachinePool("pool1"),
+					},
+				},
+			},
+			Expected: false,
+		},
+		{
+			Name: "with Cache value of true",
+			Input: ManagedControlPlaneScopeParams{
+				AzureClients: AzureClients{
+					Authorizer: autorest.NullAuthorizer{},
+				},
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster1",
+						Namespace: "default",
+					},
+				},
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster1",
+						Namespace: "default",
+					},
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
+						Version:        "v1.20.1",
+						SubscriptionID: "00000000-0000-0000-0000-000000000000",
+					},
+				},
+				ManagedMachinePools: []ManagedMachinePool{
+					{
+						MachinePool:      getMachinePool("pool0"),
+						InfraMachinePool: getAzureMachinePool("pool0", infrav1exp.NodePoolModeSystem),
+					},
+					{
+						MachinePool:      getMachinePool("pool1"),
+						InfraMachinePool: getLinuxAzureMachinePool("pool1"),
+					},
+				},
+				Cache: &ManagedControlPlaneCache{
+					isVnetManaged: to.BoolPtr(true),
+				},
+			},
+			Expected: true,
+		},
+		{
+			Name: "with Cache value of false",
+			Input: ManagedControlPlaneScopeParams{
+				AzureClients: AzureClients{
+					Authorizer: autorest.NullAuthorizer{},
+				},
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster1",
+						Namespace: "default",
+					},
+				},
+				ControlPlane: &infrav1exp.AzureManagedControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster1",
+						Namespace: "default",
+					},
+					Spec: infrav1exp.AzureManagedControlPlaneSpec{
+						Version:        "v1.20.1",
+						SubscriptionID: "00000000-0000-0000-0000-000000000000",
+					},
+				},
+				ManagedMachinePools: []ManagedMachinePool{
+					{
+						MachinePool:      getMachinePool("pool0"),
+						InfraMachinePool: getAzureMachinePool("pool0", infrav1exp.NodePoolModeSystem),
+					},
+					{
+						MachinePool:      getMachinePool("pool1"),
+						InfraMachinePool: getLinuxAzureMachinePool("pool1"),
+					},
+				},
+				Cache: &ManagedControlPlaneCache{
+					isVnetManaged: to.BoolPtr(false),
+				},
+			},
+			Expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			g := NewWithT(t)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(c.Input.ControlPlane).Build()
+			c.Input.Client = fakeClient
+			s, err := NewManagedControlPlaneScope(context.TODO(), c.Input)
+			g.Expect(err).To(Succeed())
+			isVnetManaged := s.IsVnetManaged()
+			g.Expect(isVnetManaged).To(Equal(c.Expected))
+		})
+	}
+}

--- a/azure/services/subnets/subnets.go
+++ b/azure/services/subnets/subnets.go
@@ -111,7 +111,7 @@ func (s *Service) Delete(ctx context.Context) error {
 	defer cancel()
 
 	if managed, err := s.IsManaged(ctx); err == nil && !managed {
-		log.V(4).Info("Skipping subnets deletion in custom vnet mode")
+		log.Info("Skipping subnets deletion in custom vnet mode")
 		return nil
 	} else if err != nil {
 		return errors.Wrap(err, "failed to check if subnets are managed")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind bug
/kind feature

**What this PR does / why we need it**:

This PR enables the `IsVnetManaged()` method for AKS scenarios, which results in actual GET calls against the Azure API to determine in real-time whether the expected capz owner tag (tag is applied one time during cluster create) is present on the Virtual Network.

This will address the subnet delete issue during custom VNET scenarios.

Additionally, in order to account for additional calls against the Azure APIs we've implemented a local cache to ensure we don't call the Azure APIs more than once for VNET information per reconciliation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2484

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
AKS: enable isVnetManaged, add caching
```
