### PR TITLE
add tags for ssa changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ ifneq ($(abspath $(ROOT_DIR)),$(GOPATH)/src/sigs.k8s.io/cluster-api-provider-azu
 endif
 
 # Binaries.
-CONTROLLER_GEN_VER := v0.8.0
+CONTROLLER_GEN_VER := v0.9.2
 CONTROLLER_GEN_BIN := controller-gen
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/$(CONTROLLER_GEN_BIN)-$(CONTROLLER_GEN_VER)
 

--- a/api/v1alpha3/azurecluster_conversion.go
+++ b/api/v1alpha3/azurecluster_conversion.go
@@ -241,6 +241,7 @@ func Convert_v1alpha3_SubnetSpec_To_v1beta1_SubnetSpec(in *SubnetSpec, out *infr
 	}
 
 	// Convert SubnetClassSpec fields
+	out.Name = in.Name
 	out.Role = infrav1.SubnetRole(in.Role)
 	out.CIDRBlocks = in.CIDRBlocks
 
@@ -254,6 +255,7 @@ func Convert_v1beta1_SubnetSpec_To_v1alpha3_SubnetSpec(in *infrav1.SubnetSpec, o
 	}
 
 	// Convert SubnetClassSpec fields
+	out.Name = in.Name
 	out.Role = SubnetRole(in.Role)
 	out.CIDRBlocks = in.CIDRBlocks
 

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -1500,7 +1500,7 @@ func Convert_v1beta1_SpotVMOptions_To_v1alpha3_SpotVMOptions(in *v1beta1.SpotVMO
 func autoConvert_v1alpha3_SubnetSpec_To_v1beta1_SubnetSpec(in *SubnetSpec, out *v1beta1.SubnetSpec, s conversion.Scope) error {
 	// WARNING: in.Role requires manual conversion: does not exist in peer-type
 	out.ID = in.ID
-	out.Name = in.Name
+	// WARNING: in.Name requires manual conversion: does not exist in peer-type
 	// WARNING: in.CidrBlock requires manual conversion: does not exist in peer-type
 	// WARNING: in.CIDRBlocks requires manual conversion: does not exist in peer-type
 	// WARNING: in.InternalLBIPAddress requires manual conversion: does not exist in peer-type
@@ -1515,7 +1515,6 @@ func autoConvert_v1alpha3_SubnetSpec_To_v1beta1_SubnetSpec(in *SubnetSpec, out *
 
 func autoConvert_v1beta1_SubnetSpec_To_v1alpha3_SubnetSpec(in *v1beta1.SubnetSpec, out *SubnetSpec, s conversion.Scope) error {
 	out.ID = in.ID
-	out.Name = in.Name
 	if err := Convert_v1beta1_SecurityGroup_To_v1alpha3_SecurityGroup(&in.SecurityGroup, &out.SecurityGroup, s); err != nil {
 		return err
 	}

--- a/api/v1alpha4/azurecluster_conversion.go
+++ b/api/v1alpha4/azurecluster_conversion.go
@@ -283,6 +283,7 @@ func Convert_v1alpha4_SubnetSpec_To_v1beta1_SubnetSpec(in *SubnetSpec, out *infr
 
 	// Convert SubnetClassSpec fields
 	out.Role = infrav1.SubnetRole(in.Role)
+	out.Name = in.Name
 	out.CIDRBlocks = in.CIDRBlocks
 
 	return nil
@@ -296,6 +297,7 @@ func Convert_v1beta1_SubnetSpec_To_v1alpha4_SubnetSpec(in *infrav1.SubnetSpec, o
 
 	// Convert SubnetClassSpec fields
 	out.Role = SubnetRole(in.Role)
+	out.Name = in.Name
 	out.CIDRBlocks = in.CIDRBlocks
 
 	return nil

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -1930,7 +1930,7 @@ func Convert_v1beta1_SpotVMOptions_To_v1alpha4_SpotVMOptions(in *v1beta1.SpotVMO
 func autoConvert_v1alpha4_SubnetSpec_To_v1beta1_SubnetSpec(in *SubnetSpec, out *v1beta1.SubnetSpec, s conversion.Scope) error {
 	// WARNING: in.Role requires manual conversion: does not exist in peer-type
 	out.ID = in.ID
-	out.Name = in.Name
+	// WARNING: in.Name requires manual conversion: does not exist in peer-type
 	// WARNING: in.CIDRBlocks requires manual conversion: does not exist in peer-type
 	if err := Convert_v1alpha4_SecurityGroup_To_v1beta1_SecurityGroup(&in.SecurityGroup, &out.SecurityGroup, s); err != nil {
 		return err
@@ -1946,7 +1946,6 @@ func autoConvert_v1alpha4_SubnetSpec_To_v1beta1_SubnetSpec(in *SubnetSpec, out *
 
 func autoConvert_v1beta1_SubnetSpec_To_v1alpha4_SubnetSpec(in *v1beta1.SubnetSpec, out *SubnetSpec, s conversion.Scope) error {
 	out.ID = in.ID
-	out.Name = in.Name
 	if err := Convert_v1beta1_SecurityGroup_To_v1alpha4_SecurityGroup(&in.SecurityGroup, &out.SecurityGroup, s); err != nil {
 		return err
 	}

--- a/api/v1beta1/azurecluster_default.go
+++ b/api/v1beta1/azurecluster_default.go
@@ -138,8 +138,8 @@ func (c *AzureCluster) setSubnetDefaults() {
 			SubnetClassSpec: SubnetClassSpec{
 				Role:       SubnetNode,
 				CIDRBlocks: []string{DefaultNodeSubnetCIDR},
+				Name:       generateNodeSubnetName(c.ObjectMeta.Name),
 			},
-			Name: generateNodeSubnetName(c.ObjectMeta.Name),
 			SecurityGroup: SecurityGroup{
 				Name: generateNodeSecurityGroupName(c.ObjectMeta.Name),
 			},

--- a/api/v1beta1/azurecluster_default_test.go
+++ b/api/v1beta1/azurecluster_default_test.go
@@ -106,16 +106,17 @@ func TestVnetDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetControlPlane,
+									Name: "control-plane-subnet",
 								},
-								Name:          "control-plane-subnet",
+
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet",
 								},
-								Name:          "node-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
@@ -285,8 +286,9 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetControlPlane,
 									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
+									Name:       "cluster-test-controlplane-subnet",
 								},
-								Name:          "cluster-test-controlplane-subnet",
+
 								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
 								RouteTable:    RouteTable{},
 							},
@@ -294,8 +296,8 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetNode,
 									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
+									Name:       "cluster-test-node-subnet",
 								},
-								Name:          "cluster-test-node-subnet",
 								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
 								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
 							},
@@ -317,15 +319,15 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetControlPlane,
 									CIDRBlocks: []string{"10.0.0.16/24"},
+									Name:       "my-controlplane-subnet",
 								},
-								Name: "my-controlplane-subnet",
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetNode,
 									CIDRBlocks: []string{"10.1.0.16/24"},
+									Name:       "my-node-subnet",
 								},
-								Name: "my-node-subnet",
 								NatGateway: NatGateway{
 									NatGatewayClassSpec: NatGatewayClassSpec{
 										Name: "foo-natgw",
@@ -347,8 +349,8 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetControlPlane,
 									CIDRBlocks: []string{"10.0.0.16/24"},
+									Name:       "my-controlplane-subnet",
 								},
-								Name:          "my-controlplane-subnet",
 								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
 								RouteTable:    RouteTable{},
 							},
@@ -356,8 +358,8 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetNode,
 									CIDRBlocks: []string{"10.1.0.16/24"},
+									Name:       "my-node-subnet",
 								},
-								Name:          "my-node-subnet",
 								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
 								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
 								NatGateway: NatGateway{
@@ -386,14 +388,14 @@ func TestSubnetDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetControlPlane,
+									Name: "cluster-test-controlplane-subnet",
 								},
-								Name: "cluster-test-controlplane-subnet",
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "cluster-test-node-subnet",
 								},
-								Name: "cluster-test-node-subnet",
 							},
 						},
 					},
