### PR TITLE
WIP: Fix E2E test failing to get logs for vmss machine pool

### DIFF
--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -218,13 +218,15 @@ func (m *MachinePoolScope) updateReplicasAndProviderIDs(ctx context.Context) err
 	for i, machine := range machines {
 		if machine.Status.Ready {
 			readyReplicas++
+		} else {
+			fmt.Printf("Machine status %+v\n", machine.Status)
 		}
 		providerIDs[i] = machine.Spec.ProviderID
 	}
 
-	fmt.Printf("readyReplicas: %d", int64(readyReplicas))
-	fmt.Printf("providerIds: %v", providerIDs)
-	fmt.Printf("MachinePool: %+v", m.MachinePool)
+	fmt.Printf("readyReplicas: %d\n", int64(readyReplicas))
+	fmt.Printf("providerIds: %v\n", providerIDs)
+	fmt.Printf("MachinePool: %+v\n", m.MachinePool)
 
 	m.AzureMachinePool.Status.Replicas = readyReplicas
 	m.AzureMachinePool.Spec.ProviderIDList = providerIDs

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -398,15 +398,19 @@ func (m *MachinePoolScope) DeleteLongRunningOperationState(name, service string)
 
 // setProvisioningStateAndConditions sets the AzureMachinePool provisioning state and conditions.
 func (m *MachinePoolScope) setProvisioningStateAndConditions(v infrav1.ProvisioningState) {
+	fmt.Println("setProvisioningStateAndConditions", m.AzureMachinePool.Status.ProvisioningState)
 	m.AzureMachinePool.Status.ProvisioningState = &v
 	switch {
 	case v == infrav1.Succeeded && *m.MachinePool.Spec.Replicas == m.AzureMachinePool.Status.Replicas:
+		fmt.Println("vmss ready: ", m.MachinePool.Spec.Replicas)
 		// vmss is provisioned with enough ready replicas
 		conditions.MarkTrue(m.AzureMachinePool, infrav1.ScaleSetRunningCondition)
 		conditions.MarkTrue(m.AzureMachinePool, infrav1.ScaleSetModelUpdatedCondition)
 		conditions.MarkTrue(m.AzureMachinePool, infrav1.ScaleSetDesiredReplicasCondition)
 		m.SetReady()
 	case v == infrav1.Succeeded && *m.MachinePool.Spec.Replicas != m.AzureMachinePool.Status.Replicas:
+		fmt.Println("vmss not ready, machinepool replicas: ", m.MachinePool.Spec.Replicas)
+		fmt.Println("azure machine pool replicas: ", m.AzureMachinePool.Status.Replicas)
 		// not enough ready or too many ready replicas we must still be scaling up or down
 		updatingState := infrav1.Updating
 		m.AzureMachinePool.Status.ProvisioningState = &updatingState

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -218,10 +218,10 @@ func (m *MachinePoolScope) updateReplicasAndProviderIDs(ctx context.Context) err
 	for i, machine := range machines {
 		if machine.Status.Ready {
 			readyReplicas++
+			providerIDs[i] = machine.Spec.ProviderID
 		} else {
 			fmt.Printf("Machine status %+v\n", machine.Status)
 		}
-		providerIDs[i] = machine.Spec.ProviderID
 	}
 
 	fmt.Printf("readyReplicas: %d\n", int64(readyReplicas))

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -226,7 +226,6 @@ func (m *MachinePoolScope) updateReplicasAndProviderIDs(ctx context.Context) err
 
 	fmt.Printf("readyReplicas: %d\n", int64(readyReplicas))
 	fmt.Printf("providerIds: %v\n", providerIDs)
-	fmt.Printf("MachinePool: %+v\n", m.MachinePool)
 
 	m.AzureMachinePool.Status.Replicas = readyReplicas
 	m.AzureMachinePool.Spec.ProviderIDList = providerIDs

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -402,7 +402,8 @@ func (m *MachinePoolScope) setProvisioningStateAndConditions(v infrav1.Provision
 		fmt.Printf("Succeeded setProvisioningStateAndConditions")
 		fmt.Printf("MachinePool.Spec.Replicas: %d", *m.MachinePool.Spec.Replicas)
 		fmt.Printf("MachinePool.Spec.ProviderIDList: %v", m.MachinePool.Spec.ProviderIDList)
-		m.MachinePool.Spec.ProviderIDList = m.AzureMachinePool.Spec.ProviderIDList
+		fmt.Printf("AzureMachinePool.Status.Replicas: %d", m.AzureMachinePool.Status.Replicas)
+		fmt.Printf("AzureMachinePool.Status.ProviderIDList: %v", m.AzureMachinePool.Spec.ProviderIDList)
 		conditions.MarkTrue(m.AzureMachinePool, infrav1.ScaleSetRunningCondition)
 		conditions.MarkTrue(m.AzureMachinePool, infrav1.ScaleSetModelUpdatedCondition)
 		conditions.MarkTrue(m.AzureMachinePool, infrav1.ScaleSetDesiredReplicasCondition)
@@ -412,6 +413,8 @@ func (m *MachinePoolScope) setProvisioningStateAndConditions(v infrav1.Provision
 		fmt.Printf("Not ready setProvisioningStateAndConditions")
 		fmt.Printf("MachinePool.Spec.Replicas: %d", *m.MachinePool.Spec.Replicas)
 		fmt.Printf("MachinePool.Spec.ProviderIDList: %v", m.MachinePool.Spec.ProviderIDList)
+		fmt.Printf("AzureMachinePool.Status.Replicas: %d", m.AzureMachinePool.Status.Replicas)
+		fmt.Printf("AzureMachinePool.Status.ProviderIDList: %v", m.AzureMachinePool.Spec.ProviderIDList)
 		updatingState := infrav1.Updating
 		m.AzureMachinePool.Status.ProvisioningState = &updatingState
 		if *m.MachinePool.Spec.Replicas > m.AzureMachinePool.Status.Replicas {

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -224,7 +224,6 @@ func (m *MachinePoolScope) updateReplicasAndProviderIDs(ctx context.Context) err
 	}
 
 	fmt.Println("readyReplicas: ", readyReplicas)
-	fmt.Println("desiredReplicas: ", m.DesiredReplicas())
 	fmt.Println("providerIDs: ", providerIDs)
 
 	m.AzureMachinePool.Status.Replicas = readyReplicas

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -228,6 +228,7 @@ func (m *MachinePoolScope) updateReplicasAndProviderIDs(ctx context.Context) err
 
 	m.AzureMachinePool.Status.Replicas = readyReplicas
 	m.AzureMachinePool.Spec.ProviderIDList = providerIDs
+	m.MachinePool.Spec.ProviderIDList = providerIDs
 	return nil
 }
 

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: gcr.io/k8s-staging-cluster-api-azure/cluster-api-azure-controller:latest
+      - image: localhost:5000/ci-e2e/cluster-api-azure-controller-amd64:20220830175206
         name: manager

--- a/config/default/manager_pull_policy.yaml
+++ b/config/default/manager_pull_policy.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: manager
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent

--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -104,7 +104,7 @@ func (k AzureLogCollector) CollectMachinePoolLog(ctx context.Context, management
 		return err
 	}
 
-	for i, instance := range mp.Spec.ProviderIDList {
+	for i, instance := range am.Spec.ProviderIDList {
 		if mp.Status.NodeRefs != nil && len(mp.Status.NodeRefs) >= (i+1) {
 			hostname := mp.Status.NodeRefs[i].Name
 

--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -104,6 +104,9 @@ func (k AzureLogCollector) CollectMachinePoolLog(ctx context.Context, management
 		return err
 	}
 
+	Logf("am.Spec.ProviderIDList: %v", am.Spec.ProviderIDList)
+	Logf("mp.Spec.ProviderIDList: %v", mp.Spec.ProviderIDList)
+
 	for i, instance := range am.Spec.ProviderIDList {
 		if mp.Status.NodeRefs != nil && len(mp.Status.NodeRefs) >= (i+1) {
 			hostname := mp.Status.NodeRefs[i].Name

--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -419,10 +419,13 @@ func collectVMBootLog(ctx context.Context, am *infrav1.AzureMachine, outputPath 
 
 // collectVMSSBootLog collects boot logs of the scale set by using azure boot diagnostics.
 func collectVMSSBootLog(ctx context.Context, providerID string, outputPath string) error {
+	Logf("providerID: %s\n", providerID)
+	Logf("outputPath: %s\n", outputPath)
 	resourceId := strings.TrimPrefix(providerID, azure.ProviderIDPrefix)
 	v := strings.Split(resourceId, "/")
 	instanceId := v[len(v)-1]
 	resourceId = strings.TrimSuffix(resourceId, "/virtualMachines/"+instanceId)
+	Logf("resourceId: %s\n", resourceId)
 	resource, err := autorest.ParseResourceID(resourceId)
 	if err != nil {
 		return errors.Wrap(err, "failed to parse resource id")
@@ -441,6 +444,9 @@ func collectVMSSBootLog(ctx context.Context, providerID string, outputPath strin
 		return errors.Wrap(err, "failed to get authorizer")
 	}
 
+	Logf("Resource group: %s\n", resource.ResourceGroup)
+	Logf("Resource name: %s\n", resource.ResourceName)
+	Logf("Instance id: %s\n", instanceId)
 	bootDiagnostics, err := vmssClient.RetrieveBootDiagnosticsData(ctx, resource.ResourceGroup, resource.ResourceName, instanceId, nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to get boot diagnostics data")

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -174,7 +174,7 @@ func testMachinePoolCordonAndDrain(ctx context.Context, mgmtClusterProxy, worklo
 		}
 		Logf("Success: providerIDList length (%d) matches replicas (%d)", len(owningMachinePool.Spec.ProviderIDList), decreasedReplicas)
 		return nil
-	}, 15*time.Minute, 3*time.Second).Should(Succeed())
+	}, 3*time.Minute, 3*time.Second).Should(Succeed())
 
 	// TODO setup a watcher to validate expected 2nd order drain outcomes
 	// https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2159

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -167,14 +167,14 @@ func testMachinePoolCordonAndDrain(ctx context.Context, mgmtClusterProxy, worklo
 		return helper.Patch(ctx, owningMachinePool)
 	}, 3*time.Minute, 3*time.Second).Should(Succeed())
 
-	// Eventually(func() error {
-	// 	if int32(len(owningMachinePool.Spec.ProviderIDList)) != decreasedReplicas {
-	// 		Logf("Failed providerIDList: %v", owningMachinePool.Spec.ProviderIDList)
-	// 		return errors.Errorf("providerIDList length (%d) does not match replicas (%d)", len(owningMachinePool.Spec.ProviderIDList), decreasedReplicas)
-	// 	}
-	// 	Logf("Success: providerIDList length (%d) matches replicas (%d)", len(owningMachinePool.Spec.ProviderIDList), decreasedReplicas)
-	// 	return nil
-	// }, 3*time.Minute, 3*time.Second).Should(Succeed())
+	Eventually(func() error {
+		if int32(len(amp.Spec.ProviderIDList)) != decreasedReplicas {
+			Logf("Failed providerIDList: %v", amp.Spec.ProviderIDList)
+			return errors.Errorf("providerIDList length (%d) does not match replicas (%d)", len(amp.Spec.ProviderIDList), decreasedReplicas)
+		}
+		Logf("Success: providerIDList length (%d) matches replicas (%d)", len(amp.Spec.ProviderIDList), decreasedReplicas)
+		return nil
+	}, 5*time.Minute, 3*time.Second).Should(Succeed())
 
 	// TODO setup a watcher to validate expected 2nd order drain outcomes
 	// https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2159

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -162,6 +162,8 @@ func testMachinePoolCordonAndDrain(ctx context.Context, mgmtClusterProxy, worklo
 
 		decreasedReplicas := *owningMachinePool.Spec.Replicas - int32(1)
 		owningMachinePool.Spec.Replicas = &decreasedReplicas
+		Logf("Decreasing the replica count on the machine pool to %d", decreasedReplicas)
+		Logf("ProviderIDList: %v", owningMachinePool.Spec.ProviderIDList)
 		return helper.Patch(ctx, owningMachinePool)
 	}, 3*time.Minute, 3*time.Second).Should(Succeed())
 

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -169,6 +169,7 @@ func testMachinePoolCordonAndDrain(ctx context.Context, mgmtClusterProxy, worklo
 
 	Eventually(func() error {
 		if int32(len(owningMachinePool.Spec.ProviderIDList)) != decreasedReplicas {
+			Logf("Failed providerIDList: %v", owningMachinePool.Spec.ProviderIDList)
 			return errors.Errorf("providerIDList length (%d) does not match replicas (%d)", len(owningMachinePool.Spec.ProviderIDList), decreasedReplicas)
 		}
 		Logf("Success: providerIDList length (%d) matches replicas (%d)", len(owningMachinePool.Spec.ProviderIDList), decreasedReplicas)

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -167,14 +167,14 @@ func testMachinePoolCordonAndDrain(ctx context.Context, mgmtClusterProxy, worklo
 		return helper.Patch(ctx, owningMachinePool)
 	}, 3*time.Minute, 3*time.Second).Should(Succeed())
 
-	Eventually(func() error {
-		if int32(len(owningMachinePool.Spec.ProviderIDList)) != decreasedReplicas {
-			Logf("Failed providerIDList: %v", owningMachinePool.Spec.ProviderIDList)
-			return errors.Errorf("providerIDList length (%d) does not match replicas (%d)", len(owningMachinePool.Spec.ProviderIDList), decreasedReplicas)
-		}
-		Logf("Success: providerIDList length (%d) matches replicas (%d)", len(owningMachinePool.Spec.ProviderIDList), decreasedReplicas)
-		return nil
-	}, 3*time.Minute, 3*time.Second).Should(Succeed())
+	// Eventually(func() error {
+	// 	if int32(len(owningMachinePool.Spec.ProviderIDList)) != decreasedReplicas {
+	// 		Logf("Failed providerIDList: %v", owningMachinePool.Spec.ProviderIDList)
+	// 		return errors.Errorf("providerIDList length (%d) does not match replicas (%d)", len(owningMachinePool.Spec.ProviderIDList), decreasedReplicas)
+	// 	}
+	// 	Logf("Success: providerIDList length (%d) matches replicas (%d)", len(owningMachinePool.Spec.ProviderIDList), decreasedReplicas)
+	// 	return nil
+	// }, 3*time.Minute, 3*time.Second).Should(Succeed())
 
 	// TODO setup a watcher to validate expected 2nd order drain outcomes
 	// https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2159

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -171,8 +171,9 @@ func testMachinePoolCordonAndDrain(ctx context.Context, mgmtClusterProxy, worklo
 		if int32(len(owningMachinePool.Spec.ProviderIDList)) != decreasedReplicas {
 			return errors.Errorf("providerIDList length (%d) does not match replicas (%d)", len(owningMachinePool.Spec.ProviderIDList), decreasedReplicas)
 		}
+		Logf("Success: providerIDList length (%d) matches replicas (%d)", len(owningMachinePool.Spec.ProviderIDList), decreasedReplicas)
 		return nil
-	}, 3*time.Minute, 3*time.Second).Should(Succeed())
+	}, 15*time.Minute, 3*time.Second).Should(Succeed())
 
 	// TODO setup a watcher to validate expected 2nd order drain outcomes
 	// https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2159

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -163,12 +163,11 @@ func testMachinePoolCordonAndDrain(ctx context.Context, mgmtClusterProxy, worklo
 		}
 
 		if !hasDecreasedReplicas {
+			hasDecreasedReplicas = true
 			decreasedReplicas = *owningMachinePool.Spec.Replicas - int32(1)
 			owningMachinePool.Spec.Replicas = &decreasedReplicas
-			hasDecreasedReplicas = true
+			helper.Patch(ctx, owningMachinePool)
 		}
-
-		helper.Patch(ctx, owningMachinePool)
 
 		Logf("Decreasing the replica count on the machine pool to %d", decreasedReplicas)
 		Logf("ProviderIDList: %v", owningMachinePool.Spec.ProviderIDList)

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -162,6 +162,9 @@ func testMachinePoolCordonAndDrain(ctx context.Context, mgmtClusterProxy, worklo
 
 		decreasedReplicas := *owningMachinePool.Spec.Replicas - int32(1)
 		owningMachinePool.Spec.Replicas = &decreasedReplicas
+		if int32(len(owningMachinePool.Spec.ProviderIDList)) != decreasedReplicas {
+			return errors.Errorf("providerIDList length (%d) does not match replicas (%d)", len(owningMachinePool.Spec.ProviderIDList), decreasedReplicas)
+		}
 		Logf("Decreasing the replica count on the machine pool to %d", decreasedReplicas)
 		Logf("ProviderIDList: %v", owningMachinePool.Spec.ProviderIDList)
 		return helper.Patch(ctx, owningMachinePool)

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -174,7 +174,7 @@ func testMachinePoolCordonAndDrain(ctx context.Context, mgmtClusterProxy, worklo
 		}
 		Logf("Success: providerIDList length (%d) matches replicas (%d)", len(owningMachinePool.Spec.ProviderIDList), decreasedReplicas)
 		return nil
-	}, 3*time.Minute, 3*time.Second).Should(Succeed())
+	}, 15*time.Minute, 3*time.Second).Should(Succeed())
 
 	// TODO setup a watcher to validate expected 2nd order drain outcomes
 	// https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2159

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -152,30 +152,7 @@ func testMachinePoolCordonAndDrain(ctx context.Context, mgmtClusterProxy, worklo
 	_, _, _, cleanup := deployHttpService(ctx, clientset, isWindows, customizers...)
 	defer cleanup()
 
-	// By(fmt.Sprintf("decreasing the replica count by 1 on the machine pool: %s/%s", amp.Namespace, amp.Name))
-	// hasDecreasedReplicas := false
-	// Eventually(func() error {
-	// 	var decreasedReplicas int32
-	// 	helper, err := patch.NewHelper(owningMachinePool, mgmtClusterProxy.GetClient())
-	// 	if err != nil {
-	// 		LogWarning(err.Error())
-	// 		return err
-	// 	}
-
-	// 	if !hasDecreasedReplicas {
-	// 		hasDecreasedReplicas = true
-	// 		decreasedReplicas = *owningMachinePool.Spec.Replicas - int32(1)
-	// 		owningMachinePool.Spec.Replicas = &decreasedReplicas
-	// 		helper.Patch(ctx, owningMachinePool)
-	// 	}
-
-	// 	Logf("Decreasing the replica count on the machine pool to %d", decreasedReplicas)
-	// 	Logf("ProviderIDList: %v", owningMachinePool.Spec.ProviderIDList)
-	// 	if int32(len(owningMachinePool.Spec.ProviderIDList)) != decreasedReplicas {
-	// 		return errors.Errorf("providerIDList length (%d) does not match replicas (%d)", len(owningMachinePool.Spec.ProviderIDList), decreasedReplicas)
-	// 	}
-	// 	return nil
-	// }, 3*time.Minute, 3*time.Second).Should(Succeed())
+	By(fmt.Sprintf("decreasing the replica count by 1 on the machine pool: %s/%s", amp.Namespace, amp.Name))
 	var decreasedReplicas int32
 
 	Eventually(func() error {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Every run of the E2E test has errors about failing to get boot diagnostics data. This PR attempts to fix this issue.

**Which issue(s) this PR fixes**:
Fixes

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
