### PR TITLE
clusterctl: make explicit use of --worker-machine-count=${WORKER_MACH…

### DIFF
--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -74,7 +74,7 @@ Execute clusterctl to template the resources, then apply to your kind management
 
 ```bash
 clusterctl init --infrastructure azure
-clusterctl generate cluster ${CLUSTER_NAME} --kubernetes-version ${KUBERNETES_VERSION} --flavor aks > cluster.yaml
+clusterctl generate cluster ${CLUSTER_NAME} --kubernetes-version ${KUBERNETES_VERSION} --worker-machine-count=${WORKER_MACHINE_COUNT} --flavor aks > cluster.yaml
 
 # assumes an existing management cluster
 kubectl apply -f cluster.yaml


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:

Improves the documentation to use `clusterctl` to create an AKS cluster.

**Which issue(s) this PR fixes**
Fixes #2759 

