### PR TITLE
Restore lint check for go comments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -109,6 +109,11 @@ linters-settings:
     excludes:
     - G307 # Deferring unsafe method "Close" on type "\*os.File"
     - G108 # Profiling endpoint is automatically exposed on /debug/pprof
+  revive:
+    rules:
+      - name: exported
+        arguments:
+          - disableStutteringCheck
   staticcheck:
     go: "1.18"
 
@@ -121,6 +126,7 @@ issues:
     - path: api/v1alpha3/azureclusteridentity_types.go
       text: "methods on the same type should have the same receiver name"
   include:
-  - EXC0002 # include "missing comments" issues from golint
+  - EXC0012  # revive: check for comments
+  - EXC0014  # revive: check for comments
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/api/v1alpha3/azurecluster_conversion.go
+++ b/api/v1alpha3/azurecluster_conversion.go
@@ -151,7 +151,7 @@ func Convert_v1alpha3_AzureClusterStatus_To_v1beta1_AzureClusterStatus(in *Azure
 	return autoConvert_v1alpha3_AzureClusterStatus_To_v1beta1_AzureClusterStatus(in, out, s)
 }
 
-// Convert_v1alpha3_AzureClusterSpec_To_v1beta1_AzureClusterSpec.
+// Convert_v1alpha3_AzureClusterSpec_To_v1beta1_AzureClusterSpec converts AzureCluster.Spec from v1alpha3 to v1beta1.
 func Convert_v1alpha3_AzureClusterSpec_To_v1beta1_AzureClusterSpec(in *AzureClusterSpec, out *infrav1.AzureClusterSpec, s apiconversion.Scope) error {
 	if err := autoConvert_v1alpha3_AzureClusterSpec_To_v1beta1_AzureClusterSpec(in, out, s); err != nil {
 		return err
@@ -181,12 +181,12 @@ func Convert_v1beta1_AzureClusterSpec_To_v1alpha3_AzureClusterSpec(in *infrav1.A
 	return nil
 }
 
-// Convert_v1beta1_AzureClusterStatus_To_v1alpha3_AzureClusterStatus.
+// Convert_v1beta1_AzureClusterStatus_To_v1alpha3_AzureClusterStatus converts an Azure cluster status from v1beta1 to v1alpha3.
 func Convert_v1beta1_AzureClusterStatus_To_v1alpha3_AzureClusterStatus(in *infrav1.AzureClusterStatus, out *AzureClusterStatus, s apiconversion.Scope) error {
 	return autoConvert_v1beta1_AzureClusterStatus_To_v1alpha3_AzureClusterStatus(in, out, s)
 }
 
-// Convert_v1alpha3_NetworkSpec_To_v1beta1_NetworkSpec.
+// Convert_v1alpha3_NetworkSpec_To_v1beta1_NetworkSpec converts a network spec from v1alpha3 to v1beta1.
 func Convert_v1alpha3_NetworkSpec_To_v1beta1_NetworkSpec(in *NetworkSpec, out *infrav1.NetworkSpec, s apiconversion.Scope) error {
 	if err := Convert_v1alpha3_VnetSpec_To_v1beta1_VnetSpec(&in.Vnet, &out.Vnet, s); err != nil {
 		return err
@@ -203,7 +203,7 @@ func Convert_v1alpha3_NetworkSpec_To_v1beta1_NetworkSpec(in *NetworkSpec, out *i
 	return Convert_v1alpha3_LoadBalancerSpec_To_v1beta1_LoadBalancerSpec(&in.APIServerLB, &out.APIServerLB, s)
 }
 
-// Convert_v1beta1_NetworkSpec_To_v1alpha3_NetworkSpec.
+// Convert_v1beta1_NetworkSpec_To_v1alpha3_NetworkSpec converts a network spec from v1beta1 to v1alpha3.
 func Convert_v1beta1_NetworkSpec_To_v1alpha3_NetworkSpec(in *infrav1.NetworkSpec, out *NetworkSpec, s apiconversion.Scope) error {
 	if err := Convert_v1beta1_VnetSpec_To_v1alpha3_VnetSpec(&in.Vnet, &out.Vnet, s); err != nil {
 		return err
@@ -220,7 +220,7 @@ func Convert_v1beta1_NetworkSpec_To_v1alpha3_NetworkSpec(in *infrav1.NetworkSpec
 	return Convert_v1beta1_LoadBalancerSpec_To_v1alpha3_LoadBalancerSpec(&in.APIServerLB, &out.APIServerLB, s)
 }
 
-// Convert_v1beta1_VnetSpec_To_v1alpha3_VnetSpec.
+// Convert_v1beta1_VnetSpec_To_v1alpha3_VnetSpec converts a virtual network spec from v1beta1 to v1alpha3.
 func Convert_v1beta1_VnetSpec_To_v1alpha3_VnetSpec(in *infrav1.VnetSpec, out *VnetSpec, s apiconversion.Scope) error {
 	if err := autoConvert_v1beta1_VnetSpec_To_v1alpha3_VnetSpec(in, out, s); err != nil {
 		return err
@@ -233,7 +233,7 @@ func Convert_v1beta1_VnetSpec_To_v1alpha3_VnetSpec(in *infrav1.VnetSpec, out *Vn
 	return nil
 }
 
-// Convert_v1alpha3_SubnetSpec_To_v1beta1_SubnetSpec.
+// Convert_v1alpha3_SubnetSpec_To_v1beta1_SubnetSpec converts a subnet spec from v1alpha3 to v1beta1.
 func Convert_v1alpha3_SubnetSpec_To_v1beta1_SubnetSpec(in *SubnetSpec, out *infrav1.SubnetSpec, s apiconversion.Scope) error {
 	if err := autoConvert_v1alpha3_SubnetSpec_To_v1beta1_SubnetSpec(in, out, s); err != nil {
 		return err
@@ -246,7 +246,7 @@ func Convert_v1alpha3_SubnetSpec_To_v1beta1_SubnetSpec(in *SubnetSpec, out *infr
 	return nil
 }
 
-// Convert_v1beta1_SubnetSpec_To_v1alpha3_SubnetSpec.
+// Convert_v1beta1_SubnetSpec_To_v1alpha3_SubnetSpec converts a subnet spec from v1beta1 to v1alpha3.
 func Convert_v1beta1_SubnetSpec_To_v1alpha3_SubnetSpec(in *infrav1.SubnetSpec, out *SubnetSpec, s apiconversion.Scope) error {
 	if err := autoConvert_v1beta1_SubnetSpec_To_v1alpha3_SubnetSpec(in, out, s); err != nil {
 		return err
@@ -259,6 +259,7 @@ func Convert_v1beta1_SubnetSpec_To_v1alpha3_SubnetSpec(in *infrav1.SubnetSpec, o
 	return nil
 }
 
+// Convert_v1beta1_SecurityGroup_To_v1alpha3_SecurityGroup converts a security group from v1beta1 to v1alpha3.
 func Convert_v1beta1_SecurityGroup_To_v1alpha3_SecurityGroup(in *infrav1.SecurityGroup, out *SecurityGroup, s apiconversion.Scope) error {
 	out.ID = in.ID
 	out.Name = in.Name
@@ -279,6 +280,7 @@ func Convert_v1beta1_SecurityGroup_To_v1alpha3_SecurityGroup(in *infrav1.Securit
 	return nil
 }
 
+// Convert_v1alpha3_SecurityGroup_To_v1beta1_SecurityGroup converts a security group from v1alpha3 to v1beta1.
 func Convert_v1alpha3_SecurityGroup_To_v1beta1_SecurityGroup(in *SecurityGroup, out *infrav1.SecurityGroup, s apiconversion.Scope) error {
 	out.ID = in.ID
 	out.Name = in.Name
@@ -295,7 +297,7 @@ func Convert_v1alpha3_SecurityGroup_To_v1beta1_SecurityGroup(in *SecurityGroup, 
 	return nil
 }
 
-// Convert_v1alpha3_IngressRule_To_v1beta1_SecurityRule.
+// Convert_v1alpha3_IngressRule_To_v1beta1_SecurityRule converts from a v1alpha3 IngressRule to a v1beta1 SecurityRule.
 func Convert_v1alpha3_IngressRule_To_v1beta1_SecurityRule(in *IngressRule, out *infrav1.SecurityRule, _ apiconversion.Scope) error {
 	out.Name = in.Name
 	out.Description = in.Description
@@ -309,7 +311,7 @@ func Convert_v1alpha3_IngressRule_To_v1beta1_SecurityRule(in *IngressRule, out *
 	return nil
 }
 
-// Convert_v1beta1_SecurityRule_To_v1alpha3_IngressRule.
+// Convert_v1beta1_SecurityRule_To_v1alpha3_IngressRule converts from a v1beta1 SecurityRule to a v1alpha3 IngressRule.
 func Convert_v1beta1_SecurityRule_To_v1alpha3_IngressRule(in *infrav1.SecurityRule, out *IngressRule, _ apiconversion.Scope) error {
 	out.Name = in.Name
 	out.Description = in.Description
@@ -359,6 +361,7 @@ func Convert_v1beta1_LoadBalancerSpec_To_v1alpha3_LoadBalancerSpec(in *infrav1.L
 	return nil
 }
 
+// Convert_v1alpha3_LoadBalancerSpec_To_v1beta1_LoadBalancerSpec converts an LB spec from v1alpha3 to v1beta1.
 func Convert_v1alpha3_LoadBalancerSpec_To_v1beta1_LoadBalancerSpec(in *LoadBalancerSpec, out *infrav1.LoadBalancerSpec, s apiconversion.Scope) error {
 	if err := autoConvert_v1alpha3_LoadBalancerSpec_To_v1beta1_LoadBalancerSpec(in, out, s); err != nil {
 		return err

--- a/api/v1alpha3/azureclusteridentity_conversion.go
+++ b/api/v1alpha3/azureclusteridentity_conversion.go
@@ -25,6 +25,7 @@ import (
 )
 
 const (
+	// AzureClusterKind is the Kubernetes Kind for AzureCluster.
 	AzureClusterKind = "AzureCluster"
 )
 
@@ -88,12 +89,12 @@ func (dst *AzureClusterIdentity) ConvertFrom(srcRaw conversion.Hub) error {
 	return nil
 }
 
-// Convert_v1alpha3_AzureClusterIdentitySpec_To_v1beta1_AzureClusterIdentitySpec.
+// Convert_v1alpha3_AzureClusterIdentitySpec_To_v1beta1_AzureClusterIdentitySpec converts an Azure cluster identity spec from v1alpha3 to v1beta1.
 func Convert_v1alpha3_AzureClusterIdentitySpec_To_v1beta1_AzureClusterIdentitySpec(in *AzureClusterIdentitySpec, out *infrav1.AzureClusterIdentitySpec, s apiconversion.Scope) error {
 	return autoConvert_v1alpha3_AzureClusterIdentitySpec_To_v1beta1_AzureClusterIdentitySpec(in, out, s)
 }
 
-// Convert_v1beta1_AzureClusterIdentitySpec_To_v1alpha3_AzureClusterIdentitySpec.
+// Convert_v1beta1_AzureClusterIdentitySpec_To_v1alpha3_AzureClusterIdentitySpec converts an Azure cluster identity spec from v1beta1 to v1alpha3.
 func Convert_v1beta1_AzureClusterIdentitySpec_To_v1alpha3_AzureClusterIdentitySpec(in *infrav1.AzureClusterIdentitySpec, out *AzureClusterIdentitySpec, s apiconversion.Scope) error {
 	return autoConvert_v1beta1_AzureClusterIdentitySpec_To_v1alpha3_AzureClusterIdentitySpec(in, out, s)
 }

--- a/api/v1alpha3/azuremachine_conversion.go
+++ b/api/v1alpha3/azuremachine_conversion.go
@@ -92,6 +92,7 @@ func (dst *AzureMachineList) ConvertFrom(srcRaw conversion.Hub) error {
 	return Convert_v1beta1_AzureMachineList_To_v1alpha3_AzureMachineList(src, dst, nil)
 }
 
+// Convert_v1alpha3_AzureMachineSpec_To_v1beta1_AzureMachineSpec converts this AzureMachineSpec to the Hub version (v1beta1).
 func Convert_v1alpha3_AzureMachineSpec_To_v1beta1_AzureMachineSpec(in *AzureMachineSpec, out *infrav1.AzureMachineSpec, s apiconversion.Scope) error {
 	return autoConvert_v1alpha3_AzureMachineSpec_To_v1beta1_AzureMachineSpec(in, out, s)
 }
@@ -157,6 +158,7 @@ func Convert_v1beta1_ManagedDiskParameters_To_v1alpha3_ManagedDisk(in *infrav1.M
 	return nil
 }
 
+// Convert_v1beta1_AzureMarketplaceImage_To_v1alpha3_AzureMarketplaceImage converts an Azure Marketplace image from v1beta1 to v1alpha3.
 func Convert_v1beta1_AzureMarketplaceImage_To_v1alpha3_AzureMarketplaceImage(in *infrav1.AzureMarketplaceImage, out *AzureMarketplaceImage, s apiconversion.Scope) error {
 	out.Offer = in.ImagePlan.Offer
 	out.Publisher = in.ImagePlan.Publisher
@@ -165,6 +167,7 @@ func Convert_v1beta1_AzureMarketplaceImage_To_v1alpha3_AzureMarketplaceImage(in 
 	return autoConvert_v1beta1_AzureMarketplaceImage_To_v1alpha3_AzureMarketplaceImage(in, out, s)
 }
 
+// Convert_v1alpha3_AzureMarketplaceImage_To_v1beta1_AzureMarketplaceImage converts an Azure Marketplace image from v1alpha3 to v1beta1.
 func Convert_v1alpha3_AzureMarketplaceImage_To_v1beta1_AzureMarketplaceImage(in *AzureMarketplaceImage, out *infrav1.AzureMarketplaceImage, s apiconversion.Scope) error {
 	out.ImagePlan.Offer = in.Offer
 	out.ImagePlan.Publisher = in.Publisher
@@ -173,6 +176,7 @@ func Convert_v1alpha3_AzureMarketplaceImage_To_v1beta1_AzureMarketplaceImage(in 
 	return autoConvert_v1alpha3_AzureMarketplaceImage_To_v1beta1_AzureMarketplaceImage(in, out, s)
 }
 
+// Convert_v1beta1_Image_To_v1alpha3_Image converts an image from v1beta1 to v1alpha3.
 func Convert_v1beta1_Image_To_v1alpha3_Image(in *infrav1.Image, out *Image, s apiconversion.Scope) error {
 	return autoConvert_v1beta1_Image_To_v1alpha3_Image(in, out, s)
 }

--- a/api/v1alpha3/azuremachinetemplate_conversion.go
+++ b/api/v1alpha3/azuremachinetemplate_conversion.go
@@ -91,10 +91,12 @@ func (dst *AzureMachineTemplateList) ConvertFrom(srcRaw conversion.Hub) error {
 	return Convert_v1beta1_AzureMachineTemplateList_To_v1alpha3_AzureMachineTemplateList(src, dst, nil)
 }
 
+// Convert_v1beta1_AzureSharedGalleryImage_To_v1alpha3_AzureSharedGalleryImage converts an Azure shared gallery image from v1beta1 to v1alpha3.
 func Convert_v1beta1_AzureSharedGalleryImage_To_v1alpha3_AzureSharedGalleryImage(in *infrav1.AzureSharedGalleryImage, out *AzureSharedGalleryImage, s apimachineryconversion.Scope) error {
 	return autoConvert_v1beta1_AzureSharedGalleryImage_To_v1alpha3_AzureSharedGalleryImage(in, out, s)
 }
 
+// Convert_v1beta1_AzureMachineTemplateResource_To_v1alpha3_AzureMachineTemplateResource converts an Azure machine template resource from v1beta1 to v1alpha3.
 func Convert_v1beta1_AzureMachineTemplateResource_To_v1alpha3_AzureMachineTemplateResource(in *infrav1.AzureMachineTemplateResource, out *AzureMachineTemplateResource, s apimachineryconversion.Scope) error {
 	return autoConvert_v1beta1_AzureMachineTemplateResource_To_v1alpha3_AzureMachineTemplateResource(in, out, s)
 }

--- a/api/v1alpha4/azurecluster_conversion.go
+++ b/api/v1alpha4/azurecluster_conversion.go
@@ -115,7 +115,7 @@ func (dst *AzureClusterList) ConvertFrom(srcRaw conversion.Hub) error {
 	return Convert_v1beta1_AzureClusterList_To_v1alpha4_AzureClusterList(src, dst, nil)
 }
 
-// Convert_v1beta1_VnetSpec_To_v1alpha4_VnetSpec.
+// Convert_v1beta1_VnetSpec_To_v1alpha4_VnetSpec converts from the Hub version (v1beta1) of the VnetSpec to this version.
 func Convert_v1beta1_VnetSpec_To_v1alpha4_VnetSpec(in *infrav1.VnetSpec, out *VnetSpec, s apiconversion.Scope) error {
 	if err := autoConvert_v1beta1_VnetSpec_To_v1alpha4_VnetSpec(in, out, s); err != nil {
 		return err
@@ -327,6 +327,7 @@ func Convert_v1beta1_SecurityGroup_To_v1alpha4_SecurityGroup(in *infrav1.Securit
 	return nil
 }
 
+// Convert_v1alpha4_NatGateway_To_v1beta1_NatGateway converts a NAT gateway from v1alpha4 to v1beta1.
 func Convert_v1alpha4_NatGateway_To_v1beta1_NatGateway(in *NatGateway, out *infrav1.NatGateway, s apiconversion.Scope) error {
 	if err := autoConvert_v1alpha4_NatGateway_To_v1beta1_NatGateway(in, out, s); err != nil {
 		return err
@@ -337,6 +338,7 @@ func Convert_v1alpha4_NatGateway_To_v1beta1_NatGateway(in *NatGateway, out *infr
 	return nil
 }
 
+// Convert_v1beta1_NatGateway_To_v1alpha4_NatGateway converts a NatGateway from v1beta1 to v1alpha4.
 func Convert_v1beta1_NatGateway_To_v1alpha4_NatGateway(in *infrav1.NatGateway, out *NatGateway, s apiconversion.Scope) error {
 	if err := autoConvert_v1beta1_NatGateway_To_v1alpha4_NatGateway(in, out, s); err != nil {
 		return err

--- a/api/v1alpha4/azuremachine_conversion.go
+++ b/api/v1alpha4/azuremachine_conversion.go
@@ -74,6 +74,7 @@ func (dst *AzureMachineList) ConvertFrom(srcRaw conversion.Hub) error {
 	return Convert_v1beta1_AzureMachineList_To_v1alpha4_AzureMachineList(src, dst, nil)
 }
 
+// Convert_v1beta1_AzureMarketplaceImage_To_v1alpha4_AzureMarketplaceImage converts an Azure Marketplace image from v1beta1 to v1alpha4.
 func Convert_v1beta1_AzureMarketplaceImage_To_v1alpha4_AzureMarketplaceImage(in *infrav1.AzureMarketplaceImage, out *AzureMarketplaceImage, s apiconversion.Scope) error {
 	out.Offer = in.ImagePlan.Offer
 	out.Publisher = in.ImagePlan.Publisher
@@ -82,6 +83,7 @@ func Convert_v1beta1_AzureMarketplaceImage_To_v1alpha4_AzureMarketplaceImage(in 
 	return autoConvert_v1beta1_AzureMarketplaceImage_To_v1alpha4_AzureMarketplaceImage(in, out, s)
 }
 
+// Convert_v1alpha4_AzureMarketplaceImage_To_v1beta1_AzureMarketplaceImage converts an Azure Marketplace image from v1alpha4 to v1beta1.
 func Convert_v1alpha4_AzureMarketplaceImage_To_v1beta1_AzureMarketplaceImage(in *AzureMarketplaceImage, out *infrav1.AzureMarketplaceImage, s apiconversion.Scope) error {
 	out.ImagePlan.Offer = in.Offer
 	out.ImagePlan.Publisher = in.Publisher
@@ -90,6 +92,7 @@ func Convert_v1alpha4_AzureMarketplaceImage_To_v1beta1_AzureMarketplaceImage(in 
 	return autoConvert_v1alpha4_AzureMarketplaceImage_To_v1beta1_AzureMarketplaceImage(in, out, s)
 }
 
+// Convert_v1beta1_Image_To_v1alpha4_Image converts an image from v1beta1 to v1alpha4.
 func Convert_v1beta1_Image_To_v1alpha4_Image(in *infrav1.Image, out *Image, s apiconversion.Scope) error {
 	return autoConvert_v1beta1_Image_To_v1alpha4_Image(in, out, s)
 }

--- a/api/v1alpha4/azuremachinetemplate_conversion.go
+++ b/api/v1alpha4/azuremachinetemplate_conversion.go
@@ -76,6 +76,7 @@ func (dst *AzureMachineTemplateList) ConvertFrom(srcRaw conversion.Hub) error {
 	return Convert_v1beta1_AzureMachineTemplateList_To_v1alpha4_AzureMachineTemplateList(src, dst, nil)
 }
 
+// Convert_v1beta1_AzureMachineTemplateResource_To_v1alpha4_AzureMachineTemplateResource converts an Azure Machine Template Resource from v1beta1 to v1alpha4.
 func Convert_v1beta1_AzureMachineTemplateResource_To_v1alpha4_AzureMachineTemplateResource(in *infrav1.AzureMachineTemplateResource, out *AzureMachineTemplateResource, s apimachineryconversion.Scope) error {
 	return autoConvert_v1beta1_AzureMachineTemplateResource_To_v1alpha4_AzureMachineTemplateResource(in, out, s)
 }

--- a/api/v1beta1/azurecluster_default.go
+++ b/api/v1beta1/azurecluster_default.go
@@ -194,6 +194,7 @@ func (c *AzureCluster) setAPIServerLBDefaults() {
 	}
 }
 
+// SetNodeOutboundLBDefaults sets the default values for the NodeOutboundLB.
 func (c *AzureCluster) SetNodeOutboundLBDefaults() {
 	if c.Spec.NetworkSpec.NodeOutboundLB == nil {
 		if c.Spec.NetworkSpec.APIServerLB.Type == Internal {
@@ -230,6 +231,7 @@ func (c *AzureCluster) SetNodeOutboundLBDefaults() {
 	c.setOutboundLBFrontendIPs(lb, generateNodeOutboundIPName)
 }
 
+// SetControlPlaneOutboundLBDefaults sets the default values for the control plane's outbound LB.
 func (c *AzureCluster) SetControlPlaneOutboundLBDefaults() {
 	lb := c.Spec.NetworkSpec.ControlPlaneOutboundLB
 

--- a/api/v1beta1/azureclustertemplate_webhook.go
+++ b/api/v1beta1/azureclustertemplate_webhook.go
@@ -26,9 +26,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-// AzureClusterTemplateImmutableMsg ...
+// AzureClusterTemplateImmutableMsg is the message used for errors on fields that are immutable.
 const AzureClusterTemplateImmutableMsg = "AzureClusterTemplate spec.template.spec field is immutable. Please create new resource instead. ref doc: https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-class/change-clusterclass.html"
 
+// SetupWebhookWithManager will set up the webhook to be managed by the specified manager.
 func (c *AzureClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(c).

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -120,6 +120,7 @@ type VnetPeeringSpec struct {
 	VnetPeeringClassSpec `json:",inline"`
 }
 
+// VnetPeeringClassSpec specifies a virtual network peering class.
 type VnetPeeringClassSpec struct {
 	// RemoteVnetName defines name of the remote virtual network.
 	RemoteVnetName string `json:"remoteVnetName"`
@@ -169,6 +170,7 @@ type NatGateway struct {
 	NatGatewayClassSpec `json:",inline"`
 }
 
+// NatGatewayClassSpec defines a NAT gateway class specification.
 type NatGatewayClassSpec struct {
 	Name string `json:"name"`
 }
@@ -367,6 +369,7 @@ type AzureComputeGalleryImage struct {
 	Plan *ImagePlan `json:"plan,omitempty"`
 }
 
+// ImagePlan contains plan information for marketplace images.
 type ImagePlan struct {
 	// Publisher is the name of the organization that created the image
 	// +kubebuilder:validation:MinLength=1

--- a/api/v1beta1/types_template.go
+++ b/api/v1beta1/types_template.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import "github.com/pkg/errors"
 
+// AzureClusterTemplateResourceSpec specifies an Azure cluster template resource.
 type AzureClusterTemplateResourceSpec struct {
 	AzureClusterClassSpec `json:",inline"`
 
@@ -30,6 +31,7 @@ type AzureClusterTemplateResourceSpec struct {
 	BastionSpec BastionTemplateSpec `json:"bastionSpec,omitempty"`
 }
 
+// NetworkTemplateSpec specifies a network template.
 type NetworkTemplateSpec struct {
 	NetworkClassSpec `json:",inline"`
 
@@ -65,7 +67,7 @@ func (n *NetworkTemplateSpec) GetControlPlaneSubnetTemplate() (SubnetTemplateSpe
 	return SubnetTemplateSpec{}, errors.Errorf("no subnet template found with role %s", SubnetControlPlane)
 }
 
-// UpdateControlPlaneSubnet updates the cluster control plane subnet.
+// UpdateControlPlaneSubnetTemplate updates the cluster control plane subnet template.
 func (n *NetworkTemplateSpec) UpdateControlPlaneSubnetTemplate(subnet SubnetTemplateSpec) {
 	for i, sn := range n.Subnets {
 		if sn.Role == SubnetControlPlane {
@@ -74,6 +76,7 @@ func (n *NetworkTemplateSpec) UpdateControlPlaneSubnetTemplate(subnet SubnetTemp
 	}
 }
 
+// VnetTemplateSpec defines the desired state of a virtual network.
 type VnetTemplateSpec struct {
 	VnetClassSpec `json:",inline"`
 
@@ -82,8 +85,10 @@ type VnetTemplateSpec struct {
 	Peerings VnetPeeringsTemplateSpec `json:"peerings,omitempty"`
 }
 
+// VnetPeeringsTemplateSpec defines a list of peerings of the newly created virtual network with existing virtual networks.
 type VnetPeeringsTemplateSpec []VnetPeeringClassSpec
 
+// SubnetTemplateSpec specifies a template for a subnet.
 type SubnetTemplateSpec struct {
 	SubnetClassSpec `json:",inline"`
 
@@ -96,17 +101,21 @@ type SubnetTemplateSpec struct {
 	NatGateway NatGatewayClassSpec `json:"natGateway,omitempty"`
 }
 
+// IsNatGatewayEnabled returns true if the NAT gateway is enabled.
 func (s SubnetTemplateSpec) IsNatGatewayEnabled() bool {
 	return s.NatGateway.Name != ""
 }
 
+// SubnetTemplatesSpec specifies a list of subnet templates.
 type SubnetTemplatesSpec []SubnetTemplateSpec
 
+// BastionTemplateSpec specifies a template for a bastion host.
 type BastionTemplateSpec struct {
 	// +optional
 	AzureBastion *AzureBastionTemplateSpec `json:"azureBastion,omitempty"`
 }
 
+// AzureBastionTemplateSpec specifies a template for an Azure Bastion host.
 type AzureBastionTemplateSpec struct {
 	// +optional
 	Subnet SubnetTemplateSpec `json:"subnet,omitempty"`

--- a/azure/converters/subnets.go
+++ b/azure/converters/subnets.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 )
 
+// GetSubnetAddresses returns the address prefixes contained in a subnet.
 func GetSubnetAddresses(subnet network.Subnet) []string {
 	var addresses []string
 	if subnet.SubnetPropertiesFormat != nil && subnet.SubnetPropertiesFormat.AddressPrefix != nil {

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -581,6 +581,7 @@ func (s *ClusterScope) SetSubnet(subnetSpec infrav1.SubnetSpec) {
 	}
 }
 
+// SetNatGatewayIDInSubnets sets the NAT Gateway ID in the subnets with the same name.
 func (s *ClusterScope) SetNatGatewayIDInSubnets(name string, id string) {
 	for _, subnet := range s.Subnets() {
 		if subnet.NatGateway.Name == name {
@@ -597,7 +598,7 @@ func (s *ClusterScope) UpdateSubnetCIDRs(name string, cidrBlocks []string) {
 	s.SetSubnet(subnetSpecInfra)
 }
 
-// UpdateSubnetIDs updates the subnet IDs for the subnet with the same name.
+// UpdateSubnetID updates the subnet ID for the subnet with the same name.
 func (s *ClusterScope) UpdateSubnetID(name string, id string) {
 	subnetSpecInfra := s.Subnet(name)
 	subnetSpecInfra.ID = id

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -422,7 +422,7 @@ func (m *MachineScope) ProviderID() string {
 	return parsed.String()
 }
 
-// AvailabilitySet returns the availability set for this machine if available.
+// AvailabilitySetSpec returns the availability set spec for this machine if available.
 func (m *MachineScope) AvailabilitySetSpec() azure.ResourceSpecGetter {
 	availabilitySetName, ok := m.AvailabilitySet()
 	if !ok {

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -286,7 +286,7 @@ func (s *ManagedControlPlaneScope) UpdateSubnetCIDRs(_ string, _ []string) {
 	// no-op
 }
 
-// UpdateSubnetIDs updates the subnet IDs for the subnet with the same name.
+// UpdateSubnetID updates the subnet ID for the subnet with the same name.
 // This is not used when using a managed control plane.
 func (s *ManagedControlPlaneScope) UpdateSubnetID(_ string, _ string) {
 	// no-op
@@ -331,7 +331,7 @@ func (s *ManagedControlPlaneScope) IsVnetManaged() bool {
 	return true
 }
 
-// APIServerLBName returns the API Server LB spec.
+// APIServerLB returns the API Server LB spec.
 func (s *ManagedControlPlaneScope) APIServerLB() *infrav1.LoadBalancerSpec {
 	return nil // does not apply for AKS
 }
@@ -379,6 +379,7 @@ func (s *ManagedControlPlaneScope) FailureDomains() []string {
 	return []string{}
 }
 
+// ManagedClusterAnnotations returns the annotations for the managed cluster.
 func (s *ManagedControlPlaneScope) ManagedClusterAnnotations() map[string]string {
 	return s.ControlPlane.Annotations
 }

--- a/azure/scope/managedmachinepool.go
+++ b/azure/scope/managedmachinepool.go
@@ -45,6 +45,7 @@ type ManagedMachinePoolScopeParams struct {
 	ManagedControlPlaneScope azure.ManagedClusterScoper
 }
 
+// ManagedMachinePool defines the scope interface for a managed machine pool.
 type ManagedMachinePool struct {
 	InfraMachinePool *infrav1exp.AzureManagedMachinePool
 	MachinePool      *expv1.MachinePool
@@ -285,7 +286,7 @@ func (s *ManagedMachinePoolScope) RemoveCAPIMachinePoolAnnotations(key string) {
 	delete(s.MachinePool.Annotations, key)
 }
 
-// GetCAPIMachinePoolAnnotations gets the associated MachinePool annotation.
+// GetCAPIMachinePoolAnnotation gets the associated MachinePool annotation.
 func (s *ManagedMachinePoolScope) GetCAPIMachinePoolAnnotation(key string) (bool, string) {
 	value, ok := s.MachinePool.Annotations[key]
 	return ok, value

--- a/azure/services/groups/groups.go
+++ b/azure/services/groups/groups.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
+// ServiceName is the name of this service.
 const ServiceName = "group"
 
 // Service provides operations on Azure resources.

--- a/azure/services/privatedns/record_spec.go
+++ b/azure/services/privatedns/record_spec.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 )
 
+// RecordSpec defines the specification for a record set.
 type RecordSpec struct {
 	Record        infrav1.AddressRecord
 	ZoneName      string

--- a/azure/services/publicips/client.go
+++ b/azure/services/publicips/client.go
@@ -56,7 +56,7 @@ func (ac *AzureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 	return ac.publicips.Get(ctx, spec.ResourceGroupName(), spec.ResourceName(), "")
 }
 
-// CreateOrUpdate creates or updates a static or dynamic public IP address.
+// CreateOrUpdateAsync creates or updates a static or dynamic public IP address.
 // It sends a PUT request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
 // progress of the operation.
 func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, parameters interface{}) (result interface{}, future azureautorest.FutureAPI, err error) {

--- a/azure/services/virtualnetworks/virtualnetworks.go
+++ b/azure/services/virtualnetworks/virtualnetworks.go
@@ -65,6 +65,7 @@ func (s *Service) Name() string {
 	return serviceName
 }
 
+// Reconcile creates and updates a virtual network.
 func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualnetworks.Service.Reconcile")
 	defer done()

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
@@ -43,6 +43,8 @@ spec:
                   to create an AzureCluster from a template.
                 properties:
                   spec:
+                    description: AzureClusterTemplateResourceSpec specifies an Azure
+                      cluster template resource.
                     properties:
                       additionalTags:
                         additionalProperties:
@@ -63,8 +65,12 @@ spec:
                           the Bastions in the cluster.
                         properties:
                           azureBastion:
+                            description: AzureBastionTemplateSpec specifies a template
+                              for an Azure Bastion host.
                             properties:
                               subnet:
+                                description: SubnetTemplateSpec specifies a template
+                                  for a subnet.
                                 properties:
                                   cidrBlocks:
                                     description: CIDRBlocks defines the subnet's address
@@ -386,6 +392,8 @@ spec:
                             description: Subnets is the configuration for the control-plane
                               subnet and the node subnet.
                             items:
+                              description: SubnetTemplateSpec specifies a template
+                                for a subnet.
                               properties:
                                 cidrBlocks:
                                   description: CIDRBlocks defines the subnet's address
@@ -520,6 +528,8 @@ spec:
                                   the newly created virtual network with existing
                                   virtual networks.
                                 items:
+                                  description: VnetPeeringClassSpec specifies a virtual
+                                    network peering class.
                                   properties:
                                     remoteVnetName:
                                       description: RemoteVnetName defines name of

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -533,17 +533,18 @@ spec:
               addonProfiles:
                 description: AddonProfiles are the profiles of managed cluster add-on.
                 items:
+                  description: AddonProfile represents a managed cluster add-on.
                   properties:
                     config:
                       additionalProperties:
                         type: string
-                      description: Config - Key-value pairs for configuring an add-on.
+                      description: Config - Key-value pairs for configuring the add-on.
                       type: object
                     enabled:
                       description: Enabled - Whether the add-on is enabled or not.
                       type: boolean
                     name:
-                      description: Name- The name of managed cluster add-on.
+                      description: Name - The name of the managed cluster add-on.
                       type: string
                   required:
                   - enabled

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
@@ -276,6 +276,7 @@ spec:
                 description: Taints specifies the taints for nodes present in this
                   agent pool.
                 items:
+                  description: Taint represents a Kubernetes taint.
                   properties:
                     effect:
                       description: Effect specifies the effect for the taint

--- a/exp/api/v1alpha3/azuremachinepool_conversion.go
+++ b/exp/api/v1alpha3/azuremachinepool_conversion.go
@@ -99,14 +99,17 @@ func (dst *AzureMachinePool) ConvertFrom(srcRaw conversion.Hub) error {
 	return utilconversion.MarshalData(src, dst)
 }
 
+// Convert_v1beta1_AzureMachinePoolMachineTemplate_To_v1alpha3_AzureMachinePoolMachineTemplate converts an Azure Machine Pool Machine Template from v1beta1 to v1alpha3.
 func Convert_v1beta1_AzureMachinePoolMachineTemplate_To_v1alpha3_AzureMachinePoolMachineTemplate(in *infrav1exp.AzureMachinePoolMachineTemplate, out *AzureMachinePoolMachineTemplate, s convert.Scope) error {
 	return autoConvert_v1beta1_AzureMachinePoolMachineTemplate_To_v1alpha3_AzureMachinePoolMachineTemplate(in, out, s)
 }
 
+// Convert_v1beta1_AzureMachinePoolSpec_To_v1alpha3_AzureMachinePoolSpec converts an Azure Machine Pool Spec from v1beta1 to v1alpha3.
 func Convert_v1beta1_AzureMachinePoolSpec_To_v1alpha3_AzureMachinePoolSpec(in *infrav1exp.AzureMachinePoolSpec, out *AzureMachinePoolSpec, s convert.Scope) error {
 	return autoConvert_v1beta1_AzureMachinePoolSpec_To_v1alpha3_AzureMachinePoolSpec(in, out, s)
 }
 
+// Convert_v1beta1_AzureMachinePoolStatus_To_v1alpha3_AzureMachinePoolStatus converts an Azure Machine Pool Status from v1beta1 to v1alpha3.
 func Convert_v1beta1_AzureMachinePoolStatus_To_v1alpha3_AzureMachinePoolStatus(in *infrav1exp.AzureMachinePoolStatus, out *AzureMachinePoolStatus, s convert.Scope) error {
 	if len(in.LongRunningOperationStates) > 0 {
 		if out.LongRunningOperationState == nil {
@@ -119,6 +122,7 @@ func Convert_v1beta1_AzureMachinePoolStatus_To_v1alpha3_AzureMachinePoolStatus(i
 	return autoConvert_v1beta1_AzureMachinePoolStatus_To_v1alpha3_AzureMachinePoolStatus(in, out, s)
 }
 
+// Convert_v1alpha3_AzureMachinePoolStatus_To_v1beta1_AzureMachinePoolStatus converts an Azure Machine Pool Status from v1alpha3 to v1beta1.
 func Convert_v1alpha3_AzureMachinePoolStatus_To_v1beta1_AzureMachinePoolStatus(in *AzureMachinePoolStatus, out *infrav1exp.AzureMachinePoolStatus, s convert.Scope) error {
 	if in.LongRunningOperationState != nil {
 		f := infrav1.Future{}

--- a/exp/api/v1beta1/azuremanagedcontrolplane_types.go
+++ b/exp/api/v1beta1/azuremanagedcontrolplane_types.go
@@ -125,11 +125,12 @@ type AADProfile struct {
 	AdminGroupObjectIDs []string `json:"adminGroupObjectIDs"`
 }
 
+// AddonProfile represents a managed cluster add-on.
 type AddonProfile struct {
-	// Name- The name of managed cluster add-on.
+	// Name - The name of the managed cluster add-on.
 	Name string `json:"name"`
 
-	// Config - Key-value pairs for configuring an add-on.
+	// Config - Key-value pairs for configuring the add-on.
 	// +optional
 	Config map[string]string `json:"config,omitempty"`
 

--- a/exp/api/v1beta1/azuremanagedmachinepool_types.go
+++ b/exp/api/v1beta1/azuremanagedmachinepool_types.go
@@ -109,6 +109,7 @@ type ManagedMachinePoolScaling struct {
 // TaintEffect is the effect for a Kubernetes taint.
 type TaintEffect string
 
+// Taint represents a Kubernetes taint.
 type Taint struct {
 	// Effect specifies the effect for the taint
 	// +kubebuilder:validation:Enum=NoSchedule;NoExecute;PreferNoSchedule

--- a/internal/test/env/env.go
+++ b/internal/test/env/env.go
@@ -123,10 +123,12 @@ func NewTestEnvironment() *TestEnvironment {
 	}
 }
 
+// StartManager starts the test environment manager and blocks until the context is canceled.
 func (t *TestEnvironment) StartManager() error {
 	return t.Manager.Start(context.Background())
 }
 
+// Stop stops the test environment.
 func (t *TestEnvironment) Stop() error {
 	return env.Stop()
 }

--- a/internal/test/matchers/gomega/matchers.go
+++ b/internal/test/matchers/gomega/matchers.go
@@ -27,12 +27,13 @@ import (
 )
 
 type (
-	logEntryMactcher struct {
+	logEntryMatcher struct {
 		level   *int
 		logFunc *string
 		values  []interface{}
 	}
 
+	// LogMatcher is a Gomega matcher for logs.
 	LogMatcher interface {
 		types.GomegaMatcher
 		WithLevel(int) LogMatcher
@@ -52,36 +53,43 @@ func DiffEq(x interface{}) types.GomegaMatcher {
 	}
 }
 
+// Match returns whether the actual value matches the expected value.
 func (c *cmpMatcher) Match(actual interface{}) (bool, error) {
 	c.diff = cmp.Diff(actual, c.x)
 	return c.diff == "", nil
 }
 
+// FailWithMessage returns the matcher's diff as the failure message.
 func (c *cmpMatcher) FailureMessage(_ interface{}) string {
 	return c.diff
 }
 
+// NegatedFailureMessage return the matcher's diff as the negated failure message.
 func (c *cmpMatcher) NegatedFailureMessage(_ interface{}) string {
 	return c.diff
 }
 
+// LogContains verifies that LogEntry matches the specified values.
 func LogContains(values ...interface{}) LogMatcher {
-	return &logEntryMactcher{
+	return &logEntryMatcher{
 		values: values,
 	}
 }
 
-func (l *logEntryMactcher) WithLevel(level int) LogMatcher {
+// WithLevel sets the log level to that specified.
+func (l *logEntryMatcher) WithLevel(level int) LogMatcher {
 	l.level = &level
 	return l
 }
 
-func (l *logEntryMactcher) WithLogFunc(logFunc string) LogMatcher {
+// WithLogFunc sets the log function to that specified.
+func (l *logEntryMatcher) WithLogFunc(logFunc string) LogMatcher {
 	l.logFunc = &logFunc
 	return l
 }
 
-func (l *logEntryMactcher) Match(actual interface{}) (bool, error) {
+// Match returns whether the actual value matches the expected value.
+func (l *logEntryMatcher) Match(actual interface{}) (bool, error) {
 	logEntry, ok := actual.(record.LogEntry)
 	if !ok {
 		return false, fmt.Errorf("LogContains matcher expects an record.LogEntry")
@@ -89,15 +97,17 @@ func (l *logEntryMactcher) Match(actual interface{}) (bool, error) {
 	return len(l.validate(logEntry)) == 0, nil
 }
 
-func (l *logEntryMactcher) FailureMessage(actual interface{}) string {
+// FailureMessage returns the specified value as a failure message.
+func (l *logEntryMatcher) FailureMessage(actual interface{}) string {
 	return failMessage(l.validate(actual))
 }
 
-func (l *logEntryMactcher) NegatedFailureMessage(actual interface{}) string {
+// NegatedFailureMessage returns the specified value as a negated failure message.
+func (l *logEntryMatcher) NegatedFailureMessage(actual interface{}) string {
 	return failMessage(l.validate(actual))
 }
 
-func (l *logEntryMactcher) validate(actual interface{}) []error {
+func (l *logEntryMatcher) validate(actual interface{}) []error {
 	logEntry, ok := actual.(record.LogEntry)
 	if !ok {
 		return []error{fmt.Errorf("expected record.LogEntry, but got %T", actual)}

--- a/internal/test/matchers/gomock/matchers.go
+++ b/internal/test/matchers/gomock/matchers.go
@@ -40,6 +40,7 @@ type (
 		actual interface{}
 	}
 
+	// LogMatcher is a Gomega matcher for logs.
 	LogMatcher interface {
 		types.GomegaMatcher
 		WithLevel(int) LogMatcher
@@ -93,6 +94,7 @@ func (e *errStrEq) String() string {
 	return fmt.Sprintf("error.Error() %q, but got %q", e.expected, e.actual)
 }
 
+// AContext returns a matcher that matches a context.Context.
 func AContext() gomock.Matcher {
 	return &contextMatcher{}
 }

--- a/internal/test/record/logger.go
+++ b/internal/test/record/logger.go
@@ -74,7 +74,7 @@ func NewLogger(options ...Option) *Logger {
 var _ logr.LogSink = (*Logger)(nil)
 
 type (
-	// Logger defines a test friendly logr.Logger.
+	// Logger defines a test-friendly logr.Logger.
 	Logger struct {
 		threshold  *int
 		level      int
@@ -88,6 +88,7 @@ type (
 		info       logr.RuntimeInfo
 	}
 
+	// Listener defines a listener for log entries.
 	Listener struct {
 		logger    *Logger
 		entriesMu sync.RWMutex
@@ -95,16 +96,19 @@ type (
 	}
 )
 
+// NewListener returns a new listener with the specified logger.
 func NewListener(logger *Logger) *Listener {
 	return &Listener{
 		logger: logger,
 	}
 }
 
+// Listen adds this listener to its logger.
 func (li *Listener) Listen() func() {
 	return li.logger.addListener(li)
 }
 
+// GetEntries returns a copy of the list of log entries.
 func (li *Listener) GetEntries() []LogEntry {
 	li.entriesMu.RLock()
 	defer li.entriesMu.RUnlock()
@@ -143,6 +147,7 @@ func (l *Logger) removeListener(id string) {
 	delete(l.listeners, id)
 }
 
+// Init initializes the logger from runtime information.
 func (l *Logger) Init(info logr.RuntimeInfo) {
 	l.info = info
 }

--- a/pkg/cloudtest/cloudtest.go
+++ b/pkg/cloudtest/cloudtest.go
@@ -42,10 +42,23 @@ func RuntimeRawExtension(t *testing.T, p interface{}) *runtime.RawExtension {
 // test log messages.
 type Log struct{}
 
-func (l *Log) Init(info logr.RuntimeInfo)                                {}
+// Init initializes the logger from runtime information.
+func (l *Log) Init(info logr.RuntimeInfo) {}
+
+// Error logs an error, with the given message and key/value pairs as context.
 func (l *Log) Error(err error, msg string, keysAndValues ...interface{}) {}
-func (l *Log) V(level int) logr.LogSink                                  { return l }
-func (l *Log) WithValues(keysAndValues ...interface{}) logr.LogSink      { return l }
-func (l *Log) WithName(name string) logr.LogSink                         { return l }
-func (l *Log) Info(level int, msg string, keysAndValues ...interface{})  {}
-func (l *Log) Enabled(level int) bool                                    { return false }
+
+// V returns a new Logger instance for a specific verbosity level, relative to this Logger.
+func (l *Log) V(level int) logr.LogSink { return l }
+
+// WithValues returns a new Logger instance with additional key/value pairs.
+func (l *Log) WithValues(keysAndValues ...interface{}) logr.LogSink { return l }
+
+// WithName returns a new Logger instance with the specified name element added to the Logger's name.
+func (l *Log) WithName(name string) logr.LogSink { return l }
+
+// Info logs a non-error message with the given key/value pairs as context.
+func (l *Log) Info(level int, msg string, keysAndValues ...interface{}) {}
+
+// Enabled tests whether this Logger is enabled.
+func (l *Log) Enabled(level int) bool { return false }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Once upon a time, CAPZ [required comments](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/996) on exported funcs. At some point, a `golangci-lint` upgrade disabled `golint`, which was actually doing the comment check. Its replacement is the `revive` linter, which requires this additional configuration to enable comment checking.

**Which issue(s) this PR fixes**:

Refs #948

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
