### PR TITLE
update the node labels for existing AKS nodepools

### DIFF
--- a/azure/services/agentpools/agentpools.go
+++ b/azure/services/agentpools/agentpools.go
@@ -111,6 +111,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 				EnableAutoScaling:   existingPool.EnableAutoScaling,
 				MinCount:            existingPool.MinCount,
 				MaxCount:            existingPool.MaxCount,
+				NodeLabels:          existingPool.NodeLabels,
 			},
 		}
 
@@ -122,6 +123,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 				EnableAutoScaling:   profile.EnableAutoScaling,
 				MinCount:            profile.MinCount,
 				MaxCount:            profile.MaxCount,
+				NodeLabels:          profile.NodeLabels,
 			},
 		}
 


### PR DESCRIPTION

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

AKS allows updating the node labels for its nodepools, this PR fixes the normalized diff for agentpool of AKS to include the nodelabels.


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix the bug that doesn't allow updating labels on existing nodepools in AKS
```
