### PR TITLE
Fixes Issue 2779: Fix in multitenancy docs

### DIFF
--- a/docs/book/src/topics/multitenancy.md
+++ b/docs/book/src/topics/multitenancy.md
@@ -116,7 +116,7 @@ metadata:
   name: example-identity
   namespace: default
 spec:
-  type: ServicePrincipal
+  type: UserAssignedMSI
   tenantID: <azure-tenant-id>
   clientID: <client-id-of-user-assigned-identity>
   resourceID: <resource-id-of-user-assigned-identity>


### PR DESCRIPTION
/kind documentation

Fixes #2779 

Change the value of field "type" from "ServicePrincipal" to "UserAssignedMSI"

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [X] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
AzureClusterIdentity type is "UserAssignedMSI" for User Assigned Managed Identity
```