@@ -410,9 +412,9 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetControlPlane,
 									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
+									Name:       "cluster-test-controlplane-subnet",
 								},
 
-								Name:          "cluster-test-controlplane-subnet",
 								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
 								RouteTable:    RouteTable{},
 							},
@@ -420,8 +422,8 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetNode,
 									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
+									Name:       "cluster-test-node-subnet",
 								},
-								Name:          "cluster-test-node-subnet",
 								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
 								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
 							},
@@ -442,8 +444,8 @@ func TestSubnetDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetControlPlane,
+									Name: "cluster-test-controlplane-subnet",
 								},
-								Name: "cluster-test-controlplane-subnet",
 								RouteTable: RouteTable{
 									Name: "control-plane-custom-route-table",
 								},
@@ -451,8 +453,8 @@ func TestSubnetDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "cluster-test-node-subnet",
 								},
-								Name: "cluster-test-node-subnet",
 							},
 						},
 					},
@@ -469,8 +471,8 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetControlPlane,
 									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
+									Name:       "cluster-test-controlplane-subnet",
 								},
-								Name:          "cluster-test-controlplane-subnet",
 								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
 								RouteTable:    RouteTable{Name: "control-plane-custom-route-table"},
 							},
@@ -478,8 +480,8 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetNode,
 									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
+									Name:       "cluster-test-node-subnet",
 								},
-								Name:          "cluster-test-node-subnet",
 								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
 								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
 							},
@@ -500,8 +502,8 @@ func TestSubnetDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "my-node-subnet",
 								},
-								Name: "my-node-subnet",
 							},
 						},
 					},
@@ -518,8 +520,9 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetNode,
 									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
+									Name:       "my-node-subnet",
 								},
-								Name:          "my-node-subnet",
+
 								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
 								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
 							},
@@ -527,8 +530,8 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetControlPlane,
 									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
+									Name:       "cluster-test-controlplane-subnet",
 								},
-								Name:          "cluster-test-controlplane-subnet",
 								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
 								RouteTable:    RouteTable{},
 							},
@@ -555,15 +558,15 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       "control-plane",
 									CIDRBlocks: []string{"2001:beef::1/64"},
+									Name:       "cluster-test-controlplane-subnet",
 								},
-								Name: "cluster-test-controlplane-subnet",
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       "node",
 									CIDRBlocks: []string{"2001:beea::1/64"},
+									Name:       "cluster-test-node-subnet",
 								},
-								Name: "cluster-test-node-subnet",
 							},
 						},
 					},
@@ -585,8 +588,8 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetControlPlane,
 									CIDRBlocks: []string{"2001:beef::1/64"},
+									Name:       "cluster-test-controlplane-subnet",
 								},
-								Name:          "cluster-test-controlplane-subnet",
 								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
 								RouteTable:    RouteTable{},
 							},
@@ -594,8 +597,8 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetNode,
 									CIDRBlocks: []string{"2001:beea::1/64"},
+									Name:       "cluster-test-node-subnet",
 								},
-								Name:          "cluster-test-node-subnet",
 								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
 								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
 							},
@@ -616,8 +619,8 @@ func TestSubnetDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: "control-plane",
+									Name: "cluster-test-controlplane-subnet",
 								},
