### PR TITLE
E2E test error when collecting logs after deleting

### DIFF
--- a/test/e2e/azure_privatecluster.go
+++ b/test/e2e/azure_privatecluster.go
@@ -164,7 +164,7 @@ func AzurePrivateClusterSpec(ctx context.Context, inputGetter func() AzurePrivat
 			Cluster:                cluster,
 			ClusterProxy:           publicClusterProxy,
 			Namespace:              input.Namespace,
-			CancelWatches:          input.CancelWatches,
+			CancelWatches:          publicCancelWatches,
 			IntervalsGetter:        e2eConfig.GetIntervals,
 			SkipCleanup:            input.SkipCleanup,
 			ArtifactFolder:         input.ArtifactFolder,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Every run of the E2E test results in failures collecting logs and events for the private cluster test because the cluster is already in the process of deletion

**Which issue(s) this PR fixes**:
Fixes #2617

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
