### PR TITLE
ensure AKS immutable configuration has webhook enforcement

### DIFF
--- a/exp/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/exp/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
+	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -97,131 +98,74 @@ func (m *AzureManagedControlPlane) ValidateUpdate(oldRaw runtime.Object, client 
 	var allErrs field.ErrorList
 	old := oldRaw.(*AzureManagedControlPlane)
 
-	if m.Name != old.Name {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("Name"),
-				m.Name,
-				"field is immutable"))
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Name"),
+		old.Name,
+		m.Name); err != nil {
+		allErrs = append(allErrs, err)
 	}
 
-	if m.Spec.SubscriptionID != old.Spec.SubscriptionID {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("Spec", "SubscriptionID"),
-				m.Spec.SubscriptionID,
-				"field is immutable"))
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "SubscriptionID"),
+		old.Spec.SubscriptionID,
+		m.Spec.SubscriptionID); err != nil {
+		allErrs = append(allErrs, err)
 	}
 
-	if m.Spec.ResourceGroupName != old.Spec.ResourceGroupName {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("Spec", "ResourceGroupName"),
-				m.Spec.ResourceGroupName,
-				"field is immutable"))
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "ResourceGroupName"),
+		old.Spec.ResourceGroupName,
+		m.Spec.ResourceGroupName); err != nil {
+		allErrs = append(allErrs, err)
 	}
 
-	if m.Spec.NodeResourceGroupName != old.Spec.NodeResourceGroupName {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("Spec", "NodeResourceGroupName"),
-				m.Spec.NodeResourceGroupName,
-				"field is immutable"))
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "NodeResourceGroupName"),
+		old.Spec.NodeResourceGroupName,
+		m.Spec.NodeResourceGroupName); err != nil {
+		allErrs = append(allErrs, err)
 	}
 
-	if m.Spec.Location != old.Spec.Location {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("Spec", "Location"),
-				m.Spec.Location,
-				"field is immutable"))
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "Location"),
+		old.Spec.Location,
+		m.Spec.Location); err != nil {
+		allErrs = append(allErrs, err)
 	}
 
-	if old.Spec.SSHPublicKey != "" {
-		// Prevent SSH key modification if it was already set to some value
-		if m.Spec.SSHPublicKey != old.Spec.SSHPublicKey {
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "SSHPublicKey"),
-					m.Spec.SSHPublicKey,
-					"field is immutable"))
-		}
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "SSHPublicKey"),
+		old.Spec.SSHPublicKey,
+		m.Spec.SSHPublicKey); err != nil {
+		allErrs = append(allErrs, err)
 	}
 
-	if old.Spec.DNSServiceIP != nil {
-		// Prevent DNSServiceIP modification if it was already set to some value
-		if m.Spec.DNSServiceIP == nil {
-			// unsetting the field is not allowed
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "DNSServiceIP"),
-					m.Spec.DNSServiceIP,
-					"field is immutable, unsetting is not allowed"))
-		} else if *m.Spec.DNSServiceIP != *old.Spec.DNSServiceIP {
-			// changing the field is not allowed
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "DNSServiceIP"),
-					*m.Spec.DNSServiceIP,
-					"field is immutable"))
-		}
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "DNSServiceIP"),
+		old.Spec.DNSServiceIP,
+		m.Spec.DNSServiceIP); err != nil {
+		allErrs = append(allErrs, err)
 	}
 
-	if old.Spec.NetworkPlugin != nil {
-		// Prevent NetworkPlugin modification if it was already set to some value
-		if m.Spec.NetworkPlugin == nil {
-			// unsetting the field is not allowed
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "NetworkPlugin"),
-					m.Spec.NetworkPlugin,
-					"field is immutable, unsetting is not allowed"))
-		} else if *m.Spec.NetworkPlugin != *old.Spec.NetworkPlugin {
-			// changing the field is not allowed
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "NetworkPlugin"),
-					*m.Spec.NetworkPlugin,
-					"field is immutable"))
-		}
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "NetworkPlugin"),
+		old.Spec.NetworkPlugin,
+		m.Spec.NetworkPlugin); err != nil {
+		allErrs = append(allErrs, err)
 	}
 
-	if old.Spec.NetworkPolicy != nil {
-		// Prevent NetworkPolicy modification if it was already set to some value
-		if m.Spec.NetworkPolicy == nil {
-			// unsetting the field is not allowed
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "NetworkPolicy"),
-					m.Spec.NetworkPolicy,
-					"field is immutable, unsetting is not allowed"))
-		} else if *m.Spec.NetworkPolicy != *old.Spec.NetworkPolicy {
-			// changing the field is not allowed
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "NetworkPolicy"),
-					*m.Spec.NetworkPolicy,
-					"field is immutable"))
-		}
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "NetworkPolicy"),
+		old.Spec.NetworkPolicy,
+		m.Spec.NetworkPolicy); err != nil {
+		allErrs = append(allErrs, err)
 	}
 
