### PR TITLE
add lint config for `//go:build e2e` files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ run:
   deadline: 5m
   skip-files:
   - 'zz_generated\.(\w*)\.go$'
+  build-tags:
+    - e2e
 linters:
   disable-all: true
   enable:
@@ -127,6 +129,16 @@ issues:
       text: "use underscores in package names|don't use an underscore in package name"
     - path: api/v1alpha3/azureclusteridentity_types.go
       text: "methods on the same type should have the same receiver name"
+    - path: ^test/
+      linters:
+        - dogsled
+        - goconst
+        - godot
+        - prealloc
+    - path: ^test/
+      text: exported (.+) should have comment( \(or a comment on this block\))? or be unexported
+    - source: \"github.com/onsi/(ginkgo|gomega)\"
+      text: "should not use dot imports"
   include:
   - EXC0012  # revive: check for comments
   - EXC0014  # revive: check for comments

--- a/test/e2e/aks.go
+++ b/test/e2e/aks.go
@@ -252,17 +252,17 @@ func byClusterOptions(name, namespace string) []client.ListOption {
 func GetWorkingAKSKubernetesVersion(ctx context.Context, subscriptionID, location, version string) (string, error) {
 	settings, err := auth.GetSettingsFromEnvironment()
 	if err != nil {
-		return "", errors.Wrap(err, "GetSettingsFromEnvironment failed.")
+		return "", errors.Wrap(err, "failed to get settings from environment")
 	}
 	authorizer, err := settings.GetAuthorizer()
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to create an Authorizer.")
+		return "", errors.Wrap(err, "failed to create an Authorizer")
 	}
 	containerServiceClient := containerservice.NewContainerServicesClient(subscriptionID)
 	containerServiceClient.Authorizer = authorizer
 	result, err := containerServiceClient.ListOrchestrators(ctx, location, ManagedClustersResourceType)
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to list Orchestrators.")
+		return "", errors.Wrap(err, "failed to list Orchestrators")
 	}
 
 	var latestStableVersionDesired bool
@@ -312,17 +312,17 @@ func GetWorkingAKSKubernetesVersion(ctx context.Context, subscriptionID, locatio
 func GetLatestStableAKSKubernetesVersion(ctx context.Context, subscriptionID, location string) (string, error) {
 	settings, err := auth.GetSettingsFromEnvironment()
 	if err != nil {
-		return "", errors.Wrap(err, "GetSettingsFromEnvironment failed.")
+		return "", errors.Wrap(err, "failed to get settings from environment")
 	}
 	authorizer, err := settings.GetAuthorizer()
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to create an Authorizer.")
+		return "", errors.Wrap(err, "failed to create an Authorizer")
 	}
 	containerServiceClient := containerservice.NewContainerServicesClient(subscriptionID)
 	containerServiceClient.Authorizer = authorizer
 	result, err := containerServiceClient.ListOrchestrators(ctx, location, ManagedClustersResourceType)
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to list Orchestrators.")
+		return "", errors.Wrap(err, "failed to list Orchestrators")
 	}
 
 	var orchestratorversions []string
@@ -344,7 +344,7 @@ func GetLatestStableAKSKubernetesVersion(ctx context.Context, subscriptionID, lo
 		foundWorkingVersion = true
 	}
 	if !foundWorkingVersion {
-		return "", errors.New(fmt.Sprintf("Latest stable AKS version not found."))
+		return "", errors.New("latest stable AKS version not found")
 	}
 	return maxVersion, nil
 }

--- a/test/e2e/azure_lb.go
+++ b/test/e2e/azure_lb.go
@@ -148,7 +148,7 @@ func AzureLBSpec(ctx context.Context, inputGetter func() AzureLBSpecInput) {
 		}
 		return nil
 	}, retryableOperationTimeout, retryableOperationSleepBetweenRetries).Should(Succeed())
-	ilbIP := extractServiceIp(svc)
+	ilbIP := extractServiceIP(svc)
 
 	ilbJob := job.CreateCurlJobResourceSpec("curl-to-ilb-job", ilbIP)
 	Log("starting to create a curl to ilb job")
@@ -223,7 +223,7 @@ func AzureLBSpec(ctx context.Context, inputGetter func() AzureLBSpecInput) {
 		return nil
 	}, retryableOperationTimeout, retryableOperationSleepBetweenRetries).Should(Succeed())
 
-	elbIP := extractServiceIp(svc)
+	elbIP := extractServiceIP(svc)
 	Log("starting to create curl-to-elb job")
 	elbJob := job.CreateCurlJobResourceSpec("curl-to-elb-job"+util.RandomString(6), elbIP)
 	Eventually(func() error {
@@ -294,7 +294,7 @@ func AzureLBSpec(ctx context.Context, inputGetter func() AzureLBSpecInput) {
 	}, deleteOperationTimeout, retryableOperationSleepBetweenRetries).Should(Succeed())
 }
 
