### PR TITLE
Temporarily remove cordon and drain test

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -393,16 +393,17 @@ var _ = Describe("Workload cluster creation", func() {
 				})
 			})
 
-			By("Cordon and draining a node", func() {
-				AzureMachinePoolDrainSpec(ctx, func() AzureMachinePoolDrainSpecInput {
-					return AzureMachinePoolDrainSpecInput{
-						BootstrapClusterProxy: bootstrapClusterProxy,
-						Namespace:             namespace,
-						ClusterName:           clusterName,
-						SkipCleanup:           skipCleanup,
-					}
-				})
-			})
+			// TODO: Implement more robust cordon and drain test
+			// By("Cordon and draining a node", func() {
+			// 	AzureMachinePoolDrainSpec(ctx, func() AzureMachinePoolDrainSpecInput {
+			// 		return AzureMachinePoolDrainSpecInput{
+			// 			BootstrapClusterProxy: bootstrapClusterProxy,
+			// 			Namespace:             namespace,
+			// 			ClusterName:           clusterName,
+			// 			SkipCleanup:           skipCleanup,
+			// 		}
+			// 	})
+			// })
 
 			By("PASSED!")
 		})


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Every run of the E2E test has errors about failing to get boot diagnostics data. This is because the cordon and drain scales down the machine pool, and then exits immediately. This is left over from #2160 where the cordon and drain portion of the test was removed. This causes the E2E test to attempt to retrieve logs from a machine that is in the process of being deleted. We will remove this test for now in favor of improving the cordon and drain test in the future.

**Which issue(s) this PR fixes**:
Fixes #2605 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
