### PR TITLE
Use webhook default name for node outbound lb

### DIFF
--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -253,7 +253,7 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 	// Node outbound LB
 	if s.NodeOutboundLB() != nil {
 		specs = append(specs, &loadbalancers.LBSpec{
-			Name:                 s.NodeOutboundLBName(),
+			Name:                 s.NodeOutboundLB().Name,
 			ResourceGroup:        s.ResourceGroup(),
 			SubscriptionID:       s.SubscriptionID(),
 			ClusterName:          s.ClusterName(),
@@ -263,7 +263,7 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 			FrontendIPConfigs:    s.NodeOutboundLB().FrontendIPs,
 			Type:                 s.NodeOutboundLB().Type,
 			SKU:                  s.NodeOutboundLB().SKU,
-			BackendPoolName:      s.OutboundPoolName(s.NodeOutboundLBName()),
+			BackendPoolName:      s.OutboundPoolName(s.NodeOutboundLB().Name),
 			IdleTimeoutInMinutes: s.NodeOutboundLB().IdleTimeoutInMinutes,
 			Role:                 infrav1.NodeOutboundRole,
 			AdditionalTags:       s.AdditionalTags(),
@@ -674,11 +674,6 @@ func (s *ClusterScope) GetPrivateDNSZoneName() string {
 // APIServerLBPoolName returns the API Server LB backend pool name.
 func (s *ClusterScope) APIServerLBPoolName(loadBalancerName string) string {
 	return azure.GenerateBackendAddressPoolName(loadBalancerName)
-}
-
-// NodeOutboundLBName returns the name of the node outbound LB.
-func (s *ClusterScope) NodeOutboundLBName() string {
-	return s.ClusterName()
 }
 
 // OutboundLBName returns the name of the outbound LB.


### PR DESCRIPTION
Signed-off-by: Ashutosh Kumar <sonasingh46@gmail.com>

/kind bug

**What this PR does / why we need it**:
Use webhook default for node outbound lb name
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2648 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use webhook default name for node outbound lb
```
