### PR TITLE
Fix AzureMachineTemplate roleAssignmentName validation

### DIFF
--- a/api/v1beta1/azuremachine_validation.go
+++ b/api/v1beta1/azuremachine_validation.go
@@ -42,10 +42,6 @@ func ValidateAzureMachineSpec(spec AzureMachineSpec) field.ErrorList {
 		allErrs = append(allErrs, errs...)
 	}
 
-	if errs := ValidateSystemAssignedIdentity(spec.Identity, "", spec.RoleAssignmentName, field.NewPath("roleAssignmentName")); len(errs) > 0 {
-		allErrs = append(allErrs, errs...)
-	}
-
 	if errs := ValidateUserAssignedIdentity(spec.Identity, spec.UserAssignedIdentities, field.NewPath("userAssignedIdentities")); len(errs) > 0 {
 		allErrs = append(allErrs, errs...)
 	}

--- a/api/v1beta1/azuremachine_webhook_test.go
+++ b/api/v1beta1/azuremachine_webhook_test.go
@@ -627,3 +627,14 @@ func createMachineWithRoleAssignmentName() *AzureMachine {
 	}
 	return machine
 }
+
+func createMachineWithoutRoleAssignmentName() *AzureMachine {
+	machine := &AzureMachine{
+		Spec: AzureMachineSpec{
+			SSHPublicKey: validSSHPublicKey,
+			OSDisk:       validOSDisk,
+			Identity:     VMIdentitySystemAssigned,
+		},
+	}
+	return machine
+}

--- a/api/v1beta1/azuremachinetemplate_webhook_test.go
+++ b/api/v1beta1/azuremachinetemplate_webhook_test.go
@@ -133,6 +133,11 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 			machineTemplate: createAzureMachineTemplateFromMachine(createMachineWithRoleAssignmentName()),
 			wantErr:         true,
 		},
+		{
+			name:            "azuremachinetemplate without RoleAssignmentName",
+			machineTemplate: createAzureMachineTemplateFromMachine(createMachineWithoutRoleAssignmentName()),
+			wantErr:         false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Validation of roleAssignmentName is broken for AzureMachineTemplate when using SystemAssigned identity. Validation fails if empty and it shouldn't. 

**Special notes for your reviewer**:

N/A

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix AzureMachineTemplate roleAssignmentName validation when SystemAssigned identity is used
```
