### PR TITLE
Silence kubectl deprecation warning

### DIFF
--- a/scripts/ci-configmap.sh
+++ b/scripts/ci-configmap.sh
@@ -25,5 +25,5 @@ make --directory="${REPO_ROOT}" "${KUBECTL##*/}"
 CM_NAMES=("calico-addon" "calico-ipv6-addon" "calico-dual-stack-addon" "calico-windows-addon")
 CM_FILES=("calico.yaml" "calico-ipv6.yaml" "calico-dual-stack.yaml" "windows/calico")
 for i in "${!CM_NAMES[@]}"; do
-	"${KUBECTL}" create configmap "${CM_NAMES[i]}" --from-file="${REPO_ROOT}/templates/addons/${CM_FILES[i]}" --dry-run -o yaml | kubectl apply -f -
+	"${KUBECTL}" create configmap "${CM_NAMES[i]}" --from-file="${REPO_ROOT}/templates/addons/${CM_FILES[i]}" --dry-run=client -o yaml | kubectl apply -f -
 done


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Silences this warning that shows up when running `./scripts/ci-entrypoint.sh`:

```
# apply CNI ClusterResourceSets
source ./scripts/ci-configmap.sh
make[2]: Nothing to be done for `kubectl'.
W1108 12:46:01.457097   54573 helpers.go:555] --dry-run is deprecated and can be replaced with --dry-run=client.
configmap/calico-addon created
W1108 12:46:02.317726   54575 helpers.go:555] --dry-run is deprecated and can be replaced with --dry-run=client.
configmap/calico-ipv6-addon created
W1108 12:46:02.483359   54577 helpers.go:555] --dry-run is deprecated and can be replaced with --dry-run=client.
configmap/calico-dual-stack-addon created
W1108 12:46:02.644139   54579 helpers.go:555] --dry-run is deprecated and can be replaced with --dry-run=client.
configmap/calico-windows-addon created
```

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

We have one other usage of `kubectl --dry-run` in the codebase, but it already had `--dry-run=client`.

This warning acts the same way in `kubectl` version v1.22.4 and 1.25.2, so I think it's safe to merge this change WRT version compatibility.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
