### PR TITLE
enable mutable AKS node taints

### DIFF
--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -139,6 +139,7 @@ func (s *AgentPoolSpec) Parameters(existing interface{}) (params interface{}, er
 				MinCount:            existingPool.MinCount,
 				MaxCount:            existingPool.MaxCount,
 				NodeLabels:          existingPool.NodeLabels,
+				NodeTaints:          existingPool.NodeTaints,
 			},
 		}
 
@@ -151,6 +152,7 @@ func (s *AgentPoolSpec) Parameters(existing interface{}) (params interface{}, er
 				MinCount:            s.MinCount,
 				MaxCount:            s.MaxCount,
 				NodeLabels:          s.NodeLabels,
+				NodeTaints:          existingPool.NodeTaints,
 			},
 		}
 

--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -454,7 +454,6 @@ Following is the list of immutable fields for managed clusters:
 | AzureManagedMachinePool   | .spec.sku                    |                           |
 | AzureManagedMachinePool   | .spec.osDiskSizeGB           |                           |
 | AzureManagedMachinePool   | .spec.osDiskType             |                           |
-| AzureManagedMachinePool   | .spec.taints                 |                           |
 | AzureManagedMachinePool   | .spec.availabilityZones      |                           |
 | AzureManagedMachinePool   | .spec.maxPods                |                           |
 | AzureManagedMachinePool   | .spec.osType                 |                           |

--- a/exp/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/exp/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -122,14 +122,6 @@ func (m *AzureManagedMachinePool) ValidateUpdate(oldRaw runtime.Object, client c
 		}
 	}
 
-	if !reflect.DeepEqual(m.Spec.Taints, old.Spec.Taints) {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("Spec", "Taints"),
-				m.Spec.Taints,
-				"field is immutable"))
-	}
-
 	// custom headers are immutable
 	oldCustomHeaders := maps.FilterByKeyPrefix(old.ObjectMeta.Annotations, azure.CustomHeaderPrefix)
 	newCustomHeaders := maps.FilterByKeyPrefix(m.ObjectMeta.Annotations, azure.CustomHeaderPrefix)

--- a/exp/api/v1beta1/azuremanagedmachinepool_webhook_test.go
+++ b/exp/api/v1beta1/azuremanagedmachinepool_webhook_test.go
@@ -436,6 +436,32 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "NodeTaints are mutable",
+			new: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					Taints: []Taint{
+						{
+							Effect: TaintEffect("NoSchedule"),
+							Key:    "foo",
+							Value:  "baz",
+						},
+					},
+				},
+			},
+			old: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					Taints: []Taint{
+						{
+							Effect: TaintEffect("NoSchedule"),
+							Key:    "foo",
+							Value:  "bar",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	var client client.Client
 	for _, tc := range tests {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind feature

**What this PR does / why we need it**:

This PR removes the "immutable" restriction for AKS node pool taints.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
enable mutable AKS node taints
```
