### PR TITLE
Cleanup remote peerings when resource group is deleted

### DIFF
--- a/azure/services/vnetpeerings/vnetpeerings.go
+++ b/azure/services/vnetpeerings/vnetpeerings.go
@@ -26,7 +26,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-const serviceName = "vnetpeerings"
+// ServiceName is the name of this service.
+const ServiceName = "vnetpeerings"
 
 // VnetPeeringScope defines the scope interface for a subnet service.
 type VnetPeeringScope interface {
@@ -52,7 +53,7 @@ func New(scope VnetPeeringScope) *Service {
 
 // Name returns the service name.
 func (s *Service) Name() string {
-	return serviceName
+	return ServiceName
 }
 
 // Reconcile idempotently creates or updates a peering.
@@ -73,14 +74,14 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	//  Order of precedence (highest -> lowest) is: error that is not an operationNotDoneError (i.e. error creating) -> operationNotDoneError (i.e. creating in progress) -> no error (i.e. created)
 	var result error
 	for _, peeringSpec := range specs {
-		if _, err := s.CreateOrUpdateResource(ctx, peeringSpec, serviceName); err != nil {
+		if _, err := s.CreateOrUpdateResource(ctx, peeringSpec, ServiceName); err != nil {
 			if !azure.IsOperationNotDoneError(err) || result == nil {
 				result = err
 			}
 		}
 	}
 
-	s.Scope.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, serviceName, result)
+	s.Scope.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, ServiceName, result)
 	return result
 }
 
@@ -102,13 +103,13 @@ func (s *Service) Delete(ctx context.Context) error {
 	//  Order of precedence (highest -> lowest) is: error that is not an operationNotDoneError (i.e. error deleting) -> operationNotDoneError (i.e. deleting in progress) -> no error (i.e. deleted)
 	var result error
 	for _, peeringSpec := range specs {
-		if err := s.DeleteResource(ctx, peeringSpec, serviceName); err != nil {
+		if err := s.DeleteResource(ctx, peeringSpec, ServiceName); err != nil {
 			if !azure.IsOperationNotDoneError(err) || result == nil {
 				result = err
 			}
 		}
 	}
-	s.Scope.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, serviceName, result)
+	s.Scope.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, ServiceName, result)
 	return result
 }
 

