### PR TITLE
Make base64 usage more portable in e2e setup

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -60,7 +60,7 @@ capz::util::generate_ssh_key() {
         ssh-keygen -t rsa -b 2048 -f "${SSH_KEY_FILE}" -N '' 1>/dev/null
         AZURE_SSH_PUBLIC_KEY_FILE="${SSH_KEY_FILE}.pub"
     fi
-    AZURE_SSH_PUBLIC_KEY_B64=$(base64 "${AZURE_SSH_PUBLIC_KEY_FILE}" | tr -d '\r\n')
+    AZURE_SSH_PUBLIC_KEY_B64=$(base64 < "${AZURE_SSH_PUBLIC_KEY_FILE}" | tr -d '\r\n')
     export AZURE_SSH_PUBLIC_KEY_B64
     # Windows sets the public key via cloudbase-init which take the raw text as input
     AZURE_SSH_PUBLIC_KEY=$(tr -d '\r\n' < "${AZURE_SSH_PUBLIC_KEY_FILE}")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The version of `base64` found on my macOS 13 Ventura installation doesn't work with this invocation (it would need `-i`). This change should make it work portably.

See #2755. I grepped the codebase and I'm reasonably sure there aren't any further changes like this needed.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

You can test this by running `./scripts/ci-e2e.sh`; at least that's how I discovered the issue and tested this fix.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
