### PR TITLE
standardize scope local cache

### DIFF
--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -1270,6 +1270,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachineCache{},
 			},
 			want: &infrav1.Image{
 				ID: pointer.StringPtr("1"),
@@ -1298,6 +1299,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 					},
 				},
 				ClusterScoper: clusterMock,
+				cache:         &MachineCache{},
 			},
 			want: func() *infrav1.Image {
 				image, _ := svc.GetDefaultWindowsImage(context.TODO(), "", "1.20.1", "dockershim", "")
@@ -1327,6 +1329,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 					},
 				},
 				ClusterScoper: clusterMock,
+				cache:         &MachineCache{},
 			},
 			want: func() *infrav1.Image {
 				image, _ := svc.GetDefaultWindowsImage(context.TODO(), "", "1.22.1", "containerd", "")
@@ -1359,6 +1362,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 					},
 				},
 				ClusterScoper: clusterMock,
+				cache:         &MachineCache{},
 			},
 			want: func() *infrav1.Image {
 				image, _ := svc.GetDefaultWindowsImage(context.TODO(), "", "1.22.1", "dockershim", "")
@@ -1391,6 +1395,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 					},
 				},
 				ClusterScoper: clusterMock,
+				cache:         &MachineCache{},
 			},
 			want: func() *infrav1.Image {
 				image, _ := svc.GetDefaultWindowsImage(context.TODO(), "", "1.21.1", "dockershim", "")
@@ -1423,6 +1428,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 					},
 				},
 				ClusterScoper: clusterMock,
+				cache:         &MachineCache{},
 			},
 			want:        nil,
 			expectedErr: "containerd image only supported in 1.22+",
@@ -1452,6 +1458,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 					},
 				},
 				ClusterScoper: clusterMock,
+				cache:         &MachineCache{},
 			},
 			want: func() *infrav1.Image {
 				image, _ := svc.GetDefaultWindowsImage(context.TODO(), "", "1.23.3", "", "windows-2019")
@@ -1484,6 +1491,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 					},
 				},
 				ClusterScoper: clusterMock,
+				cache:         &MachineCache{},
 			},
 			want: func() *infrav1.Image {
 				image, _ := svc.GetDefaultWindowsImage(context.TODO(), "", "1.23.3", "", "windows-2022")
@@ -1508,6 +1516,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 					},
 				},
 				ClusterScoper: clusterMock,
