### PR TITLE
use known-working Windows OS image

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -273,7 +273,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: ubuntu-1804-gen1
-          version: latest
+          version: 124.4.20220819
       osDisk:
         diskSizeGB: 128
         osType: Linux
@@ -417,7 +417,7 @@ spec:
           offer: capi-windows
           publisher: cncf-upstream
           sku: windows-2022-containerd-gen1
-          version: latest
+          version: 124.4.20220819
       osDisk:
         diskSizeGB: 128
         managedDisk:

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -273,7 +273,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: ubuntu-1804-gen1
-          version: latest
+          version: 124.4.20220819
       osDisk:
         diskSizeGB: 128
         osType: Linux
@@ -417,7 +417,7 @@ spec:
           offer: capi-windows
           publisher: cncf-upstream
           sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
-          version: latest
+          version: 124.4.20220819
       osDisk:
         diskSizeGB: 128
         managedDisk:

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
@@ -276,7 +276,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: ubuntu-1804-gen1
-          version: latest
+          version: 124.4.20220819
       osDisk:
         diskSizeGB: 128
         osType: Linux
@@ -421,7 +421,7 @@ spec:
           offer: capi-windows
           publisher: cncf-upstream
           sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
-          version: latest
+          version: 124.4.20220819
       osDisk:
         diskSizeGB: 128
         managedDisk:

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -428,7 +428,7 @@ spec:
         offer: capi-windows
         publisher: cncf-upstream
         sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
-        version: latest
+        version: 124.4.20220819
     osDisk:
       diskSizeGB: 30
       managedDisk:

--- a/templates/test/ci/prow-ci-version-windows-containerd-2022/patches/windows-image-update.yaml
+++ b/templates/test/ci/prow-ci-version-windows-containerd-2022/patches/windows-image-update.yaml
@@ -13,4 +13,4 @@ spec:
           publisher: cncf-upstream
           offer: capi-windows
           sku: windows-2022-containerd-gen1
-          version: "latest"
+          version: "124.4.20220819"

--- a/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version-windows.yaml
+++ b/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version-windows.yaml
@@ -12,4 +12,4 @@ spec:
           publisher: cncf-upstream
           offer: capi-windows
           sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
-          version: "latest"
+          version: 124.4.20220819

--- a/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version.yaml
+++ b/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version.yaml
@@ -12,4 +12,4 @@ spec:
           publisher: cncf-upstream
           offer: capi
           sku: ubuntu-1804-gen1
-          version: "latest"
+          version: 124.4.20220819

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version-windows.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version-windows.yaml
@@ -12,4 +12,4 @@ spec:
         publisher: cncf-upstream
         offer: capi-windows
         sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
-        version: latest
+        version: 124.4.20220819

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -358,7 +358,7 @@ spec:
           offer: capi-windows
           publisher: cncf-upstream
           sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
-          version: latest
+          version: 124.4.20220819
       osDisk:
         diskSizeGB: 128
         managedDisk:

--- a/templates/test/dev/custom-builds/patches/machine-deployment-pr-version-windows.yaml
+++ b/templates/test/dev/custom-builds/patches/machine-deployment-pr-version-windows.yaml
@@ -13,4 +13,4 @@ spec:
           publisher: cncf-upstream
           offer: capi-windows
           sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
-          version: latest
+          version: 124.4.20220819


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR changes the Windows OS VHD image reference to a previously known-working image. We are observing that the most recently published Windows image (pulled down by following the "latest" reference alias) is broken.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Mitigates #2614 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
