### PR TITLE
Update Kubescape to v2.0.167

### DIFF
--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -171,7 +171,7 @@ variables:
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
   WINDOWS_CONTAINERD_URL: "${WINDOWS_CONTAINERD_URL:-}"
   SECURITY_SCAN_FAIL_THRESHOLD: "${SECURITY_SCAN_FAIL_THRESHOLD:-100}"
-  SECURITY_SCAN_CONTAINER: "${SECURITY_SCAN_CONTAINER:-quay.io/armosec/kubescape:v1.0.138}"
+  SECURITY_SCAN_CONTAINER: "${SECURITY_SCAN_CONTAINER:-quay.io/armosec/kubescape:v2.0.167}"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates the [armosec/kubescape](https://github.com/kubescape/kubescape) security scanner component to v2.0.167 and makes some changes necessary to run v2 in e2e tests. The new version adds several security "frameworks" (test suites) and is more detailed.

This e2e spec is still purely informative since we have the fail threshold set to 100. But there are some interesting things to dig into here, so we could take the time to investigate and prioritize any tractable security issues that it points out.

Example output:

```
[1] Logs for pod kubescape-scan-qm4gv:
[1] {"level":"info","ts":"2022-08-26T19:19:49Z","msg":"ARMO security scanner starting"}
[1] {"level":"info","ts":"2022-08-26T19:19:50Z","msg":"Installing host scanner"}
[1] {"level":"error","ts":"2022-08-26T19:21:30Z","msg":"failed to validate host-sensor pods status","error":"host-sensor pods number (3) differ than nodes number (5) after deadline exceeded. Kubescape will take data only from the pods below: map[host-scanner-2lblk:capz-e2e-a9494t-vmss-mp-0000000 host-scanner-rmb8q:capz-e2e-a9494t-vmss-mp-0000001 host-scanner-sdjjw:capz-e2e-a9494t-vmss-control-plane-rppl6]"}
[1] {"level":"info","ts":"2022-08-26T19:21:34Z","msg":"Downloading/Loading policy definitions"}
[1] {"level":"info","ts":"2022-08-26T19:21:35Z","msg":"Downloaded/Loaded policy"}
[1] {"level":"info","ts":"2022-08-26T19:21:35Z","msg":"Accessing Kubernetes objects"}
[1] {"level":"warn","ts":"2022-08-26T19:21:35Z","msg":"failed to collect image vulnerabilities","error":"credentials are not configured for any registry adaptor"}
[1] {"level":"info","ts":"2022-08-26T19:21:38Z","msg":"Accessed to Kubernetes objects"}
[1] {"level":"info","ts":"2022-08-26T19:21:38Z","msg":"Scanning","Cluster":""}
[1] {"level":"info","ts":"2022-08-26T19:21:40Z","msg":"Done scanning","Cluster":""}
[1] 
[1] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[1] 
[1] Controls: 48 (Failed: 37, Excluded: 0, Skipped: 0)
[1] 
[1] +----------+---------------------------------------------+------------------+--------------------+---------------+--------------+
[1] | SEVERITY |                CONTROL NAME                 | FAILED RESOURCES | EXCLUDED RESOURCES | ALL RESOURCES | % RISK-SCORE |
[1] +----------+---------------------------------------------+------------------+--------------------+---------------+--------------+
[1] | Critical | Data Destruction                            |        17        |         0          |      59       |     29%      |
[1] | High     | Cluster-admin binding                       |        1         |         0          |      59       |      2%      |
[1] | High     | List Kubernetes secrets                     |        12        |         0          |      59       |     20%      |
[1] | High     | Privileged container                        |        1         |         0          |       4       |     19%      |
[1] | High     | Resources CPU limit and request             |        4         |         0          |       4       |     100%     |
[1] | High     | Resources memory limit and request          |        1         |         0          |       4       |     19%      |
[1] | High     | Writable hostPath mount                     |        3         |         0          |       4       |     81%      |
[1] | Medium   | Access container service account            |        7         |         0          |       7       |     100%     |
[1] | Medium   | Allow privilege escalation                  |        4         |         0          |       4       |     100%     |
[1] | Medium   | Allowed hostPath                            |        3         |         0          |       4       |     81%      |
[1] | Medium   | Automatic mapping of service account        |        9         |         0          |       9       |     100%     |
[1] | Medium   | CVE-2022-0185-linux-kernel-container-escape |        3         |         0          |       3       |     100%     |
[1] | Medium   | CVE-2022-0492-cgroups-container-escape      |        4         |         0          |       4       |     100%     |
[1] | Medium   | Cluster internal networking                 |        2         |         0          |       2       |     100%     |
[1] | Medium   | Configured liveness probe                   |        4         |         0          |       4       |     100%     |
[1] | Medium   | Container hostPort                          |        2         |         0          |       4       |     62%      |
[1] | Medium   | CoreDNS poisoning                           |        3         |         0          |      59       |      5%      |
[1] | Medium   | Delete Kubernetes events                    |        3         |         0          |      59       |      5%      |
[1] | Medium   | Exec into container                         |        1         |         0          |      59       |      2%      |
[1] | Medium   | Forbidden Container Registries              |        1         |         0          |       4       |     19%      |
[1] | Medium   | HostNetwork access                          |        2         |         0          |       4       |     62%      |
[1] | Medium   | HostPath mount                              |        2         |         0          |       4       |     62%      |
[1] | Medium   | Images from allowed registry                |        4         |         0          |       4       |     100%     |
[1] | Medium   | Ingress and Egress blocked                  |        4         |         0          |       4       |     100%     |
[1] | Medium   | Linux hardening                             |        4         |         0          |       4       |     100%     |
[1] | Medium   | Mount service principal                     |        2         |         0          |       4       |     62%      |
[1] | Medium   | Namespace without service accounts          |        1         |         0          |       7       |     14%      |
[1] | Medium   | Network mapping                             |        2         |         0          |       2       |     100%     |
[1] | Medium   | No impersonation                            |        1         |         0          |      59       |      2%      |
[1] | Medium   | Non-root containers                         |        4         |         0          |       4       |     100%     |
[1] | Medium   | Portforwarding privileges                   |        1         |         0          |      59       |      2%      |
[1] | Low      | Configured readiness probe                  |        4         |         0          |       4       |     100%     |
[1] | Low      | Immutable container filesystem              |        4         |         0          |       4       |     100%     |
[1] | Low      | K8s common labels usage                     |        1         |         0          |       4       |     19%      |
[1] | Low      | Label usage for resources                   |        4         |         0          |       4       |     100%     |
[1] | Low      | Pods in default namespace                   |        4         |         0          |       4       |     100%     |
[1] | Low      | Resource policies                           |        4         |         0          |       4       |     100%     |
[1] +----------+---------------------------------------------+------------------+--------------------+---------------+--------------+
[1] |          |              RESOURCE SUMMARY               |        41        |         0          |      94       |    20.90%    |
[1] +----------+---------------------------------------------+------------------+--------------------+---------------+--------------+
[1] 
[1] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[1] Scan results have not been submitted: run kubescape with the '--submit' flag
[1] Sign up for free: https://cloud.armosec.io/account/sign-up?utm_source=GitHub&utm_medium=CLI&utm_campaign=no_submit
[1] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[1] 
[1] 🕵️  Run with '--verbose'/'-v' flag for detailed resources view
[1] 
[1] FRAMEWORKS: DevOpsBest (risk: 53.97), AllControls (risk: 20.90), ArmoBest (risk: 18.04), NSA (risk: 21.34), MITRE (risk: 14.90)

```

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
