### PR TITLE
Show granular conditions during AzureCluster delete

### DIFF
--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -267,10 +267,6 @@ func (acr *AzureClusterReconciler) reconcileDelete(ctx context.Context, clusterS
 	log.Info("Reconciling AzureCluster delete")
 
 	azureCluster := clusterScope.AzureCluster
-	conditions.MarkFalse(azureCluster, infrav1.NetworkInfrastructureReadyCondition, clusterv1.DeletedReason, clusterv1.ConditionSeverityInfo, "")
-	if err := clusterScope.PatchObject(ctx); err != nil {
-		return reconcile.Result{}, err
-	}
 
 	acs, err := acr.createAzureClusterService(clusterScope)
 	if err != nil {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Small cosmetic improvement so `AzureClusters` show "Deleting" instead of "Deleted" as status while deleting, as well as more granular condition message (which resource deletion is in progress).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Show granular conditions during AzureCluster delete
```
