### PR TITLE
fix typo for clusterctl generate cluster command

### DIFF
--- a/templates/flavors/README.md
+++ b/templates/flavors/README.md
@@ -3,7 +3,7 @@
 In `clusterctl` the infrastructure provider authors can provide different type of cluster templates,
 or flavors; use the --flavor flag to specify which flavor to use; e.g
 ```shell
-clusterctl config cluster my-cluster --kubernetes-version v1.22.1 \
+clusterctl generate cluster my-cluster --kubernetes-version v1.22.1 \
     --flavor external-cloud-provider > my-cluster.yaml
 ```
 See [`clusterctl` flavors docs](https://cluster-api.sigs.k8s.io/clusterctl/commands/generate-cluster.html#flavors).


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
CLI command as it was before does not exist. 

**Release note**:
```release-note
NONE
```