-								Name: "cluster-test-controlplane-subnet",
 								SecurityGroup: SecurityGroup{
 									SecurityGroupClass: SecurityGroupClass{
 										SecurityRules: []SecurityRule{
@@ -651,8 +654,8 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       "control-plane",
 									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
+									Name:       "cluster-test-controlplane-subnet",
 								},
-								Name: "cluster-test-controlplane-subnet",
 								SecurityGroup: SecurityGroup{
 									SecurityGroupClass: SecurityGroupClass{
 										SecurityRules: []SecurityRule{
@@ -676,8 +679,8 @@ func TestSubnetDefaults(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									Role:       SubnetNode,
 									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
+									Name:       "cluster-test-node-subnet",
 								},
-								Name:          "cluster-test-node-subnet",
 								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
 								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
 							},
@@ -739,8 +742,10 @@ func TestVnetPeeringDefaults(t *testing.T) {
 						Vnet: VnetSpec{
 							Peerings: VnetPeerings{
 								{
-									VnetPeeringClassSpec: VnetPeeringClassSpec{RemoteVnetName: "my-vnet"},
-									ResourceGroup:        "cluster-test",
+									VnetPeeringClassSpec: VnetPeeringClassSpec{
+										RemoteVnetName: "my-vnet",
+										ResourceGroup:  "cluster-test",
+									},
 								},
 							},
 						},
@@ -757,8 +762,10 @@ func TestVnetPeeringDefaults(t *testing.T) {
 						Vnet: VnetSpec{
 							Peerings: VnetPeerings{
 								{
-									VnetPeeringClassSpec: VnetPeeringClassSpec{RemoteVnetName: "my-vnet"},
-									ResourceGroup:        "cluster-test",
+									VnetPeeringClassSpec: VnetPeeringClassSpec{
+										RemoteVnetName: "my-vnet",
+										ResourceGroup:  "cluster-test",
+									},
 								},
 							},
 						},
@@ -795,8 +802,10 @@ func TestVnetPeeringDefaults(t *testing.T) {
 						Vnet: VnetSpec{
 							Peerings: VnetPeerings{
 								{
-									VnetPeeringClassSpec: VnetPeeringClassSpec{RemoteVnetName: "my-vnet"},
-									ResourceGroup:        "cluster-test",
+									VnetPeeringClassSpec: VnetPeeringClassSpec{
+										RemoteVnetName: "my-vnet",
+										ResourceGroup:  "cluster-test",
+									},
 								},
 							},
 						},
@@ -1023,16 +1032,16 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetControlPlane,
+									Name: "control-plane-subnet",
 								},
-								Name:          "control-plane-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet",
 								},
-								Name:          "node-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
@@ -1050,16 +1059,16 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetControlPlane,
+									Name: "control-plane-subnet",
 								},
-								Name:          "control-plane-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet",
 								},
-								Name:          "node-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
@@ -1101,16 +1110,16 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetControlPlane,
+									Name: "control-plane-subnet",
 								},
-								Name:          "control-plane-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet",
 								},
-								Name:          "node-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 								NatGateway: NatGateway{
@@ -1133,16 +1142,16 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetControlPlane,
+									Name: "control-plane-subnet",
 								},
-								Name:          "control-plane-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet",
 								},
-								Name:          "node-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 								NatGateway: NatGateway{
@@ -1174,16 +1183,16 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetControlPlane,
+									Name: "control-plane-subnet",
 								},
-								Name:          "control-plane-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet",
 								},
-								Name:          "node-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 								NatGateway: NatGateway{
@@ -1195,8 +1204,8 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet-2",
 								},
-								Name:          "node-subnet-2",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
@@ -1214,16 +1223,16 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetControlPlane,
+									Name: "control-plane-subnet",
 								},
-								Name:          "control-plane-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet",
 								},
-								Name:          "node-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 								NatGateway: NatGateway{
@@ -1236,8 +1245,8 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet-2",
 								},
-								Name:          "node-subnet-2",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
@@ -1279,32 +1288,32 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetControlPlane,
+									Name: "control-plane-subnet",
 								},
-								Name:          "control-plane-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet",
 								},
-								Name:          "node-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet-2",
 								},
-								Name:          "node-subnet-2",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet-3",
 								},
-								Name:          "node-subnet-3",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
@@ -1322,32 +1331,32 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetControlPlane,
+									Name: "control-plane-subnet",
 								},
-								Name:          "control-plane-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet",
 								},
-								Name:          "node-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet-2",
 								},
-								Name:          "node-subnet-2",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet-3",
 								},
-								Name:          "node-subnet-3",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
@@ -1389,16 +1398,16 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetControlPlane,
+									Name: "control-plane-subnet",
 								},
-								Name:          "control-plane-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet",
 								},
-								Name:          "node-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 								NatGateway: NatGateway{
@@ -1411,8 +1420,8 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet-2",
 								},
-								Name:          "node-subnet-2",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 								NatGateway: NatGateway{
@@ -1425,8 +1434,8 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet-3",
 								},
-								Name:          "node-subnet-3",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 								NatGateway: NatGateway{
@@ -1450,16 +1459,16 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetControlPlane,
+									Name: "control-plane-subnet",
 								},
-								Name:          "control-plane-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet",
 								},
-								Name:          "node-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 								NatGateway: NatGateway{
@@ -1472,8 +1481,8 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet-2",
 								},
