### PR TITLE
make AKS node taints mutable

### DIFF
--- a/azure/scope/managedmachinepool_test.go
+++ b/azure/scope/managedmachinepool_test.go
@@ -406,7 +406,7 @@ func TestManagedMachinePoolScope_Taints(t *testing.T) {
 				Mode:         "User",
 				Cluster:      "cluster1",
 				Replicas:     1,
-				NodeTaints:   []string{"key1=value1:NoSchedule"},
+				NodeTaints:   &[]string{"key1=value1:NoSchedule"},
 				VnetSubnetID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups//providers/Microsoft.Network/virtualNetworks//subnets/",
 				Headers:      map[string]string{},
 			},

--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -454,7 +454,6 @@ Following is the list of immutable fields for managed clusters:
 | AzureManagedMachinePool   | .spec.sku                    |                           |
 | AzureManagedMachinePool   | .spec.osDiskSizeGB           |                           |
 | AzureManagedMachinePool   | .spec.osDiskType             |                           |
-| AzureManagedMachinePool   | .spec.taints                 |                           |
 | AzureManagedMachinePool   | .spec.availabilityZones      |                           |
 | AzureManagedMachinePool   | .spec.maxPods                |                           |
 | AzureManagedMachinePool   | .spec.osType                 |                           |

--- a/exp/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/exp/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -122,14 +122,6 @@ func (m *AzureManagedMachinePool) ValidateUpdate(oldRaw runtime.Object, client c
 		}
 	}
 
-	if !reflect.DeepEqual(m.Spec.Taints, old.Spec.Taints) {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("Spec", "Taints"),
-				m.Spec.Taints,
-				"field is immutable"))
-	}
-
 	// custom headers are immutable
 	oldCustomHeaders := maps.FilterByKeyPrefix(old.ObjectMeta.Annotations, azure.CustomHeaderPrefix)
 	newCustomHeaders := maps.FilterByKeyPrefix(m.ObjectMeta.Annotations, azure.CustomHeaderPrefix)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature



**What this PR does / why we need it**:
Allow AKS nodepool taints to be mutable. AKS allows the taints to be modified https://github.com/Azure/AKS/issues/1515 


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
allow AKS nodepool taints to be updated.
```
