### PR TITLE
fix scaling managed machine pool to zero

### DIFF
--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -189,10 +189,6 @@ func (s *AgentPoolSpec) Parameters(existing interface{}) (params interface{}, er
 	if len(s.AvailabilityZones) > 0 {
 		availabilityZones = &s.AvailabilityZones
 	}
-	var replicas *int32
-	if s.Replicas > 0 {
-		replicas = &s.Replicas
-	}
 	var nodeTaints *[]string
 	if len(s.NodeTaints) > 0 {
 		nodeTaints = &s.NodeTaints
@@ -209,7 +205,7 @@ func (s *AgentPoolSpec) Parameters(existing interface{}) (params interface{}, er
 	return containerservice.AgentPool{
 		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
 			AvailabilityZones:    availabilityZones,
-			Count:                replicas,
+			Count:                &s.Replicas,
 			EnableAutoScaling:    s.EnableAutoScaling,
 			EnableUltraSSD:       s.EnableUltraSSD,
 			MaxCount:             s.MaxCount,

--- a/azure/services/agentpools/spec_test.go
+++ b/azure/services/agentpools/spec_test.go
@@ -74,6 +74,28 @@ var (
 		VnetSubnetID:      "fake-vnet-subnet-id",
 		Headers:           map[string]string{"fake-header": "fake-value"},
 	}
+	fakeAgentPoolSpecWithZeroReplicas = AgentPoolSpec{
+		Name:              "fake-agent-pool-name",
+		ResourceGroup:     "fake-rg",
+		Cluster:           "fake-cluster",
+		AvailabilityZones: []string{"fake-zone"},
+		EnableAutoScaling: to.BoolPtr(false),
+		EnableUltraSSD:    to.BoolPtr(true),
+		MaxCount:          to.Int32Ptr(5),
+		MaxPods:           to.Int32Ptr(10),
+		MinCount:          to.Int32Ptr(1),
+		Mode:              "fake-mode",
+		NodeLabels:        map[string]*string{"fake-label": to.StringPtr("fake-value")},
+		NodeTaints:        []string{"fake-taint"},
+		OSDiskSizeGB:      2,
+		OsDiskType:        to.StringPtr("fake-os-disk-type"),
+		OSType:            to.StringPtr("fake-os-type"),
+		Replicas:          0,
+		SKU:               "fake-sku",
+		Version:           to.StringPtr("fake-version"),
+		VnetSubnetID:      "fake-vnet-subnet-id",
+		Headers:           map[string]string{"fake-header": "fake-value"},
+	}
 
 	fakeAgentPoolAutoScalingOutOfDate = containerservice.AgentPool{
 		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
@@ -194,6 +216,10 @@ var (
 )
 
 func fakeAgentPoolWithProvisioningState(provisioningState string) containerservice.AgentPool {
+	return fakeAgentPoolWithProvisioningStateAndCountAndAutoscaling(provisioningState, 1, true)
+}
+
+func fakeAgentPoolWithProvisioningStateAndCountAndAutoscaling(provisioningState string, count int32, autoscaling bool) containerservice.AgentPool {
 	var state *string
 	if provisioningState != "" {
 		state = to.StringPtr(provisioningState)
@@ -201,8 +227,8 @@ func fakeAgentPoolWithProvisioningState(provisioningState string) containerservi
 	return containerservice.AgentPool{
 		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
 			AvailabilityZones:   &[]string{"fake-zone"},
-			Count:               to.Int32Ptr(1),
-			EnableAutoScaling:   to.BoolPtr(true),
+			Count:               to.Int32Ptr(count),
+			EnableAutoScaling:   to.BoolPtr(autoscaling),
 			EnableUltraSSD:      to.BoolPtr(true),
 			MaxCount:            to.Int32Ptr(5),
 			MaxPods:             to.Int32Ptr(10),
@@ -351,6 +377,13 @@ func TestParameters(t *testing.T) {
 			spec:          fakeAgentPoolSpecWithAutoscaling,
 			existing:      fakeAgentPoolNodeLabelsOutOfDate,
 			expected:      fakeAgentPoolWithProvisioningState(""),
+			expectedError: nil,
+		},
+		{
+			name:          "scale to zero",
+			spec:          fakeAgentPoolSpecWithZeroReplicas,
+			existing:      fakeAgentPoolWithAutoscalingAndCount(false, 1),
+			expected:      fakeAgentPoolWithProvisioningStateAndCountAndAutoscaling("", 0, false),
 			expectedError: nil,
 		},
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Scaling a MachinePool backed by AzureManagedMachinePool to 0 replicas would never successfully apply those changes because the internal `AgentPoolSpec` type used to convert Cluster API types to the Azure resource cannot distinguish between a specified 0 and unspecified number of replicas, and assumes 0 means unspecified. This causes the resulting PUT operation during reconciliation to omit the replica count instead of setting it to 0.

For reference, this is where the `AgentPoolSpec` is constructed:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/4b5768a12ee9d14c174c8f208bddeaeac5d1acf3/azure/scope/managedmachinepool.go#L153-L156

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I'm working on a [set of e2e tests](https://github.com/kubernetes-sigs/cluster-api-provider-azure/compare/main...nojnhuh:cluster-api-provider-azure:aks-topology-test) which cover this scenario among other related scaling tests. Please let me know if those tests should be included in this PR.

Since only User node pools can be scaled to 0, I verified that scaling a System node pool to 0 fails reasonably, with this condition getting set on the MachinePool:
```yaml
- lastTransitionTime: "2022-10-26T18:05:37Z"
  message: 'agentpools failed to create or update. err: failed to update resource
    aks-22378/pool0 (service: agentpools): failed to begin operation: Code="InvalidParameter"
    Message="The value of parameter agentPoolProfile.count is invalid. Please see
    https://aka.ms/aks-naming-rules for more details." Target="agentPoolProfile.count"'
  reason: Failed
  severity: Error
  status: "False"
  type: InfrastructureReady
```

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed an issue preventing AKS "User" node pools from successfully scaling to 0 replicas
```

/area managedclusters