### PR TITLE
Restore "latest" for Ubuntu images in test templates

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -273,7 +273,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: ubuntu-1804-gen1
-          version: 124.4.20220819
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -273,7 +273,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: ubuntu-1804-gen1
-          version: 124.4.20220819
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
@@ -276,7 +276,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: ubuntu-1804-gen1
-          version: 124.4.20220819
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version.yaml
+++ b/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version.yaml
@@ -12,4 +12,4 @@ spec:
           publisher: cncf-upstream
           offer: capi
           sku: ubuntu-1804-gen1
-          version: 124.4.20220819
+          version: latest


### PR DESCRIPTION
**What type of PR is this?**:

/kind cleanup

**What this PR does / why we need it**:

In #2618 we pinned some Ubuntu image references to the same Last Known Good version as Windows, but that version doesn't exist for the "capi" Linux offer. I think it should work to leave Ubuntu at "latest" since we have logic that negotiates agreement on a version between Windows and Linux. (Alternately, we can pin these to the correct Ubuntu version, published several days earlier.)

**Which issue(s) this PR fixes**:

(Bug reported in chat by @lzhecheng.)

**Special notes for your reviewer**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