-	if old.Spec.LoadBalancerSKU != nil {
-		// Prevent LoadBalancerSKU modification if it was already set to some value
-		if m.Spec.LoadBalancerSKU == nil {
-			// unsetting the field is not allowed
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "LoadBalancerSKU"),
-					m.Spec.LoadBalancerSKU,
-					"field is immutable, unsetting is not allowed"))
-		} else if *m.Spec.LoadBalancerSKU != *old.Spec.LoadBalancerSKU {
-			// changing the field is not allowed
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "LoadBalancerSKU"),
-					*m.Spec.LoadBalancerSKU,
-					"field is immutable"))
-		}
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "LoadBalancerSKU"),
+		old.Spec.LoadBalancerSKU,
+		m.Spec.LoadBalancerSKU); err != nil {
+		allErrs = append(allErrs, err)
 	}
 
 	if old.Spec.AADProfile != nil {

--- a/exp/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/exp/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -369,6 +369,7 @@ func TestAzureManagedControlPlane_ValidateCreateFailure(t *testing.T) {
 
 func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 	g := NewWithT(t)
+	commonSSHKey := generateSSHPublicKey(true)
 
 	tests := []struct {
 		name    string
@@ -377,16 +378,16 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "AzureManagedControlPlane with valid SSHPublicKey",
+			name:    "can't add a SSHPublicKey to an existing AzureManagedControlPlane",
 			oldAMCP: createAzureManagedControlPlane("192.168.0.0", "v1.18.0", ""),
 			amcp:    createAzureManagedControlPlane("192.168.0.0", "v1.18.0", generateSSHPublicKey(true)),
-			wantErr: false,
+			wantErr: true,
 		},
 		{
-			name:    "AzureManagedControlPlane with invalid SSHPublicKey",
-			oldAMCP: createAzureManagedControlPlane("192.168.0.0", "v1.18.0", ""),
-			amcp:    createAzureManagedControlPlane("192.168.0.0", "v1.18.0", generateSSHPublicKey(false)),
-			wantErr: true,
+			name:    "same SSHPublicKey is valid",
+			oldAMCP: createAzureManagedControlPlane("192.168.0.0", "v1.18.0", commonSSHKey),
+			amcp:    createAzureManagedControlPlane("192.168.0.0", "v1.18.0", commonSSHKey),
+			wantErr: false,
 		},
 		{
 			name:    "AzureManagedControlPlane with invalid serviceIP",

--- a/exp/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/exp/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -108,31 +108,18 @@ func (m *AzureManagedMachinePool) ValidateUpdate(oldRaw runtime.Object, client c
 		allErrs = append(allErrs, err)
 	}
 
-	if m.Spec.SKU != old.Spec.SKU {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("Spec", "SKU"),
-				m.Spec.SKU,
-				"field is immutable"))
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "SKU"),
+		old.Spec.SKU,
+		m.Spec.SKU); err != nil {
+		allErrs = append(allErrs, err)
 	}
 
-	if old.Spec.OSDiskSizeGB != nil {
-		// Prevent OSDiskSizeGB modification if it was already set to some value
-		if m.Spec.OSDiskSizeGB == nil {
-			// unsetting the field is not allowed
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "OSDiskSizeGB"),
-					m.Spec.OSDiskSizeGB,
-					"field is immutable, unsetting is not allowed"))
-		} else if *m.Spec.OSDiskSizeGB != *old.Spec.OSDiskSizeGB {
-			// changing the field is not allowed
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "OSDiskSizeGB"),
-					*m.Spec.OSDiskSizeGB,
-					"field is immutable"))
-		}
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "OSDiskSizeGB"),
+		old.Spec.OSDiskSizeGB,
+		m.Spec.OSDiskSizeGB); err != nil {
+		allErrs = append(allErrs, err)
 	}
 
 	// custom headers are immutable
@@ -146,7 +133,7 @@ func (m *AzureManagedMachinePool) ValidateUpdate(oldRaw runtime.Object, client c
 				fmt.Sprintf("annotations with '%s' prefix are immutable", azure.CustomHeaderPrefix)))
 	}
 
-	if !ensureStringSlicesAreEqual(m.Spec.AvailabilityZones, old.Spec.AvailabilityZones) {
+	if !webhookutils.EnsureStringSlicesAreEquivalent(m.Spec.AvailabilityZones, old.Spec.AvailabilityZones) {
 		allErrs = append(allErrs,
 			field.Invalid(
 				field.NewPath("Spec", "AvailabilityZones"),
@@ -163,42 +150,18 @@ func (m *AzureManagedMachinePool) ValidateUpdate(oldRaw runtime.Object, client c
 		}
 	}
 
-	if old.Spec.MaxPods != nil {
-		// Prevent MaxPods modification if it was already set to some value
-		if m.Spec.MaxPods == nil {
-			// unsetting the field is not allowed
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "MaxPods"),
-					m.Spec.MaxPods,
-					"field is immutable, unsetting is not allowed"))
-		} else if *m.Spec.MaxPods != *old.Spec.MaxPods {
-			// changing the field is not allowed
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "MaxPods"),
-					*m.Spec.MaxPods,
-					"field is immutable"))
-		}
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "MaxPods"),
+		old.Spec.MaxPods,
+		m.Spec.MaxPods); err != nil {
+		allErrs = append(allErrs, err)
 	}
 
