### PR TITLE
add name and owner tags to NICs

### DIFF
--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -240,6 +240,8 @@ func (m *MachineScope) NICSpecs() []azure.ResourceSpecGetter {
 		AcceleratedNetworking: m.AzureMachine.Spec.AcceleratedNetworking,
 		IPv6Enabled:           m.IsIPv6Enabled(),
 		EnableIPForwarding:    m.AzureMachine.Spec.EnableIPForwarding,
+		AdditionalTags:        m.AdditionalTags(),
+		ClusterName:           m.ClusterName(),
 	}
 
 	if m.Role() == infrav1.ControlPlane {

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -1627,6 +1627,10 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 					IPv6Enabled:               false,
 					EnableIPForwarding:        false,
 					SKU:                       nil,
+					ClusterName:               "cluster",
+					AdditionalTags: infrav1.Tags{
+						"kubernetes.io_cluster_cluster": "owned",
+					},
 				},
 			},
 		},
@@ -1729,6 +1733,10 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 					SKU: &resourceskus.SKU{
 						Name: to.StringPtr("Standard_D2v2"),
 					},
+					ClusterName: "cluster",
+					AdditionalTags: infrav1.Tags{
+						"kubernetes.io_cluster_cluster": "owned",
+					},
 				},
 			},
 		},
@@ -1829,6 +1837,10 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 					IPv6Enabled:               false,
 					EnableIPForwarding:        false,
 					SKU:                       nil,
+					ClusterName:               "cluster",
+					AdditionalTags: infrav1.Tags{
+						"kubernetes.io_cluster_cluster": "owned",
+					},
 				},
 			},
 		},
@@ -1925,6 +1937,10 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 					IPv6Enabled:               false,
 					EnableIPForwarding:        false,
 					SKU:                       nil,
+					ClusterName:               "cluster",
+					AdditionalTags: infrav1.Tags{
+						"kubernetes.io_cluster_cluster": "owned",
+					},
 				},
 			},
 		},
@@ -2026,6 +2042,10 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 					IPv6Enabled:               false,
 					EnableIPForwarding:        false,
 					SKU:                       nil,
+					ClusterName:               "cluster",
+					AdditionalTags: infrav1.Tags{
+						"kubernetes.io_cluster_cluster": "owned",
+					},
 				},
 			},
 		},
@@ -2124,6 +2144,10 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 					IPv6Enabled:               false,
 					EnableIPForwarding:        false,
 					SKU:                       nil,
+					ClusterName:               "cluster",
+					AdditionalTags: infrav1.Tags{
+						"kubernetes.io_cluster_cluster": "owned",
+					},
 				},
 			},
 		},

--- a/azure/services/networkinterfaces/spec.go
+++ b/azure/services/networkinterfaces/spec.go
@@ -20,7 +20,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
 )
 
@@ -45,6 +47,8 @@ type NICSpec struct {
 	IPv6Enabled               bool
 	EnableIPForwarding        bool
 	SKU                       *resourceskus.SKU
+	AdditionalTags            infrav1.Tags
+	ClusterName               string
 }
 
 // ResourceName returns the name of the network interface.
@@ -152,5 +156,11 @@ func (s *NICSpec) Parameters(existing interface{}) (parameters interface{}, err 
 			IPConfigurations:            &ipConfigurations,
 			EnableIPForwarding:          to.BoolPtr(s.EnableIPForwarding),
 		},
+		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
+			ClusterName: s.ClusterName,
+			Lifecycle:   infrav1.ResourceLifecycleOwned,
+			Name:        to.StringPtr(s.Name),
+			Additional:  s.AdditionalTags,
+		})),
 	}, nil
 }

