### PR TITLE
fix irrecoverable errors in async operations

### DIFF
--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -84,8 +84,8 @@ type ClusterDescriber interface {
 // AsyncStatusUpdater is an interface used to keep track of long running operations in Status that has Conditions and Futures.
 type AsyncStatusUpdater interface {
 	SetLongRunningOperationState(*infrav1.Future)
-	GetLongRunningOperationState(string, string) *infrav1.Future
-	DeleteLongRunningOperationState(string, string)
+	GetLongRunningOperationState(string, string, string) *infrav1.Future
+	DeleteLongRunningOperationState(string, string, string)
 	UpdatePutStatus(clusterv1.ConditionType, string, error)
 	UpdateDeleteStatus(clusterv1.ConditionType, string, error)
 	UpdatePatchStatus(clusterv1.ConditionType, string, error)

--- a/azure/mock_azure/azure_mock.go
+++ b/azure/mock_azure/azure_mock.go
@@ -798,29 +798,29 @@ func (m *MockAsyncStatusUpdater) EXPECT() *MockAsyncStatusUpdaterMockRecorder {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockAsyncStatusUpdater) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockAsyncStatusUpdater) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockAsyncStatusUpdaterMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockAsyncStatusUpdaterMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockAsyncStatusUpdater)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockAsyncStatusUpdater)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockAsyncStatusUpdater) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockAsyncStatusUpdater) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockAsyncStatusUpdaterMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockAsyncStatusUpdaterMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockAsyncStatusUpdater)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockAsyncStatusUpdater)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // SetLongRunningOperationState mocks base method.

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -914,13 +914,13 @@ func (s *ClusterScope) SetLongRunningOperationState(future *infrav1.Future) {
 }
 
 // GetLongRunningOperationState will get the future on the AzureCluster status.