-	if old.Spec.OsDiskType != nil {
-		// Prevent OSDiskType modification if it was already set to some value
-		if m.Spec.OsDiskType == nil || to.String(m.Spec.OsDiskType) == "" {
-			// unsetting the field is not allowed
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "OsDiskType"),
-					m.Spec.OsDiskType,
-					"field is immutable, unsetting is not allowed"))
-		} else if *m.Spec.OsDiskType != *old.Spec.OsDiskType {
-			// changing the field is not allowed
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "OsDiskType"),
-					m.Spec.OsDiskType,
-					"field is immutable"))
-		}
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "OsDiskType"),
+		old.Spec.OsDiskType,
+		m.Spec.OsDiskType); err != nil {
+		allErrs = append(allErrs, err)
 	}
 
 	if err := webhookutils.ValidateImmutable(
@@ -355,22 +318,4 @@ func (m *AzureManagedMachinePool) validateEnableNodePublicIP() error {
 			"must be set to true when NodePublicIPPrefixID is set")
 	}
 	return nil
-}
-
-func ensureStringSlicesAreEqual(a []string, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	m := map[string]bool{}
-	for _, v := range a {
-		m[v] = true
-	}
-
-	for _, v := range b {
-		if _, ok := m[v]; !ok {
-			return false
-		}
-	}
-	return true
 }

--- a/util/webhook/validator.go
+++ b/util/webhook/validator.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"net/http"
 	"reflect"
+	"sort"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -166,4 +167,23 @@ func ValidateImmutable(path *field.Path, oldVal, newVal any) *field.Error {
 	}
 
 	return nil
+}
+
+// EnsureStringSlicesAreEquivalent returns if two string slices have equal lengths,
+// and that they have the exact same items; it does not enforce strict ordering of items.
+func EnsureStringSlicesAreEquivalent(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	sort.Strings(a)
+	sort.Strings(b)
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
 }

--- a/util/webhook/validator_test.go
+++ b/util/webhook/validator_test.go
@@ -239,3 +239,63 @@ func TestValidateImmutableInt32(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureStringSlicesAreEquivalent(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name           string
+		input1         []string
+		input2         []string
+		expectedOutput bool
+	}{
+		{
+			name:           "nil",
+			input1:         nil,
+			input2:         nil,
+			expectedOutput: true,
+		},
+		{
+			name:           "no change",
+			input1:         []string{"foo", "bar"},
+			input2:         []string{"foo", "bar"},
+			expectedOutput: true,
+		},
+		{
+			name:           "different",
+			input1:         []string{"foo", "bar"},
+			input2:         []string{"foo", "foo"},
+			expectedOutput: false,
+		},
+		{
+			name:           "different order, but equal",
+			input1:         []string{"1", "2"},
+			input2:         []string{"2", "1"},
+			expectedOutput: true,
+		},
+		{
+			name:           "different lengths",
+			input1:         []string{"foo"},
+			input2:         []string{"foo", "foo"},
+			expectedOutput: false,
+		},
+		{
+			name:           "different",
+			input1:         []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"},
+			input2:         []string{"1", "2", "3", "4", "5", "7", "8", "9"},
+			expectedOutput: false,
+		},
+		{
+			name:           "another different variant",
+			input1:         []string{"a", "a", "b"},
+			input2:         []string{"a", "b", "b"},
+			expectedOutput: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ret := EnsureStringSlicesAreEquivalent(tc.input1, tc.input2)
+			g.Expect(ret).To(Equal(tc.expectedOutput))
+		})
+	}
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind bug
/kind cleanup

**What this PR does / why we need it**:

This PR replaces a few, one-off validation implementations to re-use common funcs instead.

More importantly, the following `AzureManagedControlPlane` properties have been fixed for strict immutability as according the requirements of the AKS API for those properties:

- `Spec.SSHPublicKey`
- `Spec.DNSServiceIP`
- `Spec.NetworkPlugin`
- `Spec.NetworkPolicy`
- `Spec.LoadBalancerSKU`

And the following `AzureManagedMachinePool` properties as well:

- `Spec.OSDiskSizeGB`
- `Spec.MaxPods`
- `Spec.OsDiskType`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ensure AKS immutable configuration has webhook enforcement
```
