### PR TITLE
Add finalizer to AzureClusterIdentity

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -42,10 +42,13 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
@@ -596,4 +599,50 @@ func GetClusterIdentityFromRef(ctx context.Context, c client.Client, azureCluste
 		return identity, nil
 	}
 	return nil, nil
+}
+
+func clusterIdentityFinalizer(prefix, clusterNamespace, clusterName string) string {
+	return fmt.Sprintf("%s/%s-%s", prefix, clusterNamespace, clusterName)
+}
+
+// EnsureClusterIdentity ensures that the identity ref is allowed in the namespace and sets a finalizer.
+func EnsureClusterIdentity(ctx context.Context, c client.Client, object conditions.Setter, identityRef *corev1.ObjectReference, finalizerPrefix string) error {
+	name := object.GetName()
+	namespace := object.GetNamespace()
+	identity, err := GetClusterIdentityFromRef(ctx, c, namespace, identityRef)
+	if err != nil {
+		return err
+	}
+	if !scope.IsClusterNamespaceAllowed(ctx, c, identity.Spec.AllowedNamespaces, namespace) {
+		conditions.MarkFalse(object, infrav1.NetworkInfrastructureReadyCondition, infrav1.NamespaceNotAllowedByIdentity, clusterv1.ConditionSeverityError, "")
+		return errors.New("AzureClusterIdentity list of allowed namespaces doesn't include current cluster namespace")
+	}
+	identityHelper, err := patch.NewHelper(identity, c)
+	if err != nil {
+		return errors.Wrap(err, "failed to init patch helper")
+	}
+	// If the AzureClusterIdentity doesn't have our finalizer, add it.
+	controllerutil.AddFinalizer(identity, clusterIdentityFinalizer(finalizerPrefix, namespace, name))
+	// Register the finalizer immediately to avoid orphaning Azure resources on delete.
+	return identityHelper.Patch(ctx, identity)
+}
+
+// RemoveClusterIdentityFinalizer removes the finalizer on an AzureClusterIdentity.
+func RemoveClusterIdentityFinalizer(ctx context.Context, c client.Client, object client.Object, identityRef *corev1.ObjectReference, finalizerPrefix string) error {
+	name := object.GetName()
+	namespace := object.GetNamespace()
+	identity, err := GetClusterIdentityFromRef(ctx, c, namespace, identityRef)
+	if err != nil {
+		return err
+	}
+	identityHelper, err := patch.NewHelper(identity, c)
+	if err != nil {
+		return errors.Wrap(err, "failed to init patch helper")
+	}
+	controllerutil.RemoveFinalizer(identity, clusterIdentityFinalizer(finalizerPrefix, namespace, name))
+	err = identityHelper.Patch(ctx, identity)
+	if err != nil {
+		return errors.Wrap(err, "failed to patch AzureClusterIdentity")
+	}
+	return nil
 }

--- a/exp/api/v1beta1/azuremanagedcontrolplane_types.go
+++ b/exp/api/v1beta1/azuremanagedcontrolplane_types.go
@@ -24,6 +24,10 @@ import (
 )
 
 const (
+	// ManagedClusterFinalizer allows Reconcile to clean up Azure resources associated with the AzureManagedControlPlane before
+	// removing it from the apiserver.
+	ManagedClusterFinalizer = "azuremanagedcontrolplane.infrastructure.cluster.x-k8s.io"
+
 	// PrivateDNSZoneModeSystem represents mode System for azuremanagedcontrolplane.
 	PrivateDNSZoneModeSystem string = "System"
 

--- a/exp/controllers/azuremanagedcontrolplane_controller.go
+++ b/exp/controllers/azuremanagedcontrolplane_controller.go
@@ -181,12 +181,9 @@ func (amcpr *AzureManagedControlPlaneReconciler) Reconcile(ctx context.Context, 
 
 	// check if the control plane's namespace is allowed for this identity and update owner references for the identity.
 	if azureControlPlane.Spec.IdentityRef != nil {
-		identity, err := infracontroller.GetClusterIdentityFromRef(ctx, amcpr.Client, azureControlPlane.Namespace, azureControlPlane.Spec.IdentityRef)
+		err := infracontroller.EnsureClusterIdentity(ctx, amcpr.Client, azureControlPlane, azureControlPlane.Spec.IdentityRef, infrav1exp.ManagedClusterFinalizer)
 		if err != nil {
 			return reconcile.Result{}, err
-		}
-		if !scope.IsClusterNamespaceAllowed(ctx, amcpr.Client, identity.Spec.AllowedNamespaces, azureControlPlane.Namespace) {
-			return reconcile.Result{}, errors.New("AzureClusterIdentity list of allowed namespaces doesn't include current azure managed control plane namespace")
 		}
 	} else {
 		warningMessage := ("You're using deprecated functionality: ")
@@ -228,8 +225,10 @@ func (amcpr *AzureManagedControlPlaneReconciler) reconcileNormal(ctx context.Con
 
 	log.Info("Reconciling AzureManagedControlPlane")
 
+	// Remove deprecated Cluster finalizer if it exists.
+	controllerutil.RemoveFinalizer(scope.ControlPlane, infrav1.ClusterFinalizer)
 	// If the AzureManagedControlPlane doesn't have our finalizer, add it.
-	controllerutil.AddFinalizer(scope.ControlPlane, infrav1.ClusterFinalizer)
+	controllerutil.AddFinalizer(scope.ControlPlane, infrav1exp.ManagedClusterFinalizer)
 	// Register the finalizer immediately to avoid orphaning Azure resources on delete
 	if err := scope.PatchObject(ctx); err != nil {
 		amcpr.Recorder.Eventf(scope.ControlPlane, corev1.EventTypeWarning, "AzureManagedControlPlane unavailable", "failed to patch resource: %s", err)
@@ -274,7 +273,14 @@ func (amcpr *AzureManagedControlPlaneReconciler) reconcileDelete(ctx context.Con
 	}
 
 	// Cluster is deleted so remove the finalizer.
-	controllerutil.RemoveFinalizer(scope.ControlPlane, infrav1.ClusterFinalizer)
+	controllerutil.RemoveFinalizer(scope.ControlPlane, infrav1exp.ManagedClusterFinalizer)
+
+	if scope.ControlPlane.Spec.IdentityRef != nil {
+		err := infracontroller.RemoveClusterIdentityFinalizer(ctx, amcpr.Client, scope.ControlPlane, scope.ControlPlane.Spec.IdentityRef, infrav1exp.ManagedClusterFinalizer)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
 
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: There is no finalizer added on AzureClusterIdentity resources, which results in the AzureClusterIdentity being immediately deleted if a cluster is deleted using `kubectl delete -f cluster-template.yaml`. This causes the other resources to be stuck in deleting as they no longer have a working identity to delete Azure resources.

Why not use Owner References? Owner refs need to belong to the same namespace as their dependents. As AzureClusterIdentities can be used across multiple namespaces, owner refs are not appropriate in this case. In addition, using owner refs would cause k8s to delete "orphaned" identities when owner clusters are deleted (as part of [garbage collection ](https://kubernetes.io/docs/concepts/architecture/garbage-collection/#orphaned-dependents)) which would be undesirable in this case as an identity is not necessarily tied to a Cluster's lifecycle.

see also https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/#ownership-and-finalizers

The PR also renames the finalizer used for managed clusters as it was incorrectly using the AzureCluster finalizer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2269 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add finalizer to AzureClusterIdentity and fix AzureManagedCluster finalizer
```
