### PR TITLE
set AzureManagedMachinePool not ready for in-progress reconciliations

### DIFF
--- a/exp/controllers/azuremanagedmachinepool_controller.go
+++ b/exp/controllers/azuremanagedmachinepool_controller.go
@@ -258,6 +258,8 @@ func (ammpr *AzureManagedMachinePoolReconciler) reconcileNormal(ctx context.Cont
 	}
 
 	if err := svc.Reconcile(ctx); err != nil {
+		scope.SetAgentPoolReady(false)
+
 		// Handle transient and terminal errors
 		log := log.WithValues("name", scope.InfraMachinePool.Name, "namespace", scope.InfraMachinePool.Namespace)
 		var reconcileError azure.ReconcileError
@@ -279,7 +281,7 @@ func (ammpr *AzureManagedMachinePoolReconciler) reconcileNormal(ctx context.Cont
 	}
 
 	// No errors, so mark us ready so the Cluster API Cluster Controller can pull it
-	scope.InfraMachinePool.Status.Ready = true
+	scope.SetAgentPoolReady(true)
 	ammpr.Recorder.Eventf(scope.InfraMachinePool, corev1.EventTypeNormal, "AzureManagedMachinePool available", "agent pool successfully reconciled")
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
The `status.ready` field for AzureManagedMachinePools is set to `true` in the first successful reconciliation:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/03c509372370de7e9fe810f7d12a0469f4a34798/exp/controllers/azuremanagedmachinepool_reconciler.go#L146
https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/03c509372370de7e9fe810f7d12a0469f4a34798/exp/controllers/azuremanagedmachinepool_controller.go#L282

After, it is never set to `false`. This causes an issue during scaling operations where Cluster API's MachinePool controller does not short-circuit [here](https://github.com/kubernetes-sigs/cluster-api/blob/8b4214d72762394144b83dd6d14986ff7e274095/exp/internal/controllers/machinepool_controller_phases.go#L270-L273) and proceeds to construct replica counts for the MachinePool's status [here](https://github.com/kubernetes-sigs/cluster-api/blob/8b4214d72762394144b83dd6d14986ff7e274095/exp/internal/controllers/machinepool_controller_noderef.go#L96-L99) which may not be correct while the infrastructure is still being reconciled. This manifests in #2561 where scaling an AzureManagedMachinePool up by some n number of replicas would sometimes result in the MachinePool's `status.unavailableReplicas` converging to -n and other times to 0 as expected.

For reference, the AzureMachinePool controller sets `status.ready` to false based on the status of the backing VMSS and desired/actual replicas in [this function](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/03c509372370de7e9fe810f7d12a0469f4a34798/azure/scope/machinepool.go#L390).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2561

**Special notes for your reviewer**: I'm not exactly sure how best to express this fix, so feedback on whether there's a better way or place to do this is appreciated.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