--- a/azure/services/networkinterfaces/spec_test.go
+++ b/azure/services/networkinterfaces/spec_test.go
@@ -38,6 +38,7 @@ var (
 		VNetResourceGroup:     "my-rg",
 		PublicLBName:          "my-public-lb",
 		AcceleratedNetworking: nil,
+		ClusterName:           "my-cluster",
 	}
 	fakeSku = resourceskus.SKU{
 		Name: to.StringPtr("Standard_D2v2"),
@@ -72,6 +73,7 @@ var (
 		StaticIPAddress:         "fake.static.ip",
 		AcceleratedNetworking:   nil,
 		SKU:                     &fakeSku,
+		ClusterName:             "my-cluster",
 	}
 
 	fakeDynamicPrivateIPNICSpec = NICSpec{
@@ -87,6 +89,7 @@ var (
 		PublicLBAddressPoolName: "cluster-name-outboundBackendPool",
 		AcceleratedNetworking:   nil,
 		SKU:                     &fakeSku,
+		ClusterName:             "my-cluster",
 	}
 
 	fakeControlPlaneNICSpec = NICSpec{
@@ -105,6 +108,7 @@ var (
 		InternalLBAddressPoolName: "my-internal-lb-backendPool",
 		AcceleratedNetworking:     nil,
 		SKU:                       &fakeSku,
+		ClusterName:               "my-cluster",
 	}
 
 	fakeAcceleratedNetworkingNICSpec = NICSpec{
@@ -119,6 +123,7 @@ var (
 		PublicLBName:          "my-public-lb",
 		AcceleratedNetworking: nil,
 		SKU:                   &fakeSku,
+		ClusterName:           "my-cluster",
 	}
 
 	fakeNonAcceleratedNetworkingNICSpec = NICSpec{
@@ -132,6 +137,7 @@ var (
 		VNetResourceGroup:     "my-rg",
 		PublicLBName:          "my-public-lb",
 		AcceleratedNetworking: to.BoolPtr(false),
+		ClusterName:           "my-cluster",
 	}
 
 	fakeIpv6NICSpec = NICSpec{
@@ -148,6 +154,7 @@ var (
 		AcceleratedNetworking: nil,
 		SKU:                   &fakeSku,
 		EnableIPForwarding:    true,
+		ClusterName:           "my-cluster",
 	}
 )
 
@@ -175,6 +182,10 @@ func TestParameters(t *testing.T) {
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+					Tags: map[string]*string{
+						"Name": to.StringPtr("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": to.StringPtr("owned"),
+					},
 					Location: to.StringPtr("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 						EnableAcceleratedNetworking: to.BoolPtr(true),
@@ -202,6 +213,10 @@ func TestParameters(t *testing.T) {
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+					Tags: map[string]*string{
+						"Name": to.StringPtr("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": to.StringPtr("owned"),
+					},
 					Location: to.StringPtr("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 						EnableAcceleratedNetworking: to.BoolPtr(true),
@@ -228,6 +243,10 @@ func TestParameters(t *testing.T) {
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+					Tags: map[string]*string{
+						"Name": to.StringPtr("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": to.StringPtr("owned"),
+					},
 					Location: to.StringPtr("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 						EnableAcceleratedNetworking: to.BoolPtr(true),
@@ -257,6 +276,10 @@ func TestParameters(t *testing.T) {
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+					Tags: map[string]*string{
+						"Name": to.StringPtr("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": to.StringPtr("owned"),
+					},
 					Location: to.StringPtr("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 						EnableAcceleratedNetworking: to.BoolPtr(true),
@@ -283,6 +306,10 @@ func TestParameters(t *testing.T) {
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+					Tags: map[string]*string{
+						"Name": to.StringPtr("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": to.StringPtr("owned"),
+					},
 					Location: to.StringPtr("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 						EnableAcceleratedNetworking: to.BoolPtr(false),
@@ -309,6 +336,10 @@ func TestParameters(t *testing.T) {
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+					Tags: map[string]*string{
+						"Name": to.StringPtr("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": to.StringPtr("owned"),
+					},
 					Location: to.StringPtr("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 						EnableAcceleratedNetworking: to.BoolPtr(true),


### PR DESCRIPTION
Signed-off-by: Ashutosh Kumar <sonasingh46@gmail.com>

/kind feature

**What this PR does / why we need it**: 
Adds Name tag and sigs.k8s.io_cluster-api-provider-azure_cluster_clustername tag to NICs.

Example: 
![Screenshot 2022-08-14 at 9 13 30 PM](https://user-images.githubusercontent.com/24835120/184544691-83d62403-f5a0-4e1d-b792-9171a3c6945c.png)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2354

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
