### PR TITLE
Dump resources in private cluster test

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -42,15 +42,16 @@ import (
 
 var _ = Describe("Workload cluster creation", func() {
 	var (
-		ctx               = context.TODO()
-		specName          = "create-workload-cluster"
-		namespace         *corev1.Namespace
-		cancelWatches     context.CancelFunc
-		result            *clusterctl.ApplyClusterTemplateAndWaitResult
-		clusterName       string
-		clusterNamePrefix string
-		additionalCleanup func()
-		specTimes         = map[string]time.Time{}
+		ctx                    = context.TODO()
+		specName               = "create-workload-cluster"
+		namespace              *corev1.Namespace
+		cancelWatches          context.CancelFunc
+		result                 *clusterctl.ApplyClusterTemplateAndWaitResult
+		clusterName            string
+		clusterNamePrefix      string
+		additionalCleanup      func()
+		specTimes              = map[string]time.Time{}
+		skipResourceGroupCheck = false
 	)
 
 	BeforeEach(func() {
@@ -119,15 +120,16 @@ var _ = Describe("Workload cluster creation", func() {
 		}
 
 		cleanInput := cleanupInput{
-			SpecName:          specName,
-			Cluster:           result.Cluster,
-			ClusterProxy:      bootstrapClusterProxy,
-			Namespace:         namespace,
-			CancelWatches:     cancelWatches,
-			IntervalsGetter:   e2eConfig.GetIntervals,
-			SkipCleanup:       skipCleanup,
-			AdditionalCleanup: additionalCleanup,
-			ArtifactFolder:    artifactFolder,
+			SpecName:               specName,
+			Cluster:                result.Cluster,
+			ClusterProxy:           bootstrapClusterProxy,
+			Namespace:              namespace,
+			CancelWatches:          cancelWatches,
+			IntervalsGetter:        e2eConfig.GetIntervals,
+			SkipCleanup:            skipCleanup,
+			AdditionalCleanup:      additionalCleanup,
+			ArtifactFolder:         artifactFolder,
+			SkipResourceGroupCheck: skipResourceGroupCheck,
 		}
 		dumpSpecResourcesAndCleanup(ctx, cleanInput)
 		Expect(os.Unsetenv(AzureResourceGroup)).To(Succeed())
@@ -189,6 +191,7 @@ var _ = Describe("Workload cluster creation", func() {
 							E2EConfig:             e2eConfig,
 							ArtifactFolder:        artifactFolder,
 							SkipCleanup:           skipCleanup,
+							CancelWatches:         cancelWatches,
 						}
 					})
 				})

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -122,15 +122,16 @@ func setupSpecNamespace(ctx context.Context, namespaceName string, clusterProxy 
 }
 
 type cleanupInput struct {
-	SpecName          string
-	ClusterProxy      framework.ClusterProxy
-	ArtifactFolder    string
-	Namespace         *corev1.Namespace
-	CancelWatches     context.CancelFunc
-	Cluster           *clusterv1.Cluster
-	IntervalsGetter   func(spec, key string) []interface{}
-	SkipCleanup       bool
-	AdditionalCleanup func()
+	SpecName               string
+	ClusterProxy           framework.ClusterProxy
+	ArtifactFolder         string
+	Namespace              *corev1.Namespace
+	CancelWatches          context.CancelFunc
+	Cluster                *clusterv1.Cluster
+	IntervalsGetter        func(spec, key string) []interface{}
+	SkipCleanup            bool
+	AdditionalCleanup      func()
+	SkipResourceGroupCheck bool
 }
 
 func dumpSpecResourcesAndCleanup(ctx context.Context, input cleanupInput) {
@@ -183,7 +184,10 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, input cleanupInput) {
 	}
 
 	Logf("Checking if any resources are left over in Azure for spec %q", input.SpecName)
-	ExpectResourceGroupToBe404(ctx)
+
+	if !input.SkipResourceGroupCheck {
+		ExpectResourceGroupToBe404(ctx)
+	}
 }
 
 // ExpectResourceGroupToBe404 performs a GET request to Azure to determine if the cluster resource group still exists.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
The private cluster spec doesn't dump resources before cleaning up as expected. We can solve this by having the test use the same cleanup function as the rest of the test specs.

**Which issue(s) this PR fixes**:
Fixes #2584 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
