### PR TITLE
Fixes docs bug in api server endpoint

### DIFF
--- a/docs/book/src/topics/api-server-endpoint.md
+++ b/docs/book/src/topics/api-server-endpoint.md
@@ -94,7 +94,7 @@ spec:
         - name: lb-public-ip-frontend
           publicIP:
             name: my-public-ip
-            dns: my-cluster-986b4408.eastus.cloudapp.azure.com
+            dnsName: my-cluster-986b4408.eastus.cloudapp.azure.com
 ````
 
 Note that `dns` is the FQDN associated to your public IP address (look for "DNS name" in the Azure Portal).


### PR DESCRIPTION
/kind documentation

Fixes #2780

Change the value of key "dns" from "dns" to "dnsName"

- [X] squashed commits
- [X] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
Key "dns" is now "dnsName" in spec.networkSpec.apiServerLB.frontendIPs[0].publicIP
```


