### PR TITLE
e2e test: Log status of test before cleaning up

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -118,6 +118,8 @@ var _ = Describe("Workload cluster creation", func() {
 			_ = bootstrapClusterProxy.GetClient().Get(ctx, types.NamespacedName{Name: clusterName, Namespace: namespace.Name}, result.Cluster)
 		}
 
+		CheckTestBeforeCleanup()
+
 		cleanInput := cleanupInput{
 			SpecName:          specName,
 			Cluster:           result.Cluster,
@@ -192,6 +194,8 @@ var _ = Describe("Workload cluster creation", func() {
 						}
 					})
 				})
+
+				By("PASSED!")
 			})
 		})
 	} else {
@@ -272,6 +276,8 @@ var _ = Describe("Workload cluster creation", func() {
 					}
 				})
 			})
+
+			By("PASSED!")
 		})
 	})
 
@@ -314,6 +320,8 @@ var _ = Describe("Workload cluster creation", func() {
 					}
 				})
 			})
+
+			By("PASSED!")
 		})
 	})
 
@@ -393,6 +401,8 @@ var _ = Describe("Workload cluster creation", func() {
 					}
 				})
 			})
+
+			By("PASSED!")
 		})
 	})
 
@@ -442,6 +452,8 @@ var _ = Describe("Workload cluster creation", func() {
 					}
 				})
 			})
+
+			By("PASSED!")
 		})
 	})
 
@@ -495,6 +507,8 @@ var _ = Describe("Workload cluster creation", func() {
 					}
 				})
 			})
+
+			By("PASSED!")
 		})
 	})
 
@@ -584,6 +598,8 @@ var _ = Describe("Workload cluster creation", func() {
 					}
 				})
 			})
+
+			By("PASSED!")
 		})
 	})
 
@@ -619,6 +635,7 @@ var _ = Describe("Workload cluster creation", func() {
 				},
 			}, result)
 
+			By("PASSED!")
 		})
 	})
 })

--- a/test/e2e/capi_test.go
+++ b/test/e2e/capi_test.go
@@ -94,6 +94,7 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 	})
 
 	AfterEach(func() {
+		CheckTestBeforeCleanup()
 		redactLogs()
 
 		Expect(os.Unsetenv(AzureResourceGroup)).To(Succeed())

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -252,6 +252,15 @@ func EnsureControlPlaneInitialized(ctx context.Context, input clusterctl.ApplyCl
 
 }
 
+// CheckTestBeforeCleanup checks to see if the current running Ginkgo test failed, and prints
+// a status message regarding cleanup.
+func CheckTestBeforeCleanup() {
+	if CurrentGinkgoTestDescription().Failed {
+		Logf("FAILED!")
+	}
+	Logf("Cleaning up after \"%s\" spec", CurrentGinkgoTestDescription().FullTestText)
+}
+
 func discoveryAndWaitForControlPlaneInitialized(ctx context.Context, input clusterctl.ApplyClusterTemplateAndWaitInput, result *clusterctl.ApplyClusterTemplateAndWaitResult) *kubeadmv1.KubeadmControlPlane {
 	return framework.DiscoveryAndWaitForControlPlaneInitialized(ctx, framework.DiscoveryAndWaitForControlPlaneInitializedInput{
 		Lister:  input.ClusterProxy.GetClient(),

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -244,6 +244,8 @@ var _ = Describe("Conformance Tests", func() {
 			_ = bootstrapClusterProxy.GetClient().Get(ctx, types.NamespacedName{Name: clusterName, Namespace: namespace.Name}, result.Cluster)
 		}
 
+		CheckTestBeforeCleanup()
+
 		cleanInput := cleanupInput{
 			SpecName:        specName,
 			Cluster:         result.Cluster,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Currently, the e2e test does not log whether a test has passed/failed before cleaning up. This makes it unclear when and where a test has failed.

**Which issue(s) this PR fixes**:
Fixes #2583 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