-								Name:          "node-subnet-2",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 								NatGateway: NatGateway{
@@ -1486,8 +1495,8 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							{
 								SubnetClassSpec: SubnetClassSpec{
 									Role: SubnetNode,
+									Name: "node-subnet-3",
 								},
-								Name:          "node-subnet-3",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 								NatGateway: NatGateway{
@@ -1777,10 +1786,11 @@ func TestBastionDefault(t *testing.T) {
 						AzureBastion: &AzureBastion{
 							Name: "foo-azure-bastion",
 							Subnet: SubnetSpec{
-								Name: "AzureBastionSubnet",
+
 								SubnetClassSpec: SubnetClassSpec{
 									CIDRBlocks: []string{DefaultAzureBastionSubnetCIDR},
 									Role:       DefaultAzureBastionSubnetRole,
+									Name:       "AzureBastionSubnet",
 								},
 							},
 							PublicIP: PublicIPSpec{
@@ -1813,10 +1823,11 @@ func TestBastionDefault(t *testing.T) {
 						AzureBastion: &AzureBastion{
 							Name: "my-fancy-name",
 							Subnet: SubnetSpec{
-								Name: "AzureBastionSubnet",
+
 								SubnetClassSpec: SubnetClassSpec{
 									CIDRBlocks: []string{DefaultAzureBastionSubnetCIDR},
 									Role:       DefaultAzureBastionSubnetRole,
+									Name:       "AzureBastionSubnet",
 								},
 							},
 							PublicIP: PublicIPSpec{
@@ -1849,10 +1860,10 @@ func TestBastionDefault(t *testing.T) {
 						AzureBastion: &AzureBastion{
 							Name: "foo-azure-bastion",
 							Subnet: SubnetSpec{
-								Name: "AzureBastionSubnet",
 								SubnetClassSpec: SubnetClassSpec{
 									CIDRBlocks: []string{DefaultAzureBastionSubnetCIDR},
 									Role:       DefaultAzureBastionSubnetRole,
+									Name:       "AzureBastionSubnet",
 								},
 							},
 							PublicIP: PublicIPSpec{
@@ -1872,9 +1883,9 @@ func TestBastionDefault(t *testing.T) {
 					BastionSpec: BastionSpec{
 						AzureBastion: &AzureBastion{
 							Subnet: SubnetSpec{
-								Name: "my-superfancy-name",
 								SubnetClassSpec: SubnetClassSpec{
 									CIDRBlocks: []string{"10.10.0.0/16"},
+									Name:       "my-superfancy-name",
 								},
 							},
 						},
@@ -1890,10 +1901,10 @@ func TestBastionDefault(t *testing.T) {
 						AzureBastion: &AzureBastion{
 							Name: "foo-azure-bastion",
 							Subnet: SubnetSpec{
-								Name: "my-superfancy-name",
 								SubnetClassSpec: SubnetClassSpec{
 									CIDRBlocks: []string{"10.10.0.0/16"},
 									Role:       DefaultAzureBastionSubnetRole,
+									Name:       "my-superfancy-name",
 								},
 							},
 							PublicIP: PublicIPSpec{
@@ -1931,8 +1942,8 @@ func TestBastionDefault(t *testing.T) {
 								SubnetClassSpec: SubnetClassSpec{
 									CIDRBlocks: []string{DefaultAzureBastionSubnetCIDR},
 									Role:       DefaultAzureBastionSubnetRole,
+									Name:       "AzureBastionSubnet",
 								},
-								Name: "AzureBastionSubnet",
 							},
 							PublicIP: PublicIPSpec{
 								Name: "my-ultrafancy-pip-name",

--- a/api/v1beta1/azurecluster_validation_test.go
+++ b/api/v1beta1/azurecluster_validation_test.go
@@ -135,9 +135,9 @@ func TestClusterWithPreexistingVnetInvalid(t *testing.T) {
 
 	// invalid because it doesn't specify a controlplane subnet
 	testCase.cluster.Spec.NetworkSpec.Subnets[0] = SubnetSpec{
-		Name: "random-subnet",
 		SubnetClassSpec: SubnetClassSpec{
 			Role: "random",
+			Name: "random-subnet",
 		},
 	}
 
@@ -204,9 +204,9 @@ func TestClusterSpecWithPreexistingVnetInvalid(t *testing.T) {
 
 	// invalid because it doesn't specify a controlplane subnet
 	testCase.cluster.Spec.NetworkSpec.Subnets[0] = SubnetSpec{
-		Name: "random-subnet",
 		SubnetClassSpec: SubnetClassSpec{
 			Role: "random",
+			Name: "random-subnet",
 		},
 	}
 
@@ -1312,15 +1312,15 @@ func createValidNetworkSpec() NetworkSpec {
 func createValidSubnets() Subnets {
 	return Subnets{
 		{
-			Name: "control-plane-subnet",
 			SubnetClassSpec: SubnetClassSpec{
 				Role: "control-plane",
+				Name: "control-plane-subnet",
 			},
 		},
 		{
-			Name: "node-subnet",
 			SubnetClassSpec: SubnetClassSpec{
 				Role: "node",
+				Name: "node-subnet",
 			},
 		},
 	}

--- a/api/v1beta1/azurecluster_webhook_test.go
+++ b/api/v1beta1/azurecluster_webhook_test.go
@@ -89,7 +89,7 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 			cluster: func() *AzureCluster {
 				cluster := createValidCluster()
 				cluster.Spec.NetworkSpec.Subnets = append(cluster.Spec.NetworkSpec.Subnets,
-					SubnetSpec{Name: "invalid-subnet-name###", SubnetClassSpec: SubnetClassSpec{Role: "random-role"}})
+					SubnetSpec{SubnetClassSpec: SubnetClassSpec{Name: "invalid-subnet-name###", Role: "random-role"}})
 				return cluster
 			}(),
 			wantErr: true,
@@ -205,7 +205,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 			cluster: func() *AzureCluster {
 				cluster := createValidCluster()
 				cluster.Spec.NetworkSpec.Subnets = append(cluster.Spec.NetworkSpec.Subnets,
-					SubnetSpec{Name: "invalid-name###", SubnetClassSpec: SubnetClassSpec{Role: "random-role"}})
+					SubnetSpec{SubnetClassSpec: SubnetClassSpec{Name: "invalid-name###", Role: "random-role"}})
 				return cluster
 			}(),
 			wantErr: true,

--- a/api/v1beta1/azureclustertemplate_validation_test.go
+++ b/api/v1beta1/azureclustertemplate_validation_test.go
@@ -122,12 +122,14 @@ func TestValidateSubnetTemplates(t *testing.T) {
 										SubnetClassSpec: SubnetClassSpec{
 											Role:       SubnetControlPlane,
 											CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
+											Name:       "foo-controlPlane-subnet",
 										},
 									},
 									{
 										SubnetClassSpec: SubnetClassSpec{
 											Role:       SubnetNode,
 											CIDRBlocks: []string{DefaultNodeSubnetCIDR},
+											Name:       "foo-workerSubnet-subnet",
 										},
 									},
 								},
@@ -137,6 +139,89 @@ func TestValidateSubnetTemplates(t *testing.T) {
 				},
 			},
 			expectValid: true,
+		},
+		{
+			name: "invalid subnets - missing/empty subnet name",
+			clusterTemplate: &AzureClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-template",
+				},
+				Spec: AzureClusterTemplateSpec{
+					Template: AzureClusterTemplateResource{
+						Spec: AzureClusterTemplateResourceSpec{
+							NetworkSpec: NetworkTemplateSpec{
+								Vnet: VnetTemplateSpec{
+									VnetClassSpec: VnetClassSpec{
+										CIDRBlocks: []string{DefaultVnetCIDR},
+									},
+								},
+								Subnets: SubnetTemplatesSpec{
+									{
+										SubnetClassSpec: SubnetClassSpec{
+											Role:       SubnetControlPlane,
+											CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
+											Name:       "",
+										},
+									},
+									{
+										SubnetClassSpec: SubnetClassSpec{
+											Role:       SubnetNode,
+											CIDRBlocks: []string{DefaultNodeSubnetCIDR},
+											Name:       "",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectValid: false,
+		},
+		{
+			name: "invalid subnets - duplicate subnet names",
+			clusterTemplate: &AzureClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-template",
+				},
+				Spec: AzureClusterTemplateSpec{
+					Template: AzureClusterTemplateResource{
+						Spec: AzureClusterTemplateResourceSpec{
+							NetworkSpec: NetworkTemplateSpec{
+								Vnet: VnetTemplateSpec{
+									VnetClassSpec: VnetClassSpec{
+										CIDRBlocks: []string{DefaultVnetCIDR},
+									},
+								},
+								Subnets: SubnetTemplatesSpec{
+									{
+										SubnetClassSpec: SubnetClassSpec{
+											Role:       SubnetControlPlane,
+											CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
+											Name:       "foo-controlPlane-subnet",
+										},
+									},
+									{
+										SubnetClassSpec: SubnetClassSpec{
+											Role:       SubnetNode,
+											CIDRBlocks: []string{DefaultNodeSubnetCIDR},
+											Name:       "foo-workerSubnet-subnet",
+										},
+									},
+									{
+										SubnetClassSpec: SubnetClassSpec{
+											Role:       SubnetNode,
+											CIDRBlocks: []string{"10.2.0.0/16"},
+											Name:       "foo-workerSubnet-subnet",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectValid: false,
 		},
 		{
 			name: "invalid subnets - wrong security rule priorities - lower than minimum",

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -113,15 +113,15 @@ type VnetSpec struct {
 
 // VnetPeeringSpec specifies an existing remote virtual network to peer with the AzureCluster's virtual network.
 type VnetPeeringSpec struct {
-	// ResourceGroup is the resource group name of the remote virtual network.
-	// +optional
-	ResourceGroup string `json:"resourceGroup,omitempty"`
-
 	VnetPeeringClassSpec `json:",inline"`
 }
 
 // VnetPeeringClassSpec specifies a virtual network peering class.
 type VnetPeeringClassSpec struct {
+	// ResourceGroup is the resource group name of the remote virtual network.
+	// +optional
+	ResourceGroup string `json:"resourceGroup,omitempty"`
+
 	// RemoteVnetName defines name of the remote virtual network.
 	RemoteVnetName string `json:"remoteVnetName"`
 }
@@ -135,6 +135,8 @@ func (v *VnetSpec) IsManaged(clusterName string) bool {
 }
 
 // Subnets is a slice of Subnet.
+// +listType=map
+// +listMapKey=name
 type Subnets []SubnetSpec
 
 // SecurityGroup defines an Azure security group.
@@ -230,6 +232,8 @@ type SecurityRule struct {
 }
 
 // SecurityRules is a slice of Azure security rules for security groups.
+// +listType=map
+// +listMapKey=name
 type SecurityRules []SecurityRule
 
 // LoadBalancerSpec defines an Azure load balancer.
@@ -589,9 +593,6 @@ type SubnetSpec struct {
 	// READ-ONLY
 	// +optional
 	ID string `json:"id,omitempty"`
-
-	// Name defines a name for the subnet resource.
-	Name string `json:"name"`
 
 	// SecurityGroup defines the NSG (network security group) that should be attached to this subnet.
 	// +optional

--- a/api/v1beta1/types_class.go
+++ b/api/v1beta1/types_class.go
@@ -72,6 +72,9 @@ type VnetClassSpec struct {
 
 // SubnetClassSpec defines the SubnetSpec properties that may be shared across several Azure clusters.
 type SubnetClassSpec struct {
+	// Name defines a name for the subnet resource.
+	Name string `json:"name"`
+
 	// Role defines the subnet role (eg. Node, ControlPlane)
 	// +kubebuilder:validation:Enum=node;control-plane;bastion
 	Role SubnetRole `json:"role"`

--- a/api/v1beta1/types_template.go
+++ b/api/v1beta1/types_template.go
@@ -107,6 +107,8 @@ func (s SubnetTemplateSpec) IsNatGatewayEnabled() bool {
 }
 
 // SubnetTemplatesSpec specifies a list of subnet templates.
+// +listType=map
+// +listMapKey=name
 type SubnetTemplatesSpec []SubnetTemplateSpec
 
 // BastionTemplateSpec specifies a template for a bastion host.

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -215,9 +215,9 @@ func TestGettingSecurityRules(t *testing.T) {
 			NetworkSpec: infrav1.NetworkSpec{
 				Subnets: infrav1.Subnets{
 					{
-						Name: "node",
 						SubnetClassSpec: infrav1.SubnetClassSpec{
 							Role: infrav1.SubnetNode,
+							Name: "node",
 						},
 					},
 				},
@@ -1239,10 +1239,10 @@ func TestSubnetSpecs(t *testing.T) {
 							},
 							Subnets: infrav1.Subnets{
 								{
-									Name: "fake-subnet-1",
 									SubnetClassSpec: infrav1.SubnetClassSpec{
 										Role:       infrav1.SubnetNode,
 										CIDRBlocks: []string{"192.168.1.1/16"},
+										Name:       "fake-subnet-1",
 									},
 									NatGateway: infrav1.NatGateway{
 										NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
@@ -1308,10 +1308,10 @@ func TestSubnetSpecs(t *testing.T) {
 							AzureBastion: &infrav1.AzureBastion{
 								Name: "fake-azure-bastion",
 								Subnet: infrav1.SubnetSpec{
-									Name: "fake-bastion-subnet-1",
 									SubnetClassSpec: infrav1.SubnetClassSpec{
 										Role:       infrav1.SubnetBastion,
 										CIDRBlocks: []string{"172.122.1.1./16"},
+										Name:       "fake-bastion-subnet-1",
 									},
 									RouteTable: infrav1.RouteTable{
 										ID:   "fake-bastion-route-table-id-1",
@@ -1342,10 +1342,10 @@ func TestSubnetSpecs(t *testing.T) {
 							},
 							Subnets: infrav1.Subnets{
 								{
-									Name: "fake-subnet-1",
 									SubnetClassSpec: infrav1.SubnetClassSpec{
 										Role:       infrav1.SubnetNode,
 										CIDRBlocks: []string{"192.168.1.1/16"},
+										Name:       "fake-subnet-1",
 									},
 									NatGateway: infrav1.NatGateway{
 										NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
@@ -1570,10 +1570,10 @@ func TestAzureBastionSpec(t *testing.T) {
 							AzureBastion: &infrav1.AzureBastion{
 								Name: "fake-azure-bastion-1",
 								Subnet: infrav1.SubnetSpec{
-									Name: "fake-bastion-subnet-1",
 									SubnetClassSpec: infrav1.SubnetClassSpec{
 										Role:       infrav1.SubnetBastion,
 										CIDRBlocks: []string{"172.122.1.1./16"},
+										Name:       "fake-bastion-subnet-1",
 									},
 									RouteTable: infrav1.RouteTable{
 										ID:   "fake-bastion-route-table-id-1",
@@ -1607,10 +1607,10 @@ func TestAzureBastionSpec(t *testing.T) {
 							},
 							Subnets: infrav1.Subnets{
 								{
-									Name: "fake-subnet-1",
 									SubnetClassSpec: infrav1.SubnetClassSpec{
 										Role:       infrav1.SubnetNode,
 										CIDRBlocks: []string{"192.168.1.1/16"},
+										Name:       "fake-subnet-1",
 									},
 									NatGateway: infrav1.NatGateway{
 										NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
@@ -1681,22 +1681,30 @@ func TestSubnet(t *testing.T) {
 			azureClusterNetworkSpec: infrav1.NetworkSpec{
 				Subnets: infrav1.Subnets{
 					infrav1.SubnetSpec{
-						ID:   "subnet-1-id",
-						Name: "subnet-1",
+						SubnetClassSpec: infrav1.SubnetClassSpec{
+							Name: "subnet-1",
+						},
+						ID: "subnet-1-id",
 					},
 					infrav1.SubnetSpec{
-						ID:   "subnet-1-id",
-						Name: "subnet-2",
+						SubnetClassSpec: infrav1.SubnetClassSpec{
+							Name: "subnet-2",
+						},
+						ID: "subnet-1-id",
 					},
 					infrav1.SubnetSpec{
-						ID:   "subnet-2-id",
-						Name: "subnet-3",
+						SubnetClassSpec: infrav1.SubnetClassSpec{
+							Name: "subnet-3",
+						},
+						ID: "subnet-2-id",
 					},
 				},
 			},
 			expectSubnet: infrav1.SubnetSpec{
-				ID:   "subnet-1-id",
-				Name: "subnet-1",
+				SubnetClassSpec: infrav1.SubnetClassSpec{
+					Name: "subnet-1",
+				},
+				ID: "subnet-1-id",
 			},
 		},
 	}
@@ -2080,8 +2088,8 @@ func TestOutboundLBName(t *testing.T) {
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							{
-								Name: "node",
 								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Name: "node",
 									Role: infrav1.SubnetNode,
 								},
 							},

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -861,10 +861,14 @@ func TestMachineScope_Subnet(t *testing.T) {
 							NetworkSpec: infrav1.NetworkSpec{
 								Subnets: []infrav1.SubnetSpec{
 									{
-										Name: "machine-name-subnet",
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Name: "machine-name-subnet",
+										},
 									},
 									{
-										Name: "another-machine-name-subnet",
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Name: "another-machine-name-subnet",
+										},
 									},
 								},
 							},
@@ -873,7 +877,9 @@ func TestMachineScope_Subnet(t *testing.T) {
 				},
 			},
 			want: infrav1.SubnetSpec{
-				Name: "machine-name-subnet",
+				SubnetClassSpec: infrav1.SubnetClassSpec{
+					Name: "machine-name-subnet",
+				},
 			},
 		},
 		{
@@ -1655,8 +1661,8 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 									{
 										SubnetClassSpec: infrav1.SubnetClassSpec{
 											Role: infrav1.SubnetNode,
+											Name: "subnet1",
 										},
-										Name: "subnet1",
 									},
 								},
 								NodeOutboundLB: &infrav1.LoadBalancerSpec{
@@ -1755,8 +1761,8 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 									{
 										SubnetClassSpec: infrav1.SubnetClassSpec{
 											Role: infrav1.SubnetNode,
+											Name: "subnet1",
 										},
-										Name: "subnet1",
 									},
 								},
 								NodeOutboundLB: &infrav1.LoadBalancerSpec{
@@ -1862,8 +1868,8 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 									{
 										SubnetClassSpec: infrav1.SubnetClassSpec{
 											Role: infrav1.SubnetNode,
+											Name: "subnet1",
 										},
-										Name: "subnet1",
 										NatGateway: infrav1.NatGateway{
 											NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
 												Name: "natgw",
@@ -1967,8 +1973,8 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 									{
 										SubnetClassSpec: infrav1.SubnetClassSpec{
 											Role: infrav1.SubnetNode,
+											Name: "subnet1",
 										},
-										Name: "subnet1",
 									},
 								},
 								NodeOutboundLB: &infrav1.LoadBalancerSpec{
@@ -2068,8 +2074,8 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 									{
 										SubnetClassSpec: infrav1.SubnetClassSpec{
 											Role: infrav1.SubnetNode,
+											Name: "subnet1",
 										},
-										Name: "subnet1",
 									},
 								},
 								APIServerLB: infrav1.LoadBalancerSpec{
@@ -2174,8 +2180,8 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 									{
 										SubnetClassSpec: infrav1.SubnetClassSpec{
 											Role: infrav1.SubnetNode,
+											Name: "subnet1",
 										},
-										Name: "subnet1",
 									},
 								},
 								APIServerLB: infrav1.LoadBalancerSpec{
@@ -2277,8 +2283,8 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 									{
 										SubnetClassSpec: infrav1.SubnetClassSpec{
 											Role: infrav1.SubnetNode,
+											Name: "subnet1",
 										},
-										Name: "subnet1",
 									},
 								},
 								APIServerLB: infrav1.LoadBalancerSpec{

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -280,9 +280,9 @@ func (s *ManagedControlPlaneScope) Subnets() infrav1.Subnets {
 // NodeSubnet returns the cluster node subnet.
 func (s *ManagedControlPlaneScope) NodeSubnet() infrav1.SubnetSpec {
 	return infrav1.SubnetSpec{
-		Name: s.ControlPlane.Spec.VirtualNetwork.Subnet.Name,
 		SubnetClassSpec: infrav1.SubnetClassSpec{
 			CIDRBlocks: []string{s.ControlPlane.Spec.VirtualNetwork.Subnet.CIDRBlock},
+			Name:       s.ControlPlane.Spec.VirtualNetwork.Subnet.Name,
 		},
 	}
 }
@@ -314,9 +314,9 @@ func (s *ManagedControlPlaneScope) ControlPlaneSubnet() infrav1.SubnetSpec {
 func (s *ManagedControlPlaneScope) NodeSubnets() []infrav1.SubnetSpec {
 	return []infrav1.SubnetSpec{
 		{
-			Name: s.ControlPlane.Spec.VirtualNetwork.Subnet.Name,
 			SubnetClassSpec: infrav1.SubnetClassSpec{
 				CIDRBlocks: []string{s.ControlPlane.Spec.VirtualNetwork.Subnet.CIDRBlock},
+				Name:       s.ControlPlane.Spec.VirtualNetwork.Subnet.Name,
 			},
 		},
 	}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: azureclusteridentities.infrastructure.cluster.x-k8s.io
 spec:
@@ -64,6 +64,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               resourceID:
                 description: User assigned MSI resource id.
                 type: string
@@ -224,6 +225,7 @@ spec:
                           "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                 type: object
               clientID:
                 description: Both User Assigned MSI and SP can use this field.
@@ -241,6 +243,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               resourceID:
                 description: User assigned MSI resource id.
                 type: string
@@ -401,6 +404,7 @@ spec:
                           "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                 type: object
               clientID:
                 description: ClientID is the service principal client ID. Both User
@@ -419,6 +423,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               resourceID:
                 description: ResourceID is the Azure resource ID for the User Assigned
                   MSI resource. Only applicable when type is UserAssignedMSI.
@@ -495,9 +500,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: azureclusters.infrastructure.cluster.x-k8s.io
 spec:
@@ -121,6 +121,7 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               location:
                 type: string
               networkSpec:
@@ -778,6 +779,7 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               location:
                 type: string
               networkSpec:
@@ -1508,6 +1510,9 @@ spec:
                                   - protocol
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                               tags:
                                 additionalProperties:
                                   type: string
@@ -1667,6 +1672,7 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               location:
                 type: string
               networkSpec:
@@ -2057,6 +2063,9 @@ spec:
                                 - protocol
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             tags:
                               additionalProperties:
                                 type: string
@@ -2070,6 +2079,9 @@ spec:
                       - role
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   vnet:
                     description: Vnet is the configuration for the Azure virtual network.
                     properties:
@@ -2248,9 +2260,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: azureclustertemplates.infrastructure.cluster.x-k8s.io
 spec:
@@ -79,6 +79,10 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  name:
+                                    description: Name defines a name for the subnet
+                                      resource.
+                                    type: string
                                   natGateway:
                                     description: NatGateway associated with this subnet.
                                     properties:
@@ -181,6 +185,9 @@ spec:
                                           - protocol
                                           type: object
                                         type: array
+                                        x-kubernetes-list-map-keys:
+                                        - name
+                                        x-kubernetes-list-type: map
                                       tags:
                                         additionalProperties:
                                           type: string
@@ -188,6 +195,7 @@ spec:
                                         type: object
                                     type: object
                                 required:
+                                - name
                                 - role
                                 type: object
                             type: object
@@ -325,6 +333,7 @@ spec:
                             description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       location:
                         type: string
                       networkSpec:
@@ -402,6 +411,10 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                name:
+                                  description: Name defines a name for the subnet
+                                    resource.
+                                  type: string
                                 natGateway:
                                   description: NatGateway associated with this subnet.
                                   properties:
@@ -502,6 +515,9 @@ spec:
                                         - protocol
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
                                     tags:
                                       additionalProperties:
                                         type: string
@@ -509,9 +525,13 @@ spec:
                                       type: object
                                   type: object
                               required:
+                              - name
                               - role
                               type: object
                             type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           vnet:
                             description: Vnet is the configuration for the Azure virtual
                               network.
@@ -534,6 +554,10 @@ spec:
                                     remoteVnetName:
                                       description: RemoteVnetName defines name of
                                         the remote virtual network.
+                                      type: string
+                                    resourceGroup:
+                                      description: ResourceGroup is the resource group
+                                        name of the remote virtual network.
                                       type: string
                                   required:
                                   - remoteVnetName
@@ -561,9 +585,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepoolmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepoolmachines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: azuremachinepoolmachines.infrastructure.cluster.x-k8s.io
 spec:
@@ -465,9 +465,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: azuremachinepools.infrastructure.cluster.x-k8s.io
 spec:
@@ -2208,9 +2208,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: azuremachines.infrastructure.cluster.x-k8s.io
 spec:
@@ -1621,9 +1621,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: azuremachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
@@ -1271,9 +1271,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: azuremanagedclusters.infrastructure.cluster.x-k8s.io
 spec:
@@ -166,9 +166,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io
 spec:
@@ -856,9 +856,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: azuremanagedmachinepools.infrastructure.cluster.x-k8s.io
 spec:
@@ -414,9 +414,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/controllers/azurejson_machine_controller_test.go
+++ b/controllers/azurejson_machine_controller_test.go
@@ -123,8 +123,8 @@ func TestAzureJSONMachineReconciler(t *testing.T) {
 			NetworkSpec: infrav1.NetworkSpec{
 				Subnets: infrav1.Subnets{
 					{
-						Name: "node",
 						SubnetClassSpec: infrav1.SubnetClassSpec{
+							Name: "node",
 							Role: infrav1.SubnetNode,
 						},
 					},

--- a/controllers/azurejson_machinepool_controller_test.go
+++ b/controllers/azurejson_machinepool_controller_test.go
@@ -73,8 +73,8 @@ func TestAzureJSONPoolReconciler(t *testing.T) {
 			NetworkSpec: infrav1.NetworkSpec{
 				Subnets: infrav1.Subnets{
 					{
-						Name: "node",
 						SubnetClassSpec: infrav1.SubnetClassSpec{
+							Name: "node",
 							Role: infrav1.SubnetNode,
 						},
 					},

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -426,14 +426,14 @@ func newAzureClusterWithCustomVnet(location string) *infrav1.AzureCluster {
 				},
 				Subnets: infrav1.Subnets{
 					infrav1.SubnetSpec{
-						Name: "foo-controlplane-subnet",
 						SubnetClassSpec: infrav1.SubnetClassSpec{
+							Name: "foo-controlplane-subnet",
 							Role: infrav1.SubnetControlPlane,
 						},
 					},
 					infrav1.SubnetSpec{
-						Name: "foo-node-subnet",
 						SubnetClassSpec: infrav1.SubnetClassSpec{
+							Name: "foo-node-subnet",
 							Role: infrav1.SubnetNode,
 						},
 					},

--- a/templates/test/ci/cluster-template-prow-clusterclass-ci-default.yaml
+++ b/templates/test/ci/cluster-template-prow-clusterclass-ci-default.yaml
@@ -464,8 +464,10 @@ spec:
       location: replace_me
       networkSpec:
         subnets:
-        - role: control-plane
-        - natGateway:
+        - name: control-plane-subnet
+          role: control-plane
+        - name: node-subnet
+          natGateway:
             name: node-natgateway
           role: node
 ---

--- a/templates/test/ci/prow-clusterclass-ci-default/base.yaml
+++ b/templates/test/ci/prow-clusterclass-ci-default/base.yaml
@@ -152,9 +152,11 @@ spec:
       networkSpec:
         subnets:
           - role: control-plane
+            name: control-plane-subnet
           - natGateway:
               name: node-natgateway
             role: node
+            name: node-subnet
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate


### PR DESCRIPTION

**What type of PR is this?**
This PR adds tags to adapt the SSA changes of CAPI. 

This PR does the following: 
- Bumps the cotroller gen to v0.9.2 ( Required for SSA tags ) 
- Adds `name` field to `SubnetClassSpec`, drop from `SubnetSpec`
- Add tags  `+listType=map` and  `+listMapKey=name` to `SubnetTemplatesSpec` and `Subnet` to support SSA. Note that `SubnetClassSpec` is a child field of `AzureClusterTemplate` and `Subnet` is a child field of `AzureCluster`

Some useful discussion can be found here on this original PR 
https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2636


/kind api-change


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2659 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes a cluster class bug where capz and topology controller updates the AzureCluster object continuously 
```
