### PR TITLE
Quiet down VM image log messages

### DIFF
--- a/azure/services/virtualmachineimages/cache.go
+++ b/azure/services/virtualmachineimages/cache.go
@@ -114,12 +114,12 @@ func (c *Cache) Get(ctx context.Context, location, publisher, offer, sku string)
 	}
 
 	if _, ok := c.data[key]; !ok {
-		log.Info("VM images cache miss", "location", key.location, "publisher", key.publisher, "offer", key.offer, "sku", key.sku)
+		log.V(4).Info("VM images cache miss", "location", key.location, "publisher", key.publisher, "offer", key.offer, "sku", key.sku)
 		if err := c.refresh(ctx, key); err != nil {
 			return compute.ListVirtualMachineImageResource{}, err
 		}
 	} else {
-		log.Info("VM images cache hit", "location", key.location, "publisher", key.publisher, "offer", key.offer, "sku", key.sku)
+		log.V(4).Info("VM images cache hit", "location", key.location, "publisher", key.publisher, "offer", key.offer, "sku", key.sku)
 	}
 
 	return c.data[key], nil

--- a/azure/services/virtualmachineimages/images.go
+++ b/azure/services/virtualmachineimages/images.go
@@ -121,7 +121,7 @@ func (s *Service) getSKUAndVersion(ctx context.Context, location, publisher, off
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "virtualmachineimages.Service.getSKUAndVersion")
 	defer done()
 
-	log.Info("Getting VM image SKU and version", "location", location, "publisher", publisher, "offer", offer, "k8sVersion", k8sVersion, "osAndVersion", osAndVersion)
+	log.V(4).Info("Getting VM image SKU and version", "location", location, "publisher", publisher, "offer", offer, "k8sVersion", k8sVersion, "osAndVersion", osAndVersion)
 
 	v, err := semver.ParseTolerant(k8sVersion)
 	if err != nil {
@@ -173,7 +173,7 @@ func (s *Service) getSKUAndVersion(ctx context.Context, location, publisher, off
 		return "", "", errors.Errorf("no VM image found for publisher \"%s\" offer \"%s\" sku \"%s\" with Kubernetes version \"%s\"", publisher, offer, sku, k8sVersion)
 	}
 
-	log.Info("Found VM image SKU and version", "location", location, "publisher", publisher, "offer", offer, "sku", sku, "version", version)
+	log.V(4).Info("Found VM image SKU and version", "location", location, "publisher", publisher, "offer", offer, "sku", sku, "version", version)
 
 	return sku, version, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Changes the verbosity of VM image-related log messages to `V(4)`, meaning they won't show by default. These messages in particular were meant more for debugging and IMHO are distracting in the controller-manager logs, but please let me know if you disagree and find them valuable.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
