### PR TITLE
add back 0.5 metadata contract for v1alpha4

### DIFF
--- a/docs/book/src/developers/releasing.md
+++ b/docs/book/src/developers/releasing.md
@@ -21,6 +21,9 @@ For example, if the latest stable API version of capz that we run E2E tests agai
 ```yaml
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 releaseSeries:
+  - major: 0
+    minor: 5
+    contract: v1alpha4
   - major: 1
     minor: 5
     contract: v1beta1

--- a/test/e2e/data/shared/v1beta1_provider/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1_provider/metadata.yaml
@@ -7,6 +7,9 @@
 # one capz version at a time against one API version
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 releaseSeries:
+  - major: 0
+    minor: 5
+    contract: v1alpha4
   - major: 1
     minor: 5
     contract: v1beta1


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR restores the 0.5 part of the metadata.yaml contract removed via this PR: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2497

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
