### PR TITLE
standardize AzureManagedCluster webhooks

### DIFF
--- a/exp/api/v1beta1/azuremanagedcluster_webhook.go
+++ b/exp/api/v1beta1/azuremanagedcluster_webhook.go
@@ -43,20 +43,19 @@ var _ webhook.Validator = &AzureManagedCluster{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AzureManagedCluster) ValidateCreate() error {
-	return nil
-}
-
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *AzureManagedCluster) ValidateUpdate(oldRaw runtime.Object) error {
 	// NOTE: AzureManagedCluster is behind AKS feature gate flag; the web hook
-	// must prevent creating new objects new case the feature flag is disabled.
+	// must prevent creating new objects in case the feature flag is disabled.
 	if !feature.Gates.Enabled(feature.AKS) {
 		return field.Forbidden(
 			field.NewPath("spec"),
 			"can be set only if the AKS feature flag is enabled",
 		)
 	}
+	return nil
+}
 
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (r *AzureManagedCluster) ValidateUpdate(oldRaw runtime.Object) error {
 	old := oldRaw.(*AzureManagedCluster)
 	var allErrs field.ErrorList
 

--- a/exp/api/v1beta1/azuremanagedcluster_webhook_test.go
+++ b/exp/api/v1beta1/azuremanagedcluster_webhook_test.go
@@ -131,3 +131,35 @@ func TestAzureManagedCluster_ValidateUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestAzureManagedCluster_ValidateCreateFailure(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name      string
+		amc       *AzureManagedCluster
+		deferFunc func()
+	}{
+		{
+			name:      "feature gate explicitly disabled",
+			amc:       getKnownValidAzureManagedCluster(),
+			deferFunc: utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.AKS, false),
+		},
+		{
+			name:      "feature gate implicitly disabled",
+			amc:       getKnownValidAzureManagedCluster(),
+			deferFunc: func() {},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer tc.deferFunc()
+			err := tc.amc.ValidateCreate()
+			g.Expect(err).To(HaveOccurred())
+		})
+	}
+}
+
+func getKnownValidAzureManagedCluster() *AzureManagedCluster {
+	return &AzureManagedCluster{}
+}

--- a/exp/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/exp/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -30,6 +30,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -80,6 +81,14 @@ func (m *AzureManagedControlPlane) Default(_ client.Client) {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (m *AzureManagedControlPlane) ValidateCreate(client client.Client) error {
+	// NOTE: AzureManagedControlPlane is behind AKS feature gate flag; the web hook
+	// must prevent creating new objects in case the feature flag is disabled.
+	if !feature.Gates.Enabled(feature.AKS) {
+		return field.Forbidden(
+			field.NewPath("spec"),
+			"can be set only if the AKS feature flag is enabled",
+		)
+	}
 	return m.Validate(client)
 }
 

--- a/main.go
+++ b/main.go
@@ -523,21 +523,19 @@ func registerWebhooks(mgr manager.Manager) {
 		os.Exit(1)
 	}
 
-	if feature.Gates.Enabled(feature.AKS) {
-		hookServer := mgr.GetWebhookServer()
-		hookServer.Register("/mutate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedmachinepool", webhook.NewMutatingWebhook(
-			&infrav1exp.AzureManagedMachinePool{}, mgr.GetClient(),
-		))
-		hookServer.Register("/validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedmachinepool", webhook.NewValidatingWebhook(
-			&infrav1exp.AzureManagedMachinePool{}, mgr.GetClient(),
-		))
-		hookServer.Register("/mutate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcontrolplane", webhook.NewMutatingWebhook(
-			&infrav1exp.AzureManagedControlPlane{}, mgr.GetClient(),
-		))
-		hookServer.Register("/validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcontrolplane", webhook.NewValidatingWebhook(
-			&infrav1exp.AzureManagedControlPlane{}, mgr.GetClient(),
-		))
-	}
+	hookServer := mgr.GetWebhookServer()
+	hookServer.Register("/mutate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedmachinepool", webhook.NewMutatingWebhook(
+		&infrav1exp.AzureManagedMachinePool{}, mgr.GetClient(),
+	))
+	hookServer.Register("/validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedmachinepool", webhook.NewValidatingWebhook(
+		&infrav1exp.AzureManagedMachinePool{}, mgr.GetClient(),
+	))
+	hookServer.Register("/mutate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcontrolplane", webhook.NewMutatingWebhook(
+		&infrav1exp.AzureManagedControlPlane{}, mgr.GetClient(),
+	))
+	hookServer.Register("/validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcontrolplane", webhook.NewValidatingWebhook(
+		&infrav1exp.AzureManagedControlPlane{}, mgr.GetClient(),
+	))
 
 	if err := mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {
 		setupLog.Error(err, "unable to create ready check")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind bug
/kind cleanup

**What this PR does / why we need it**:

This PR updates AzureManagedCluster webhooks to prefer the approach from this PR: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2376

This adds CRD feature-gate validation as part of the webhook validation, so that users get a clear message when attempting to create a resource currently behind a feature flag (e.g., `AzureManagedCluster`).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
standardize AzureManagedCluster webhooks
```
