### PR TITLE
Apidiff test runs only if the changes are in api/ and exp/api/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,9 +213,11 @@ clean-temporary: ## Remove all temporary files and folders.
 clean-release: ## Remove the release folder.
 	rm -rf $(RELEASE_DIR)
 
+APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
+
 .PHONY: apidiff
 apidiff: $(GO_APIDIFF) ## Check for API differences.
-	$(GO_APIDIFF) $(shell git rev-parse origin/main) --print-compatible
+	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT)
 
 .PHONY: format-tiltfile
 format-tiltfile: ## Format the Tiltfile.

--- a/scripts/ci-apidiff.sh
+++ b/scripts/ci-apidiff.sh
@@ -14,15 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o errexit
 set -o nounset
 set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
-APIDIFF="${REPO_ROOT}/hack/tools/bin/go-apidiff"
+cd "${REPO_ROOT}" || exit
 
-make --directory="${REPO_ROOT}" "${APIDIFF##*/}"
 echo "*** Running go-apidiff ***"
+APIDIFF=$(APIDIFF_OLD_COMMIT="${PULL_BASE_SHA}" make apidiff 2> /dev/null)
 
-${APIDIFF} "${PULL_BASE_SHA}" --print-compatible
+if [[ "${APIDIFF}" == *"sigs.k8s.io/cluster-api-provider-azure/api/"* ]] || [[ "${APIDIFF}" == *"sigs.k8s.io/cluster-api-provider-azure/exp/api/"* ]]; then
+    echo "${APIDIFF}"
+    exit 1
+else
+    echo "No files under api/ or exp/api/ changed."
+fi

--- a/scripts/go_install.sh
+++ b/scripts/go_install.sh
@@ -37,7 +37,7 @@ if [ -z "${GOBIN}" ]; then
   exit 1
 fi
 
-rm "${GOBIN}/${2}"* || true
+rm "${GOBIN}/${2}"* 2> /dev/null || true
 
 # install the golang module specified as the first argument
 go install -tags tools "${1}@${3}"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
The apidiff test fails as soon as there is a breaking change in an exposed field or exposed function. This PR changes the test to only look at changes in the api/ and exp/api/ directories. Used #2206 as a reference.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2051 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
