### PR TITLE
Enable race detector for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -634,15 +634,19 @@ promote-images: $(KPROMO) ## Promote images.
 
 ##@ Testing:
 .PHONY: test
-test: generate lint go-test ## Run "generate", "lint" and "go-tests" rules.
+test: generate lint go-test-race ## Run "generate", "lint" and "go-test-race" rules.
+
+.PHONY: go-test-race
+go-test-race: TEST_ARGS+= -race
+go-test-race: go-test ## Run go tests with the race detector enabled.
 
 .PHONY: go-test
 go-test: $(SETUP_ENVTEST) ## Run go tests.
 	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./... $(TEST_ARGS)
 
 .PHONY: test-cover
-test-cover: $(SETUP_ENVTEST) ## Run tests with code coverage and code generate reports.
-	$(MAKE) test TEST_ARGS="$(TEST_ARGS) -coverprofile=coverage.out"
+test-cover: TEST_ARGS+= -coverprofile coverage.out
+test-cover: go-test-race ## Run tests with code coverage and generate reports.
 	go tool cover -func=coverage.out -o coverage.txt
 	go tool cover -html=coverage.out -o coverage.html
 
@@ -667,7 +671,7 @@ test-e2e-local: ## Run "docker-build" rule then run e2e tests.
 	$(MAKE) docker-build \
 	test-e2e-run
 
-CONFORMANCE_FLAVOR ?= 
+CONFORMANCE_FLAVOR ?=
 CONFORMANCE_E2E_ARGS ?= -kubetest.config-file=$(KUBETEST_CONF_PATH)
 CONFORMANCE_E2E_ARGS += $(E2E_ARGS)
 .PHONY: test-conformance

--- a/api/v1beta1/azuremachinetemplate_webhook_test.go
+++ b/api/v1beta1/azuremachinetemplate_webhook_test.go
@@ -337,7 +337,6 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 	for _, amt := range tests {
 		amt := amt
 		t.Run(amt.name, func(t *testing.T) {
-			t.Parallel()
 			ctx := admission.NewContextWithRequest(context.Background(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: pointer.Bool(true)}})
 			err := amt.template.ValidateUpdate(ctx, amt.oldTemplate, amt.template)
 			if amt.wantErr {

--- a/azure/services/inboundnatrules/inboundnatrules_test.go
+++ b/azure/services/inboundnatrules/inboundnatrules_test.go
@@ -179,7 +179,7 @@ func TestReconcileInboundNATRule(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			t.Parallel()
+			// TODO: investigate why t.Parallel() trips the race detector here.
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 			scopeMock := mock_inboundnatrules.NewMockInboundNatScope(mockCtrl)


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Enables the Go [race detector](https://go.dev/doc/articles/race_detector) in unit tests, because that seems like a best practice. However, it does more than double the time:

```shell
% git co ill-race-you && time TEST_ARGS="-race -count=1" make go-test
...
TEST_ARGS="-race -count=1" make go-test  518.22s user 31.92s system 447% cpu 2:02.92 total
% git co main && time TEST_ARGS="-count=1" make go-test
...
TEST_ARGS="-count=1" make go-test  144.72s user 20.40s system 343% cpu 48.067 total
```

Maybe we could leave `-race` enabled for CI but users can disable it locally via `TEST_ARGS`? I don't want to make tests take longer, but this flag already found two data races.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

> If your tests have incomplete coverage, you may find more races by running a binary built with -race under a realistic workload.

This sentence in the race detector docs is very intriguing to me. I wonder if we could build a debug binary with `-race` that we used in CI; I have a strong intuition it would find *something*.

Or maybe add `RACE_DETECTOR` as a toggle for Tilt binaries? *Edit*: see #2727.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