-func (s *ClusterScope) GetLongRunningOperationState(name, service string) *infrav1.Future {
-	return futures.Get(s.AzureCluster, name, service)
+func (s *ClusterScope) GetLongRunningOperationState(name, service, futureType string) *infrav1.Future {
+	return futures.Get(s.AzureCluster, name, service, futureType)
 }
 
 // DeleteLongRunningOperationState will delete the future from the AzureCluster status.
-func (s *ClusterScope) DeleteLongRunningOperationState(name, service string) {
-	futures.Delete(s.AzureCluster, name, service)
+func (s *ClusterScope) DeleteLongRunningOperationState(name, service, futureType string) {
+	futures.Delete(s.AzureCluster, name, service, futureType)
 }
 
 // UpdateDeleteStatus updates a condition on the AzureCluster status after a DELETE operation.

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -359,9 +359,9 @@ func (m *MachineScope) Subnet() infrav1.SubnetSpec {
 
 // AvailabilityZone returns the AzureMachine Availability Zone.
 // Priority for selecting the AZ is
-//   1) Machine.Spec.FailureDomain
-//   2) AzureMachine.Spec.FailureDomain (This is to support deprecated AZ)
-//   3) No AZ
+//  1. Machine.Spec.FailureDomain
+//  2. AzureMachine.Spec.FailureDomain (This is to support deprecated AZ)
+//  3. No AZ
 func (m *MachineScope) AvailabilityZone() string {
 	if m.Machine.Spec.FailureDomain != nil {
 		return *m.Machine.Spec.FailureDomain
@@ -687,13 +687,13 @@ func (m *MachineScope) SetLongRunningOperationState(future *infrav1.Future) {
 }
 
 // GetLongRunningOperationState will get the future on the AzureMachine status.
-func (m *MachineScope) GetLongRunningOperationState(name, service string) *infrav1.Future {
-	return futures.Get(m.AzureMachine, name, service)
+func (m *MachineScope) GetLongRunningOperationState(name, service, futureType string) *infrav1.Future {
+	return futures.Get(m.AzureMachine, name, service, futureType)
 }
 
 // DeleteLongRunningOperationState will delete the future from the AzureMachine status.
-func (m *MachineScope) DeleteLongRunningOperationState(name, service string) {
-	futures.Delete(m.AzureMachine, name, service)
+func (m *MachineScope) DeleteLongRunningOperationState(name, service, futureType string) {
+	futures.Delete(m.AzureMachine, name, service, futureType)
 }
 
 // UpdateDeleteStatus updates a condition on the AzureMachine status after a DELETE operation.

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -297,7 +297,9 @@ func (m *MachinePoolScope) applyAzureMachinePoolMachines(ctx context.Context) er
 		return nil
 	}
 
-	if futures.Has(m.AzureMachinePool, m.Name(), ScalesetsServiceName) {
+	if futures.Has(m.AzureMachinePool, m.Name(), ScalesetsServiceName, infrav1.PatchFuture) ||
+		futures.Has(m.AzureMachinePool, m.Name(), ScalesetsServiceName, infrav1.PutFuture) ||
+		futures.Has(m.AzureMachinePool, m.Name(), ScalesetsServiceName, infrav1.DeleteFuture) {
 		log.V(4).Info("exiting early due an in-progress long running operation on the ScaleSet")
 		// exit early to be less greedy about delete
 		return nil
@@ -377,13 +379,13 @@ func (m *MachinePoolScope) SetLongRunningOperationState(future *infrav1.Future) 
 }
 
 // GetLongRunningOperationState will get the future on the AzureMachinePool status.
-func (m *MachinePoolScope) GetLongRunningOperationState(name, service string) *infrav1.Future {
-	return futures.Get(m.AzureMachinePool, name, service)
+func (m *MachinePoolScope) GetLongRunningOperationState(name, service, futureType string) *infrav1.Future {
+	return futures.Get(m.AzureMachinePool, name, service, futureType)
 }
 
 // DeleteLongRunningOperationState will delete the future from the AzureMachinePool status.
-func (m *MachinePoolScope) DeleteLongRunningOperationState(name, service string) {
-	futures.Delete(m.AzureMachinePool, name, service)
+func (m *MachinePoolScope) DeleteLongRunningOperationState(name, service, futureType string) {
+	futures.Delete(m.AzureMachinePool, name, service, futureType)
 }
 
 // setProvisioningStateAndConditions sets the AzureMachinePool provisioning state and conditions.

--- a/azure/scope/machinepoolmachine.go
+++ b/azure/scope/machinepoolmachine.go
@@ -170,13 +170,13 @@ func (s *MachinePoolMachineScope) SetLongRunningOperationState(future *infrav1.F
 }
 
 // GetLongRunningOperationState will get the future on the AzureMachinePoolMachine status.
-func (s *MachinePoolMachineScope) GetLongRunningOperationState(name, service string) *infrav1.Future {
-	return futures.Get(s.AzureMachinePoolMachine, name, service)
+func (s *MachinePoolMachineScope) GetLongRunningOperationState(name, service, futureType string) *infrav1.Future {
+	return futures.Get(s.AzureMachinePoolMachine, name, service, futureType)
 }
 
 // DeleteLongRunningOperationState will delete the future from the AzureMachinePoolMachine status.
-func (s *MachinePoolMachineScope) DeleteLongRunningOperationState(name, service string) {
-	futures.Delete(s.AzureMachinePoolMachine, name, service)
+func (s *MachinePoolMachineScope) DeleteLongRunningOperationState(name, service, futureType string) {
+	futures.Delete(s.AzureMachinePoolMachine, name, service, futureType)
 }
 
 // UpdateDeleteStatus updates a condition on the AzureMachinePoolMachine status after a DELETE operation.

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -561,13 +561,13 @@ func (s *ManagedControlPlaneScope) SetLongRunningOperationState(future *infrav1.
 }
 
 // GetLongRunningOperationState will get the future on the AzureManagedControlPlane status.
-func (s *ManagedControlPlaneScope) GetLongRunningOperationState(name, service string) *infrav1.Future {
-	return futures.Get(s.ControlPlane, name, service)
+func (s *ManagedControlPlaneScope) GetLongRunningOperationState(name, service, futureType string) *infrav1.Future {
+	return futures.Get(s.ControlPlane, name, service, futureType)
 }
 
 // DeleteLongRunningOperationState will delete the future from the AzureManagedControlPlane status.
-func (s *ManagedControlPlaneScope) DeleteLongRunningOperationState(name, service string) {
-	futures.Delete(s.ControlPlane, name, service)
+func (s *ManagedControlPlaneScope) DeleteLongRunningOperationState(name, service, futureType string) {
+	futures.Delete(s.ControlPlane, name, service, futureType)
 }
 
 // UpdateDeleteStatus updates a condition on the AzureManagedControlPlane status after a DELETE operation.

--- a/azure/scope/managedmachinepool.go
+++ b/azure/scope/managedmachinepool.go
@@ -221,20 +221,20 @@ func (s *ManagedMachinePoolScope) SetAgentPoolReady(ready bool) {
 	s.InfraMachinePool.Status.Ready = ready
 }
 
-// SetLongRunningOperationState will set the future on the AzureManagedControlPlane status to allow the resource to continue
+// SetLongRunningOperationState will set the future on the AzureManagedMachinePool status to allow the resource to continue
 // in the next reconciliation.
 func (s *ManagedMachinePoolScope) SetLongRunningOperationState(future *infrav1.Future) {
-	futures.Set(s.ControlPlane, future)
+	futures.Set(s.InfraMachinePool, future)
 }
 
-// GetLongRunningOperationState will get the future on the AzureManagedControlPlane status.
-func (s *ManagedMachinePoolScope) GetLongRunningOperationState(name, service string) *infrav1.Future {
-	return futures.Get(s.ControlPlane, name, service)
+// GetLongRunningOperationState will get the future on the AzureManagedMachinePool status.
+func (s *ManagedMachinePoolScope) GetLongRunningOperationState(name, service, futureType string) *infrav1.Future {
+	return futures.Get(s.InfraMachinePool, name, service, futureType)
 }
 
-// DeleteLongRunningOperationState will delete the future from the AzureManagedControlPlane status.
-func (s *ManagedMachinePoolScope) DeleteLongRunningOperationState(name, service string) {
-	futures.Delete(s.ControlPlane, name, service)
+// DeleteLongRunningOperationState will delete the future from the AzureManagedMachinePool status.
+func (s *ManagedMachinePoolScope) DeleteLongRunningOperationState(name, service, futureType string) {
+	futures.Delete(s.InfraMachinePool, name, service, futureType)
 }
 
 // UpdateDeleteStatus updates a condition on the AzureManagedControlPlane status after a DELETE operation.

--- a/azure/services/agentpools/client.go
+++ b/azure/services/agentpools/client.go
@@ -131,12 +131,7 @@ func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "agentpools.azureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.agentpools)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.agentpools)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/agentpools/mock_agentpools/agentpools_mock.go
+++ b/azure/services/agentpools/mock_agentpools/agentpools_mock.go
@@ -208,15 +208,15 @@ func (mr *MockAgentPoolScopeMockRecorder) ClusterName() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockAgentPoolScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockAgentPoolScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockAgentPoolScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockAgentPoolScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockAgentPoolScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockAgentPoolScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // FailureDomains mocks base method.
@@ -234,17 +234,17 @@ func (mr *MockAgentPoolScopeMockRecorder) FailureDomains() *gomock.Call {
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockAgentPoolScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockAgentPoolScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockAgentPoolScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockAgentPoolScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockAgentPoolScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockAgentPoolScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/async/async.go
+++ b/azure/services/async/async.go
@@ -47,11 +47,11 @@ func New(scope FutureScope, createClient Creator, deleteClient Deleter) *Service
 
 // processOngoingOperation is a helper function that will process an ongoing operation to check if it is done.
 // If it is not done, it will return a transient error.
-func processOngoingOperation(ctx context.Context, scope FutureScope, client FutureHandler, resourceName string, serviceName string) (result interface{}, err error) {
+func processOngoingOperation(ctx context.Context, scope FutureScope, client FutureHandler, resourceName string, serviceName string, futureType string) (result interface{}, err error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "async.Service.processOngoingOperation")
 	defer done()
 
-	future := scope.GetLongRunningOperationState(resourceName, serviceName)
+	future := scope.GetLongRunningOperationState(resourceName, serviceName, futureType)
 	if future == nil {
 		log.V(2).Info("no long running operation found", "service", serviceName, "resource", resourceName)
 		return nil, nil
@@ -61,31 +61,36 @@ func processOngoingOperation(ctx context.Context, scope FutureScope, client Futu
 		// Reset the future data to avoid getting stuck in a bad loop.
 		// In theory, this should never happen, but if for some reason the future that is already stored in Status isn't properly formatted
 		// and we don't reset it we would be stuck in an infinite loop trying to parse it.
-		scope.DeleteLongRunningOperationState(resourceName, serviceName)
+		scope.DeleteLongRunningOperationState(resourceName, serviceName, futureType)
 		return nil, errors.Wrap(err, "could not decode future data, resetting long-running operation state")
 	}
 
 	isDone, err := client.IsDone(ctx, sdkFuture)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
+	// Assume that if isDone is true, then we successfully checked that the
+	// operation was complete even if err is non-nil. Assume the error in that
+	// case is unrelated and will be captured in Result below.
 	if !isDone {
+		if err != nil {
+			return nil, errors.Wrap(err, "failed checking if the operation was complete")
+		}
+
 		// Operation is still in progress, update conditions and requeue.
 		log.V(2).Info("long running operation is still ongoing", "service", serviceName, "resource", resourceName)
 		return nil, azure.WithTransientError(azure.NewOperationNotDoneError(future), retryAfter(sdkFuture))
 	}
+	if err != nil {
+		log.V(2).Error(err, "error checking long running operation status after it finished")
+	}
+
+	// Once the operation is done, we can delete the long running operation state.
+	// If the operation failed, this will allow it to be retried during the next reconciliation.
+	// If the resource is not found, we also reset the long-running operation state so we can attempt to create it again.
+	// This can happen if the resource was deleted by another process before we could get the result.
+	scope.DeleteLongRunningOperationState(resourceName, serviceName, futureType)
 
 	// Resource has been created/deleted/updated.
 	log.V(2).Info("long running operation has completed", "service", serviceName, "resource", resourceName)
-	result, err = client.Result(ctx, sdkFuture, future.Type)
-	if err == nil || azure.ResourceNotFound(err) {
-		// Once we have the result, we can delete the long running operation state.
-		// If the resource is not found, we also reset the long-running operation state so we can attempt to create it again.
-		// This can happen if the resource was deleted by another process before we could get the result.
-		scope.DeleteLongRunningOperationState(resourceName, serviceName)
-	}
-	return result, err
+	return client.Result(ctx, sdkFuture, future.Type)
 }
 
 // CreateResource implements the logic for creating a resource Asynchronously.
@@ -95,11 +100,12 @@ func (s *Service) CreateResource(ctx context.Context, spec azure.ResourceSpecGet
 
 	resourceName := spec.ResourceName()
 	rgName := spec.ResourceGroupName()
+	futureType := infrav1.PutFuture
 
 	// Check if there is an ongoing long running operation.
-	future := s.Scope.GetLongRunningOperationState(resourceName, serviceName)
+	future := s.Scope.GetLongRunningOperationState(resourceName, serviceName, futureType)
 	if future != nil {
-		return processOngoingOperation(ctx, s.Scope, s.Creator, resourceName, serviceName)
+		return processOngoingOperation(ctx, s.Scope, s.Creator, resourceName, serviceName, futureType)
 	}
 
 	// Get the resource if it already exists, and use it to construct the desired resource parameters.
@@ -146,11 +152,12 @@ func (s *Service) DeleteResource(ctx context.Context, spec azure.ResourceSpecGet
 
 	resourceName := spec.ResourceName()
 	rgName := spec.ResourceGroupName()
+	futureType := infrav1.DeleteFuture
 
 	// Check if there is an ongoing long running operation.
-	future := s.Scope.GetLongRunningOperationState(resourceName, serviceName)
+	future := s.Scope.GetLongRunningOperationState(resourceName, serviceName, futureType)
 	if future != nil {
-		_, err := processOngoingOperation(ctx, s.Scope, s.Deleter, resourceName, serviceName)
+		_, err := processOngoingOperation(ctx, s.Scope, s.Deleter, resourceName, serviceName, futureType)
 		return err
 	}
 

--- a/azure/services/async/async_test.go
+++ b/azure/services/async/async_test.go
@@ -68,6 +68,7 @@ func TestProcessOngoingOperation(t *testing.T) {
 		name           string
 		resourceName   string
 		serviceName    string
+		futureType     string
 		expectedError  string
 		expectedResult interface{}
 		expect         func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockFutureHandlerMockRecorder)
@@ -77,8 +78,9 @@ func TestProcessOngoingOperation(t *testing.T) {
 			expectedError: "",
 			resourceName:  "test-resource",
 			serviceName:   "test-service",
+			futureType:    infrav1.DeleteFuture,
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockFutureHandlerMockRecorder) {
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(nil)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture).Return(nil)
 			},
 		},
 		{
@@ -86,9 +88,10 @@ func TestProcessOngoingOperation(t *testing.T) {
 			expectedError: "could not decode future data, resetting long-running operation state",
 			resourceName:  "test-resource",
 			serviceName:   "test-service",
+			futureType:    infrav1.DeleteFuture,
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockFutureHandlerMockRecorder) {
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(&invalidFuture)
-				s.DeleteLongRunningOperationState("test-resource", "test-service")
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture).Return(&invalidFuture)
+				s.DeleteLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture)
 			},
 		},
 		{
@@ -96,8 +99,9 @@ func TestProcessOngoingOperation(t *testing.T) {
 			expectedError: "failed checking if the operation was complete",
 			resourceName:  "test-resource",
 			serviceName:   "test-service",
+			futureType:    infrav1.DeleteFuture,
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockFutureHandlerMockRecorder) {
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(&validDeleteFuture)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture).Return(&validDeleteFuture)
 				c.IsDone(gomockinternal.AContext(), gomock.AssignableToTypeOf(&azureautorest.Future{})).Return(false, fakeInternalError)
 			},
 		},
@@ -106,8 +110,9 @@ func TestProcessOngoingOperation(t *testing.T) {
 			expectedError: "operation type DELETE on Azure resource test-group/test-resource is not done",
 			resourceName:  "test-resource",
 			serviceName:   "test-service",
+			futureType:    infrav1.DeleteFuture,
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockFutureHandlerMockRecorder) {
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(&validDeleteFuture)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture).Return(&validDeleteFuture)
 				c.IsDone(gomockinternal.AContext(), gomock.AssignableToTypeOf(&azureautorest.Future{})).Return(false, nil)
 			},
 		},
@@ -117,11 +122,12 @@ func TestProcessOngoingOperation(t *testing.T) {
 			expectedResult: &fakeExistingResource,
 			resourceName:   "test-resource",
 			serviceName:    "test-service",
+			futureType:     infrav1.DeleteFuture,
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockFutureHandlerMockRecorder) {
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(&validDeleteFuture)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture).Return(&validDeleteFuture)
 				c.IsDone(gomockinternal.AContext(), gomock.AssignableToTypeOf(&azureautorest.Future{})).Return(true, nil)
 				c.Result(gomockinternal.AContext(), gomock.AssignableToTypeOf(&azureautorest.Future{}), infrav1.DeleteFuture).Return(&fakeExistingResource, nil)
-				s.DeleteLongRunningOperationState("test-resource", "test-service")
+				s.DeleteLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture)
 			},
 		},
 		{
@@ -130,11 +136,12 @@ func TestProcessOngoingOperation(t *testing.T) {
 			expectedResult: nil,
 			resourceName:   "test-resource",
 			serviceName:    "test-service",
+			futureType:     infrav1.DeleteFuture,
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockFutureHandlerMockRecorder) {
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(&validDeleteFuture)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture).Return(&validDeleteFuture)
 				c.IsDone(gomockinternal.AContext(), gomock.AssignableToTypeOf(&azureautorest.Future{})).Return(true, nil)
 				c.Result(gomockinternal.AContext(), gomock.AssignableToTypeOf(&azureautorest.Future{}), infrav1.DeleteFuture).Return(nil, fakeNotFoundError)
-				s.DeleteLongRunningOperationState("test-resource", "test-service")
+				s.DeleteLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture)
 			},
 		},
 		{
@@ -143,10 +150,26 @@ func TestProcessOngoingOperation(t *testing.T) {
 			expectedResult: nil,
 			resourceName:   "test-resource",
 			serviceName:    "test-service",
+			futureType:     infrav1.DeleteFuture,
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockFutureHandlerMockRecorder) {
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(&validDeleteFuture)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture).Return(&validDeleteFuture)
 				c.IsDone(gomockinternal.AContext(), gomock.AssignableToTypeOf(&azureautorest.Future{})).Return(true, nil)
 				c.Result(gomockinternal.AContext(), gomock.AssignableToTypeOf(&azureautorest.Future{}), infrav1.DeleteFuture).Return(nil, fakeInternalError)
+				s.DeleteLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture)
+			},
+		},
+		{
+			name:           "terminal failure with IsDone error",
+			expectedError:  fakeInternalError.Error(),
+			expectedResult: nil,
+			resourceName:   "test-resource",
+			serviceName:    "test-service",
+			futureType:     infrav1.DeleteFuture,
+			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockFutureHandlerMockRecorder) {
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture).Return(&validDeleteFuture)
+				c.IsDone(gomockinternal.AContext(), gomock.AssignableToTypeOf(&azureautorest.Future{})).Return(true, errors.New("IsDone error"))
+				c.Result(gomockinternal.AContext(), gomock.AssignableToTypeOf(&azureautorest.Future{}), infrav1.DeleteFuture).Return(nil, fakeInternalError)
+				s.DeleteLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture)
 			},
 		},
 	}
@@ -164,7 +187,7 @@ func TestProcessOngoingOperation(t *testing.T) {
 
 			tc.expect(scopeMock.EXPECT(), clientMock.EXPECT())
 
-			result, err := processOngoingOperation(context.TODO(), scopeMock, clientMock, tc.resourceName, tc.serviceName)
+			result, err := processOngoingOperation(context.TODO(), scopeMock, clientMock, tc.resourceName, tc.serviceName, tc.futureType)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectedError))
@@ -196,7 +219,7 @@ func TestCreateResource(t *testing.T) {
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockCreatorMockRecorder, r *mock_azure.MockResourceSpecGetterMockRecorder) {
 				r.ResourceName().Return("test-resource")
 				r.ResourceGroupName().Return("test-group")
-				s.GetLongRunningOperationState("test-resource", "test-service").Times(2).Return(&validCreateFuture)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.PutFuture).Times(2).Return(&validCreateFuture)
 				c.IsDone(gomockinternal.AContext(), gomock.AssignableToTypeOf(&azureautorest.Future{})).Return(false, nil)
 			},
 		},
