### PR TITLE
AzureManagedCluster spec.controlPlaneEndpoint is immutable

### DIFF
--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -532,7 +532,12 @@ func (s *ManagedControlPlaneScope) GetAllAgentPoolSpecs() ([]azure.ResourceSpecG
 
 // SetControlPlaneEndpoint sets a control plane endpoint.
 func (s *ManagedControlPlaneScope) SetControlPlaneEndpoint(endpoint clusterv1.APIEndpoint) {
-	s.ControlPlane.Spec.ControlPlaneEndpoint = endpoint
+	if s.ControlPlane.Spec.ControlPlaneEndpoint.Host == "" {
+		s.ControlPlane.Spec.ControlPlaneEndpoint.Host = endpoint.Host
+	}
+	if s.ControlPlane.Spec.ControlPlaneEndpoint.Port == 0 {
+		s.ControlPlane.Spec.ControlPlaneEndpoint.Port = endpoint.Port
+	}
 }
 
 // MakeEmptyKubeConfigSecret creates an empty secret object that is used for storing kubeconfig secret data.

--- a/exp/controllers/azuremanagedcluster_controller.go
+++ b/exp/controllers/azuremanagedcluster_controller.go
@@ -162,7 +162,14 @@ func (amcr *AzureManagedClusterReconciler) Reconcile(ctx context.Context, req ct
 	// Infrastructure must be ready before control plane. We should also enqueue
 	// requests from control plane to infra cluster to keep control plane endpoint accurate.
 	aksCluster.Status.Ready = true
-	aksCluster.Spec.ControlPlaneEndpoint = controlPlane.Spec.ControlPlaneEndpoint
+	// We only expect to set the apiserver endpoint values once;
+	// if we attempted to update existing ControlPlaneEndpoint values, they would be rejected via webhook enforcement.
+	if aksCluster.Spec.ControlPlaneEndpoint.Host == "" {
+		aksCluster.Spec.ControlPlaneEndpoint.Host = controlPlane.Spec.ControlPlaneEndpoint.Host
+	}
+	if aksCluster.Spec.ControlPlaneEndpoint.Port == 0 {
+		aksCluster.Spec.ControlPlaneEndpoint.Port = controlPlane.Spec.ControlPlaneEndpoint.Port
+	}
 
 	if err := patchhelper.Patch(ctx, aksCluster); err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind bug

**What this PR does / why we need it**:

While auditing AzureManagedCluster property CRUD operations, I observed that you're able to edit both the `azuremanagedcluster` resource and the `azuremanagedcontrolplane` resource and change the values of the `spec.controlPlaneEndpoint` configuration. The changes are accepted, and then it seems that the controllers are smart enough to revert the changes (or possibly they are calling the AKS API and resetting it to its authoritative value).

Rather than the above, we should fail updates on that configuration via webhook.

For cluster creates, we explicity fail (via webhook) if either of the `ControlPlaneEndpoint` property values are present, which expresses the actual API contract (these properties are designed to be user-facing).

For cluster updates, we explicitly fail all updates that change non-zero type values, which has the upside of preventing user modifications to this AKS-owned property surface area. Because this is an intrinsic, immutable configuration property from AKS's perspective, it is appropriate to enforce this immutability even if updates originat from AKS API (if CAPZ detected that the AKS API wanted to change these properties that would not an unexpected violation of the AKS feature contract).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
AzureManagedCluster spec.controlPlaneEndpoint is immutable
```
