### PR TITLE
Update README for office hours time changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ This repository uses the Kubernetes bots.  See a full list of the commands [here
 
 ### Office hours
 
-The community holds office hours every two weeks, with sessions open to all users and
+The community holds office hours every week, with sessions open to all users and
 developers.
 
-Office hours are hosted on a zoom video chat every other Thursday
-at 08:00 (PT) / 11:00 (ET) / 16:00 (UTC),
+Office hours are hosted on a zoom video chat every Thursday
+at 09:00 (PT) / 12:00 (ET) / 17:00 (UTC),
 and are published on the [Kubernetes community meetings calendar][gcal]. Please add your questions or ideas to [the agenda][capz_agenda].
 
 ### Other ways to communicate with the contributors

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,7 +6,7 @@ If you have questions about using this project or need help, please:
 
   - Consult the [Cluster API Provider Azure Book][docs]
   - Ask in the [#cluster-api-azure][slack] Slack channel
-  - Join us for bi-weekly [office hours][office-hours]
+  - Join us for weekly [office hours][office-hours]
 
 ## How to create issues
 


### PR DESCRIPTION
**What type of PR is this?**:

/kind documentation

**What this PR does / why we need it**:

After discussing at the last two office hours meetings, and separately in Slack, there was consensus to make the CAPZ office hours meeting weekly at 9 a.m. Pacific time. This updates the README to make it so.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

I've asked in [#sig-clstr-life-leads](https://kubernetes.slack.com/archives/C9L3M2G82) for help in changing the overall k8s community calendar.

Is there anywhere else the CAPZ office hours meeting is mentioned that should change? I'm hoping kubernetes/community#6821 covers it.

**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
