### PR TITLE
fix: set evictionPolicy Delete when Spot & Ephemeral OsDisk

### DIFF
--- a/azure/converters/spotinstances.go
+++ b/azure/converters/spotinstances.go
@@ -25,7 +25,7 @@ import (
 
 // GetSpotVMOptions takes the spot vm options
 // and returns the individual vm priority, eviction policy and billing profile.
-func GetSpotVMOptions(spotVMOptions *infrav1.SpotVMOptions) (compute.VirtualMachinePriorityTypes, compute.VirtualMachineEvictionPolicyTypes, *compute.BillingProfile, error) {
+func GetSpotVMOptions(spotVMOptions *infrav1.SpotVMOptions, diffDiskSettings *infrav1.DiffDiskSettings) (compute.VirtualMachinePriorityTypes, compute.VirtualMachineEvictionPolicyTypes, *compute.BillingProfile, error) {
 	// Spot VM not requested, return zero values to apply defaults
 	if spotVMOptions == nil {
 		return "", "", nil, nil
@@ -40,5 +40,9 @@ func GetSpotVMOptions(spotVMOptions *infrav1.SpotVMOptions) (compute.VirtualMach
 			MaxPrice: &maxPrice,
 		}
 	}
-	return compute.VirtualMachinePriorityTypesSpot, compute.VirtualMachineEvictionPolicyTypesDeallocate, billingProfile, nil
+	evictionPolicy := compute.VirtualMachineEvictionPolicyTypesDeallocate
+	if diffDiskSettings != nil && diffDiskSettings.Option == "Local" {
+		evictionPolicy = compute.VirtualMachineEvictionPolicyTypesDelete
+	}
+	return compute.VirtualMachinePriorityTypesSpot, evictionPolicy, billingProfile, nil
 }

--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -414,7 +414,7 @@ func (s *Service) buildVMSSFromSpec(ctx context.Context, vmssSpec azure.ScaleSet
 		return compute.VirtualMachineScaleSet{}, err
 	}
 
-	priority, evictionPolicy, billingProfile, err := converters.GetSpotVMOptions(vmssSpec.SpotVMOptions)
+	priority, evictionPolicy, billingProfile, err := converters.GetSpotVMOptions(vmssSpec.SpotVMOptions, vmssSpec.OSDisk.DiffDiskSettings)
 	if err != nil {
 		return compute.VirtualMachineScaleSet{}, errors.Wrapf(err, "failed to get Spot VM options")
 	}

--- a/azure/services/virtualmachines/spec.go
+++ b/azure/services/virtualmachines/spec.go
@@ -101,7 +101,7 @@ func (s *VMSpec) Parameters(existing interface{}) (params interface{}, err error
 		return nil, errors.Wrap(err, "failed to generate OS Profile")
 	}
 
-	priority, evictionPolicy, billingProfile, err := converters.GetSpotVMOptions(s.SpotVMOptions)
+	priority, evictionPolicy, billingProfile, err := converters.GetSpotVMOptions(s.SpotVMOptions, s.OSDisk.DiffDiskSettings)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get Spot VM options")
 	}

--- a/azure/services/virtualmachines/spec_test.go
+++ b/azure/services/virtualmachines/spec_test.go
@@ -268,6 +268,33 @@ func TestParameters(t *testing.T) {
 			expectedError: "",
 		},
 		{
+			name: "can create a spot vm with evictionPolicy Delete",
+			spec: &VMSpec{
+				Name:       "my-vm",
+				Role:       infrav1.Node,
+				NICIDs:     []string{"my-nic"},
+				SSHKeyData: "fakesshpublickey",
+				Size:       "Standard_D2v3",
+				Zone:       "1",
+				Image:      &infrav1.Image{ID: to.StringPtr("fake-image-id")},
+				OSDisk: infrav1.OSDisk{
+					DiffDiskSettings: &infrav1.DiffDiskSettings{
+						Option: string(compute.DiffDiskOptionsLocal),
+					},
+				},
+				SpotVMOptions: &infrav1.SpotVMOptions{},
+				SKU:           validSKUWithEphemeralOS,
+			},
+			existing: nil,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
+				g.Expect(result.(compute.VirtualMachine).Priority).To(Equal(compute.VirtualMachinePriorityTypesSpot))
+				g.Expect(result.(compute.VirtualMachine).EvictionPolicy).To(Equal(compute.VirtualMachineEvictionPolicyTypesDelete))
+				g.Expect(result.(compute.VirtualMachine).BillingProfile).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
 			name: "can create a windows vm",
 			spec: &VMSpec{
 				Name:       "my-vm",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When using a spot instance and ephemeral OsDisks, the evictionPolicy needs to be set to `Delete`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2579 

**Special notes for your reviewer**:
There's some amount of overlap with #2578 (mainly in the tests). Will most likely result in a conflict when merging either of them first. 

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
fix evictionPolicy when using Spot & Ephemeral OsDisk
```