--- a/azure/services/vnetpeerings/vnetpeerings_test.go
+++ b/azure/services/vnetpeerings/vnetpeerings_test.go
@@ -90,8 +90,8 @@ func TestReconcileVnetPeerings(t *testing.T) {
 			expectedError: "",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs[:1])
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(&fakePeering1To2, nil)
-				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, serviceName, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(&fakePeering1To2, nil)
+				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, ServiceName, nil)
 			},
 		},
 		{
@@ -106,9 +106,9 @@ func TestReconcileVnetPeerings(t *testing.T) {
 			expectedError: "",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs[:2])
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(&fakePeering1To2, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(&fakePeering2To1, nil)
-				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, serviceName, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(&fakePeering1To2, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(&fakePeering2To1, nil)
+				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, ServiceName, nil)
 			},
 		},
 		{
@@ -116,10 +116,10 @@ func TestReconcileVnetPeerings(t *testing.T) {
 			expectedError: "",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringExtraSpecs)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(&fakePeering1To2, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(&fakePeering2To1, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeeringExtra, serviceName).Return(&fakePeeringExtra, nil)
-				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, serviceName, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(&fakePeering1To2, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(&fakePeering2To1, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeeringExtra, ServiceName).Return(&fakePeeringExtra, nil)
+				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, ServiceName, nil)
 			},
 		},
 		{
@@ -127,11 +127,11 @@ func TestReconcileVnetPeerings(t *testing.T) {
 			expectedError: "",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(&fakePeering1To2, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(&fakePeering2To1, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To3, serviceName).Return(&fakePeering1To3, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering3To1, serviceName).Return(&fakePeering3To1, nil)
-				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, serviceName, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(&fakePeering1To2, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(&fakePeering2To1, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To3, ServiceName).Return(&fakePeering1To3, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering3To1, ServiceName).Return(&fakePeering3To1, nil)
+				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, ServiceName, nil)
 			},
 		},
 		{
@@ -139,11 +139,11 @@ func TestReconcileVnetPeerings(t *testing.T) {
 			expectedError: "#: Internal Server Error: StatusCode=500",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(&fakePeering1To2, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(&fakePeering2To1, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To3, serviceName).Return(nil, internalError)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering3To1, serviceName).Return(&fakePeering3To1, nil)
-				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, serviceName, internalError)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(&fakePeering1To2, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(&fakePeering2To1, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To3, ServiceName).Return(nil, internalError)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering3To1, ServiceName).Return(&fakePeering3To1, nil)
+				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, ServiceName, internalError)
 			},
 		},
 		{
@@ -151,11 +151,11 @@ func TestReconcileVnetPeerings(t *testing.T) {
 			expectedError: "#: Internal Server Error: StatusCode=500",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(&fakePeering1To2, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(&fakePeering2To1, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To3, serviceName).Return(nil, internalError)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering3To1, serviceName).Return(&fakePeering3To1, nil)
-				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, serviceName, internalError)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(&fakePeering1To2, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(&fakePeering2To1, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To3, ServiceName).Return(nil, internalError)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering3To1, ServiceName).Return(&fakePeering3To1, nil)
+				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, ServiceName, internalError)
 			},
 		},
 		{
@@ -163,11 +163,11 @@ func TestReconcileVnetPeerings(t *testing.T) {
 			expectedError: "#: Internal Server Error: StatusCode=500",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(&fakePeering1To2, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(nil, internalError)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To3, serviceName).Return(nil, notDoneError)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering3To1, serviceName).Return(&fakePeering3To1, nil)
-				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, serviceName, internalError)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(&fakePeering1To2, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(nil, internalError)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To3, ServiceName).Return(nil, notDoneError)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering3To1, ServiceName).Return(&fakePeering3To1, nil)
+				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, ServiceName, internalError)
 			},
 		},
 		{
@@ -175,11 +175,11 @@ func TestReconcileVnetPeerings(t *testing.T) {
 			expectedError: "#: Internal Server Error: StatusCode=500",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(&fakePeering1To2, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(&fakePeering2To1, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To3, serviceName).Return(nil, notDoneError)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering3To1, serviceName).Return(nil, internalError)
-				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, serviceName, internalError)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(&fakePeering1To2, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(&fakePeering2To1, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To3, ServiceName).Return(nil, notDoneError)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering3To1, ServiceName).Return(nil, internalError)
+				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, ServiceName, internalError)
 			},
 		},
 		{
@@ -187,11 +187,11 @@ func TestReconcileVnetPeerings(t *testing.T) {
 			expectedError: "operation type  on Azure resource / is not done",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(&fakePeering1To2, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(&fakePeering2To1, nil)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To3, serviceName).Return(nil, notDoneError)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering3To1, serviceName).Return(&fakePeering3To1, nil)
-				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, serviceName, notDoneError)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(&fakePeering1To2, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(&fakePeering2To1, nil)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering1To3, ServiceName).Return(nil, notDoneError)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakePeering3To1, ServiceName).Return(&fakePeering3To1, nil)
+				p.UpdatePutStatus(infrav1.VnetPeeringReadyCondition, ServiceName, notDoneError)
 			},
 		},
 	}
@@ -236,8 +236,8 @@ func TestDeleteVnetPeerings(t *testing.T) {
 			expectedError: "",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs[:1])
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(nil)
-				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, serviceName, nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(nil)
+				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, ServiceName, nil)
 			},
 		},
 		{
@@ -252,9 +252,9 @@ func TestDeleteVnetPeerings(t *testing.T) {
 			expectedError: "",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs[:2])
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(nil)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(nil)
-				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, serviceName, nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(nil)
+				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, ServiceName, nil)
 			},
 		},
 		{
@@ -262,10 +262,10 @@ func TestDeleteVnetPeerings(t *testing.T) {
 			expectedError: "",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringExtraSpecs)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(nil)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(nil)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeeringExtra, serviceName).Return(nil)
