### PR TITLE
AzureMachineTemplate webhooks dry-run

### DIFF
--- a/api/v1beta1/azuremachinetemplate_webhook.go
+++ b/api/v1beta1/azuremachinetemplate_webhook.go
@@ -17,13 +17,17 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
+	"fmt"
 	"reflect"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/cluster-api/util/topology"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // AzureMachineTemplateImmutableMsg ...
@@ -36,24 +40,27 @@ const (
 func (r *AzureMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
+		WithValidator(r).
+		WithDefaulter(r).
 		Complete()
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-azuremachinetemplate,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=azuremachinetemplates,versions=v1beta1,name=default.azuremachinetemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremachinetemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=azuremachinetemplates,versions=v1beta1,name=validation.azuremachinetemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
-var _ webhook.Defaulter = &AzureMachineTemplate{}
-var _ webhook.Validator = &AzureMachineTemplate{}
+var _ webhook.CustomDefaulter = &AzureMachineTemplate{}
+var _ webhook.CustomValidator = &AzureMachineTemplate{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *AzureMachineTemplate) ValidateCreate() error {
-	spec := r.Spec.Template.Spec
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *AzureMachineTemplate) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	t := obj.(*AzureMachineTemplate)
+	spec := t.Spec.Template.Spec
 
 	allErrs := ValidateAzureMachineSpec(spec)
 
-	if r.Spec.Template.Spec.RoleAssignmentName != "" {
+	if spec.RoleAssignmentName != "" {
 		allErrs = append(allErrs,
-			field.Invalid(field.NewPath("AzureMachineTemplate", "spec", "template", "spec", "roleAssignmentName"), r, AzureMachineTemplateRoleAssignmentNameMsg),
+			field.Invalid(field.NewPath("AzureMachineTemplate", "spec", "template", "spec", "roleAssignmentName"), t, AzureMachineTemplateRoleAssignmentNameMsg),
 		)
 	}
 
@@ -61,15 +68,22 @@ func (r *AzureMachineTemplate) ValidateCreate() error {
 		return nil
 	}
 
-	return apierrors.NewInvalid(GroupVersion.WithKind("AzureMachineTemplate").GroupKind(), r.Name, allErrs)
+	return apierrors.NewInvalid(GroupVersion.WithKind("AzureMachineTemplate").GroupKind(), t.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *AzureMachineTemplate) ValidateUpdate(oldRaw runtime.Object) error {
+func (r *AzureMachineTemplate) ValidateUpdate(ctx context.Context, oldRaw runtime.Object, newRaw runtime.Object) error {
 	var allErrs field.ErrorList
 	old := oldRaw.(*AzureMachineTemplate)
+	t := newRaw.(*AzureMachineTemplate)
 
-	if !reflect.DeepEqual(r.Spec.Template.Spec, old.Spec.Template.Spec) {
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a admission.Request inside context: %v", err))
+	}
+
+	if !topology.ShouldSkipImmutabilityChecks(req, t) &&
+		!reflect.DeepEqual(t.Spec.Template.Spec, old.Spec.Template.Spec) {
 		// The equality failure could be because of default mismatch between v1alpha3 and v1beta1. This happens because
 		// the new object `r` will have run through the default webhooks but the old object `old` would not have so.
 		// This means if the old object was in v1alpha3, it would not get the new defaults set in v1beta1 resulting
@@ -78,15 +92,19 @@ func (r *AzureMachineTemplate) ValidateUpdate(oldRaw runtime.Object) error {
 
 		// We need to set ssh key explicitly, otherwise Default() will create a new one.
 		if old.Spec.Template.Spec.SSHPublicKey == "" {
-			old.Spec.Template.Spec.SSHPublicKey = r.Spec.Template.Spec.SSHPublicKey
+			old.Spec.Template.Spec.SSHPublicKey = t.Spec.Template.Spec.SSHPublicKey
 		}
 
-		old.Default()
+		if err := r.Default(ctx, old); err != nil {
+			allErrs = append(allErrs,
+				field.Invalid(field.NewPath("AzureMachineTemplate"), r, fmt.Sprintf("Unable to apply defaults: %v", err)),
+			)
+		}
 
 		// if it's still not equal, return error.
-		if !reflect.DeepEqual(r.Spec.Template.Spec, old.Spec.Template.Spec) {
+		if !reflect.DeepEqual(t.Spec.Template.Spec, old.Spec.Template.Spec) {
 			allErrs = append(allErrs,
-				field.Invalid(field.NewPath("AzureMachineTemplate", "spec", "template", "spec"), r, AzureMachineTemplateImmutableMsg),
+				field.Invalid(field.NewPath("AzureMachineTemplate", "spec", "template", "spec"), t, AzureMachineTemplateImmutableMsg),
 			)
 		}
 	}
@@ -94,19 +112,21 @@ func (r *AzureMachineTemplate) ValidateUpdate(oldRaw runtime.Object) error {
 	if len(allErrs) == 0 {
 		return nil
 	}
-	return apierrors.NewInvalid(GroupVersion.WithKind("AzureMachineTemplate").GroupKind(), r.Name, allErrs)
+	return apierrors.NewInvalid(GroupVersion.WithKind("AzureMachineTemplate").GroupKind(), t.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (r *AzureMachineTemplate) ValidateDelete() error {
+func (r *AzureMachineTemplate) ValidateDelete(ctx context.Context, obj runtime.Object) error {
 	return nil
 }
 
 // Default implements webhookutil.defaulter so a webhook will be registered for the type.
-func (r *AzureMachineTemplate) Default() {
-	if err := r.Spec.Template.Spec.SetDefaultSSHPublicKey(); err != nil {
+func (r *AzureMachineTemplate) Default(ctx context.Context, obj runtime.Object) error {
+	t := obj.(*AzureMachineTemplate)
+	if err := t.Spec.Template.Spec.SetDefaultSSHPublicKey(); err != nil {
 		ctrl.Log.WithName("SetDefault").Error(err, "SetDefaultSSHPublicKey failed")
 	}
-	r.Spec.Template.Spec.SetDefaultCachingType()
-	r.Spec.Template.Spec.SetDataDisksDefaults()
+	t.Spec.Template.Spec.SetDefaultCachingType()
+	t.Spec.Template.Spec.SetDataDisksDefaults()
+	return nil
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind api-change

**What this PR does / why we need it**:

This PR wires up the `AzureMachineTemplate` to support server-side dry run reconciliation, as specified here:

- https://cluster-api.sigs.k8s.io/developer/providers/v1.1-to-v1.2.html#required-api-changes-for-providers

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
AzureMachineTemplate webhooks dry-run
```
