### PR TITLE
use cluster name for managed cluster spec's name

### DIFF
--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -413,7 +413,7 @@ func (s *ManagedControlPlaneScope) ManagedClusterAnnotations() map[string]string
 // ManagedClusterSpec returns the managed cluster spec.
 func (s *ManagedControlPlaneScope) ManagedClusterSpec(ctx context.Context) azure.ResourceSpecGetter {
 	managedClusterSpec := managedclusters.ManagedClusterSpec{
-		Name:              s.ControlPlane.Name,
+		Name:              s.ClusterName(),
 		ResourceGroup:     s.ControlPlane.Spec.ResourceGroupName,
 		NodeResourceGroup: s.ControlPlane.Spec.NodeResourceGroupName,
 		Location:          s.ControlPlane.Spec.Location,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- With this PR `ManagedClusterSpec.name` will be set as `ManagedControlPlaneScope.Cluster.Name` _instead_ of `ManagedControlPlaneScope.ControlPlane.Name`.
- By doing this, the `AzureManagedCluster`'s Name is independent of `AzureManagedControlPlane`'s Name value. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2438 

**Special notes for your reviewer**:
#####  Current Code flow 
1. `managedClusterSpec` is fetched/formed at this line. 
    - https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/240f5dd4104e7fb0603494a77e429b6884dbfc3f/azure/services/managedclusters/managedclusters.go#L77 
    - `managedClusterSpec.Name`'s value is set to `ManagedControlPlaneScope.ControlPlane.Name` which later gets passed down as `managedClusterSpec.ResourceName()` in 2,3,4 below. https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/240f5dd4104e7fb0603494a77e429b6884dbfc3f/azure/scope/managedcontrolplane.go#L389
2.  https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/240f5dd4104e7fb0603494a77e429b6884dbfc3f/azure/services/managedclusters/managedclusters.go#L97
3. https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/240f5dd4104e7fb0603494a77e429b6884dbfc3f/azure/services/managedclusters/client.go#L66
4. https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/240f5dd4104e7fb0603494a77e429b6884dbfc3f/azure/services/managedclusters/client.go#L70

##### Reasoning behind this change. 
- Changing the  `managedClusterSpec.Name`'s value to `ManagedControlPlaneScope.ClusterName()` makes `managedClusterSpec.Name`' independent of  `ManagedControlPlaneScope.ControlPlane.Name` 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
