### PR TITLE
AKS: clarify that one system pool is required

### DIFF
--- a/exp/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/exp/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -154,10 +154,9 @@ func (m *AzureManagedMachinePool) ValidateUpdate(oldRaw runtime.Object, client c
 	if m.Spec.Mode != string(NodePoolModeSystem) && old.Spec.Mode == string(NodePoolModeSystem) {
 		// validate for last system node pool
 		if err := m.validateLastSystemNodePool(client); err != nil {
-			allErrs = append(allErrs, field.Invalid(
+			allErrs = append(allErrs, field.Forbidden(
 				field.NewPath("Spec", "Mode"),
-				m.Spec.Mode,
-				"Last system node pool cannot be mutated to user node pool"))
+				"Cannot change node pool mode to User, you must have at least one System node pool in your cluster"))
 		}
 	}
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind cleanup

**What this PR does / why we need it**:

This is a suggested improvement to the language that we print out when trying to set all node pools to `User`. The simplest way to run into this error is to build a single node pool AKS cluster, and then change the `mode` configuration from `System` to `User`.

I was a little confused with the existing error message:

```
# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
# azuremanagedmachinepools.infrastructure.cluster.x-k8s.io "pool0" was not valid:
# * Spec.Mode: Invalid value: "User": Last system node pool cannot be mutated to user node pool
#
```

I think this one might be a bit clearer:

```
# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
# azuremanagedmachinepools.infrastructure.cluster.x-k8s.io "pool0" was not valid:
# * Spec.Mode: Invalid value: "User": Cannot change node pool mode to User, you must have at least one System node pool in your cluster
#
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