@@ -208,7 +231,7 @@ func TestCreateResource(t *testing.T) {
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockCreatorMockRecorder, r *mock_azure.MockResourceSpecGetterMockRecorder) {
 				r.ResourceName().Return("test-resource")
 				r.ResourceGroupName().Return("test-group")
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(nil)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.PutFuture).Return(nil)
 				c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(&fakeExistingResource, nil)
 				r.Parameters(&fakeExistingResource).Return(&fakeResourceParameters, nil)
 				c.CreateOrUpdateAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{}), &fakeResourceParameters).Return("test-resource", nil, nil)
@@ -221,7 +244,7 @@ func TestCreateResource(t *testing.T) {
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockCreatorMockRecorder, r *mock_azure.MockResourceSpecGetterMockRecorder) {
 				r.ResourceName().Return("test-resource")
 				r.ResourceGroupName().Return("test-group")
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(nil)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.PutFuture).Return(nil)
 				c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(nil, fakeInternalError)
 			},
 		},
@@ -233,7 +256,7 @@ func TestCreateResource(t *testing.T) {
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockCreatorMockRecorder, r *mock_azure.MockResourceSpecGetterMockRecorder) {
 				r.ResourceName().Return("test-resource")
 				r.ResourceGroupName().Return("test-group")
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(nil)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.PutFuture).Return(nil)
 				c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(nil, fakeNotFoundError)
 				r.Parameters(nil).Return(&fakeResourceParameters, nil)
 				c.CreateOrUpdateAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{}), &fakeResourceParameters).Return(&fakeExistingResource, nil, nil)
@@ -246,7 +269,7 @@ func TestCreateResource(t *testing.T) {
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockCreatorMockRecorder, r *mock_azure.MockResourceSpecGetterMockRecorder) {
 				r.ResourceName().Return("test-resource")
 				r.ResourceGroupName().Return("test-group")
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(nil)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.PutFuture).Return(nil)
 				c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(&fakeExistingResource, nil)
 				r.Parameters(&fakeExistingResource).Return(nil, fakeInternalError)
 			},
@@ -259,7 +282,7 @@ func TestCreateResource(t *testing.T) {
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockCreatorMockRecorder, r *mock_azure.MockResourceSpecGetterMockRecorder) {
 				r.ResourceName().Return("test-resource")
 				r.ResourceGroupName().Return("test-group")
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(nil)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.PutFuture).Return(nil)
 				c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(&fakeExistingResource, nil)
 				r.Parameters(&fakeExistingResource).Return(nil, nil)
 			},
@@ -271,7 +294,7 @@ func TestCreateResource(t *testing.T) {
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockCreatorMockRecorder, r *mock_azure.MockResourceSpecGetterMockRecorder) {
 				r.ResourceName().Return("test-resource")
 				r.ResourceGroupName().Return("test-group")
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(nil)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.PutFuture).Return(nil)
 				c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(&fakeExistingResource, nil)
 				r.Parameters(&fakeExistingResource).Return(&fakeResourceParameters, nil)
 				c.CreateOrUpdateAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{}), &fakeResourceParameters).Return(nil, nil, fakeInternalError)
