### PR TITLE
fix: format azure compute gallery image ID

### DIFF
--- a/azure/converters/image.go
+++ b/azure/converters/image.go
@@ -69,8 +69,8 @@ func computeImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 	if image.ComputeGallery.ResourceGroup != nil && image.ComputeGallery.SubscriptionID != nil {
 		return &compute.ImageReference{
 			ID: to.StringPtr(fmt.Sprintf(idTemplate,
-				image.ComputeGallery.SubscriptionID,
-				image.ComputeGallery.ResourceGroup,
+				to.String(image.ComputeGallery.SubscriptionID),
+				to.String(image.ComputeGallery.ResourceGroup),
 				image.ComputeGallery.Gallery,
 				image.ComputeGallery.Name,
 				image.ComputeGallery.Version,

--- a/azure/converters/image.go
+++ b/azure/converters/image.go
@@ -50,8 +50,11 @@ func mpImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 }
 
 func computeImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
-	idTemplate := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s/versions/%s"
+	if image.ComputeGallery == nil && image.SharedGallery == nil {
+		return nil, errors.New("unable to convert compute image to SDK as sharedGallery or compute gallery fields are not set")
+	}
 
+	idTemplate := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s/versions/%s"
 	if image.SharedGallery != nil {
 		return &compute.ImageReference{
 			ID: to.StringPtr(fmt.Sprintf(idTemplate,

--- a/azure/converters/image.go
+++ b/azure/converters/image.go
@@ -51,7 +51,7 @@ func mpImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 
 func computeImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 	if image.ComputeGallery == nil && image.SharedGallery == nil {
-		return nil, errors.New("unable to convert compute image to SDK as sharedGallery or compute gallery fields are not set")
+		return nil, errors.New("unable to convert compute image to SDK as SharedGallery or ComputeGallery fields are not set")
 	}
 
 	idTemplate := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s/versions/%s"

--- a/azure/converters/image_test.go
+++ b/azure/converters/image_test.go
@@ -205,6 +205,16 @@ func Test_ComputeImageToSDK(t *testing.T) {
 				}))
 			},
 		},
+		{
+			name: "Should return error if SharedGallery and ComputeGallery are nil",
+			image: &infrav1.Image{
+				ComputeGallery: nil,
+				SharedGallery:  nil,
+			},
+			expect: func(g *GomegaWithT, result *compute.ImageReference, err error) {
+				g.Expect(err).ShouldNot(BeNil())
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/azure/converters/image_test.go
+++ b/azure/converters/image_test.go
@@ -146,3 +146,74 @@ func Test_ImageToPlan(t *testing.T) {
 		})
 	}
 }
+
+func Test_ComputeImageToSDK(t *testing.T) {
+	cases := []struct {
+		name   string
+		image  *infrav1.Image
+		expect func(*GomegaWithT, *compute.ImageReference, error)
+	}{
+		{
+			name: "Should return parsed compute gallery image id",
+			image: &infrav1.Image{
+				ComputeGallery: &infrav1.AzureComputeGalleryImage{
+					ResourceGroup:  to.StringPtr("my-resourcegroup"),
+					SubscriptionID: to.StringPtr("my-subscription-id"),
+					Gallery:        "my-gallery",
+					Name:           "my-image",
+					Version:        "my-version",
+				},
+			},
+			expect: func(g *GomegaWithT, result *compute.ImageReference, err error) {
+				g.Expect(err).Should(BeNil())
+				g.Expect(result).To(Equal(&compute.ImageReference{
+					ID: to.StringPtr("/subscriptions/my-subscription-id/resourceGroups/my-resourcegroup/providers/Microsoft.Compute/galleries/my-gallery/images/my-image/versions/my-version"),
+				}))
+			},
+		},
+		{
+			name: "Should return parsed shared gallery image id",
+			image: &infrav1.Image{
+				SharedGallery: &infrav1.AzureSharedGalleryImage{
+					ResourceGroup:  "my-resourcegroup",
+					SubscriptionID: "my-subscription-id",
+					Gallery:        "my-gallery",
+					Name:           "my-image",
+					Version:        "my-version",
+				},
+			},
+			expect: func(g *GomegaWithT, result *compute.ImageReference, err error) {
+				g.Expect(err).Should(BeNil())
+				g.Expect(result).To(Equal(&compute.ImageReference{
+					ID: to.StringPtr("/subscriptions/my-subscription-id/resourceGroups/my-resourcegroup/providers/Microsoft.Compute/galleries/my-gallery/images/my-image/versions/my-version"),
+				}))
+			},
+		},
+		{
+			name: "Should return parsed community gallery image id",
+			image: &infrav1.Image{
+				ComputeGallery: &infrav1.AzureComputeGalleryImage{
+					Gallery: "my-gallery",
+					Name:    "my-image",
+					Version: "my-version",
+				},
+			},
+			expect: func(g *GomegaWithT, result *compute.ImageReference, err error) {
+				g.Expect(err).Should(BeNil())
+				g.Expect(result).To(Equal(&compute.ImageReference{
+					CommunityGalleryImageID: to.StringPtr("/CommunityGalleries/my-gallery/Images/my-image/Versions/my-version"),
+				}))
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+			result, err := computeImageToSDK(c.image)
+			c.expect(g, result, err)
+		})
+	}
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->
/kind bug
**What this PR does / why we need it**:
[Invalid formatting ](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/converters/image.go#L72) of compute gallery image id results in Azure machine fails to reconcile when compute gallery image is used. 

```
E1020 05:16:10.545726       1 controller.go:326]  "msg"="Reconciler error" "error"="failed to reconcile AzureMachine: failed to reconcile AzureMachine service virtualmachine: failed to create resource e2e-azure-test-3661259/e2e-azure-test-3661259-control-plane-npm7k (service: virtualmachine): compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=403 -- Original Error: Code=\"LinkedAuthorizationFailed\" Message=\"The client has permission to perform action 'Microsoft.Compute/galleries/images/versions/read' on scope '/subscriptions/*****-****-****-****-*******/resourceGroups/e2e-azure-test-3661259/providers/Microsoft.Compute/virtualMachines/e2e-azure-test-3661259-control-plane-npm7k', however the linked subscription '%!s(*string=0xc0010f00e0)' was not found. \"" "azureMachine"={"name":"e2e-azure-test-3661259-control-plane-npm7k","namespace":"default"} "controller"="azuremachine" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="AzureMachine" "name"="e2e-azure-test-3661259-control-plane-npm7k" "namespace"="default" "reconcileID"="db366495-2601-4701-8b2c-cd2a41bc43e7"
```
The `SubscriptionID` and `ResrouceGroup` fields are string pointers in [AzureComputeGalleryImage](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/api/v1beta1/types.go#L356)
When creating the compute gallery image id, they should be dereferenced to string.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2746

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

Added unit test to verify the bug fix.
before bugfix:
```
go test -timeout 30s -run ^Test_ComputeImageToSDK$ sigs.k8s.io/cluster-api-provider-azure/azure/converters

--- FAIL: Test_ComputeImageToSDK (0.00s)
    --- FAIL: Test_ComputeImageToSDK/Should_returned_parsed_compute_gallery_image_id (0.00s)
        /gitrepos/cluster-api-provider-azure/azure/converters/image_test.go:169: 
            Expected
                <*compute.ImageReference | 0xc00037f140>: {
                    Publisher: nil,
                    Offer: nil,
                    Sku: nil,
                    Version: nil,
                    ExactVersion: nil,
                    SharedGalleryImageID: nil,
                    CommunityGalleryImageID: nil,
                    ID: "/subscriptions/%!s(*string=0xc000428960)/resourceGroups/%!s(*string=0xc000428950)/providers/Microsoft.Compute/galleries/my-gallery/images/my-image/versions/my-version",
                }
            to equal
                <*compute.ImageReference | 0xc00037f540>: {
                    Publisher: nil,
                    Offer: nil,
                    Sku: nil,
                    Version: nil,
                    ExactVersion: nil,
                    SharedGalleryImageID: nil,
                    CommunityGalleryImageID: nil,
                    ID: "/subscriptions/my-subscription-id/resourceGroups/my-resourcegroup/providers/Microsoft.Compute/galleries/my-gallery/images/my-image/versions/my-version",
                }
FAIL
FAIL	sigs.k8s.io/cluster-api-provider-azure/azure/converters	0.701s
FAIL
```


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix formatting of compute gallery image id
```