-				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, serviceName, nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeeringExtra, ServiceName).Return(nil)
+				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, ServiceName, nil)
 			},
 		},
 		{
@@ -273,11 +273,11 @@ func TestDeleteVnetPeerings(t *testing.T) {
 			expectedError: "",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(nil)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(nil)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To3, serviceName).Return(nil)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering3To1, serviceName).Return(nil)
-				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, serviceName, nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To3, ServiceName).Return(nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering3To1, ServiceName).Return(nil)
+				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, ServiceName, nil)
 			},
 		},
 		{
@@ -285,11 +285,11 @@ func TestDeleteVnetPeerings(t *testing.T) {
 			expectedError: "#: Internal Server Error: StatusCode=500",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(nil)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(nil)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To3, serviceName).Return(internalError)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering3To1, serviceName).Return(nil)
-				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, serviceName, internalError)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To3, ServiceName).Return(internalError)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering3To1, ServiceName).Return(nil)
+				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, ServiceName, internalError)
 			},
 		},
 		{
@@ -297,11 +297,11 @@ func TestDeleteVnetPeerings(t *testing.T) {
 			expectedError: "#: Internal Server Error: StatusCode=500",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(nil)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(internalError)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To3, serviceName).Return(notDoneError)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering3To1, serviceName).Return(nil)
-				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, serviceName, internalError)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(internalError)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To3, ServiceName).Return(notDoneError)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering3To1, ServiceName).Return(nil)
+				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, ServiceName, internalError)
 			},
 		},
 		{
@@ -309,11 +309,11 @@ func TestDeleteVnetPeerings(t *testing.T) {
 			expectedError: "#: Internal Server Error: StatusCode=500",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(nil)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(nil)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To3, serviceName).Return(notDoneError)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering3To1, serviceName).Return(internalError)
-				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, serviceName, internalError)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To3, ServiceName).Return(notDoneError)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering3To1, ServiceName).Return(internalError)
+				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, ServiceName, internalError)
 			},
 		},
 		{
@@ -321,11 +321,11 @@ func TestDeleteVnetPeerings(t *testing.T) {
 			expectedError: "operation type  on Azure resource / is not done",
 			expect: func(p *mock_vnetpeerings.MockVnetPeeringScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				p.VnetPeeringSpecs().Return(fakePeeringSpecs)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, serviceName).Return(nil)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering2To1, serviceName).Return(nil)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To3, serviceName).Return(notDoneError)
-				r.DeleteResource(gomockinternal.AContext(), &fakePeering3To1, serviceName).Return(nil)
-				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, serviceName, notDoneError)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To2, ServiceName).Return(nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering2To1, ServiceName).Return(nil)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering1To3, ServiceName).Return(notDoneError)
+				r.DeleteResource(gomockinternal.AContext(), &fakePeering3To1, ServiceName).Return(nil)
+				p.UpdateDeleteStatus(infrav1.VnetPeeringReadyCondition, ServiceName, notDoneError)
 			},
 		},
 	}

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -114,7 +114,16 @@ func (s *azureClusterService) Delete(ctx context.Context) error {
 		return errors.Wrap(err, "failed to determine if the AzureCluster resource group is managed")
 	}
 	if managed {
-		// if the resource group is managed, we delete the entire resource group directly.
+		// If the resource group is managed, delete it.
+		// We need to explicitly delete vnet peerings, as it is not part of the resource group.
+		vnetPeeringsSvc, err := s.getService(vnetpeerings.ServiceName)
+		if err != nil {
+			return errors.Wrap(err, "failed to get vnet peerings service")
+		}
+		if err := vnetPeeringsSvc.Delete(ctx); err != nil {
+			return errors.Wrap(err, "failed to delete peerings")
+		}
+		// Delete the entire resource group directly.
 		if err := groupSvc.Delete(ctx); err != nil {
 			return errors.Wrap(err, "failed to delete resource group")
 		}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
When a cluster owned by CAPZ is deleted, the resource group is deleted entirely, but the vnet remote peering is left in a disconnected state instead of deleted. This is because the remote peering is technically not part of the resource group itself. This PR adds an explicit delete for vnet peerings when the resource group is deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2638 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Cleanup remote peerings when resource group is deleted
```
