### PR TITLE
Fix typo in ReconcileError logs

### DIFF
--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -220,7 +220,7 @@ func (acr *AzureClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 		var reconcileError azure.ReconcileError
 		if errors.As(err, &reconcileError) {
 			if reconcileError.IsTerminal() {
-				acr.Recorder.Eventf(clusterScope.AzureCluster, corev1.EventTypeWarning, "ReconcileErrror", errors.Wrapf(err, "failed to reconcile AzureCluster").Error())
+				acr.Recorder.Eventf(clusterScope.AzureCluster, corev1.EventTypeWarning, "ReconcileError", errors.Wrapf(err, "failed to reconcile AzureCluster").Error())
 				log.Error(err, "failed to reconcile AzureCluster", "name", clusterScope.ClusterName())
 				conditions.MarkFalse(azureCluster, infrav1.NetworkInfrastructureReadyCondition, infrav1.FailedReason, clusterv1.ConditionSeverityError, "")
 				return reconcile.Result{}, nil


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**: 

It fixes a typo on ReconcileError word where it has an extra 'r'. When filtering logs this can make some logs go unnoticed.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
