### PR TITLE
Add more linters and config from CAPI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
   enable:
     - asciicheck
     - bodyclose
+    - containedctx
     - deadcode
     - depguard
     - dogsled
@@ -30,6 +31,7 @@ linters:
     - misspell
     - nakedret
     - nilerr
+    - noctx
     - nolintlint
     - prealloc
     - predeclared
@@ -97,6 +99,9 @@ linters-settings:
         alias: infrav1alpha4exp
       - pkg: sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1
         alias: infrav1exp
+  gocritic:
+    enabled-tags:
+      - "experimental"
   godot:
     #   declarations - for top level declaration comments (default);
     #   toplevel     - for top level comments;
@@ -115,6 +120,10 @@ linters-settings:
         arguments:
           - disableStutteringCheck
   staticcheck:
+    go: "1.18"
+  stylecheck:
+    go: "1.18"
+  unused:
     go: "1.18"
 
 issues:

--- a/api/v1alpha3/azurecluster_conversion.go
+++ b/api/v1alpha3/azurecluster_conversion.go
@@ -91,19 +91,20 @@ func (src *AzureCluster) ConvertTo(dstRaw conversion.Hub) error {
 	// is converted to v1alpha3. We loop through all security group rules. For all previously existing outbound rules we restore the full rule.
 	for _, restoredSubnet := range restored.Spec.NetworkSpec.Subnets {
 		for i, dstSubnet := range dst.Spec.NetworkSpec.Subnets {
-			if dstSubnet.Name == restoredSubnet.Name {
-				var restoredOutboundRules []infrav1.SecurityRule
-				for _, restoredSecurityRule := range restoredSubnet.SecurityGroup.SecurityRules {
-					if restoredSecurityRule.Direction != infrav1.SecurityRuleDirectionInbound {
-						// For non-inbound rules which are only supported starting in v1alpha4/v1beta1, we restore the entire rule.
-						restoredOutboundRules = append(restoredOutboundRules, restoredSecurityRule)
-					}
-				}
-				dst.Spec.NetworkSpec.Subnets[i].SecurityGroup.SecurityRules = append(dst.Spec.NetworkSpec.Subnets[i].SecurityGroup.SecurityRules, restoredOutboundRules...)
-				dst.Spec.NetworkSpec.Subnets[i].NatGateway = restoredSubnet.NatGateway
-
-				break
+			if dstSubnet.Name != restoredSubnet.Name {
+				continue
 			}
+			var restoredOutboundRules []infrav1.SecurityRule
+			for _, restoredSecurityRule := range restoredSubnet.SecurityGroup.SecurityRules {
+				if restoredSecurityRule.Direction != infrav1.SecurityRuleDirectionInbound {
+					// For non-inbound rules which are only supported starting in v1alpha4/v1beta1, we restore the entire rule.
+					restoredOutboundRules = append(restoredOutboundRules, restoredSecurityRule)
+				}
+			}
+			dst.Spec.NetworkSpec.Subnets[i].SecurityGroup.SecurityRules = append(dst.Spec.NetworkSpec.Subnets[i].SecurityGroup.SecurityRules, restoredOutboundRules...)
+			dst.Spec.NetworkSpec.Subnets[i].NatGateway = restoredSubnet.NatGateway
+
+			break
 		}
 	}
 

--- a/api/v1beta1/azurecluster_default.go
+++ b/api/v1beta1/azurecluster_default.go
@@ -106,30 +106,31 @@ func (c *AzureCluster) setSubnetDefaults() {
 	var nodeSubnetFound bool
 	var nodeSubnetCounter int
 	for i, subnet := range c.Spec.NetworkSpec.Subnets {
-		if subnet.Role == SubnetNode {
-			nodeSubnetCounter++
-			nodeSubnetFound = true
-			if subnet.Name == "" {
-				subnet.Name = withIndex(generateNodeSubnetName(c.ObjectMeta.Name), nodeSubnetCounter)
-			}
-			subnet.SubnetClassSpec.setDefaults(fmt.Sprintf(DefaultNodeSubnetCIDRPattern, nodeSubnetCounter))
-
-			if subnet.SecurityGroup.Name == "" {
-				subnet.SecurityGroup.Name = generateNodeSecurityGroupName(c.ObjectMeta.Name)
-			}
-			cpSubnet.SecurityGroup.SecurityGroupClass.setDefaults()
-
-			if subnet.RouteTable.Name == "" {
-				subnet.RouteTable.Name = generateNodeRouteTableName(c.ObjectMeta.Name)
-			}
-			if subnet.IsNatGatewayEnabled() {
-				if subnet.NatGateway.NatGatewayIP.Name == "" {
-					subnet.NatGateway.NatGatewayIP.Name = generateNatGatewayIPName(c.ObjectMeta.Name, subnet.Name)
-				}
-			}
-
-			c.Spec.NetworkSpec.Subnets[i] = subnet
+		if subnet.Role != SubnetNode {
+			continue
 		}
+		nodeSubnetCounter++
+		nodeSubnetFound = true
+		if subnet.Name == "" {
+			subnet.Name = withIndex(generateNodeSubnetName(c.ObjectMeta.Name), nodeSubnetCounter)
+		}
+		subnet.SubnetClassSpec.setDefaults(fmt.Sprintf(DefaultNodeSubnetCIDRPattern, nodeSubnetCounter))
+
+		if subnet.SecurityGroup.Name == "" {
+			subnet.SecurityGroup.Name = generateNodeSecurityGroupName(c.ObjectMeta.Name)
+		}
+		cpSubnet.SecurityGroup.SecurityGroupClass.setDefaults()
+
+		if subnet.RouteTable.Name == "" {
+			subnet.RouteTable.Name = generateNodeRouteTableName(c.ObjectMeta.Name)
+		}
+		if subnet.IsNatGatewayEnabled() {
+			if subnet.NatGateway.NatGatewayIP.Name == "" {
+				subnet.NatGateway.NatGatewayIP.Name = generateNatGatewayIPName(c.ObjectMeta.Name, subnet.Name)
+			}
+		}
+
+		c.Spec.NetworkSpec.Subnets[i] = subnet
 	}
 
 	if !nodeSubnetFound {

--- a/api/v1beta1/azureclustertemplate_default.go
+++ b/api/v1beta1/azureclustertemplate_default.go
@@ -65,13 +65,14 @@ func (c *AzureClusterTemplate) setSubnetsTemplateDefaults() {
 	var nodeSubnetFound bool
 	var nodeSubnetCounter int
 	for i, subnet := range c.Spec.Template.Spec.NetworkSpec.Subnets {
-		if subnet.Role == SubnetNode {
-			nodeSubnetCounter++
-			nodeSubnetFound = true
-			subnet.SubnetClassSpec.setDefaults(fmt.Sprintf(DefaultNodeSubnetCIDRPattern, nodeSubnetCounter))
-			cpSubnet.SecurityGroup.setDefaults()
-			c.Spec.Template.Spec.NetworkSpec.Subnets[i] = subnet
+		if subnet.Role != SubnetNode {
+			continue
 		}
+		nodeSubnetCounter++
+		nodeSubnetFound = true
+		subnet.SubnetClassSpec.setDefaults(fmt.Sprintf(DefaultNodeSubnetCIDRPattern, nodeSubnetCounter))
+		cpSubnet.SecurityGroup.setDefaults()
+		c.Spec.Template.Spec.NetworkSpec.Subnets[i] = subnet
 	}
 
 	if !nodeSubnetFound {

--- a/api/v1beta1/azuremachine_validation.go
+++ b/api/v1beta1/azuremachine_validation.go
@@ -86,7 +86,7 @@ func ValidateSystemAssignedIdentity(identityType VMIdentity, oldIdentity, newIde
 		if oldIdentity != "" && oldIdentity != newIdentity {
 			allErrs = append(allErrs, field.Invalid(fldPath, newIdentity, "Role assignment name should not be modified after AzureMachine creation."))
 		}
-	} else if len(newIdentity) != 0 {
+	} else if newIdentity != "" {
 		allErrs = append(allErrs, field.Forbidden(fldPath, "Role assignment name should only be set when using system assigned identity."))
 	}
 

--- a/azure/defaults_test.go
+++ b/azure/defaults_test.go
@@ -92,7 +92,7 @@ func TestMSCorrelationIDSendDecorator(t *testing.T) {
 		// preserve the incoming headers to the fake server, so that
 		// we can test that the fake server received the right
 		// correlation ID header.
-		req, err := http.NewRequest("GET", testSrv.URL, nil)
+		req, err := http.NewRequest("GET", testSrv.URL, http.NoBody)
 		if err != nil {
 			return nil, err
 		}
@@ -102,7 +102,7 @@ func TestMSCorrelationIDSendDecorator(t *testing.T) {
 	newSender := autorest.DecorateSender(origSender, msCorrelationIDSendDecorator)
 
 	// create a new HTTP request and send it via the new decorated sender
-	req, err := http.NewRequest("GET", "/abc", nil)
+	req, err := http.NewRequest("GET", "/abc", http.NoBody)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	req = req.WithContext(ctx)

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -739,7 +739,7 @@ func (s *ClusterScope) CloudProviderConfigOverrides() *infrav1.CloudProviderConf
 // GenerateFQDN generates a fully qualified domain name, based on a hash, cluster name and cluster location.
 func (s *ClusterScope) GenerateFQDN(ipName string) string {
 	h := fnv.New32a()
-	if _, err := h.Write([]byte(fmt.Sprintf("%s/%s/%s", s.SubscriptionID(), s.ResourceGroup(), ipName))); err != nil {
+	if _, err := fmt.Fprintf(h, "%s/%s/%s", s.SubscriptionID(), s.ResourceGroup(), ipName); err != nil {
 		return ""
 	}
 	hash := fmt.Sprintf("%x", h.Sum32())
@@ -748,9 +748,9 @@ func (s *ClusterScope) GenerateFQDN(ipName string) string {
 
 // GenerateLegacyFQDN generates an IP name and a fully qualified domain name, based on a hash, cluster name and cluster location.
 // Deprecated: use GenerateFQDN instead.
-func (s *ClusterScope) GenerateLegacyFQDN() (string, string) {
+func (s *ClusterScope) GenerateLegacyFQDN() (ip string, domain string) {
 	h := fnv.New32a()
-	if _, err := h.Write([]byte(fmt.Sprintf("%s/%s/%s", s.SubscriptionID(), s.ResourceGroup(), s.ClusterName()))); err != nil {
+	if _, err := fmt.Fprintf(h, "%s/%s/%s", s.SubscriptionID(), s.ResourceGroup(), s.ClusterName()); err != nil {
 		return "", ""
 	}
 	ipName := fmt.Sprintf("%s-%x", s.ClusterName(), h.Sum32())
@@ -968,7 +968,7 @@ func (s *ClusterScope) UpdatePatchStatus(condition clusterv1.ConditionType, serv
 func (s *ClusterScope) AnnotationJSON(annotation string) (map[string]interface{}, error) {
 	out := map[string]interface{}{}
 	jsonAnnotation := s.AzureCluster.GetAnnotations()[annotation]
-	if len(jsonAnnotation) == 0 {
+	if jsonAnnotation == "" {
 		return out, nil
 	}
 	err := json.Unmarshal([]byte(jsonAnnotation), &out)

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -550,7 +550,7 @@ func (m *MachineScope) SetAnnotation(key, value string) {
 func (m *MachineScope) AnnotationJSON(annotation string) (map[string]interface{}, error) {
 	out := map[string]interface{}{}
 	jsonAnnotation := m.AzureMachine.GetAnnotations()[annotation]
-	if len(jsonAnnotation) == 0 {
+	if jsonAnnotation == "" {
 		return out, nil
 	}
 	err := json.Unmarshal([]byte(jsonAnnotation), &out)

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -19,7 +19,6 @@ package scope
 import (
 	"context"
 	"encoding/base64"
-	"strings"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
@@ -339,7 +338,7 @@ func (m *MachinePoolScope) createMachine(ctx context.Context, machine azure.VMSS
 
 	ampm := infrav1exp.AzureMachinePoolMachine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      strings.Join([]string{m.AzureMachinePool.Name, machine.InstanceID}, "-"),
+			Name:      m.AzureMachinePool.Name + "-" + machine.InstanceID,
 			Namespace: m.AzureMachinePool.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -610,7 +610,7 @@ func (s *ManagedControlPlaneScope) UpdatePatchStatus(condition clusterv1.Conditi
 func (s *ManagedControlPlaneScope) AnnotationJSON(annotation string) (map[string]interface{}, error) {
 	out := map[string]interface{}{}
 	jsonAnnotation := s.ControlPlane.GetAnnotations()[annotation]
-	if len(jsonAnnotation) == 0 {
+	if jsonAnnotation == "" {
 		return out, nil
 	}
 	err := json.Unmarshal([]byte(jsonAnnotation), &out)

--- a/azure/scope/managedmachinepool.go
+++ b/azure/scope/managedmachinepool.go
@@ -287,7 +287,7 @@ func (s *ManagedMachinePoolScope) RemoveCAPIMachinePoolAnnotations(key string) {
 }
 
 // GetCAPIMachinePoolAnnotation gets the associated MachinePool annotation.
-func (s *ManagedMachinePoolScope) GetCAPIMachinePoolAnnotation(key string) (bool, string) {
-	value, ok := s.MachinePool.Annotations[key]
-	return ok, value
+func (s *ManagedMachinePoolScope) GetCAPIMachinePoolAnnotation(key string) (success bool, value string) {
+	val, ok := s.MachinePool.Annotations[key]
+	return ok, val
 }

--- a/azure/services/resourceskus/cache.go
+++ b/azure/services/resourceskus/cache.go
@@ -169,38 +169,39 @@ func (c *Cache) GetZones(ctx context.Context, location string) ([]string, error)
 		if sku.ResourceType != nil && strings.EqualFold(*sku.ResourceType, string(VirtualMachines)) {
 			// find matching location
 			for _, locationInfo := range *sku.LocationInfo {
-				if strings.EqualFold(*locationInfo.Location, location) {
-					// Use map for easy deletion and iteration
-					availableZones := make(map[string]bool)
+				if !strings.EqualFold(*locationInfo.Location, location) {
+					continue
+				}
+				// Use map for easy deletion and iteration
+				availableZones := make(map[string]bool)
 
-					// add all zones
-					for _, zone := range *locationInfo.Zones {
-						availableZones[zone] = true
-					}
+				// add all zones
+				for _, zone := range *locationInfo.Zones {
+					availableZones[zone] = true
+				}
 
-					if sku.Restrictions != nil {
-						for _, restriction := range *sku.Restrictions {
-							// Can't deploy anything in this subscription in this location. Bail out.
-							if restriction.Type == compute.ResourceSkuRestrictionsTypeLocation {
-								availableZones = nil
-								break
-							}
+				if sku.Restrictions != nil {
+					for _, restriction := range *sku.Restrictions {
+						// Can't deploy anything in this subscription in this location. Bail out.
+						if restriction.Type == compute.ResourceSkuRestrictionsTypeLocation {
+							availableZones = nil
+							break
+						}
 
-							// remove restricted zones
-							for _, restrictedZone := range *restriction.RestrictionInfo.Zones {
-								delete(availableZones, restrictedZone)
-							}
+						// remove restricted zones
+						for _, restrictedZone := range *restriction.RestrictionInfo.Zones {
+							delete(availableZones, restrictedZone)
 						}
 					}
-
-					// add to global list, if any exist. it's okay for the final list to be empty.
-					// that means the region may not support AZ yet.
-					for zone := range availableZones {
-						allZones[zone] = true
-					}
-
-					break
 				}
+
+				// add to global list, if any exist. it's okay for the final list to be empty.
+				// that means the region may not support AZ yet.
+				for zone := range availableZones {
+					allZones[zone] = true
+				}
+
+				break
 			}
 		}
 	}
@@ -230,38 +231,39 @@ func (c *Cache) GetZonesWithVMSize(ctx context.Context, size, location string) (
 		if sku.Name != nil && strings.EqualFold(*sku.Name, size) && sku.ResourceType != nil && strings.EqualFold(*sku.ResourceType, string(VirtualMachines)) {
 			// find matching location
 			for _, locationInfo := range *sku.LocationInfo {
-				if strings.EqualFold(*locationInfo.Location, location) {
-					// Use map for easy deletion and iteration
-					availableZones := make(map[string]bool)
+				if !strings.EqualFold(*locationInfo.Location, location) {
+					continue
+				}
+				// Use map for easy deletion and iteration
+				availableZones := make(map[string]bool)
 
-					// add all zones
-					for _, zone := range *locationInfo.Zones {
-						availableZones[zone] = true
-					}
+				// add all zones
+				for _, zone := range *locationInfo.Zones {
+					availableZones[zone] = true
+				}
 
-					if sku.Restrictions != nil {
-						for _, restriction := range *sku.Restrictions {
-							// Can't deploy anything in this subscription in this location. Bail out.
-							if restriction.Type == compute.ResourceSkuRestrictionsTypeLocation {
-								availableZones = nil
-								break
-							}
+				if sku.Restrictions != nil {
+					for _, restriction := range *sku.Restrictions {
+						// Can't deploy anything in this subscription in this location. Bail out.
+						if restriction.Type == compute.ResourceSkuRestrictionsTypeLocation {
+							availableZones = nil
+							break
+						}
 
-							// remove restricted zones
-							for _, restrictedZone := range *restriction.RestrictionInfo.Zones {
-								delete(availableZones, restrictedZone)
-							}
+						// remove restricted zones
+						for _, restrictedZone := range *restriction.RestrictionInfo.Zones {
+							delete(availableZones, restrictedZone)
 						}
 					}
-
-					// add to global list, if any exist. it's okay for the final list to be empty.
-					// that means the region may not support AZ yet.
-					for zone := range availableZones {
-						allZones[zone] = true
-					}
-
-					break
 				}
+
+				// add to global list, if any exist. it's okay for the final list to be empty.
+				// that means the region may not support AZ yet.
+				for zone := range availableZones {
+					allZones[zone] = true
+				}
+
+				break
 			}
 		}
 	}

--- a/azure/services/tags/tags.go
+++ b/azure/services/tags/tags.go
@@ -107,7 +107,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			}
 
 			// We also need to update the annotation if anything changed.
-			if err = s.Scope.UpdateAnnotationJSON(tagsSpec.Annotation, newAnnotation); err != nil {
+			if err := s.Scope.UpdateAnnotationJSON(tagsSpec.Annotation, newAnnotation); err != nil {
 				return err
 			}
 			log.V(2).Info("successfully updated tags")
@@ -129,7 +129,7 @@ func (s *Service) Delete(ctx context.Context) error {
 }
 
 // tagsChanged determines which tags to delete and which to add.
-func tagsChanged(lastAppliedTags map[string]interface{}, desiredTags map[string]string, currentTags map[string]*string) (bool, map[string]string, map[string]string, map[string]interface{}) {
+func tagsChanged(lastAppliedTags map[string]interface{}, desiredTags map[string]string, currentTags map[string]*string) (change bool, createOrUpdates map[string]string, deletes map[string]string, annotation map[string]interface{}) {
 	// Bool tracking if we found any changed state.
 	changed := false
 

--- a/azure/services/virtualmachineimages/images.go
+++ b/azure/services/virtualmachineimages/images.go
@@ -117,7 +117,7 @@ func (s *Service) GetDefaultWindowsImage(ctx context.Context, location, k8sVersi
 
 // getSKUAndVersion gets the SKU ID and version of the image to use for the provided version of Kubernetes.
 // note: osAndVersion is expected to be in the format of {os}-{version} (ex: ubuntu-2004 or windows-2022)
-func (s *Service) getSKUAndVersion(ctx context.Context, location, publisher, offer, k8sVersion, osAndVersion string) (string, string, error) {
+func (s *Service) getSKUAndVersion(ctx context.Context, location, publisher, offer, k8sVersion, osAndVersion string) (skuID string, imageVersion string, err error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "virtualmachineimages.Service.getSKUAndVersion")
 	defer done()
 

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -212,7 +212,7 @@ func GetCloudProviderSecret(d azure.ClusterScoper, namespace, name string, owner
 	return secret, nil
 }
 
-func systemAssignedIdentityCloudProviderConfig(d azure.ClusterScoper) (*CloudProviderConfig, *CloudProviderConfig) {
+func systemAssignedIdentityCloudProviderConfig(d azure.ClusterScoper) (cpConfig *CloudProviderConfig, wkConfig *CloudProviderConfig) {
 	controlPlaneConfig, workerConfig := newCloudProviderConfig(d)
 	controlPlaneConfig.AadClientID = ""
 	controlPlaneConfig.AadClientSecret = ""
@@ -223,7 +223,7 @@ func systemAssignedIdentityCloudProviderConfig(d azure.ClusterScoper) (*CloudPro
 	return controlPlaneConfig, workerConfig
 }
 
-func userAssignedIdentityCloudProviderConfig(d azure.ClusterScoper, identityID string) (*CloudProviderConfig, *CloudProviderConfig) {
+func userAssignedIdentityCloudProviderConfig(d azure.ClusterScoper, identityID string) (cpConfig *CloudProviderConfig, wkConfig *CloudProviderConfig) {
 	controlPlaneConfig, workerConfig := newCloudProviderConfig(d)
 	controlPlaneConfig.AadClientID = ""
 	controlPlaneConfig.AadClientSecret = ""
@@ -290,6 +290,31 @@ func getOneNodeSubnet(d azure.ClusterScoper) infrav1.SubnetSpec {
 	return infrav1.SubnetSpec{}
 }
 
+// CloudProviderConfig is an abbreviated version of the same struct in k/k.
+type CloudProviderConfig struct {
+	Cloud                        string `json:"cloud"`
+	TenantID                     string `json:"tenantId"`
+	SubscriptionID               string `json:"subscriptionId"`
+	AadClientID                  string `json:"aadClientId,omitempty"`
+	AadClientSecret              string `json:"aadClientSecret,omitempty"`
+	ResourceGroup                string `json:"resourceGroup"`
+	SecurityGroupName            string `json:"securityGroupName"`
+	SecurityGroupResourceGroup   string `json:"securityGroupResourceGroup"`
+	Location                     string `json:"location"`
+	VMType                       string `json:"vmType"`
+	VnetName                     string `json:"vnetName"`
+	VnetResourceGroup            string `json:"vnetResourceGroup"`
+	SubnetName                   string `json:"subnetName"`
+	RouteTableName               string `json:"routeTableName"`
+	LoadBalancerSku              string `json:"loadBalancerSku"`
+	MaximumLoadBalancerRuleCount int    `json:"maximumLoadBalancerRuleCount"`
+	UseManagedIdentityExtension  bool   `json:"useManagedIdentityExtension"`
+	UseInstanceMetadata          bool   `json:"useInstanceMetadata"`
+	UserAssignedIdentityID       string `json:"userAssignedIdentityID,omitempty"`
+	CloudProviderRateLimitConfig
+	BackOffConfig
+}
+
 // overrideFromSpec overrides cloud provider config with the values provided in cluster spec.
 func (cpc *CloudProviderConfig) overrideFromSpec(d azure.ClusterScoper) *CloudProviderConfig {
 	if d.CloudProviderConfigOverrides() == nil {
@@ -348,31 +373,6 @@ func toCloudProviderRateLimitConfig(source infrav1.RateLimitConfig) *RateLimitCo
 	}
 	rateLimitConfig.CloudProviderRateLimitBucketWrite = source.CloudProviderRateLimitBucketWrite
 	return &rateLimitConfig
-}
-
-// CloudProviderConfig is an abbreviated version of the same struct in k/k.
-type CloudProviderConfig struct {
-	Cloud                        string `json:"cloud"`
-	TenantID                     string `json:"tenantId"`
-	SubscriptionID               string `json:"subscriptionId"`
-	AadClientID                  string `json:"aadClientId,omitempty"`
-	AadClientSecret              string `json:"aadClientSecret,omitempty"`
-	ResourceGroup                string `json:"resourceGroup"`
-	SecurityGroupName            string `json:"securityGroupName"`
-	SecurityGroupResourceGroup   string `json:"securityGroupResourceGroup"`
-	Location                     string `json:"location"`
-	VMType                       string `json:"vmType"`
-	VnetName                     string `json:"vnetName"`
-	VnetResourceGroup            string `json:"vnetResourceGroup"`
-	SubnetName                   string `json:"subnetName"`
-	RouteTableName               string `json:"routeTableName"`
-	LoadBalancerSku              string `json:"loadBalancerSku"`
-	MaximumLoadBalancerRuleCount int    `json:"maximumLoadBalancerRuleCount"`
-	UseManagedIdentityExtension  bool   `json:"useManagedIdentityExtension"`
-	UseInstanceMetadata          bool   `json:"useInstanceMetadata"`
-	UserAssignedIdentityID       string `json:"userAssignedIdentityID,omitempty"`
-	CloudProviderRateLimitConfig
-	BackOffConfig
 }
 
 // CloudProviderRateLimitConfig represents the rate limiting configurations in azure cloud provider config.

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -464,7 +464,7 @@ const (
     "useManagedIdentityExtension": false,
     "useInstanceMetadata": true
 }`
-	//nolint:gosec
+	//nolint:gosec // Ignore "G101: Potential hardcoded credentials" check.
 	spWorkerNodeCloudConfig = `{
     "cloud": "AzurePublicCloud",
     "tenantId": "fooTenant",

--- a/exp/controllers/azuremachinepool_annotations.go
+++ b/exp/controllers/azuremachinepool_annotations.go
@@ -27,7 +27,7 @@ func (ampr *AzureMachinePoolReconciler) AnnotationJSON(rw annotationReaderWriter
 	out := map[string]interface{}{}
 
 	jsonAnnotation := ampr.Annotation(rw, annotation)
-	if len(jsonAnnotation) == 0 {
+	if jsonAnnotation == "" {
 		return out, nil
 	}
 

--- a/exp/controllers/helpers_test.go
+++ b/exp/controllers/helpers_test.go
@@ -212,7 +212,6 @@ func TestMachinePoolToAzureManagedControlPlaneMapFuncSuccess(t *testing.T) {
 		Namespace:  cluster.Namespace,
 	}
 
-	// controlPlane.Spec.DefaultPoolRef.Name = "azuremy-mmp-0"
 	managedMachinePool0 := newManagedMachinePoolInfraReference(clusterName, "my-mmp-0")
 	azureManagedMachinePool0 := newAzureManagedMachinePool(clusterName, "azuremy-mmp-0", "System")
 	managedMachinePool0.Spec.ClusterName = clusterName

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	// nolint:godot
+	//nolint:godot // Ignore "Comment should end in a period" check.
 	// Every capz-specific feature gate should add a method here following this template:
 	//
 	// // MyFeature is the feature gate for my feature.

--- a/internal/test/env/env.go
+++ b/internal/test/env/env.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -66,7 +65,7 @@ func init() {
 	utilruntime.Must(infrav1alpha4.AddToScheme(scheme))
 
 	// Get the root of the current file to use in CRD paths.
-	_, filename, _, _ := goruntime.Caller(0) //nolint:dogsled
+	_, filename, _, _ := goruntime.Caller(0) //nolint:dogsled // Ignore "declaration has 3 blank identifiers" check.
 	root := path.Join(path.Dir(filename), "..", "..", "..")
 
 	crdPaths := []string{
@@ -134,7 +133,7 @@ func (t *TestEnvironment) Stop() error {
 }
 
 func getFilePathToCAPICRDs(root string) string {
-	modBits, err := ioutil.ReadFile(filepath.Join(root, "go.mod"))
+	modBits, err := os.ReadFile(filepath.Join(root, "go.mod"))
 	if err != nil {
 		return ""
 	}

--- a/internal/test/env/env_test.go
+++ b/internal/test/env/env_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestGetFilePathToCAPICRDs(t *testing.T) {
-	_, filename, _, _ := goruntime.Caller(0) //nolint:dogsled
+	_, filename, _, _ := goruntime.Caller(0) //nolint:dogsled // Ignore "declaration has 3 blank identifiers" check.
 	root := path.Join(path.Dir(filename), "..", "..", "..")
 	g := gomega.NewWithT(t)
 	g.Expect(getFilePathToCAPICRDs(root)).To(gomega.MatchRegexp("(.+)/pkg/mod/sigs.k8s.io/cluster-api@v(.+)/config/crd/bases"))


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adds two linters and some configuration directives from CAPI's [`.golangci.yml`](https://github.com/kubernetes-sigs/cluster-api/blob/main/.golangci.yml) so the development experience is more consistent between the two projects.

In particular, enabling `"experimental"` for `gocritic` led to many code changes. I thought they were all good ones, but please let me know if you disagree.

**Which issue(s) this PR fixes**:

See also #2534

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
