### PR TITLE
Update and verify go modules in hack/tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ verify-boilerplate: ## Verify boilerplate header.
 
 .PHONY: verify-modules
 verify-modules: modules ## Verify go.sum go.mod are the latest.
-	@if !(git diff --quiet HEAD -- go.sum go.mod); then \
+	@if !(git diff --quiet HEAD -- go.sum go.mod $(TOOLS_DIR)/go.sum $(TOOLS_DIR)/go.mod); then \
 		echo "go module files are out of date"; exit 1; \
 	fi
 
@@ -509,6 +509,7 @@ $(CALICO_MANIFESTS_DIR):
 .PHONY: modules
 modules: ## Runs go mod tidy to ensure proper vendoring.
 	go mod tidy
+	pushd $(TOOLS_DIR) && go mod tidy; popd
 
 ## --------------------------------------
 ## Help


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Adds the go.mod and go.sum files under hack/tools to the `make modules` and `make verify-modules` Makefile targets.

**Which issue(s) this PR fixes**:

Refs #2546

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
