### PR TITLE
detect Retry-After during async “does resource exist?” flow

### DIFF
--- a/azure/services/async/async_test.go
+++ b/azure/services/async/async_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
 	"github.com/Azure/go-autorest/autorest"
@@ -31,6 +32,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
 	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
+	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 )
 
 var (
@@ -430,6 +432,89 @@ func TestDeleteResource(t *testing.T) {
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectedError))
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestGetRetryAfterFromError(t *testing.T) {
+	cases := []struct {
+		name                   string
+		input                  error
+		expected               time.Duration
+		expectedRangeTolerance time.Duration
+	}{
+		{
+			name: "Retry-After header data present in the form of units of seconds",
+			input: autorest.DetailedError{
+				Response: &http.Response{
+					Header: http.Header{
+						"Retry-After": []string{"2"},
+					},
+				},
+			},
+			expected: 2 * time.Second,
+		},
+		{
+			name: "Retry-After header data present in the form of units of absolute time",
+			input: autorest.DetailedError{
+				Response: &http.Response{
+					Header: http.Header{
+						"Retry-After": []string{time.Now().Add(1 * time.Hour).Format(time.RFC1123)},
+					},
+				},
+			},
+			expected:               1 * time.Hour,
+			expectedRangeTolerance: 5 * time.Second,
+		},
+		{
+			name: "Retry-After header data not present",
+			input: autorest.DetailedError{
+				Response: &http.Response{
+					Header: http.Header{
+						"foo": []string{"bar"},
+					},
+				},
+			},
+			expected: reconciler.DefaultReconcilerRequeue,
+		},
+		{
+			name: "Retry-After header data not present in HTTP 429",
+			input: autorest.DetailedError{
+				Response: &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Header: http.Header{
+						"foo": []string{"bar"},
+					},
+				},
+			},
+			expected: reconciler.DefaultHTTP429RetryAfter,
+		},
+		{
+			name: "nil http.Response",
+			input: autorest.DetailedError{
+				Response: nil,
+			},
+			expected: reconciler.DefaultReconcilerRequeue,
+		},
+		{
+			name:     "error type is not autorest.DetailedError",
+			input:    errors.New("error"),
+			expected: reconciler.DefaultReconcilerRequeue,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			ret := getRetryAfterFromError(c.input)
+			if c.expectedRangeTolerance > 0 {
+				g.Expect(ret).To(BeNumerically("<", c.expected))
+				g.Expect(ret + c.expectedRangeTolerance).To(BeNumerically(">", c.expected))
+			} else {
+				g.Expect(ret).To(Equal(c.expected))
 			}
 		})
 	}

--- a/util/reconciler/defaults.go
+++ b/util/reconciler/defaults.go
@@ -31,6 +31,8 @@ const (
 	DefaultAzureCallTimeout = 2 * time.Second
 	// DefaultReconcilerRequeue is the default value for the reconcile retry.
 	DefaultReconcilerRequeue = 15 * time.Second
+	// DefaultHTTP429RetryAfter is a default backoff wait time when we get a HTTP 429 response with no Retry-After data.
+	DefaultHTTP429RetryAfter = 1 * time.Minute
 )
 
 // DefaultedLoopTimeout will default the timeout if it is zero-valued.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind feature

**What this PR does / why we need it**:

This PR adds a single additional vector of `Retry-After` HTTP response detection during async resource reconciliation. When we enter into the `CreateResource` async service method (which is in fact a "create or update resource" flow) then we initiate a GET against the Azure API to determine if the resource already exists. Because this GET may yield a HTTP 429 response (or any other response w/ `Retry-After` header data) we want to check that, to ensure that we inform the parent controller that we should requeue the request for later at a time after the specified `Retry-After` value from Azure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
detect Retry-After during async “does resource exist?” flow
```