+				cache:         &MachineCache{},
 			},
 			want: func() *infrav1.Image {
 				image, _ := svc.GetDefaultUbuntuImage(context.TODO(), "", "1.20.1")
@@ -1606,6 +1615,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachineCache{},
 			},
 			want: []azure.ResourceSpecGetter{
 				&networkinterfaces.NICSpec{
@@ -1707,7 +1717,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 					},
 				},
 				cache: &MachineCache{
-					VMSKU: resourceskus.SKU{
+					VMSKU: &resourceskus.SKU{
 						Name: to.StringPtr("Standard_D2v2"),
 					},
 				},
@@ -1818,6 +1828,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachineCache{},
 			},
 			want: []azure.ResourceSpecGetter{
 				&networkinterfaces.NICSpec{
@@ -1919,6 +1930,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachineCache{},
 			},
 			want: []azure.ResourceSpecGetter{
 				&networkinterfaces.NICSpec{
@@ -2025,6 +2037,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachineCache{},
 			},
 			want: []azure.ResourceSpecGetter{
 				&networkinterfaces.NICSpec{
@@ -2128,6 +2141,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachineCache{},
 			},
 			want: []azure.ResourceSpecGetter{
 				&networkinterfaces.NICSpec{
@@ -2232,6 +2246,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachineCache{},
 			},
 			want: []azure.ResourceSpecGetter{
 				&networkinterfaces.NICSpec{
@@ -2264,7 +2279,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotNicSpecs := tt.machineScope.NICSpecs()
+			gotNicSpecs := tt.machineScope.NICSpecs(context.TODO())
 			if !reflect.DeepEqual(gotNicSpecs, tt.want) {
 				t.Errorf("NICSpecs(), gotNicSpecs = %s, want %s", specArrayToString(gotNicSpecs), specArrayToString(tt.want))
 			}

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -407,6 +407,7 @@ func TestMachinePoolScope_GetVMImage(t *testing.T) {
 				MachinePool:      mp,
 				AzureMachinePool: amp,
 				ClusterScoper:    clusterMock,
+				cache:            &MachinePoolCache{},
 			}
 			image, err := s.GetVMImage(context.TODO())
 			c.Verify(g, amp, image, err)

--- a/azure/services/availabilitysets/availabilitysets.go
+++ b/azure/services/availabilitysets/availabilitysets.go
@@ -35,7 +35,7 @@ const serviceName = "availabilitysets"
 type AvailabilitySetScope interface {
 	azure.ClusterDescriber
 	azure.AsyncStatusUpdater
-	AvailabilitySetSpec() azure.ResourceSpecGetter
+	AvailabilitySetSpec(context.Context) azure.ResourceSpecGetter
 }
 
 // Service provides operations on Azure resources.
@@ -71,7 +71,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	defer cancel()
 
 	var err error
-	if setSpec := s.Scope.AvailabilitySetSpec(); setSpec != nil {
+	if setSpec := s.Scope.AvailabilitySetSpec(ctx); setSpec != nil {
 		_, err = s.CreateResource(ctx, setSpec, serviceName)
 	} else {
 		log.V(2).Info("skip creation when no availability set spec is found")
@@ -91,7 +91,7 @@ func (s *Service) Delete(ctx context.Context) error {
 	defer cancel()
 
 	var resultingErr error
-	setSpec := s.Scope.AvailabilitySetSpec()
+	setSpec := s.Scope.AvailabilitySetSpec(ctx)
 	if setSpec == nil {
 		log.V(2).Info("skip deletion when no availability set spec is found")
 		return nil

--- a/azure/services/availabilitysets/availabilitysets_test.go
+++ b/azure/services/availabilitysets/availabilitysets_test.go
@@ -83,7 +83,7 @@ func TestReconcileAvailabilitySets(t *testing.T) {
 			name:          "create or update availability set",
 			expectedError: "",
 			expect: func(s *mock_availabilitysets.MockAvailabilitySetScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.AvailabilitySetSpec().Return(&fakeSetSpec)
+				s.AvailabilitySetSpec(gomockinternal.AContext()).Return(&fakeSetSpec)
 				r.CreateResource(gomockinternal.AContext(), &fakeSetSpec, serviceName).Return(nil, nil)
 				s.UpdatePutStatus(infrav1.AvailabilitySetReadyCondition, serviceName, nil)
 			},
@@ -92,14 +92,14 @@ func TestReconcileAvailabilitySets(t *testing.T) {
 			name:          "noop if no availability set spec returns nil",
 			expectedError: "",
 			expect: func(s *mock_availabilitysets.MockAvailabilitySetScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.AvailabilitySetSpec().Return(nil)
+				s.AvailabilitySetSpec(gomockinternal.AContext()).Return(nil)
 			},
 		},
 		{
 			name:          "missing required value in availability set spec",
 			expectedError: "some error with parameters",
 			expect: func(s *mock_availabilitysets.MockAvailabilitySetScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.AvailabilitySetSpec().Return(&fakeSetSpecMissing)
+				s.AvailabilitySetSpec(gomockinternal.AContext()).Return(&fakeSetSpecMissing)
 				r.CreateResource(gomockinternal.AContext(), &fakeSetSpecMissing, serviceName).Return(nil, parameterError)
 				s.UpdatePutStatus(infrav1.AvailabilitySetReadyCondition, serviceName, parameterError)
 			},
@@ -108,7 +108,7 @@ func TestReconcileAvailabilitySets(t *testing.T) {
 			name:          "error in creating availability set",
 			expectedError: "#: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_availabilitysets.MockAvailabilitySetScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.AvailabilitySetSpec().Return(&fakeSetSpec)
+				s.AvailabilitySetSpec(gomockinternal.AContext()).Return(&fakeSetSpec)
 				r.CreateResource(gomockinternal.AContext(), &fakeSetSpec, serviceName).Return(nil, internalError)
 				s.UpdatePutStatus(infrav1.AvailabilitySetReadyCondition, serviceName, internalError)
 			},
@@ -153,7 +153,7 @@ func TestDeleteAvailabilitySets(t *testing.T) {
 			name:          "deletes availability set",
 			expectedError: "",
 			expect: func(s *mock_availabilitysets.MockAvailabilitySetScopeMockRecorder, m *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.AvailabilitySetSpec().Return(&fakeSetSpec)
+				s.AvailabilitySetSpec(gomockinternal.AContext()).Return(&fakeSetSpec)
 				gomock.InOrder(
 					m.Get(gomockinternal.AContext(), &fakeSetSpec).Return(compute.AvailabilitySet{}, nil),
 					r.DeleteResource(gomockinternal.AContext(), &fakeSetSpec, serviceName).Return(nil),
@@ -165,14 +165,14 @@ func TestDeleteAvailabilitySets(t *testing.T) {
 			name:          "noop if AvailabilitySetSpec returns nil",
 			expectedError: "",
 			expect: func(s *mock_availabilitysets.MockAvailabilitySetScopeMockRecorder, m *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.AvailabilitySetSpec().Return(nil)
+				s.AvailabilitySetSpec(gomockinternal.AContext()).Return(nil)
 			},
 		},
 		{
 			name:          "delete proceeds with missing required value in availability set spec",
 			expectedError: "",
 			expect: func(s *mock_availabilitysets.MockAvailabilitySetScopeMockRecorder, m *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.AvailabilitySetSpec().Return(&fakeSetSpecMissing)
+				s.AvailabilitySetSpec(gomockinternal.AContext()).Return(&fakeSetSpecMissing)
 				gomock.InOrder(
 					m.Get(gomockinternal.AContext(), &fakeSetSpecMissing).Return(compute.AvailabilitySet{}, nil),
 					r.DeleteResource(gomockinternal.AContext(), &fakeSetSpecMissing, serviceName).Return(nil),
@@ -184,7 +184,7 @@ func TestDeleteAvailabilitySets(t *testing.T) {
 			name:          "noop if availability set has vms",
 			expectedError: "",
 			expect: func(s *mock_availabilitysets.MockAvailabilitySetScopeMockRecorder, m *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.AvailabilitySetSpec().Return(&fakeSetSpec)
+				s.AvailabilitySetSpec(gomockinternal.AContext()).Return(&fakeSetSpec)
 				gomock.InOrder(
 					m.Get(gomockinternal.AContext(), &fakeSetSpec).Return(fakeSetWithVMs, nil),
 					s.UpdateDeleteStatus(infrav1.AvailabilitySetReadyCondition, serviceName, nil),
@@ -195,7 +195,7 @@ func TestDeleteAvailabilitySets(t *testing.T) {
 			name:          "availability set not found",
 			expectedError: "",
 			expect: func(s *mock_availabilitysets.MockAvailabilitySetScopeMockRecorder, m *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.AvailabilitySetSpec().Return(&fakeSetSpec)
+				s.AvailabilitySetSpec(gomockinternal.AContext()).Return(&fakeSetSpec)
 				gomock.InOrder(
 					m.Get(gomockinternal.AContext(), &fakeSetSpec).Return(nil, notFoundError),
 					s.UpdateDeleteStatus(infrav1.AvailabilitySetReadyCondition, serviceName, nil),
@@ -206,7 +206,7 @@ func TestDeleteAvailabilitySets(t *testing.T) {
 			name:          "error in getting availability set",
 			expectedError: "failed to get availability set test-as in resource group test-rg: #: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_availabilitysets.MockAvailabilitySetScopeMockRecorder, m *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.AvailabilitySetSpec().Return(&fakeSetSpec)
+				s.AvailabilitySetSpec(gomockinternal.AContext()).Return(&fakeSetSpec)
 				gomock.InOrder(
 					m.Get(gomockinternal.AContext(), &fakeSetSpec).Return(nil, internalError),
 					s.UpdateDeleteStatus(infrav1.AvailabilitySetReadyCondition, serviceName, gomockinternal.ErrStrEq("failed to get availability set test-as in resource group test-rg: #: Internal Server Error: StatusCode=500")),
@@ -217,7 +217,7 @@ func TestDeleteAvailabilitySets(t *testing.T) {
 			name:          "availability set get result is not an availability set",
 			expectedError: "string is not a compute.AvailabilitySet",
 			expect: func(s *mock_availabilitysets.MockAvailabilitySetScopeMockRecorder, m *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.AvailabilitySetSpec().Return(&fakeSetSpec)
+				s.AvailabilitySetSpec(gomockinternal.AContext()).Return(&fakeSetSpec)
 				gomock.InOrder(
 					m.Get(gomockinternal.AContext(), &fakeSetSpec).Return("not an availability set", nil),
 					s.UpdateDeleteStatus(infrav1.AvailabilitySetReadyCondition, serviceName, gomockinternal.ErrStrEq("string is not a compute.AvailabilitySet")),
@@ -228,7 +228,7 @@ func TestDeleteAvailabilitySets(t *testing.T) {
 			name:          "error in deleting availability set",
 			expectedError: "#: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_availabilitysets.MockAvailabilitySetScopeMockRecorder, m *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.AvailabilitySetSpec().Return(&fakeSetSpec)
+				s.AvailabilitySetSpec(gomockinternal.AContext()).Return(&fakeSetSpec)
 				gomock.InOrder(
 					m.Get(gomockinternal.AContext(), &fakeSetSpec).Return(compute.AvailabilitySet{}, nil),
 					r.DeleteResource(gomockinternal.AContext(), &fakeSetSpec, serviceName).Return(internalError),

--- a/azure/services/availabilitysets/mock_availabilitysets/availabilitysets_mock.go
+++ b/azure/services/availabilitysets/mock_availabilitysets/availabilitysets_mock.go
@@ -21,6 +21,7 @@ limitations under the License.
 package mock_availabilitysets
 
 import (
+	context "context"
 	reflect "reflect"
 
 	autorest "github.com/Azure/go-autorest/autorest"
@@ -96,17 +97,17 @@ func (mr *MockAvailabilitySetScopeMockRecorder) AvailabilitySetEnabled() *gomock
 }
 
 // AvailabilitySetSpec mocks base method.
-func (m *MockAvailabilitySetScope) AvailabilitySetSpec() azure.ResourceSpecGetter {
+func (m *MockAvailabilitySetScope) AvailabilitySetSpec(arg0 context.Context) azure.ResourceSpecGetter {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AvailabilitySetSpec")
+	ret := m.ctrl.Call(m, "AvailabilitySetSpec", arg0)
 	ret0, _ := ret[0].(azure.ResourceSpecGetter)
 	return ret0
 }
 
 // AvailabilitySetSpec indicates an expected call of AvailabilitySetSpec.
-func (mr *MockAvailabilitySetScopeMockRecorder) AvailabilitySetSpec() *gomock.Call {
+func (mr *MockAvailabilitySetScopeMockRecorder) AvailabilitySetSpec(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetSpec", reflect.TypeOf((*MockAvailabilitySetScope)(nil).AvailabilitySetSpec))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetSpec", reflect.TypeOf((*MockAvailabilitySetScope)(nil).AvailabilitySetSpec), arg0)
 }
 
 // BaseURI mocks base method.

--- a/azure/services/networkinterfaces/mock_networkinterfaces/networkinterfaces_mock.go
+++ b/azure/services/networkinterfaces/mock_networkinterfaces/networkinterfaces_mock.go
@@ -21,6 +21,7 @@ limitations under the License.
 package mock_networkinterfaces
 
 import (
+	context "context"
 	reflect "reflect"
 
 	autorest "github.com/Azure/go-autorest/autorest"
@@ -248,17 +249,17 @@ func (mr *MockNICScopeMockRecorder) Location() *gomock.Call {
 }
 
 // NICSpecs mocks base method.
-func (m *MockNICScope) NICSpecs() []azure.ResourceSpecGetter {
+func (m *MockNICScope) NICSpecs(arg0 context.Context) []azure.ResourceSpecGetter {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NICSpecs")
+	ret := m.ctrl.Call(m, "NICSpecs", arg0)
 	ret0, _ := ret[0].([]azure.ResourceSpecGetter)
 	return ret0
 }
 
 // NICSpecs indicates an expected call of NICSpecs.
-func (mr *MockNICScopeMockRecorder) NICSpecs() *gomock.Call {
+func (mr *MockNICScopeMockRecorder) NICSpecs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NICSpecs", reflect.TypeOf((*MockNICScope)(nil).NICSpecs))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NICSpecs", reflect.TypeOf((*MockNICScope)(nil).NICSpecs), arg0)
 }
 
 // ResourceGroup mocks base method.

--- a/azure/services/networkinterfaces/networkinterfaces.go
+++ b/azure/services/networkinterfaces/networkinterfaces.go
@@ -33,7 +33,7 @@ const serviceName = "interfaces"
 type NICScope interface {
 	azure.ClusterDescriber
 	azure.AsyncStatusUpdater
-	NICSpecs() []azure.ResourceSpecGetter
+	NICSpecs(context.Context) []azure.ResourceSpecGetter
 }
 
 // Service provides operations on Azure resources.
@@ -66,7 +66,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
 	defer cancel()
 
-	specs := s.Scope.NICSpecs()
+	specs := s.Scope.NICSpecs(ctx)
 	if len(specs) == 0 {
 		return nil
 	}
@@ -95,7 +95,7 @@ func (s *Service) Delete(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
 	defer cancel()
 
-	specs := s.Scope.NICSpecs()
+	specs := s.Scope.NICSpecs(ctx)
 	if len(specs) == 0 {
 		return nil
 	}

--- a/azure/services/networkinterfaces/networkinterfaces_test.go
+++ b/azure/services/networkinterfaces/networkinterfaces_test.go
@@ -71,14 +71,14 @@ func TestReconcileNetworkInterface(t *testing.T) {
 			name:          "noop if no network interface specs are found",
 			expectedError: "",
 			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.NICSpecs().Return([]azure.ResourceSpecGetter{})
+				s.NICSpecs(gomockinternal.AContext()).Return([]azure.ResourceSpecGetter{})
 			},
 		},
 		{
 			name:          "successfully create a network interface",
 			expectedError: "",
 			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.NICSpecs().Return([]azure.ResourceSpecGetter{&fakeNICSpec1})
+				s.NICSpecs(gomockinternal.AContext()).Return([]azure.ResourceSpecGetter{&fakeNICSpec1})
 				r.CreateResource(gomockinternal.AContext(), &fakeNICSpec1, serviceName).Return(nil, nil)
 				s.UpdatePutStatus(infrav1.NetworkInterfaceReadyCondition, serviceName, nil)
 			},
@@ -87,7 +87,7 @@ func TestReconcileNetworkInterface(t *testing.T) {
 			name:          "successfully create multiple network interfaces",
 			expectedError: "",
 			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.NICSpecs().Return([]azure.ResourceSpecGetter{&fakeNICSpec1, &fakeNICSpec2})
+				s.NICSpecs(gomockinternal.AContext()).Return([]azure.ResourceSpecGetter{&fakeNICSpec1, &fakeNICSpec2})
 				r.CreateResource(gomockinternal.AContext(), &fakeNICSpec1, serviceName).Return(nil, nil)
 				r.CreateResource(gomockinternal.AContext(), &fakeNICSpec2, serviceName).Return(nil, nil)
 				s.UpdatePutStatus(infrav1.NetworkInterfaceReadyCondition, serviceName, nil)
@@ -97,7 +97,7 @@ func TestReconcileNetworkInterface(t *testing.T) {
 			name:          "network interface create fails",
 			expectedError: internalError.Error(),
 			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.NICSpecs().Return([]azure.ResourceSpecGetter{&fakeNICSpec1, &fakeNICSpec2})
+				s.NICSpecs(gomockinternal.AContext()).Return([]azure.ResourceSpecGetter{&fakeNICSpec1, &fakeNICSpec2})
 				r.CreateResource(gomockinternal.AContext(), &fakeNICSpec1, serviceName).Return(nil, internalError)
 				r.CreateResource(gomockinternal.AContext(), &fakeNICSpec2, serviceName).Return(nil, nil)
 				s.UpdatePutStatus(infrav1.NetworkInterfaceReadyCondition, serviceName, internalError)
@@ -145,14 +145,14 @@ func TestDeleteNetworkInterface(t *testing.T) {
 			name:          "noop if no network interface specs are found",
 			expectedError: "",
 			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.NICSpecs().Return([]azure.ResourceSpecGetter{})
+				s.NICSpecs(gomockinternal.AContext()).Return([]azure.ResourceSpecGetter{})
 			},
 		},
 		{
 			name:          "successfully delete an existing network interface",
 			expectedError: "",
 			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.NICSpecs().Return([]azure.ResourceSpecGetter{&fakeNICSpec1})
+				s.NICSpecs(gomockinternal.AContext()).Return([]azure.ResourceSpecGetter{&fakeNICSpec1})
 				r.DeleteResource(gomockinternal.AContext(), &fakeNICSpec1, serviceName).Return(nil)
 				s.UpdateDeleteStatus(infrav1.NetworkInterfaceReadyCondition, serviceName, nil)
 			},
@@ -161,7 +161,7 @@ func TestDeleteNetworkInterface(t *testing.T) {
 			name:          "successfully delete multiple existing network interfaces",
 			expectedError: "",
 			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.NICSpecs().Return([]azure.ResourceSpecGetter{&fakeNICSpec1, &fakeNICSpec2})
+				s.NICSpecs(gomockinternal.AContext()).Return([]azure.ResourceSpecGetter{&fakeNICSpec1, &fakeNICSpec2})
 				r.DeleteResource(gomockinternal.AContext(), &fakeNICSpec1, serviceName).Return(nil)
 				r.DeleteResource(gomockinternal.AContext(), &fakeNICSpec2, serviceName).Return(nil)
 				s.UpdateDeleteStatus(infrav1.NetworkInterfaceReadyCondition, serviceName, nil)
@@ -171,7 +171,7 @@ func TestDeleteNetworkInterface(t *testing.T) {
 			name:          "network interface deletion fails",
 			expectedError: internalError.Error(),
 			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.NICSpecs().Return([]azure.ResourceSpecGetter{&fakeNICSpec1, &fakeNICSpec2})
+				s.NICSpecs(gomockinternal.AContext()).Return([]azure.ResourceSpecGetter{&fakeNICSpec1, &fakeNICSpec2})
 				r.DeleteResource(gomockinternal.AContext(), &fakeNICSpec1, serviceName).Return(nil)
 				r.DeleteResource(gomockinternal.AContext(), &fakeNICSpec2, serviceName).Return(internalError)
 				s.UpdateDeleteStatus(infrav1.NetworkInterfaceReadyCondition, serviceName, internalError)

--- a/azure/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
+++ b/azure/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
@@ -21,6 +21,7 @@ limitations under the License.
 package mock_virtualmachines
 
 import (
+	context "context"
 	reflect "reflect"
 
 	autorest "github.com/Azure/go-autorest/autorest"
@@ -289,15 +290,15 @@ func (mr *MockVMScopeMockRecorder) UpdatePutStatus(arg0, arg1, arg2 interface{})
 }
 
 // VMSpec mocks base method.
-func (m *MockVMScope) VMSpec() azure.ResourceSpecGetter {
+func (m *MockVMScope) VMSpec(arg0 context.Context) azure.ResourceSpecGetter {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VMSpec")
+	ret := m.ctrl.Call(m, "VMSpec", arg0)
 	ret0, _ := ret[0].(azure.ResourceSpecGetter)
 	return ret0
 }
 
 // VMSpec indicates an expected call of VMSpec.
-func (mr *MockVMScopeMockRecorder) VMSpec() *gomock.Call {
+func (mr *MockVMScopeMockRecorder) VMSpec(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VMSpec", reflect.TypeOf((*MockVMScope)(nil).VMSpec))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VMSpec", reflect.TypeOf((*MockVMScope)(nil).VMSpec), arg0)
 }

--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -42,7 +42,7 @@ const serviceName = "virtualmachine"
 type VMScope interface {
 	azure.Authorizer
 	azure.AsyncStatusUpdater
-	VMSpec() azure.ResourceSpecGetter
+	VMSpec(context.Context) azure.ResourceSpecGetter
 	SetAnnotation(string, string)
 	SetProviderID(string)
 	SetAddresses([]corev1.NodeAddress)
@@ -81,7 +81,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
 	defer cancel()
 
-	vmSpec := s.Scope.VMSpec()
+	vmSpec := s.Scope.VMSpec(ctx)
 	if vmSpec == nil {
 		return nil
 	}
@@ -123,7 +123,7 @@ func (s *Service) Delete(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
 	defer cancel()
 
-	vmSpec := s.Scope.VMSpec()
+	vmSpec := s.Scope.VMSpec(ctx)
 	if vmSpec == nil {
 		return nil
 	}

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -120,14 +120,14 @@ func TestReconcileVM(t *testing.T) {
 			name:          "noop if no vm spec is found",
 			expectedError: "",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, mnic *mock_async.MockGetterMockRecorder, mpip *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.VMSpec().Return(nil)
+				s.VMSpec(gomockinternal.AContext()).Return(nil)
 			},
 		},
 		{
 			name:          "create vm succeeds",
 			expectedError: "",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, mnic *mock_async.MockGetterMockRecorder, mpip *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.VMSpec().Return(&fakeVMSpec)
+				s.VMSpec(gomockinternal.AContext()).Return(&fakeVMSpec)
 				r.CreateResource(gomockinternal.AContext(), &fakeVMSpec, serviceName).Return(fakeExistingVM, nil)
 				s.UpdatePutStatus(infrav1.VMRunningCondition, serviceName, nil)
 				s.UpdatePutStatus(infrav1.DisksReadyCondition, serviceName, nil)
@@ -143,7 +143,7 @@ func TestReconcileVM(t *testing.T) {
 			name:          "creating vm fails",
 			expectedError: "#: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, mnic *mock_async.MockGetterMockRecorder, mpip *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.VMSpec().Return(&fakeVMSpec)
+				s.VMSpec(gomockinternal.AContext()).Return(&fakeVMSpec)
 				r.CreateResource(gomockinternal.AContext(), &fakeVMSpec, serviceName).Return(nil, internalError)
 				s.UpdatePutStatus(infrav1.VMRunningCondition, serviceName, internalError)
 				s.UpdatePutStatus(infrav1.DisksReadyCondition, serviceName, internalError)
@@ -153,7 +153,7 @@ func TestReconcileVM(t *testing.T) {
 			name:          "create vm succeeds but failed to get network interfaces",
 			expectedError: "failed to fetch VM addresses: #: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, mnic *mock_async.MockGetterMockRecorder, mpip *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.VMSpec().Return(&fakeVMSpec)
+				s.VMSpec(gomockinternal.AContext()).Return(&fakeVMSpec)
 				r.CreateResource(gomockinternal.AContext(), &fakeVMSpec, serviceName).Return(fakeExistingVM, nil)
 				s.UpdatePutStatus(infrav1.VMRunningCondition, serviceName, nil)
 				s.UpdatePutStatus(infrav1.DisksReadyCondition, serviceName, nil)
@@ -166,7 +166,7 @@ func TestReconcileVM(t *testing.T) {
 			name:          "create vm succeeds but failed to get public IPs",
 			expectedError: "failed to fetch VM addresses: #: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, mnic *mock_async.MockGetterMockRecorder, mpip *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.VMSpec().Return(&fakeVMSpec)
+				s.VMSpec(gomockinternal.AContext()).Return(&fakeVMSpec)
 				r.CreateResource(gomockinternal.AContext(), &fakeVMSpec, serviceName).Return(fakeExistingVM, nil)
 				s.UpdatePutStatus(infrav1.VMRunningCondition, serviceName, nil)
 				s.UpdatePutStatus(infrav1.DisksReadyCondition, serviceName, nil)
@@ -221,14 +221,14 @@ func TestDeleteVM(t *testing.T) {
 			name:          "noop if no vm spec is found",
 			expectedError: "",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.VMSpec().Return(nil)
+				s.VMSpec(gomockinternal.AContext()).Return(nil)
 			},
 		},
 		{
 			name:          "vm doesn't exist",
 			expectedError: "",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.VMSpec().AnyTimes().Return(&fakeVMSpec)
+				s.VMSpec(gomockinternal.AContext()).AnyTimes().Return(&fakeVMSpec)
 				r.DeleteResource(gomockinternal.AContext(), &fakeVMSpec, serviceName).Return(nil)
 				s.SetVMState(infrav1.Deleted)
 				s.UpdateDeleteStatus(infrav1.VMRunningCondition, serviceName, nil)
@@ -238,7 +238,7 @@ func TestDeleteVM(t *testing.T) {
 			name:          "error occurs when deleting vm",
 			expectedError: "#: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.VMSpec().AnyTimes().Return(&fakeVMSpec)
+				s.VMSpec(gomockinternal.AContext()).AnyTimes().Return(&fakeVMSpec)
 				r.DeleteResource(gomockinternal.AContext(), &fakeVMSpec, serviceName).Return(internalError)
 				s.SetVMState(infrav1.Deleting)
 				s.UpdateDeleteStatus(infrav1.VMRunningCondition, serviceName, internalError)
@@ -248,7 +248,7 @@ func TestDeleteVM(t *testing.T) {
 			name:          "delete the vm successfully",
 			expectedError: "",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.VMSpec().AnyTimes().Return(&fakeVMSpec)
+				s.VMSpec(gomockinternal.AContext()).AnyTimes().Return(&fakeVMSpec)
 				r.DeleteResource(gomockinternal.AContext(), &fakeVMSpec, serviceName).Return(nil)
 				s.SetVMState(infrav1.Deleted)
 				s.UpdateDeleteStatus(infrav1.VMRunningCondition, serviceName, nil)

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -270,20 +270,6 @@ func (amr *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineS
 
 	var reconcileError azure.ReconcileError
 
-	// Initialize the cache to be used by the AzureMachine services.
-	err := machineScope.InitMachineCache(ctx)
-	if err != nil {
-		if errors.As(err, &reconcileError) && reconcileError.IsTerminal() {
-			amr.Recorder.Eventf(machineScope.AzureMachine, corev1.EventTypeWarning, "SKUNotFound", errors.Wrap(err, "failed to initialize machine cache").Error())
-			log.Error(err, "Failed to initialize machine cache")
-			machineScope.SetFailureReason(capierrors.InvalidConfigurationMachineError)
-			machineScope.SetFailureMessage(err)
-			machineScope.SetNotReady()
-			return reconcile.Result{}, nil
-		}
-		return reconcile.Result{}, errors.Wrap(err, "failed to init machine scope cache")
-	}
-
 	ams, err := amr.createAzureMachineService(machineScope)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to create azure machine service")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind feature
/kind cleanup

**What this PR does / why we need it**:

This PR picks up where this one left off:

https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2604

Here we standardize the way we maintain a local scope cache (in other words, we cache values that are retrieved externally so that we only have to fetch them once in any given scope lifecycle [e.g., one reconciliation loop]).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
standardize scope local cache
```
