### PR TITLE
fix error getting activity logs in e2e for managed clusters

### DIFF
--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -183,8 +183,19 @@ func getAzureCluster(ctx context.Context, managementClusterClient client.Client,
 	}
 
 	azCluster := &v1beta1.AzureCluster{}
-	err := managementClusterClient.Get(context.TODO(), key, azCluster)
+	err := managementClusterClient.Get(ctx, key, azCluster)
 	return azCluster, err
+}
+
+func getAzureManagedControlPlane(ctx context.Context, managementClusterClient client.Client, namespace, name string) (*expv1alpha4.AzureManagedControlPlane, error) {
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	azManagedControlPlane := &expv1alpha4.AzureManagedControlPlane{}
+	err := managementClusterClient.Get(ctx, key, azManagedControlPlane)
+	return azManagedControlPlane, err
 }
 
 func getAzureMachine(ctx context.Context, managementClusterClient client.Client, m *clusterv1.Machine) (*v1beta1.AzureMachine, error) {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Currently, when the e2e framework grabs the activity logs based on the resource group name, it derives that from an `AzureCluster` resource. For managed clusters, the resource group is instead defined on an `AzureManagedControlPlane` resource. These changes fallback to getting the resource group name from an `AzureManagedControlPlane` when the expected `AzureCluster` does not exist.

**Which issue(s) this PR fixes**:
Fixes #2530

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