@@ -284,7 +307,7 @@ func TestCreateResource(t *testing.T) {
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockCreatorMockRecorder, r *mock_azure.MockResourceSpecGetterMockRecorder) {
 				r.ResourceName().Return("test-resource")
 				r.ResourceGroupName().Return("test-group")
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(nil)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.PutFuture).Return(nil)
 				c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(&fakeExistingResource, nil)
 				r.Parameters(&fakeExistingResource).Return(&fakeResourceParameters, nil)
 				c.CreateOrUpdateAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{}), &fakeResourceParameters).Return(nil, &azureautorest.Future{}, errCtxExceeded)
@@ -335,7 +358,7 @@ func TestDeleteResource(t *testing.T) {
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockDeleterMockRecorder, r *mock_azure.MockResourceSpecGetterMockRecorder) {
 				r.ResourceName().Return("test-resource")
 				r.ResourceGroupName().Return("test-group")
-				s.GetLongRunningOperationState("test-resource", "test-service").Times(2).Return(&validDeleteFuture)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture).Times(2).Return(&validDeleteFuture)
 				c.IsDone(gomockinternal.AContext(), gomock.AssignableToTypeOf(&azureautorest.Future{})).Return(false, nil)
 			},
 		},
@@ -346,7 +369,7 @@ func TestDeleteResource(t *testing.T) {
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockDeleterMockRecorder, r *mock_azure.MockResourceSpecGetterMockRecorder) {
 				r.ResourceName().Return("test-resource")
 				r.ResourceGroupName().Return("test-group")
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(nil)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture).Return(nil)
 				c.DeleteAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(nil, nil)
 			},
 		},
@@ -357,7 +380,7 @@ func TestDeleteResource(t *testing.T) {
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockDeleterMockRecorder, r *mock_azure.MockResourceSpecGetterMockRecorder) {
 				r.ResourceName().Return("test-resource")
 				r.ResourceGroupName().Return("test-group")
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(nil)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture).Return(nil)
 				c.DeleteAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(nil, fakeNotFoundError)
 			},
 		},
@@ -368,7 +391,7 @@ func TestDeleteResource(t *testing.T) {
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockDeleterMockRecorder, r *mock_azure.MockResourceSpecGetterMockRecorder) {
 				r.ResourceName().Return("test-resource")
 				r.ResourceGroupName().Return("test-group")
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(nil)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture).Return(nil)
 				c.DeleteAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(nil, fakeInternalError)
 			},
 		},
@@ -379,7 +402,7 @@ func TestDeleteResource(t *testing.T) {
 			expect: func(s *mock_async.MockFutureScopeMockRecorder, c *mock_async.MockDeleterMockRecorder, r *mock_azure.MockResourceSpecGetterMockRecorder) {
 				r.ResourceName().Return("test-resource")
 				r.ResourceGroupName().Return("test-group")
-				s.GetLongRunningOperationState("test-resource", "test-service").Return(nil)
+				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.DeleteFuture).Return(nil)
 				c.DeleteAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(&azureautorest.Future{}, errCtxExceeded)
 				s.SetLongRunningOperationState(gomock.AssignableToTypeOf(&infrav1.Future{}))
 			},