-func extractServiceIp(svc *corev1.Service) string {
+func extractServiceIP(svc *corev1.Service) string {
 	var ilbIP string
 	for _, i := range svc.Status.LoadBalancer.Ingress {
 		if net.ParseIP(i.IP) != nil {

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -46,11 +46,8 @@ import (
 )
 
 const (
-	AzureMachinePoolDrainSpecName               = "azure-mp-drain"
-	waitForDrainOperationTimeout                = 5 * time.Minute
-	waitForDrainSleepBetweenRetries             = 500 * time.Millisecond
-	waitforResourceOperationTimeout             = 30 * time.Second
-	waitforResourceOperationSleepBetweenRetries = 3 * time.Second
+	AzureMachinePoolDrainSpecName   = "azure-mp-drain"
+	waitforResourceOperationTimeout = 30 * time.Second
 )
 
 // AzureMachinePoolDrainSpecInput is the input for AzureMachinePoolDrainSpec.
@@ -149,7 +146,7 @@ func testMachinePoolCordonAndDrain(ctx context.Context, mgmtClusterProxy, worklo
 	labelNodesWithMachinePoolName(ctx, workloadClusterProxy.GetClient(), amp.Name, ampmls)
 
 	By(fmt.Sprintf("deploying a publicly exposed HTTP service with pod anti-affinity on machine pool: %s/%s", amp.Namespace, amp.Name))
-	_, _, _, cleanup := deployHttpService(ctx, clientset, isWindows, customizers...)
+	_, _, _, cleanup := deployHTTPService(ctx, clientset, isWindows, customizers...)
 	defer cleanup()
 
 	By(fmt.Sprintf("decreasing the replica count by 1 on the machine pool: %s/%s", amp.Namespace, amp.Name))
@@ -234,8 +231,8 @@ func getOwnerMachinePool(ctx context.Context, c client.Client, obj metav1.Object
 	return nil, fmt.Errorf("failed to find owner machine pool for obj %+v", obj)
 }
 
-// deployHttpService creates a publicly exposed http service for Linux or Windows
-func deployHttpService(ctx context.Context, clientset *kubernetes.Clientset, isWindows bool, opts ...deployCustomizerOption) (*deployments.Builder, *v1.Deployment, *corev1.Service, func()) {
+// deployHTTPService creates a publicly exposed http service for Linux or Windows
+func deployHTTPService(ctx context.Context, clientset *kubernetes.Clientset, isWindows bool, opts ...deployCustomizerOption) (*deployments.Builder, *v1.Deployment, *corev1.Service, func()) {
 	var (
 		deploymentName = func() string {
 			if isWindows {

--- a/test/e2e/azure_net_pol.go
+++ b/test/e2e/azure_net_pol.go
@@ -22,7 +22,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"time"
@@ -68,7 +67,7 @@ func AzureNetPolSpec(ctx context.Context, inputGetter func() AzureNetPolSpecInpu
 	Expect(clusterProxy).NotTo(BeNil())
 	clientset = clusterProxy.GetClientSet()
 	Expect(clientset).NotTo(BeNil())
-	testTmpDir, err := ioutil.TempDir("/tmp", "azure-test")
+	testTmpDir, err := os.MkdirTemp("/tmp", "azure-test")
 	defer os.RemoveAll(testTmpDir)
 	Expect(err).NotTo(HaveOccurred())
 	config = createRestConfig(ctx, testTmpDir, input.Namespace.Name, input.ClusterName)
@@ -86,6 +85,8 @@ func AzureNetPolSpec(ctx context.Context, inputGetter func() AzureNetPolSpecInpu
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Creating frontendProd, backend and network-policy pod deployments")
+	//nolint:gosec // This is only generating one random number which is used to
+	// name resources, so using crypto/rand isn't necessary here.
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	randInt := r.Intn(99999)
 

--- a/test/e2e/azure_privatecluster.go
+++ b/test/e2e/azure_privatecluster.go
@@ -108,21 +108,21 @@ func AzurePrivateClusterSpec(ctx context.Context, inputGetter func() AzurePrivat
 
 	// **************
 	// Get the Client ID for the user assigned identity
-	subscriptionID := os.Getenv(AzureSubscriptionId)
+	subscriptionID := os.Getenv(AzureSubscriptionID)
 	identityRG, ok := os.LookupEnv(AzureIdentityResourceGroup)
 	if !ok {
 		identityRG = "capz-ci"
 	}
-	userId, ok := os.LookupEnv(AzureUserIdentity)
+	userID, ok := os.LookupEnv(AzureUserIdentity)
 	if !ok {
-		userId = "cloud-provider-user-identity"
+		userID = "cloud-provider-user-identity"
 	}
-	resourceID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", subscriptionID, identityRG, userId)
+	resourceID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", subscriptionID, identityRG, userID)
 	os.Setenv("UAMI_CLIENT_ID", getClientIDforMSI(resourceID))
 
 	os.Setenv("CLUSTER_IDENTITY_NAME", "cluster-identity-user-assigned")
 	os.Setenv("CLUSTER_IDENTITY_NAMESPACE", input.Namespace.Name)
-	//*************
+	// *************
 
 	By("Creating a private workload cluster")
 	clusterName = fmt.Sprintf("capz-e2e-%s-%s", util.RandomString(6), "private")

--- a/test/e2e/azure_selfhosted.go
+++ b/test/e2e/azure_selfhosted.go
@@ -69,7 +69,7 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 		Expect(input.E2EConfig).NotTo(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
 		Expect(input.ClusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. input.ClusterctlConfigPath must be an existing file when calling %s spec", specName)
 		Expect(input.BootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
-		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+		Expect(os.MkdirAll(input.ArtifactFolder, 0o750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
 		Expect(input.E2EConfig.Variables).To(HaveKey(capi_e2e.KubernetesVersion))
 
 		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Workload cluster creation", func() {
 		Expect(e2eConfig).NotTo(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
 		Expect(clusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. clusterctlConfigPath must be an existing file when calling %s spec", specName)
 		Expect(bootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. bootstrapClusterProxy can't be nil when calling %s spec", specName)
-		Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
+		Expect(os.MkdirAll(artifactFolder, 0o755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
 		Expect(e2eConfig.Variables).To(HaveKey(capi_e2e.KubernetesVersion))
 
 		// CLUSTER_NAME and CLUSTER_NAMESPACE allows for testing existing clusters

--- a/test/e2e/csi_migration_test.go
+++ b/test/e2e/csi_migration_test.go
@@ -26,19 +26,18 @@ import (
 	"strings"
 	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/utils/pointer"
-	"sigs.k8s.io/cluster-api/test/framework"
-	"sigs.k8s.io/cluster-api/util"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
 )
 
 var _ = Describe("[K8s-Upgrade] Running the workload cluster upgrade tests", func() {
@@ -62,7 +61,7 @@ var _ = Describe("[K8s-Upgrade] Running the workload cluster upgrade tests", fun
 		Expect(e2eConfig).NotTo(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
 		Expect(clusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. clusterctlConfigPath must be an existing file when calling %s spec", specName)
 		Expect(bootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. bootstrapClusterProxy can't be nil when calling %s spec", specName)
-		Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
+		Expect(os.MkdirAll(artifactFolder, 0o755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
 		Expect(e2eConfig.Variables).To(HaveKey(capi_e2e.KubernetesVersionUpgradeFrom))
 		Expect(e2eConfig.Variables).To(HaveKey(capi_e2e.KubernetesVersionUpgradeTo))
 
@@ -183,7 +182,7 @@ var _ = Describe("[K8s-Upgrade] Running the workload cluster upgrade tests", fun
 				By("Upgrade the workload cluster to v1.23")
 				configCluster.KubernetesVersion = postCSIKubernetesVersion
 				configCluster.Flavor = "azurediskcsi-migration-off"
-				upgradedCluster, _, kcp := createClusterWithControlPlaneWaiters(ctx, configCluster, clusterctl.ControlPlaneWaiters{}, result)
+				upgradedCluster, kcp := createClusterWithControlPlaneWaiters(ctx, configCluster, clusterctl.ControlPlaneWaiters{}, result)
 				// Wait for control plane to be upgraded successfully
 				By("Waiting for control-plane machines to have the upgraded kubernetes version")
 				framework.WaitForControlPlaneMachinesToBeUpgraded(ctx, framework.WaitForControlPlaneMachinesToBeUpgradedInput{
@@ -246,7 +245,7 @@ var _ = Describe("[K8s-Upgrade] Running the workload cluster upgrade tests", fun
 				cpWaiters := clusterctl.ControlPlaneWaiters{
 					WaitForControlPlaneInitialized: EnsureControlPlaneInitialized,
 				}
-				upgradedCluster, _, kcp := createClusterWithControlPlaneWaiters(ctx, configCluster, cpWaiters, result)
+				upgradedCluster, kcp := createClusterWithControlPlaneWaiters(ctx, configCluster, cpWaiters, result)
 				// Wait for control plane to be upgraded successfully
 				By("Waiting for control-plane machines to have the upgraded kubernetes version")
 				framework.WaitForControlPlaneMachinesToBeUpgraded(ctx, framework.WaitForControlPlaneMachinesToBeUpgradedInput{
@@ -307,7 +306,7 @@ var _ = Describe("[K8s-Upgrade] Running the workload cluster upgrade tests", fun
 				cpWaiters := clusterctl.ControlPlaneWaiters{
 					WaitForControlPlaneInitialized: EnsureControlPlaneInitialized,
 				}
-				upgradedCluster, _, kcp := createClusterWithControlPlaneWaiters(ctx, configCluster, cpWaiters, result)
+				upgradedCluster, kcp := createClusterWithControlPlaneWaiters(ctx, configCluster, cpWaiters, result)
 
 				// Wait for control plane to be upgraded successfully
 				By("Waiting for control-plane machines to have the upgraded kubernetes version")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -63,7 +63,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	// Before all ParallelNodes.
 
 	Expect(configPath).To(BeAnExistingFile(), "Invalid test suite argument. e2e.config should be an existing file.")
-	Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid test suite argument. Can't create e2e.artifacts-folder %q", artifactFolder)
+	Expect(os.MkdirAll(artifactFolder, 0o755)).To(Succeed(), "Invalid test suite argument. Can't create e2e.artifacts-folder %q", artifactFolder)
 
 	Byf("Loading the e2e test configuration from %q", configPath)
 	e2eConfig = loadE2EConfig(configPath)
@@ -86,7 +86,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		strings.Join([]string{
 			artifactFolder,
 			clusterctlConfigPath,
-			string(configBuf.Bytes()),
+			configBuf.String(),
 			bootstrapClusterProxy.GetKubeconfigPath(),
 		}, ","),
 	)

--- a/test/e2e/kubernetes/job/job.go
+++ b/test/e2e/kubernetes/job/job.go
@@ -27,7 +27,7 @@ import (
 )
 
 func CreateCurlJobResourceSpec(name, endpoint string) *batchv1.Job {
-	name = name + util.RandomString(5)
+	name += util.RandomString(5)
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -68,7 +68,7 @@ func Exec(clientset *kubernetes.Clientset, config *restclient.Config, pod corev1
 		}
 		// If we get here we are validating that the command returned an expected error
 		if err == nil {
-			return fmt.Errorf("Expected error from command %s but got nil", command)
+			return fmt.Errorf("expected error from command %s but got nil", command)
 		}
 		return nil
 	}, podExecOperationTimeout, podExecOperationSleepBetweenRetries).Should(Succeed())

--- a/test/e2e/log.go
+++ b/test/e2e/log.go
@@ -51,7 +51,7 @@ func Log(message string) {
 	logf("INFO", message)
 }
 
-// Log prints warning logs with a timestamp.
+// LogWarning prints warning logs with a timestamp.
 func LogWarning(message string) {
 	logf("WARNING", message)
 }

--- a/test/e2e/retry.go
+++ b/test/e2e/retry.go
@@ -36,12 +36,12 @@ const (
 // retryWithTimeout retries a function that returns an error until a timeout is reached
 func retryWithTimeout(interval, timeout time.Duration, fn func() error) error {
 	var pollError error
-	err := wait.PollImmediate(collectLogInterval, collectLogTimeout, func() (bool, error) {
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 		pollError = nil
 		err := fn()
 		if err != nil {
 			pollError = err
-			return false, nil
+			return false, nil //nolint:nilerr // We don't want to return err here
 		}
 		return true, nil
 	})


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Files guarded by the `//go:build e2e` tag currently have no golangci-lint rules enforced. This PR:
- adds the `e2e` build tag to golangci-lint's config so these files are linted
- ignores some linter rules that are not (as) applicable to test code
- fixes the remaining linter issues

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

<details>
<summary>Of the new errors, these are fixed:</summary>

```
test/e2e/aks.go:347:25: S1039: unnecessary use of fmt.Sprintf (gosimple)
		return "", errors.New(fmt.Sprintf("Latest stable AKS version not found."))
		                      ^
test/e2e/azure_clusterproxy.go:62:15: S1040: type assertion to the same type: framework.NewClusterProxy(name, kubeconfigPath, initScheme(), options...) already has type framework.ClusterProxy (gosimple)
	proxy, ok := framework.NewClusterProxy(name, kubeconfigPath, initScheme(), options...).(framework.ClusterProxy)
	             ^
test/e2e/azure_clusterproxy.go:137:19: Error return value of `os.MkdirAll` is not checked (errcheck)
				if os.MkdirAll(filepath.Dir(logFile), 0755); err != nil {
				              ^
test/e2e/azure_clusterproxy.go:143:73: octalLiteral: use new octal literal style, 0o644 (gocritic)
				f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
				                                                                    ^
test/e2e/azure_clusterproxy.go:167:22: comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error (errorlint)
				if err != nil && err != io.ErrUnexpectedEOF {
				                 ^
test/e2e/azure_clusterproxy.go:179:51: octalLiteral: use new octal literal style, 0o755 (gocritic)
			if err := os.MkdirAll(filepath.Dir(eventFile), 0755); err != nil {
			                                               ^
test/e2e/azure_clusterproxy.go:185:74: octalLiteral: use new octal literal style, 0o644 (gocritic)
			f, err := os.OpenFile(eventFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
			                                                                      ^
test/e2e/azure_clusterproxy.go:202:21: comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error (errorlint)
			if err != nil && err != io.ErrUnexpectedEOF {
			                 ^
test/e2e/azure_clusterproxy.go:252:44: octalLiteral: use new octal literal style, 0o755 (gocritic)
	Expect(os.MkdirAll(filepath.Dir(logFile), 0755)).To(Succeed())
	                                          ^
test/e2e/azure_clusterproxy.go:254:70: octalLiteral: use new octal literal style, 0o644 (gocritic)
	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
	                                                                    ^
test/e2e/azure_lb.go:297:6: ST1003: func extractServiceIp should be extractServiceIP (stylecheck)
func extractServiceIp(svc *corev1.Service) string {
     ^
test/e2e/azure_logcollector.go:24:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
	^
test/e2e/azure_logcollector.go:128:26: `collectLogsFromNode` - `ctx` is unused (unparam)
func collectLogsFromNode(ctx context.Context, managementClusterClient client.Client, cluster *clusterv1.Cluster, hostname string, isWindows bool, outputPath string) error {
                         ^
test/e2e/azure_logcollector.go:389:53: SA5011: possible nil pointer dereference (staticcheck)
	Logf("Collecting boot logs for AzureMachine %s\n", am.GetName())
	                                                   ^
test/e2e/azure_logcollector.go:391:5: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
	if am == nil || am.Spec.ProviderID == nil {
	   ^
test/e2e/azure_logcollector.go:395:2: ST1003: var resourceId should be resourceID (stylecheck)
	resourceId := strings.TrimPrefix(*am.Spec.ProviderID, azure.ProviderIDPrefix)
	^
test/e2e/azure_logcollector.go:422:2: ST1003: var resourceId should be resourceID (stylecheck)
	resourceId := strings.TrimPrefix(providerID, azure.ProviderIDPrefix)
	^
test/e2e/azure_logcollector.go:424:2: ST1003: var instanceId should be instanceID (stylecheck)
	instanceId := v[len(v)-1]
	^
test/e2e/azure_logcollector.go:454:23: response body must be closed (bodyclose)
	resp, err := http.Get(*bootDiagnostics.SerialConsoleLogBlobURI)
	                     ^
test/e2e/azure_logcollector.go:459:18: ioutilDeprecated: ioutil.ReadAll is deprecated, use io.ReadAll instead (gocritic)
	content, err := ioutil.ReadAll(resp.Body)
	                ^
test/e2e/azure_logcollector.go:464:12: ioutilDeprecated: ioutil.WriteFile is deprecated, use os.WriteFile instead (gocritic)
	if err := ioutil.WriteFile(filepath.Join(outputPath, "boot.log"), content, 0644); err != nil {
	          ^
test/e2e/azure_machinepool_drain.go:238:6: ST1003: func deployHttpService should be deployHTTPService (stylecheck)
func deployHttpService(ctx context.Context, clientset *kubernetes.Clientset, isWindows bool, opts ...deployCustomizerOption) (*deployments.Builder, *v1.Deployment, *corev1.Service, func()) {
     ^
test/e2e/azure_net_pol.go:25:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
	^
test/e2e/azure_privatecluster.go:116:2: ST1003: var userId should be userID (stylecheck)
	userId, ok := os.LookupEnv(AzureUserIdentity)
	^
test/e2e/azure_privatecluster.go:125:2: commentFormatting: put a space between `//` and comment text (gocritic)
	//*************
	^
test/e2e/azure_selfhosted.go:72:44: octalLiteral: use new octal literal style, 0o750 (gocritic)
		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
		                                         ^
test/e2e/azure_test.go:63:38: octalLiteral: use new octal literal style, 0o755 (gocritic)
		Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
		                                   ^
test/e2e/common.go:25:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
	^
test/e2e/common.go:212:9: Error return value of `cmd.Run` is not checked (errcheck)
	cmd.Run()
	       ^
test/e2e/common.go:224:9: ioutilDeprecated: ioutil.WriteFile is deprecated, use os.WriteFile instead (gocritic)
	Expect(ioutil.WriteFile(kubeConfigPath, kubeConfigData, 0640)).To(Succeed())
	       ^
test/e2e/csi_migration_test.go:29: File is not `gci`-ed with --skip-generated -s standard,default (gci)
	apierrors "k8s.io/apimachinery/pkg/api/errors"
	"k8s.io/utils/pointer"
	"sigs.k8s.io/cluster-api/test/framework"
	"sigs.k8s.io/cluster-api/util"

test/e2e/csi_migration_test.go:36: File is not `gci`-ed with --skip-generated -s standard,default (gci)
	corev1 "k8s.io/api/core/v1"
test/e2e/csi_migration_test.go:38: File is not `gci`-ed with --skip-generated -s standard,default (gci)
	"k8s.io/apimachinery/pkg/types"
test/e2e/csi_migration_test.go:40: File is not `gci`-ed with --skip-generated -s standard,default (gci)
	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
test/e2e/csi_migration_test.go:41: File is not `gci`-ed with --skip-generated -s standard,default (gci)
	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
test/e2e/csi_migration_test.go:65:38: octalLiteral: use new octal literal style, 0o755 (gocritic)
		Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
		                                   ^
test/e2e/e2e_suite_test.go:66:37: octalLiteral: use new octal literal style, 0o755 (gocritic)
	Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid test suite argument. Can't create e2e.artifacts-folder %q", artifactFolder)
	                                   ^
test/e2e/e2e_suite_test.go:89:4: S1030: should use configBuf.String() instead of string(configBuf.Bytes()) (gosimple)
			string(configBuf.Bytes()),
			^
test/e2e/helpers.go:28:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
	^
test/e2e/helpers.go:283:7: S1009: should omit nil check; len() for []k8s.io/api/core/v1.LoadBalancerIngress is defined as zero (gosimple)
			if ingress != nil && len(ingress) > 0 {
			   ^
test/e2e/helpers.go:353:49: filepathJoin: "data/availableZonesPerLocation.json" contains a path separator (gocritic)
	file, err := ioutil.ReadFile(filepath.Join(wd, "data/availableZonesPerLocation.json"))
	                                               ^
test/e2e/helpers.go:359:5: sloppyReassign: re-assignment to `err` can be replaced with `err := json.Unmarshal(file, &data)` (gocritic)
	if err = json.Unmarshal(file, &data); err != nil {
	   ^
test/e2e/helpers.go:403:6: type `nodeSSHInfo` is unused (unused)
type nodeSSHInfo struct {
     ^
test/e2e/helpers.go:412:6: func `getClusterSSHInfo` is unused (unused)
func getClusterSSHInfo(ctx context.Context, mgmtClusterProxy framework.ClusterProxy, namespace, clusterName string) ([]nodeSSHInfo, error) {
     ^
test/e2e/helpers.go:485:6: func `getReadyNodes` is unused (unused)
func getReadyNodes(ctx context.Context, c client.Client, refs []corev1.ObjectReference) ([]corev1.Node, error) {
     ^
test/e2e/helpers.go:514:6: func `getMachinesInCluster` is unused (unused)
func getMachinesInCluster(ctx context.Context, c framework.Lister, namespace, name string) (*clusterv1.MachineList, error) {
     ^
test/e2e/helpers.go:530:6: func `getMachinePoolsInCluster` is unused (unused)
func getMachinePoolsInCluster(ctx context.Context, c framework.Lister, namespace, name string) (*expv1.MachinePoolList, error) {
     ^
test/e2e/helpers.go:642:20: Error return value of `sourceFile.WriteTo` is not checked (errcheck)
	sourceFile.WriteTo(destFile)
	                  ^
test/e2e/helpers.go:686:17: ioutilDeprecated: ioutil.ReadFile is deprecated, use os.ReadFile instead (gocritic)
	buffer, err := ioutil.ReadFile(file)
	               ^
test/e2e/helpers.go:699:1: unnamedResult: consider giving a name to these results (gocritic)
func validateStableReleaseString(stableVersion string) (bool, []string) {
^
test/e2e/helpers.go:700:44: regexpSimplify: can re-write `^stable-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$` as `^stable-(0|[1-9]\d*)\.(0|[1-9]\d*)$` (gocritic)
	stableReleaseFormat := regexp.MustCompile(`^stable-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
	                                          ^
test/e2e/helpers.go:724:15: G107: Potential HTTP request made with variable url (gosec)
	resp, err := http.Get(ciVersionURL)
	             ^
test/e2e/helpers.go:963:6: func `podListHasNumPods` is unused (unused)
func podListHasNumPods(numPods int) func(pl *corev1.PodList) error {
     ^
test/e2e/helpers.go:980:6: func `podListHasAtLeastNumPods` is unused (unused)
func podListHasAtLeastNumPods(numPods int) func(pl *corev1.PodList) error {
     ^
test/e2e/helpers.go:1013:2: createClusterWithControlPlaneWaiters - result 1 ([]*sigs.k8s.io/cluster-api/api/v1beta1.MachineDeployment) is never used (unparam)
	[]*clusterv1.MachineDeployment, *controlplanev1.KubeadmControlPlane) {
	^
test/e2e/kubernetes/job/job.go:30:2: assignOp: replace `name = name + util.RandomString(5)` with `name += util.RandomString(5)` (gocritic)
	name = name + util.RandomString(5)
	^
test/e2e/kubernetes/networkpolicy/networkpolicy.go:25:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
	^
test/e2e/kubernetes/networkpolicy/networkpolicy.go:47:15: ioutilDeprecated: ioutil.ReadFile is deprecated, use os.ReadFile instead (gocritic)
	data, err := ioutil.ReadFile(filename)
	             ^
test/e2e/kubernetes/networkpolicy/networkpolicy.go:63:10: ST1005: error strings should not be capitalized (stylecheck)
		return fmt.Errorf("Error: unsupported k8s manifest type %T", o)
		       ^
test/e2e/kubernetes/networkpolicy/networkpolicy.go:66:2: unreachable: unreachable code (govet)
	return nil
	^
test/e2e/kubernetes/networkpolicy/networkpolicy.go:104:16: Error return value of `e2e_pod.Exec` is not checked (errcheck)
			e2e_pod.Exec(clientset, config, fromPod, command, shouldHaveConnection)
			            ^
test/e2e/kubernetes/networkpolicy/networkpolicy.go:111:14: Error return value of `e2e_pod.Exec` is not checked (errcheck)
	e2e_pod.Exec(clientset, config, pod, command, true)
	            ^
test/e2e/kubernetes/node/node.go:58:11: ST1005: error strings should not end with punctuation or newlines (stylecheck)
			return fmt.Errorf("No Windows Nodes found.")
			       ^
test/e2e/kubernetes/node/node.go:66:27: ST1005: error strings should not be capitalized (stylecheck)
		return windows.Unknown, fmt.Errorf("Not a valid Windows kernel version: %s", kernalVersion)
		                        ^
test/e2e/kubernetes/node/node.go:88:11: ST1005: error strings should not end with punctuation or newlines (stylecheck)
			return fmt.Errorf("No Nodes found.")
			       ^
test/e2e/kubernetes/node/node.go:94:44: G601: Implicit memory aliasing in for loop. (gosec)
		newNode, needsUpdate := addOrUpdateTaint(&n, taint)
		                                         ^
test/e2e/kubernetes/node/node.go:99:51: G601: Implicit memory aliasing in for loop. (gosec)
		err := PatchNodeTaints(clientset, newNode.Name, &n, newNode)
		                                                ^
test/e2e/kubernetes/node/node.go:108:1: exported: comment on exported function PatchNodeTaints should be of the form "PatchNodeTaints ..." (revive)
// https://github.com/kubernetes/kubernetes/blob/v1.21.1/staging/src/k8s.io/cloud-provider/node/helpers/taints.go#L91
^
test/e2e/kubernetes/node/node.go:112:90: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
		return fmt.Errorf("failed to marshal old node %#v for node %q: %v", oldNode, nodeName, err)
		                                                                                       ^
test/e2e/kubernetes/node/node.go:120:95: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
		return fmt.Errorf("failed to marshal new node %#v for node %q: %v", newNodeClone, nodeName, err)
		                                                                                            ^
test/e2e/kubernetes/node/node.go:125:73: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
		return fmt.Errorf("failed to create patch for node %q: %v", nodeName, err)
		                                                                      ^
test/e2e/kubernetes/pod/pod.go:71:11: ST1005: error strings should not be capitalized (stylecheck)
			return fmt.Errorf("Expected error from command %s but got nil", command)
			       ^
test/e2e/log.go:54:1: exported: comment on exported function LogWarning should be of the form "LogWarning ..." (revive)
// Log prints warning logs with a timestamp.
^
test/e2e/retry.go:37:23: `retryWithTimeout` - `interval` is unused (unparam)
func retryWithTimeout(interval, timeout time.Duration, fn func() error) error {
                      ^
```
</details>

<details>
<summary>And these are ignored:</summary>

```
test/e2e/aks.go:28:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/ginkgo"
	^
test/e2e/aks.go:29:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/aks.go:167:64: Comment should end in a period (godot)
// value returns the integer equivalent of controlPlaneReplicas
                                                               ^
test/e2e/aks.go:197:20: string `MachinePool` has 3 occurrences, make it a constant (goconst)
				if ref.Kind != "MachinePool" {
				               ^
test/e2e/aks.go:328:2: Consider pre-allocating `orchestratorversions` (prealloc)
	var orchestratorversions []string
	^
test/e2e/azure_clusterproxy.go:39:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/ginkgo"
	^
test/e2e/azure_clusterproxy.go:40:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/azure_clusterproxy.go:54:2: exported: exported type AzureClusterProxy should have comment or be unexported (revive)
	AzureClusterProxy struct {
	^
test/e2e/azure_clusterproxy.go:62:1: exported: exported function NewAzureClusterProxy should have comment or be unexported (revive)
func NewAzureClusterProxy(name string, kubeconfigPath string, options ...framework.Option) *AzureClusterProxy {
^
test/e2e/azure_clusterproxy.go:91:1: exported: exported method AzureClusterProxy.CollectWorkloadClusterLogs should have comment or be unexported (revive)
func (acp *AzureClusterProxy) CollectWorkloadClusterLogs(ctx context.Context, namespace, name, outputPath string) {
^
test/e2e/azure_csidriver.go:25:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/ginkgo"
	^
test/e2e/azure_csidriver.go:26:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/azure_csidriver.go:38:2: exported: exported const DriverTypeInternal should have comment (or a comment on this block) or be unexported (revive)
	DriverTypeInternal = "Internal"
	^
test/e2e/azure_csidriver.go:41:6: exported: exported type AzureDiskCSISpecInput should have comment or be unexported (revive)
type AzureDiskCSISpecInput struct {
     ^
test/e2e/azure_failuredomains.go:26:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/ginkgo"
	^
test/e2e/azure_failuredomains.go:27:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/azure_gpu.go:28:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/ginkgo"
	^
test/e2e/azure_gpu.go:29:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/azure_lb.go:29:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/ginkgo"
	^
test/e2e/azure_lb.go:30:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/azure_logcollector.go:128:83: Comment should end in a period (godot)
// collectLogsFromNode collects logs from various sources by ssh'ing into the node
                                                                                  ^
test/e2e/azure_machinepool_drain.go:27:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/ginkgo"
	^
test/e2e/azure_machinepool_drain.go:28:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/azure_machinepool_drain.go:49:2: exported: exported const AzureMachinePoolDrainSpecName should have comment (or a comment on this block) or be unexported (revive)
	AzureMachinePoolDrainSpecName   = "azure-mp-drain"
	^
test/e2e/azure_machinepool_drain.go:149:2: declaration has 3 blank identifiers (dogsled)
	_, _, _, cleanup := deployHTTPService(ctx, clientset, isWindows, customizers...)
	^
test/e2e/azure_machinepool_drain.go:234:82: Comment should end in a period (godot)
// deployHTTPService creates a publicly exposed http service for Linux or Windows
                                                                                 ^
test/e2e/azure_net_pol.go:29:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/ginkgo"
	^
test/e2e/azure_net_pol.go:30:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/azure_net_pol.go:41:2: exported: exported const PolicyDir should have comment (or a comment on this block) or be unexported (revive)
	PolicyDir = "workloads/policies"
	^
test/e2e/azure_net_pol.go:88:7: G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec)
	r := rand.New(rand.NewSource(time.Now().UnixNano()))
	     ^
test/e2e/azure_privatecluster.go:37:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/ginkgo"
	^
test/e2e/azure_privatecluster.go:38:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/azure_privatecluster.go:312:2: Consider pre-allocating `subnets` (prealloc)
	var subnets []network.Subnet
	^
test/e2e/azure_selfhosted.go:28:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/ginkgo"
	^
test/e2e/azure_selfhosted.go:29:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/azure_test.go:149:32: string `true` has 3 occurrences, make it a constant (goconst)
	if os.Getenv("LOCAL_ONLY") != "true" {
	                              ^
test/e2e/cloud-provider-azure.go:26:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/ginkgo"
	^
test/e2e/cloud-provider-azure.go:59:93: Comment should end in a period (godot)
// InstallAzureDiskCSIDriverHelmChart installs the official azure-disk CSI driver helm chart
                                                                                            ^
test/e2e/common.go:33:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/ginkgo"
	^
test/e2e/common.go:34:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/common.go:49:49: Comment should end in a period (godot)
// Test suite constants for e2e config variables
                                                ^
test/e2e/common.go:64:2: G101: Potential hardcoded credentials (gosec)
	ClusterIdentitySecretName      = "AZURE_CLUSTER_IDENTITY_SECRET_NAME"
	^
test/e2e/common.go:65:2: G101: Potential hardcoded credentials (gosec)
	ClusterIdentitySecretNamespace = "AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE"
	^
test/e2e/common.go:66:2: G101: Potential hardcoded credentials (gosec)
	AzureClientSecret              = "AZURE_CLIENT_SECRET"
	^
test/e2e/common.go:83:1: exported: exported function Byf should have comment or be unexported (revive)
func Byf(format string, a ...interface{}) {
^
test/e2e/common.go:209:9: G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
	cmd := exec.Command(e2eConfig.GetVariable(RedactLogScriptPath))
	       ^
test/e2e/conformance_test.go:266:18: Comment should end in a period (godot)
// for OS version
                 ^
test/e2e/csi_migration_test.go:166:28: string `user-assigned-managed-identity` has 3 occurrences, make it a constant (goconst)
				configCluster.Flavor = "user-assigned-managed-identity"
				                       ^
test/e2e/e2e_suite_vars.go:33:20: Comment should end in a period (godot)
// Test suite flags
                   ^
test/e2e/e2e_suite_vars.go:48:26: Comment should end in a period (godot)
// Test suite global vars
                         ^
test/e2e/e2e_suite_vars.go:64:74: Comment should end in a period (godot)
	// kubetestConfigFilePath is the path to the kubetest configuration file
	                                                                        ^
test/e2e/e2e_suite_vars.go:67:25: Comment should end in a period (godot)
	// kubetestRepoListPath
	                       ^
test/e2e/e2e_suite_vars.go:70:118: Comment should end in a period (godot)
	// useCIArtifacts specifies whether or not to use the latest build from the main branch of the Kubernetes repository
	                                                                                                                    ^
test/e2e/e2e_suite_vars.go:73:100: Comment should end in a period (godot)
	// usePRArtifacts specifies whether or not to use the build from a PR of the Kubernetes repository
	                                                                                                  ^
test/e2e/helpers.go:41:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/ginkgo"
	^
test/e2e/helpers.go:43:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/helpers.go:123:107: Comment should end in a period (godot)
// GetWaitForDeploymentsAvailableInput is a convenience func to compose a WaitForDeploymentsAvailableInput
                                                                                                          ^
test/e2e/helpers.go:342:163: Comment should end in a period (godot)
// az vm list-skus -r "virtualMachines"  -z | jq 'map({(.locationInfo[0].location + "_" + .name): .locationInfo[0].zones}) | add' > availableZonesPerLocation.json
                                                                                                                                                                  ^
test/e2e/helpers.go:533:20: G106: Use of ssh InsecureIgnoreHostKey should be audited (gosec)
		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
		                 ^
test/e2e/helpers.go:554:97: Comment should end in a period (godot)
// it should be called wherever we process a stable version string expression like "stable-1.22"
                                                                                                ^
test/e2e/helpers.go:602:63: Comment should end in a period (godot)
// - if unable to determine version falls back to using latest
                                                              ^
test/e2e/kubernetes/deployment/deployment.go:28:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/kubernetes/deployment/deployment.go:41:2: exported: exported const ExternalLoadbalancer should have comment (or a comment on this block) or be unexported (revive)
	ExternalLoadbalancer                   = LoadbalancerType("external")
	^
test/e2e/kubernetes/deployment/deployment.go:48:99: Comment should end in a period (godot)
	// Builder provides a helper interface for building Kubernetes deployments within this test suite
	                                                                                                 ^
test/e2e/kubernetes/deployment/deployment.go:53:2: exported: exported type LoadbalancerType should have comment or be unexported (revive)
	LoadbalancerType string
	^
test/e2e/kubernetes/deployment/deployment.go:56:80: Comment should end in a period (godot)
// Create will create a deployment for a given image with a name in a namespace
                                                                               ^
test/e2e/kubernetes/deployment/deployment.go:103:1: exported: exported method Builder.AddLabels should have comment or be unexported (revive)
func (d *Builder) AddLabels(labels map[string]string) {
^
test/e2e/kubernetes/deployment/deployment.go:111:1: exported: exported method Builder.GetName should have comment or be unexported (revive)
func (d *Builder) GetName() string {
^
test/e2e/kubernetes/deployment/deployment.go:115:1: exported: exported method Builder.SetReplicas should have comment or be unexported (revive)
func (d *Builder) SetReplicas(replicas int32) *Builder {
^
test/e2e/kubernetes/deployment/deployment.go:120:1: exported: exported method Builder.AddContainerPort should have comment or be unexported (revive)
func (d *Builder) AddContainerPort(name, portName string, portNumber int32, protocol corev1.Protocol) {
^
test/e2e/kubernetes/deployment/deployment.go:134:1: exported: exported method Builder.AddPVC should have comment or be unexported (revive)
func (d *Builder) AddPVC(pvcName string) *Builder {
^
test/e2e/kubernetes/deployment/deployment.go:149:1: exported: exported method Builder.Deploy should have comment or be unexported (revive)
func (d *Builder) Deploy(ctx context.Context, clientset *kubernetes.Clientset) (*appsv1.Deployment, error) {
^
test/e2e/kubernetes/deployment/deployment.go:164:1: exported: exported method Builder.Client should have comment or be unexported (revive)
func (d *Builder) Client(clientset *kubernetes.Clientset) typedappsv1.DeploymentInterface {
^
test/e2e/kubernetes/deployment/deployment.go:168:1: exported: exported method Builder.GetPodsFromDeployment should have comment or be unexported (revive)
func (d *Builder) GetPodsFromDeployment(ctx context.Context, clientset *kubernetes.Clientset) ([]corev1.Pod, error) {
^
test/e2e/kubernetes/deployment/deployment.go:186:1: exported: exported method Builder.CreateServiceResourceSpec should have comment or be unexported (revive)
func (d *Builder) CreateServiceResourceSpec(ports []corev1.ServicePort, lbtype LoadbalancerType, ipFamilies []corev1.IPFamily) *corev1.Service {
^
test/e2e/kubernetes/deployment/deployment.go:211:1: exported: exported method Builder.SetImage should have comment or be unexported (revive)
func (d *Builder) SetImage(name, image string) {
^
test/e2e/kubernetes/deployment/deployment.go:220:1: exported: exported method Builder.AddWindowsSelectors should have comment or be unexported (revive)
func (d *Builder) AddWindowsSelectors() *Builder {
^
test/e2e/kubernetes/deployment/deployment.go:229:113: Comment should end in a period (godot)
// AddMachinePoolSelectors will add node selectors which will ensure the workload runs on a specific MachinePool
                                                                                                                ^
test/e2e/kubernetes/deployment/deployment.go:240:1: exported: exported method Builder.AddPodAntiAffinity should have comment or be unexported (revive)
func (d *Builder) AddPodAntiAffinity(affinity corev1.PodAntiAffinity) *Builder {
^
test/e2e/kubernetes/job/job.go:29:1: exported: exported function CreateCurlJobResourceSpec should have comment or be unexported (revive)
func CreateCurlJobResourceSpec(name, endpoint string) *batchv1.Job {
^
test/e2e/kubernetes/namespace/namespace.go:27:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/kubernetes/namespace/namespace.go:38:42: Comment should end in a period (godot)
// Create a namespace with the given name
                                         ^
test/e2e/kubernetes/namespace/namespace.go:60:91: Comment should end in a period (godot)
// CreateNamespaceDeleteIfExist creates a namespace, deletes it first if it already exists
                                                                                          ^
test/e2e/kubernetes/namespace/namespace.go:76:49: Comment should end in a period (godot)
// Get returns a namespace for with a given name
                                                ^
test/e2e/kubernetes/networkpolicy/networkpolicy.go:30:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/kubernetes/networkpolicy/networkpolicy.go:45:81: Comment should end in a period (godot)
// CreateNetworkPolicyFromFile will create a NetworkPolicy from file with a name
                                                                                ^
test/e2e/kubernetes/networkpolicy/networkpolicy.go:79:73: Comment should end in a period (godot)
// DeleteNetworkPolicy will create a NetworkPolicy from file with a name
                                                                        ^
test/e2e/kubernetes/networkpolicy/networkpolicy.go:92:1: exported: exported function EnsureOutboundInternetAccess should have comment or be unexported (revive)
func EnsureOutboundInternetAccess(clientset *kubernetes.Clientset, config *restclient.Config, pods []corev1.Pod) {
^
test/e2e/kubernetes/networkpolicy/networkpolicy.go:98:1: exported: exported function EnsureConnectivityResultBetweenPods should have comment or be unexported (revive)
func EnsureConnectivityResultBetweenPods(clientset *kubernetes.Clientset, config *restclient.Config, fromPods []corev1.Pod, toPods []corev1.Pod, shouldHaveConnection bool) {
^
test/e2e/kubernetes/networkpolicy/networkpolicy.go:108:1: exported: exported function CheckOutboundConnection should have comment or be unexported (revive)
func CheckOutboundConnection(clientset *kubernetes.Clientset, config *restclient.Config, pod corev1.Pod) {
^
test/e2e/kubernetes/networkpolicy/networkpolicy.go:114:1: exported: exported function ApplyNetworkPolicy should have comment or be unexported (revive)
func ApplyNetworkPolicy(ctx context.Context, clientset *kubernetes.Clientset, nwpolicyName string, namespace string, nwpolicyFileName string, policyDir string) {
^
test/e2e/kubernetes/node/node.go:30:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/kubernetes/node/node.go:45:1: exported: exported function GetWindowsVersion should have comment or be unexported (revive)
func GetWindowsVersion(ctx context.Context, clientset *kubernetes.Clientset) (windows.OSVersion, error) {
^
test/e2e/kubernetes/node/node.go:77:1: exported: exported function TaintNode should have comment or be unexported (revive)
func TaintNode(clientset *kubernetes.Clientset, options metav1.ListOptions, taint *corev1.Taint) error {
^
test/e2e/kubernetes/node/node.go:146:2: Consider pre-allocating `newTaints` (prealloc)
	var newTaints []corev1.Taint
	^
test/e2e/kubernetes/pod/pod.go:27:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/kubernetes/pod/pod.go:40:1: exported: exported function Exec should have comment or be unexported (revive)
func Exec(clientset *kubernetes.Clientset, config *restclient.Config, pod corev1.Pod, command []string, testSuccess bool) error {
^
test/e2e/kubernetes/pvc/pvc.go:28:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/kubernetes/pvc/pvc.go:73:6: exported: exported type Builder should have comment or be unexported (revive)
type Builder struct {
     ^
test/e2e/kubernetes/pvc/pvc.go:77:1: exported: exported function Create should have comment or be unexported (revive)
func Create(pvcName string, storageRequest string) (*Builder, error) {
^
test/e2e/kubernetes/pvc/pvc.go:102:1: exported: exported method Builder.WithAnnotations should have comment or be unexported (revive)
func (b *Builder) WithAnnotations(annotations map[string]string) *Builder {
^
test/e2e/kubernetes/pvc/pvc.go:107:1: exported: exported method Builder.WithStorageClass should have comment or be unexported (revive)
func (b *Builder) WithStorageClass(scName string) *Builder {
^
test/e2e/kubernetes/pvc/pvc.go:112:1: exported: exported method Builder.DeployPVC should have comment or be unexported (revive)
func (b *Builder) DeployPVC(clientset *kubernetes.Clientset) error {
^
test/e2e/kubernetes/storageclass/storageclass.go:27:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/kubernetes/storageclass/storageclass.go:57:27: Comment should end in a period (godot)
allowVolumeExpansion: true
                          ^
test/e2e/kubernetes/storageclass/storageclass.go:63:2: exported: exported const AzureDiskProvisioner should have comment (or a comment on this block) or be unexported (revive)
	AzureDiskProvisioner           = "kubernetes.io/azure-disk"
	^
test/e2e/kubernetes/windows/windows.go:27:6: exported: exported type OSVersion should have comment or be unexported (revive)
type OSVersion string
     ^
test/e2e/kubernetes/windows/windows.go:28:6: exported: exported type WindowsTestImages should have comment or be unexported (revive)
type WindowsTestImages string
     ^
test/e2e/kubernetes/windows/windows.go:31:2: exported: exported const Unknown should have comment (or a comment on this block) or be unexported (revive)
	Unknown  = OSVersion("")
	^
test/e2e/kubernetes/windows/windows.go:36:2: exported: exported const IIS should have comment (or a comment on this block) or be unexported (revive)
	IIS   = WindowsTestImages("IIS")
	^
test/e2e/kubernetes/windows/windows.go:40:6: exported: exported type WindowsImage should have comment or be unexported (revive)
type WindowsImage struct {
     ^
test/e2e/kubernetes/windows/windows.go:45:1: exported: exported method WindowsImage.GetImage should have comment or be unexported (revive)
func (i *WindowsImage) GetImage(version OSVersion) string {
^
test/e2e/kubernetes/windows/windows.go:53:1: exported: exported function GetWindowsImage should have comment or be unexported (revive)
func GetWindowsImage(testImage WindowsTestImages, version OSVersion) string {
^
test/e2e/kubescape.go:27:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/ginkgo"
	^
test/e2e/kubescape.go:28:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/e2e/retry.go:36:88: Comment should end in a period (godot)
// retryWithTimeout retries a function that returns an error until a timeout is reached
                                                                                       ^
test/e2e/retry.go:44:4: error is not nil (line 41) but it returns nil (nilerr)
			return false, nil
			^
test/logger.go:30:2: ST1001: should not use dot imports (stylecheck)
	. "github.com/onsi/gomega"
	^
test/logger.go:35:1: exported: exported function Fail should have comment or be unexported (revive)
func Fail(message string, callerSkip ...int) {
^
```
</details>

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
