### PR TITLE
Use GetAtScope() to get tags when checking if a resource is managed

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -281,6 +281,16 @@ func AvailabilitySetID(subscriptionID, resourceGroup, availabilitySetName string
 	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/availabilitySets/%s", subscriptionID, resourceGroup, availabilitySetName)
 }
 
+// PrivateDNSZoneID returns the azure resource ID for a given private DNS zone.
+func PrivateDNSZoneID(subscriptionID, resourceGroup, privateDNSZoneName string) string {
+	return fmt.Sprintf("subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s", subscriptionID, resourceGroup, privateDNSZoneName)
+}
+
+// VirtualNetworkLinkID returns the azure resource ID for a given virtual network link.
+func VirtualNetworkLinkID(subscriptionID, resourceGroup, privateDNSZoneName, virtualNetworkLinkName string) string {
+	return fmt.Sprintf("subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/virtualNetworkLinks/%s", subscriptionID, resourceGroup, privateDNSZoneName, virtualNetworkLinkName)
+}
+
 // GetBootstrappingVMExtension returns the CAPZ Bootstrapping VM extension.
 // The CAPZ Bootstrapping extension is a simple clone of https://github.com/Azure/custom-script-extension-linux for Linux or
 // https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-windows for Windows.

--- a/azure/services/async/interfaces.go
+++ b/azure/services/async/interfaces.go
@@ -19,6 +19,7 @@ package async
 import (
 	"context"
 
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
@@ -39,6 +40,11 @@ type FutureHandler interface {
 // Getter is an interface that can get a resource.
 type Getter interface {
 	Get(ctx context.Context, spec azure.ResourceSpecGetter) (result interface{}, err error)
+}
+
+// TagsGetter is an interface that can get a tags resource.
+type TagsGetter interface {
+	GetAtScope(ctx context.Context, scope string) (result resources.TagsResource, err error)
 }
 
 // Creator is a client that can create or update a resource asynchronously.

--- a/azure/services/async/mock_async/async_mock.go
+++ b/azure/services/async/mock_async/async_mock.go
@@ -24,6 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	resources "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
 	azure "github.com/Azure/go-autorest/autorest/azure"
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -217,6 +218,44 @@ func (m *MockGetter) Get(ctx context.Context, spec azure0.ResourceSpecGetter) (i
 func (mr *MockGetterMockRecorder) Get(ctx, spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockGetter)(nil).Get), ctx, spec)
+}
+
+// MockTagsGetter is a mock of TagsGetter interface.
+type MockTagsGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockTagsGetterMockRecorder
+}
+
+// MockTagsGetterMockRecorder is the mock recorder for MockTagsGetter.
+type MockTagsGetterMockRecorder struct {
+	mock *MockTagsGetter
+}
+
+// NewMockTagsGetter creates a new mock instance.
+func NewMockTagsGetter(ctrl *gomock.Controller) *MockTagsGetter {
+	mock := &MockTagsGetter{ctrl: ctrl}
+	mock.recorder = &MockTagsGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockTagsGetter) EXPECT() *MockTagsGetterMockRecorder {
+	return m.recorder
+}
+
+// GetAtScope mocks base method.
+func (m *MockTagsGetter) GetAtScope(ctx context.Context, scope string) (resources.TagsResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAtScope", ctx, scope)
+	ret0, _ := ret[0].(resources.TagsResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAtScope indicates an expected call of GetAtScope.
+func (mr *MockTagsGetterMockRecorder) GetAtScope(ctx, scope interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAtScope", reflect.TypeOf((*MockTagsGetter)(nil).GetAtScope), ctx, scope)
 }
 
 // MockCreator is a mock of Creator interface.

--- a/azure/services/privatedns/privatedns.go
+++ b/azure/services/privatedns/privatedns.go
@@ -19,12 +19,12 @@ package privatedns
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/pkg/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/tags"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
@@ -42,8 +42,7 @@ type Scope interface {
 // Service provides operations on Azure resources.
 type Service struct {
 	Scope              Scope
-	zoneGetter         async.Getter
-	vnetLinkGetter     async.Getter
+	TagsGetter         async.TagsGetter
 	zoneReconciler     async.Reconciler
 	vnetLinkReconciler async.Reconciler
 	recordReconciler   async.Reconciler
@@ -54,10 +53,10 @@ func New(scope Scope) *Service {
 	zoneClient := newPrivateZonesClient(scope)
 	vnetLinkClient := newVirtualNetworkLinksClient(scope)
 	recordSetsClient := newRecordSetsClient(scope)
+	tagsClient := tags.NewClient(scope)
 	return &Service{
 		Scope:              scope,
-		zoneGetter:         zoneClient,
-		vnetLinkGetter:     vnetLinkClient,
+		TagsGetter:         tagsClient,
 		zoneReconciler:     async.New(scope, zoneClient, zoneClient),
 		vnetLinkReconciler: async.New(scope, vnetLinkClient, vnetLinkClient),
 		recordReconciler:   async.New(scope, recordSetsClient, recordSetsClient),
@@ -136,17 +135,18 @@ func (s *Service) Delete(ctx context.Context) error {
 // isVnetLinkManaged returns true if the vnet link has an owned tag with the cluster name as value,
 // meaning that the vnet link lifecycle is managed.
 func (s *Service) isVnetLinkManaged(ctx context.Context, spec azure.ResourceSpecGetter) (bool, error) {
-	result, err := s.vnetLinkGetter.Get(ctx, spec)
+	scope := azure.VirtualNetworkLinkID(s.Scope.SubscriptionID(), spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName())
+	result, err := s.TagsGetter.GetAtScope(ctx, scope)
 	if err != nil {
 		return false, err
 	}
 
-	link, ok := result.(privatedns.VirtualNetworkLink)
-	if !ok {
-		return false, errors.Errorf("%T is not a privatedns.VirtualNetworkLink", link)
+	tagsMap := make(map[string]*string)
+	if result.Properties != nil && result.Properties.Tags != nil {
+		tagsMap = result.Properties.Tags
 	}
 
-	tags := converters.MapToTags(link.Tags)
+	tags := converters.MapToTags(tagsMap)
 	return tags.HasOwned(s.Scope.ClusterName()), nil
 }
 
@@ -158,15 +158,17 @@ func (s *Service) IsManaged(ctx context.Context) (bool, error) {
 		return false, errors.Errorf("no private dns zone spec available")
 	}
 
-	result, err := s.zoneGetter.Get(ctx, zoneSpec)
+	scope := azure.PrivateDNSZoneID(s.Scope.SubscriptionID(), zoneSpec.ResourceGroupName(), zoneSpec.ResourceName())
+	result, err := s.TagsGetter.GetAtScope(ctx, scope)
 	if err != nil {
 		return false, err
 	}
-	zone, ok := result.(privatedns.PrivateZone)
-	if !ok {
-		return false, errors.Errorf("%T is not a privatedns.PrivateZone", zone)
+
+	tagsMap := make(map[string]*string)
+	if result.Properties != nil && result.Properties.Tags != nil {
+		tagsMap = result.Properties.Tags
 	}
 
-	tags := converters.MapToTags(zone.Tags)
+	tags := converters.MapToTags(tagsMap)
 	return tags.HasOwned(s.Scope.ClusterName()), nil
 }

--- a/azure/services/tags/client.go
+++ b/azure/services/tags/client.go
@@ -31,17 +31,17 @@ type client interface {
 	UpdateAtScope(context.Context, string, resources.TagsPatchResource) (resources.TagsResource, error)
 }
 
-// azureClient contains the Azure go-sdk Client.
-type azureClient struct {
+// AzureClient contains the Azure go-sdk client.
+type AzureClient struct {
 	tags resources.TagsClient
 }
 
-var _ client = (*azureClient)(nil)
+var _ client = (*AzureClient)(nil)
 
-// newClient creates a new tags client from subscription ID.
-func newClient(auth azure.Authorizer) *azureClient {
+// NewClient creates a new tags client from subscription ID.
+func NewClient(auth azure.Authorizer) *AzureClient {
 	c := newTagsClient(auth.SubscriptionID(), auth.BaseURI(), auth.Authorizer())
-	return &azureClient{c}
+	return &AzureClient{c}
 }
 
 // newTagsClient creates a new tags client from subscription ID.
@@ -52,7 +52,7 @@ func newTagsClient(subscriptionID string, baseURI string, authorizer autorest.Au
 }
 
 // GetAtScope sends the get at scope request.
-func (ac *azureClient) GetAtScope(ctx context.Context, scope string) (resources.TagsResource, error) {
+func (ac *AzureClient) GetAtScope(ctx context.Context, scope string) (resources.TagsResource, error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "tags.AzureClient.GetAtScope")
 	defer done()
 
@@ -61,7 +61,7 @@ func (ac *azureClient) GetAtScope(ctx context.Context, scope string) (resources.
 
 // UpdateAtScope this operation allows replacing, merging or selectively deleting tags on the specified resource or
 // subscription.
-func (ac *azureClient) UpdateAtScope(ctx context.Context, scope string, parameters resources.TagsPatchResource) (resources.TagsResource, error) {
+func (ac *AzureClient) UpdateAtScope(ctx context.Context, scope string, parameters resources.TagsPatchResource) (resources.TagsResource, error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "tags.AzureClient.UpdateAtScope")
 	defer done()
 

--- a/azure/services/tags/tags.go
+++ b/azure/services/tags/tags.go
@@ -48,7 +48,7 @@ type Service struct {
 func New(scope TagScope) *Service {
 	return &Service{
 		Scope:  scope,
-		client: newClient(scope),
+		client: NewClient(scope),
 	}
 }
 

--- a/azure/services/virtualnetworks/virtualnetworks.go
+++ b/azure/services/virtualnetworks/virtualnetworks.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/tags"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
@@ -48,14 +49,17 @@ type Service struct {
 	Scope VNetScope
 	async.Reconciler
 	async.Getter
+	async.TagsGetter
 }
 
 // New creates a new service.
 func New(scope VNetScope) *Service {
 	client := newClient(scope)
+	tagsClient := tags.NewClient(scope)
 	return &Service{
 		Scope:      scope,
 		Getter:     client,
+		TagsGetter: tagsClient,
 		Reconciler: async.New(scope, client, client),
 	}
 }
@@ -156,14 +160,17 @@ func (s *Service) IsManaged(ctx context.Context) (bool, error) {
 		return false, errors.New("cannot get vnet to check if it is managed: spec is nil")
 	}
 
-	vnetIface, err := s.Get(ctx, spec)
+	scope := azure.VNetID(s.Scope.SubscriptionID(), spec.ResourceGroupName(), spec.ResourceName())
+	result, err := s.TagsGetter.GetAtScope(ctx, scope)
 	if err != nil {
 		return false, err
 	}
-	vnet, ok := vnetIface.(network.VirtualNetwork)
-	if !ok {
-		return false, errors.Errorf("%T is not a network.VirtualNetwork", vnetIface)
+
+	tagsMap := make(map[string]*string)
+	if result.Properties != nil && result.Properties.Tags != nil {
+		tagsMap = result.Properties.Tags
 	}
-	tags := converters.MapToTags(vnet.Tags)
+
+	tags := converters.MapToTags(tagsMap)
 	return tags.HasOwned(s.Scope.ClusterName()), nil
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?** 
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Use GetAtScope() to get tags when checking if a resource is managed so we don't need to get the entire resource.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1899 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use GetAtScope() to get tags when checking if a resource is managed
```
