### PR TITLE
Update list of immutable fields for AzureManagedControlPlane

### DIFF
--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -475,6 +475,7 @@ Following is the list of immutable fields for managed clusters:
 | AzureManagedControlPlane  | .spec.loadBalancerSKU        |                           |
 | AzureManagedControlPlane  | .spec.apiServerAccessProfile | except AuthorizedIPRanges |
 | AzureManagedControlPlane  | .spec.virtualNetwork         |                           |
+| AzureManagedControlPlane  | .spec.virtualNetwork.subnet  | except serviceEndpoints   |
 | AzureManagedMachinePool   | .spec.sku                    |                           |
 | AzureManagedMachinePool   | .spec.osDiskSizeGB           |                           |
 | AzureManagedMachinePool   | .spec.osDiskType             |                           |


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
Update the list of immutable fields to exclude `AzureManagedControlPlane.spec.virtualNetwork.subnet.serviceEndpoints`. This was missed in https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2635


**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
NONE
```
