### PR TITLE
fix: MachinePool ephemeral osDisk support

### DIFF
--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -637,6 +637,10 @@ func (s *Service) generateStorageProfile(ctx context.Context, vmssSpec azure.Sca
 		}
 	}
 
+	if vmssSpec.OSDisk.CachingType != "" {
+		storageProfile.OsDisk.Caching = compute.CachingTypes(vmssSpec.OSDisk.CachingType)
+	}
+
 	dataDisks := make([]compute.VirtualMachineScaleSetDataDisk, len(vmssSpec.DataDisks))
 	for i, disk := range vmssSpec.DataDisks {
 		dataDisks[i] = compute.VirtualMachineScaleSetDataDisk{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adds setting cachingType without which ephemeral osDisk is not supported.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2577 

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
fixes ephemeral osDisk support in MachinePools
```