--- a/azure/services/async/mock_async/async_mock.go
+++ b/azure/services/async/mock_async/async_mock.go
@@ -55,29 +55,29 @@ func (m *MockFutureScope) EXPECT() *MockFutureScopeMockRecorder {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockFutureScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockFutureScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockFutureScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockFutureScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockFutureScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockFutureScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockFutureScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockFutureScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockFutureScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockFutureScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockFutureScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockFutureScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // SetLongRunningOperationState mocks base method.

--- a/azure/services/availabilitysets/client.go
+++ b/azure/services/availabilitysets/client.go
@@ -97,10 +97,5 @@ func (ac *AzureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "availabilitysets.AzureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.availabilitySets)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.availabilitySets)
 }

--- a/azure/services/availabilitysets/mock_availabilitysets/availabilitysets_mock.go
+++ b/azure/services/availabilitysets/mock_availabilitysets/availabilitysets_mock.go
@@ -194,15 +194,15 @@ func (mr *MockAvailabilitySetScopeMockRecorder) ClusterName() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockAvailabilitySetScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockAvailabilitySetScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockAvailabilitySetScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockAvailabilitySetScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockAvailabilitySetScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockAvailabilitySetScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // FailureDomains mocks base method.
@@ -220,17 +220,17 @@ func (mr *MockAvailabilitySetScopeMockRecorder) FailureDomains() *gomock.Call {
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockAvailabilitySetScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockAvailabilitySetScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockAvailabilitySetScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockAvailabilitySetScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockAvailabilitySetScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockAvailabilitySetScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/bastionhosts/client.go
+++ b/azure/services/bastionhosts/client.go
@@ -119,12 +119,7 @@ func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "bastionhosts.azureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.bastionhosts)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.bastionhosts)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
+++ b/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
@@ -264,15 +264,15 @@ func (mr *MockBastionScopeMockRecorder) ControlPlaneSubnet() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockBastionScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockBastionScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockBastionScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBastionScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockBastionScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockBastionScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // FailureDomains mocks base method.
@@ -290,17 +290,17 @@ func (mr *MockBastionScopeMockRecorder) FailureDomains() *gomock.Call {
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockBastionScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockBastionScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockBastionScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBastionScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockBastionScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockBastionScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetPrivateDNSZoneName mocks base method.

--- a/azure/services/disks/client.go
+++ b/azure/services/disks/client.go
@@ -22,7 +22,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
-	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
@@ -82,10 +81,5 @@ func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "disks.azureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.disks)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.disks)
 }

--- a/azure/services/disks/mock_disks/disks_mock.go
+++ b/azure/services/disks/mock_disks/disks_mock.go
@@ -180,15 +180,15 @@ func (mr *MockDiskScopeMockRecorder) ClusterName() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockDiskScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockDiskScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockDiskScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDiskScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockDiskScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockDiskScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // DiskSpecs mocks base method.
@@ -220,17 +220,17 @@ func (mr *MockDiskScopeMockRecorder) FailureDomains() *gomock.Call {
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockDiskScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockDiskScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockDiskScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDiskScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockDiskScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockDiskScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/groups/client.go
+++ b/azure/services/groups/client.go
@@ -115,12 +115,7 @@ func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.AzureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.groups)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.groups)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/groups/groups.go
+++ b/azure/services/groups/groups.go
@@ -98,7 +98,7 @@ func (s *Service) Delete(ctx context.Context) error {
 	if err != nil {
 		if azure.ResourceNotFound(err) {
 			// already deleted or doesn't exist, cleanup status and return.
-			s.Scope.DeleteLongRunningOperationState(groupSpec.ResourceName(), ServiceName)
+			s.Scope.DeleteLongRunningOperationState(groupSpec.ResourceName(), ServiceName, infrav1.DeleteFuture)
 			s.Scope.UpdateDeleteStatus(infrav1.ResourceGroupReadyCondition, ServiceName, nil)
 			return nil
 		}

--- a/azure/services/groups/groups_test.go
+++ b/azure/services/groups/groups_test.go
@@ -166,7 +166,7 @@ func TestDeleteGroups(t *testing.T) {
 			expect: func(s *mock_groups.MockGroupScopeMockRecorder, m *mock_groups.MockclientMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				s.GroupSpec().AnyTimes().Return(&fakeGroupSpec)
 				m.Get(gomockinternal.AContext(), &fakeGroupSpec).Return(resources.Group{}, notFoundError)
-				s.DeleteLongRunningOperationState("test-group", ServiceName)
+				s.DeleteLongRunningOperationState("test-group", ServiceName, infrav1.DeleteFuture)
 				s.UpdateDeleteStatus(infrav1.ResourceGroupReadyCondition, ServiceName, nil)
 			},
 		},

--- a/azure/services/groups/mock_groups/groups_mock.go
+++ b/azure/services/groups/mock_groups/groups_mock.go
@@ -138,29 +138,29 @@ func (mr *MockGroupScopeMockRecorder) ClusterName() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockGroupScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockGroupScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockGroupScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockGroupScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockGroupScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockGroupScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockGroupScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockGroupScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockGroupScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockGroupScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockGroupScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockGroupScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GroupSpec mocks base method.

--- a/azure/services/inboundnatrules/client.go
+++ b/azure/services/inboundnatrules/client.go
@@ -155,12 +155,7 @@ func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.azureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.inboundnatrules)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.inboundnatrules)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/inboundnatrules/mock_inboundnatrules/inboundnatrules_mock.go
+++ b/azure/services/inboundnatrules/mock_inboundnatrules/inboundnatrules_mock.go
@@ -194,15 +194,15 @@ func (mr *MockInboundNatScopeMockRecorder) ClusterName() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockInboundNatScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockInboundNatScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockInboundNatScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInboundNatScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockInboundNatScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockInboundNatScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // FailureDomains mocks base method.
@@ -220,17 +220,17 @@ func (mr *MockInboundNatScopeMockRecorder) FailureDomains() *gomock.Call {
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockInboundNatScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockInboundNatScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockInboundNatScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInboundNatScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockInboundNatScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockInboundNatScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/loadbalancers/client.go
+++ b/azure/services/loadbalancers/client.go
@@ -138,12 +138,7 @@ func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "loadbalancers.azureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.loadbalancers)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.loadbalancers)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
+++ b/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
@@ -250,15 +250,15 @@ func (mr *MockLBScopeMockRecorder) ControlPlaneSubnet() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockLBScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockLBScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockLBScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockLBScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockLBScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockLBScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // FailureDomains mocks base method.
@@ -276,17 +276,17 @@ func (mr *MockLBScopeMockRecorder) FailureDomains() *gomock.Call {
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockLBScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockLBScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockLBScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockLBScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockLBScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockLBScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetPrivateDNSZoneName mocks base method.

--- a/azure/services/managedclusters/client.go
+++ b/azure/services/managedclusters/client.go
@@ -156,12 +156,7 @@ func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "managedclusters.azureClient.IsDone")
 	defer done()
 
-	isDone, err := future.DoneWithContext(ctx, ac.managedclusters)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.managedclusters)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
+++ b/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
@@ -126,15 +126,15 @@ func (mr *MockManagedClusterScopeMockRecorder) CloudEnvironment() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockManagedClusterScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockManagedClusterScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockManagedClusterScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockManagedClusterScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockManagedClusterScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockManagedClusterScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetKubeConfigData mocks base method.
@@ -152,17 +152,17 @@ func (mr *MockManagedClusterScopeMockRecorder) GetKubeConfigData() *gomock.Call 
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockManagedClusterScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockManagedClusterScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockManagedClusterScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockManagedClusterScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockManagedClusterScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockManagedClusterScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/natgateways/client.go
+++ b/azure/services/natgateways/client.go
@@ -119,12 +119,7 @@ func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "natgateways.azureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.natgateways)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.natgateways)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/natgateways/mock_natgateways/natgateways_mock.go
+++ b/azure/services/natgateways/mock_natgateways/natgateways_mock.go
@@ -250,15 +250,15 @@ func (mr *MockNatGatewayScopeMockRecorder) ControlPlaneSubnet() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockNatGatewayScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockNatGatewayScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockNatGatewayScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNatGatewayScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockNatGatewayScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockNatGatewayScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // FailureDomains mocks base method.
@@ -276,17 +276,17 @@ func (mr *MockNatGatewayScopeMockRecorder) FailureDomains() *gomock.Call {
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockNatGatewayScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockNatGatewayScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockNatGatewayScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNatGatewayScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockNatGatewayScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockNatGatewayScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetPrivateDNSZoneName mocks base method.

--- a/azure/services/networkinterfaces/client.go
+++ b/azure/services/networkinterfaces/client.go
@@ -119,12 +119,7 @@ func (ac *AzureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.interfaces)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.interfaces)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/networkinterfaces/mock_networkinterfaces/networkinterfaces_mock.go
+++ b/azure/services/networkinterfaces/mock_networkinterfaces/networkinterfaces_mock.go
@@ -180,15 +180,15 @@ func (mr *MockNICScopeMockRecorder) ClusterName() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockNICScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockNICScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockNICScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNICScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockNICScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockNICScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // FailureDomains mocks base method.
@@ -206,17 +206,17 @@ func (mr *MockNICScopeMockRecorder) FailureDomains() *gomock.Call {
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockNICScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockNICScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockNICScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNICScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockNICScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockNICScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/privatedns/link_client.go
+++ b/azure/services/privatedns/link_client.go
@@ -116,12 +116,7 @@ func (avc *azureVirtualNetworkLinksClient) IsDone(ctx context.Context, future az
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.azureVirtualNetworkLinksClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, avc.vnetlinks)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, avc.vnetlinks)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/privatedns/link_reconciler.go
+++ b/azure/services/privatedns/link_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
@@ -76,7 +77,7 @@ func (s *Service) deleteLinks(ctx context.Context, links []azure.ResourceSpecGet
 		if err != nil {
 			if azure.ResourceNotFound(err) {
 				// already deleted or doesn't exist, cleanup status and return.
-				s.Scope.DeleteLongRunningOperationState(linkSpec.ResourceName(), serviceName)
+				s.Scope.DeleteLongRunningOperationState(linkSpec.ResourceName(), serviceName, infrav1.DeleteFuture)
 				continue
 			}
 			return managed, errors.Wrapf(err, "could not get vnet link state of %s in resource group %s",

--- a/azure/services/privatedns/mock_privatedns/privatedns_mock.go
+++ b/azure/services/privatedns/mock_privatedns/privatedns_mock.go
@@ -180,15 +180,15 @@ func (mr *MockScopeMockRecorder) ClusterName() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // FailureDomains mocks base method.
@@ -206,17 +206,17 @@ func (mr *MockScopeMockRecorder) FailureDomains() *gomock.Call {
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/privatedns/zone_client.go
+++ b/azure/services/privatedns/zone_client.go
@@ -116,12 +116,7 @@ func (azc *azureZonesClient) IsDone(ctx context.Context, future azureautorest.Fu
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.azureZonesClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, azc.privatezones)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, azc.privatezones)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/privatedns/zone_reconciler.go
+++ b/azure/services/privatedns/zone_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
@@ -58,7 +59,7 @@ func (s *Service) deleteZone(ctx context.Context, zoneSpec azure.ResourceSpecGet
 	if err != nil {
 		if azure.ResourceNotFound(err) {
 			// already deleted or doesn't exist, cleanup status and return.
-			s.Scope.DeleteLongRunningOperationState(zoneSpec.ResourceName(), serviceName)
+			s.Scope.DeleteLongRunningOperationState(zoneSpec.ResourceName(), serviceName, infrav1.DeleteFuture)
 			return managed, nil
 		}
 		return managed, errors.Wrapf(err, "could not get private DNS zone state of %s in resource group %s", zoneSpec.ResourceName(), zoneSpec.ResourceGroupName())

--- a/azure/services/publicips/client.go
+++ b/azure/services/publicips/client.go
@@ -119,12 +119,7 @@ func (ac *AzureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "publicips.AzureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.publicips)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.publicips)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/publicips/mock_publicips/publicips_mock.go
+++ b/azure/services/publicips/mock_publicips/publicips_mock.go
@@ -180,15 +180,15 @@ func (mr *MockPublicIPScopeMockRecorder) ClusterName() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockPublicIPScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockPublicIPScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockPublicIPScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPublicIPScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockPublicIPScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockPublicIPScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // FailureDomains mocks base method.
@@ -206,17 +206,17 @@ func (mr *MockPublicIPScopeMockRecorder) FailureDomains() *gomock.Call {
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockPublicIPScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockPublicIPScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockPublicIPScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPublicIPScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockPublicIPScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockPublicIPScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/roleassignments/client.go
+++ b/azure/services/roleassignments/client.go
@@ -70,11 +70,7 @@ func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "roleassignments.AzureClient.IsDone")
 	defer done()
 
-	isDone, err := future.DoneWithContext(ctx, ac.roleassignments)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.roleassignments)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/roleassignments/mock_roleassignments/roleassignments_mock.go
+++ b/azure/services/roleassignments/mock_roleassignments/roleassignments_mock.go
@@ -124,29 +124,29 @@ func (mr *MockRoleAssignmentScopeMockRecorder) CloudEnvironment() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockRoleAssignmentScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockRoleAssignmentScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockRoleAssignmentScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRoleAssignmentScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockRoleAssignmentScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockRoleAssignmentScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockRoleAssignmentScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockRoleAssignmentScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockRoleAssignmentScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRoleAssignmentScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockRoleAssignmentScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockRoleAssignmentScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HasSystemAssignedIdentity mocks base method.

--- a/azure/services/routetables/client.go
+++ b/azure/services/routetables/client.go
@@ -118,12 +118,7 @@ func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "routetables.azureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.routetables)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.routetables)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/routetables/mock_routetables/routetables_mock.go
+++ b/azure/services/routetables/mock_routetables/routetables_mock.go
@@ -124,29 +124,29 @@ func (mr *MockRouteTableScopeMockRecorder) CloudEnvironment() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockRouteTableScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockRouteTableScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockRouteTableScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRouteTableScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockRouteTableScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockRouteTableScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockRouteTableScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockRouteTableScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockRouteTableScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRouteTableScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockRouteTableScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockRouteTableScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/scalesets/mock_scalesets/scalesets_mock.go
+++ b/azure/services/scalesets/mock_scalesets/scalesets_mock.go
@@ -181,15 +181,15 @@ func (mr *MockScaleSetScopeMockRecorder) ClusterName() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockScaleSetScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockScaleSetScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockScaleSetScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockScaleSetScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockScaleSetScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockScaleSetScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // FailureDomains mocks base method.
@@ -222,17 +222,17 @@ func (mr *MockScaleSetScopeMockRecorder) GetBootstrapData(arg0 interface{}) *gom
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockScaleSetScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockScaleSetScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockScaleSetScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockScaleSetScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockScaleSetScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockScaleSetScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetVMImage mocks base method.

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -220,7 +220,8 @@ func TestReconcileVMSS(t *testing.T) {
 				instances := newDefaultInstances()
 
 				setupDefaultVMSSInProgressOperationDoneExpectations(s, m, createdVMSS, instances)
-				s.DeleteLongRunningOperationState(defaultSpec.Name, serviceName)
+				s.DeleteLongRunningOperationState(defaultSpec.Name, serviceName, infrav1.PutFuture)
+				s.DeleteLongRunningOperationState(defaultSpec.Name, serviceName, infrav1.PatchFuture)
 				s.UpdatePutStatus(infrav1.BootstrapSucceededCondition, serviceName, nil)
 			},
 		},
@@ -234,7 +235,8 @@ func TestReconcileVMSS(t *testing.T) {
 				instances := newDefaultInstances()
 
 				setupDefaultVMSSInProgressOperationDoneExpectations(s, m, createdVMSS, instances)
-				s.DeleteLongRunningOperationState(defaultSpec.Name, serviceName)
+				s.DeleteLongRunningOperationState(defaultSpec.Name, serviceName, infrav1.PutFuture)
+				s.DeleteLongRunningOperationState(defaultSpec.Name, serviceName, infrav1.PatchFuture)
 				s.UpdatePutStatus(infrav1.BootstrapSucceededCondition, serviceName, nil)
 			},
 		},
@@ -659,11 +661,11 @@ func TestDeleteVMSS(t *testing.T) {
 				}).AnyTimes()
 				s.ResourceGroup().AnyTimes().Return("my-existing-rg")
 				future := &infrav1.Future{}
-				s.GetLongRunningOperationState("my-existing-vmss", serviceName).Return(future)
+				s.GetLongRunningOperationState("my-existing-vmss", serviceName, infrav1.DeleteFuture).Return(future)
 				m.GetResultIfDone(gomockinternal.AContext(), future).Return(compute.VirtualMachineScaleSet{}, nil)
 				m.Get(gomockinternal.AContext(), "my-existing-rg", "my-existing-vmss").
 					Return(compute.VirtualMachineScaleSet{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
-				s.DeleteLongRunningOperationState("my-existing-vmss", serviceName)
+				s.DeleteLongRunningOperationState("my-existing-vmss", serviceName, infrav1.DeleteFuture)
 				s.UpdateDeleteStatus(infrav1.BootstrapSucceededCondition, serviceName, nil)
 			},
 		},
@@ -677,7 +679,7 @@ func TestDeleteVMSS(t *testing.T) {
 					Capacity: 3,
 				}).AnyTimes()
 				s.ResourceGroup().AnyTimes().Return(resourceGroup)
-				s.GetLongRunningOperationState(name, serviceName).Return(nil)
+				s.GetLongRunningOperationState(name, serviceName, infrav1.DeleteFuture).Return(nil)
 				m.DeleteAsync(gomockinternal.AContext(), resourceGroup, name).
 					Return(nil, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				m.Get(gomockinternal.AContext(), resourceGroup, name).
@@ -694,7 +696,7 @@ func TestDeleteVMSS(t *testing.T) {
 					Capacity: 3,
 				}).AnyTimes()
 				s.ResourceGroup().AnyTimes().Return(resourceGroup)
-				s.GetLongRunningOperationState(name, serviceName).Return(nil)
+				s.GetLongRunningOperationState(name, serviceName, infrav1.DeleteFuture).Return(nil)
 				m.DeleteAsync(gomockinternal.AContext(), resourceGroup, name).
 					Return(nil, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
 				m.Get(gomockinternal.AContext(), resourceGroup, name).
@@ -1291,7 +1293,7 @@ func setupDefaultVMSSInProgressOperationDoneExpectations(s *mock_scalesets.MockS
 		Name:          defaultVMSSName,
 		Data:          "",
 	}
-	s.GetLongRunningOperationState(defaultVMSSName, serviceName).Return(future)
+	s.GetLongRunningOperationState(defaultVMSSName, serviceName, infrav1.PutFuture).Return(future)
 	m.GetResultIfDone(gomockinternal.AContext(), future).Return(createdVMSS, nil).AnyTimes()
 	m.ListInstances(gomockinternal.AContext(), defaultResourceGroup, defaultVMSSName).Return(instances, nil).AnyTimes()
 	s.MaxSurge().Return(1, nil)
@@ -1301,7 +1303,8 @@ func setupDefaultVMSSInProgressOperationDoneExpectations(s *mock_scalesets.MockS
 
 func setupDefaultVMSSStartCreatingExpectations(s *mock_scalesets.MockScaleSetScopeMockRecorder, m *mock_scalesets.MockClientMockRecorder) {
 	setupDefaultVMSSExpectations(s)
-	s.GetLongRunningOperationState(defaultVMSSName, serviceName).Return(nil)
+	s.GetLongRunningOperationState(defaultVMSSName, serviceName, infrav1.PutFuture).Return(nil)
+	s.GetLongRunningOperationState(defaultVMSSName, serviceName, infrav1.PatchFuture).Return(nil)
 	m.Get(gomockinternal.AContext(), defaultResourceGroup, defaultVMSSName).
 		Return(compute.VirtualMachineScaleSet{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 }
@@ -1373,7 +1376,8 @@ func setupVMSSExpectationsWithoutVMImage(s *mock_scalesets.MockScaleSetScopeMock
 func setupDefaultVMSSUpdateExpectations(s *mock_scalesets.MockScaleSetScopeMockRecorder) {
 	setupUpdateVMSSExpectations(s)
 	s.SetProviderID(azure.ProviderIDPrefix + "subscriptions/1234/resourceGroups/my_resource_group/providers/Microsoft.Compute/virtualMachines/my-vm")
-	s.GetLongRunningOperationState(defaultVMSSName, serviceName).Return(nil)
+	s.GetLongRunningOperationState(defaultVMSSName, serviceName, infrav1.PutFuture).Return(nil)
+	s.GetLongRunningOperationState(defaultVMSSName, serviceName, infrav1.PatchFuture).Return(nil)
 	s.MaxSurge().Return(1, nil)
 	s.SetVMSSState(gomock.Any())
 }

--- a/azure/services/scalesetvms/mock_scalesetvms/scalesetvms_mock.go
+++ b/azure/services/scalesetvms/mock_scalesetvms/scalesetvms_mock.go
@@ -180,15 +180,15 @@ func (mr *MockScaleSetVMScopeMockRecorder) ClusterName() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockScaleSetVMScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockScaleSetVMScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockScaleSetVMScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockScaleSetVMScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockScaleSetVMScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockScaleSetVMScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // FailureDomains mocks base method.
@@ -206,17 +206,17 @@ func (mr *MockScaleSetVMScopeMockRecorder) FailureDomains() *gomock.Call {
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockScaleSetVMScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockScaleSetVMScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockScaleSetVMScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockScaleSetVMScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockScaleSetVMScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockScaleSetVMScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/scalesetvms/scalesetvms.go
+++ b/azure/services/scalesetvms/scalesetvms.go
@@ -108,12 +108,8 @@ func (s *Service) Delete(ctx context.Context) error {
 	}()
 
 	log.V(4).Info("entering delete")
-	future := s.Scope.GetLongRunningOperationState(instanceID, serviceName)
+	future := s.Scope.GetLongRunningOperationState(instanceID, serviceName, infrav1.DeleteFuture)
 	if future != nil {
-		if future.Type != infrav1.DeleteFuture {
-			return azure.WithTransientError(errors.New("attempting to delete, non-delete operation in progress"), 30*time.Second)
-		}
-
 		log.V(4).Info("checking if the instance is done deleting")
 		if _, err := s.Client.GetResultIfDone(ctx, future); err != nil {
 			// fetch instance to update status
@@ -122,7 +118,7 @@ func (s *Service) Delete(ctx context.Context) error {
 
 		// there was no error in fetching the result, the future has been completed
 		log.V(4).Info("successfully deleted the instance")
-		s.Scope.DeleteLongRunningOperationState(instanceID, serviceName)
+		s.Scope.DeleteLongRunningOperationState(instanceID, serviceName, infrav1.DeleteFuture)
 		return nil
 	}
 
@@ -144,6 +140,6 @@ func (s *Service) Delete(ctx context.Context) error {
 		return errors.Wrap(err, "failed to get result of long running operation")
 	}
 
-	s.Scope.DeleteLongRunningOperationState(instanceID, serviceName)
+	s.Scope.DeleteLongRunningOperationState(instanceID, serviceName, infrav1.DeleteFuture)
 	return nil
 }

--- a/azure/services/scalesetvms/scalesetvms_test.go
+++ b/azure/services/scalesetvms/scalesetvms_test.go
@@ -177,7 +177,7 @@ func TestService_Delete(t *testing.T) {
 				s.ResourceGroup().Return("rg")
 				s.InstanceID().Return("0")
 				s.ScaleSetName().Return("scaleset")
-				s.GetLongRunningOperationState("0", serviceName).Return(nil)
+				s.GetLongRunningOperationState("0", serviceName, infrav1.DeleteFuture).Return(nil)
 				future := &infrav1.Future{
 					Type: infrav1.DeleteFuture,
 				}
@@ -200,9 +200,9 @@ func TestService_Delete(t *testing.T) {
 				future := &infrav1.Future{
 					Type: infrav1.DeleteFuture,
 				}
-				s.GetLongRunningOperationState("0", serviceName).Return(future)
+				s.GetLongRunningOperationState("0", serviceName, infrav1.DeleteFuture).Return(future)
 				m.GetResultIfDone(gomock2.AContext(), future).Return(compute.VirtualMachineScaleSetVM{}, nil)
-				s.DeleteLongRunningOperationState("0", serviceName)
+				s.DeleteLongRunningOperationState("0", serviceName, infrav1.DeleteFuture)
 				m.Get(gomock2.AContext(), "rg", "scaleset", "0").Return(compute.VirtualMachineScaleSetVM{}, nil)
 			},
 		},
@@ -212,7 +212,7 @@ func TestService_Delete(t *testing.T) {
 				s.ResourceGroup().Return("rg")
 				s.InstanceID().Return("0")
 				s.ScaleSetName().Return("scaleset")
-				s.GetLongRunningOperationState("0", serviceName).Return(nil)
+				s.GetLongRunningOperationState("0", serviceName, infrav1.DeleteFuture).Return(nil)
 				m.DeleteAsync(gomock2.AContext(), "rg", "scaleset", "0").Return(nil, autorest404)
 				m.Get(gomock2.AContext(), "rg", "scaleset", "0").Return(compute.VirtualMachineScaleSetVM{}, nil)
 			},
@@ -223,7 +223,7 @@ func TestService_Delete(t *testing.T) {
 				s.ResourceGroup().Return("rg")
 				s.InstanceID().Return("0")
 				s.ScaleSetName().Return("scaleset")
-				s.GetLongRunningOperationState("0", serviceName).Return(nil)
+				s.GetLongRunningOperationState("0", serviceName, infrav1.DeleteFuture).Return(nil)
 				m.DeleteAsync(gomock2.AContext(), "rg", "scaleset", "0").Return(nil, errors.New("boom"))
 				m.Get(gomock2.AContext(), "rg", "scaleset", "0").Return(compute.VirtualMachineScaleSetVM{}, nil)
 			},
@@ -238,7 +238,7 @@ func TestService_Delete(t *testing.T) {
 				future := &infrav1.Future{
 					Type: infrav1.DeleteFuture,
 				}
-				s.GetLongRunningOperationState("0", serviceName).Return(future)
+				s.GetLongRunningOperationState("0", serviceName, infrav1.DeleteFuture).Return(future)
 				m.GetResultIfDone(gomock2.AContext(), future).Return(compute.VirtualMachineScaleSetVM{}, errors.New("boom"))
 				m.Get(gomock2.AContext(), "rg", "scaleset", "0").Return(compute.VirtualMachineScaleSetVM{}, nil)
 			},

--- a/azure/services/securitygroups/client.go
+++ b/azure/services/securitygroups/client.go
@@ -132,12 +132,7 @@ func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "securitygroups.azureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.securitygroups)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.securitygroups)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/securitygroups/mock_securitygroups/securitygroups_mock.go
+++ b/azure/services/securitygroups/mock_securitygroups/securitygroups_mock.go
@@ -124,29 +124,29 @@ func (mr *MockNSGScopeMockRecorder) CloudEnvironment() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockNSGScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockNSGScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockNSGScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNSGScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockNSGScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockNSGScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockNSGScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockNSGScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockNSGScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNSGScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockNSGScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockNSGScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/subnets/client.go
+++ b/azure/services/subnets/client.go
@@ -119,12 +119,7 @@ func (ac *AzureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "subnets.AzureClient.IsDone")
 	defer done()
 
-	isDone, err := future.DoneWithContext(ctx, ac.subnets)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.subnets)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/subnets/mock_subnets/subnets_mock.go
+++ b/azure/services/subnets/mock_subnets/subnets_mock.go
@@ -124,29 +124,29 @@ func (mr *MockSubnetScopeMockRecorder) CloudEnvironment() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockSubnetScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockSubnetScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockSubnetScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSubnetScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockSubnetScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockSubnetScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockSubnetScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockSubnetScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockSubnetScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSubnetScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockSubnetScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockSubnetScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/virtualmachines/client.go
+++ b/azure/services/virtualmachines/client.go
@@ -120,12 +120,7 @@ func (ac *AzureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.AzureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.virtualmachines)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.virtualmachines)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
+++ b/azure/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
@@ -125,29 +125,29 @@ func (mr *MockVMScopeMockRecorder) CloudEnvironment() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockVMScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockVMScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockVMScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockVMScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockVMScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockVMScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockVMScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockVMScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockVMScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockVMScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockVMScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockVMScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/virtualnetworks/client.go
+++ b/azure/services/virtualnetworks/client.go
@@ -120,12 +120,7 @@ func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualnetworks.azureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.virtualnetworks)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.virtualnetworks)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/virtualnetworks/mock_virtualnetworks/virtualnetworks_mock.go
+++ b/azure/services/virtualnetworks/mock_virtualnetworks/virtualnetworks_mock.go
@@ -138,29 +138,29 @@ func (mr *MockVNetScopeMockRecorder) ClusterName() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockVNetScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockVNetScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockVNetScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockVNetScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockVNetScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockVNetScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockVNetScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockVNetScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockVNetScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockVNetScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockVNetScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockVNetScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/virtualnetworks/virtualnetworks.go
+++ b/azure/services/virtualnetworks/virtualnetworks.go
@@ -129,7 +129,7 @@ func (s *Service) Delete(ctx context.Context) error {
 	if err != nil {
 		if azure.ResourceNotFound(err) {
 			// already deleted or doesn't exist, cleanup status and return.
-			s.Scope.DeleteLongRunningOperationState(vnetSpec.ResourceName(), serviceName)
+			s.Scope.DeleteLongRunningOperationState(vnetSpec.ResourceName(), serviceName, infrav1.DeleteFuture)
 			s.Scope.UpdateDeleteStatus(infrav1.VNetReadyCondition, serviceName, nil)
 			return nil
 		}

--- a/azure/services/vmextensions/client.go
+++ b/azure/services/vmextensions/client.go
@@ -118,12 +118,7 @@ func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualnetworks.azureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.vmextensions)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.vmextensions)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/vmextensions/mock_vmextensions/vmextensions_mock.go
+++ b/azure/services/vmextensions/mock_vmextensions/vmextensions_mock.go
@@ -124,29 +124,29 @@ func (mr *MockVMExtensionScopeMockRecorder) CloudEnvironment() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockVMExtensionScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockVMExtensionScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockVMExtensionScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockVMExtensionScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockVMExtensionScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockVMExtensionScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockVMExtensionScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockVMExtensionScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockVMExtensionScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockVMExtensionScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockVMExtensionScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockVMExtensionScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/azure/services/vnetpeerings/client.go
+++ b/azure/services/vnetpeerings/client.go
@@ -119,12 +119,7 @@ func (ac *AzureClient) IsDone(ctx context.Context, future azureautorest.FutureAP
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "vnetpeerings.AzureClient.IsDone")
 	defer done()
 
-	isDone, err = future.DoneWithContext(ctx, ac.peerings)
-	if err != nil {
-		return false, errors.Wrap(err, "failed checking if the operation was complete")
-	}
-
-	return isDone, nil
+	return future.DoneWithContext(ctx, ac.peerings)
 }
 
 // Result fetches the result of a long-running operation future.

--- a/azure/services/vnetpeerings/mock_vnetpeerings/vnetpeerings_mock.go
+++ b/azure/services/vnetpeerings/mock_vnetpeerings/vnetpeerings_mock.go
@@ -124,29 +124,29 @@ func (mr *MockVnetPeeringScopeMockRecorder) CloudEnvironment() *gomock.Call {
 }
 
 // DeleteLongRunningOperationState mocks base method.
-func (m *MockVnetPeeringScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+func (m *MockVnetPeeringScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1, arg2)
 }
 
 // DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
-func (mr *MockVnetPeeringScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockVnetPeeringScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockVnetPeeringScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockVnetPeeringScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // GetLongRunningOperationState mocks base method.
-func (m *MockVnetPeeringScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+func (m *MockVnetPeeringScope) GetLongRunningOperationState(arg0, arg1, arg2 string) *v1beta1.Future {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1beta1.Future)
 	return ret0
 }
 
 // GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
-func (mr *MockVnetPeeringScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockVnetPeeringScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockVnetPeeringScope)(nil).GetLongRunningOperationState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockVnetPeeringScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
 // HashKey mocks base method.

--- a/util/futures/getter.go
+++ b/util/futures/getter.go
@@ -32,14 +32,14 @@ type Getter interface {
 
 // Get returns the future with the given name, if the future does not exists,
 // it returns nil.
-func Get(from Getter, name, service string) *infrav1.Future {
+func Get(from Getter, name, service, futureType string) *infrav1.Future {
 	futures := from.GetFutures()
 	if futures == nil {
 		return nil
 	}
 
 	for _, f := range futures {
-		if f.Name == name && f.ServiceName == service {
+		if f.Name == name && f.ServiceName == service && f.Type == futureType {
 			return &f
 		}
 	}
@@ -47,6 +47,6 @@ func Get(from Getter, name, service string) *infrav1.Future {
 }
 
 // Has returns true if a future with the given name exists.
-func Has(from Getter, name, service string) bool {
-	return Get(from, name, service) != nil
+func Has(from Getter, name, service, futureType string) bool {
+	return Get(from, name, service, futureType) != nil
 }

--- a/util/futures/getter_test.go
+++ b/util/futures/getter_test.go
@@ -23,6 +23,8 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
+const fakeFutureType = "PUT"
+
 func TestGet(t *testing.T) {
 	g := NewWithT(t)
 
@@ -35,14 +37,15 @@ func TestGet(t *testing.T) {
 	vmFuture := fakeFuture(vmName, vm)
 	vnetFuture := fakeFuture(vnetName, vnet)
 
-	g.Expect(Get(azurecluster, vmName, vm)).To(BeNil())
-	g.Expect(Get(azurecluster, vnetName, vnet)).To(BeNil())
+	g.Expect(Get(azurecluster, vmName, vm, fakeFutureType)).To(BeNil())
+	g.Expect(Get(azurecluster, vnetName, vnet, fakeFutureType)).To(BeNil())
 
 	azurecluster.SetFutures(infrav1.Futures{vmFuture, vnetFuture})
 
-	g.Expect(Get(azurecluster, vmName, vm)).To(Equal(&vmFuture))
-	g.Expect(Get(azurecluster, vmName, vnet)).To(BeNil())
-	g.Expect(Get(azurecluster, vnetName, vnet)).To(Equal(&vnetFuture))
+	g.Expect(Get(azurecluster, vmName, vm, fakeFutureType)).To(Equal(&vmFuture))
+	g.Expect(Get(azurecluster, vmName, vnet, fakeFutureType)).To(BeNil())
+	g.Expect(Get(azurecluster, vnetName, vnet, fakeFutureType)).To(Equal(&vnetFuture))
+	g.Expect(Get(azurecluster, vnetName, vnet, "not-"+fakeFutureType)).To(BeNil())
 }
 
 func TestHas(t *testing.T) {
@@ -55,19 +58,19 @@ func TestHas(t *testing.T) {
 	vnet := "virtualnetworks"
 	vmFuture := fakeFuture(vmName, vm)
 
-	g.Expect(Has(azurecluster, vmName, vm)).To(BeFalse())
-	g.Expect(Has(azurecluster, "foo", vm)).To(BeFalse())
+	g.Expect(Has(azurecluster, vmName, vm, fakeFutureType)).To(BeFalse())
+	g.Expect(Has(azurecluster, "foo", vm, fakeFutureType)).To(BeFalse())
 
 	azurecluster.SetFutures(infrav1.Futures{vmFuture})
 
-	g.Expect(Has(azurecluster, vmName, vm)).To(BeTrue())
-	g.Expect(Has(azurecluster, "foo", vm)).To(BeFalse())
-	g.Expect(Has(azurecluster, vmName, vnet)).To(BeFalse())
+	g.Expect(Has(azurecluster, vmName, vm, fakeFutureType)).To(BeTrue())
+	g.Expect(Has(azurecluster, "foo", vm, fakeFutureType)).To(BeFalse())
+	g.Expect(Has(azurecluster, vmName, vnet, fakeFutureType)).To(BeFalse())
 }
 
 func fakeFuture(name string, service string) infrav1.Future {
 	return infrav1.Future{
-		Type:          "PUT",
+		Type:          fakeFutureType,
 		Name:          name,
 		ResourceGroup: "test-rg",
 		Data:          "",

--- a/util/futures/setter.go
+++ b/util/futures/setter.go
@@ -55,14 +55,14 @@ func Set(to Setter, future *infrav1.Future) {
 }
 
 // Delete deletes the specified future.
-func Delete(to Setter, name, service string) {
-	if to == nil || name == "" || service == "" {
+func Delete(to Setter, name, service, futureType string) {
+	if to == nil || name == "" || service == "" || futureType == "" {
 		return
 	}
 
 	futures := to.GetFutures()
 	for i, f := range futures {
-		if f.Name == name && f.ServiceName == service {
+		if f.Name == name && f.ServiceName == service && f.Type == futureType {
 			futures = append(futures[:i], futures[i+1:]...)
 			break
 		}

--- a/util/futures/setter_test.go
+++ b/util/futures/setter_test.go
@@ -104,7 +104,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			Delete(tt.to, tt.future, testService)
+			Delete(tt.to, tt.future, testService, fakeFutureType)
 
 			g.Expect(tt.to.GetFutures()).To(Equal(tt.want))
 		})


### PR DESCRIPTION

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Reconciliations involving asynchronous operations can fall into a loop
where an eventual "Failed" result can block future reconciliations from
making any further changes to that particular resource to fix the
problem.

This change sets `longRunningOperationStates` for agent pools on the
corresponding AzureManagedMachinePool instead of the
AzureManagedControlPlane, since changes to that resource were not being
persisted. It also only blocks starting new operations on the status of
existing operations of the same type. In-progress PUT operations will no
longer block new DELETEs and in-progress DELETEs will not block
in-progress PUTs.

In cases where polling a future from the Azure API would eventually
return both `isDone==true` and a non-nil error, a "failed checking if
the operation was complete" message would be logged and the error would
refer to the ultimate failure unrelated to polling the future itself.
This change treats all `isDone==true` polling checks as successful and
relies on the operation's error to be captured in the future's `Result`.
The future will always be deleted from the status when the operation is
done so it can be retried the next reconciliation if it failed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I found these issues while working on #2664 and testing failure scenarios like creating an AKS cluster with more nodes than available public IP addresses. Incorporating that feature here will exercise these changes.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
