### PR TITLE
Disable Kubescape security scanner in e2e tests

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -388,19 +388,6 @@ var _ = Describe("Workload cluster creation", func() {
 				})
 			})
 
-			By("Running a security scanner", func() {
-				KubescapeSpec(ctx, func() KubescapeSpecInput {
-					return KubescapeSpecInput{
-						BootstrapClusterProxy: bootstrapClusterProxy,
-						Namespace:             namespace,
-						ClusterName:           clusterName,
-						FailThreshold:         e2eConfig.GetVariable(SecurityScanFailThreshold),
-						Container:             e2eConfig.GetVariable(SecurityScanContainer),
-						SkipCleanup:           skipCleanup,
-					}
-				})
-			})
-
 			By("Creating an accessible load balancer", func() {
 				AzureLBSpec(ctx, func() AzureLBSpecInput {
 					return AzureLBSpecInput{


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test


**What this PR does / why we need it**:

The optional Kubescape scanner test has somehow begun failing, even though we pinned it at a known working version. Since this is purely an informative test spec, let's disable it so it doesn't block PRs in e2e.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
