### PR TITLE
tags converters: return nil if src is nil

### DIFF
--- a/azure/converters/tags.go
+++ b/azure/converters/tags.go
@@ -23,6 +23,10 @@ import (
 
 // MapToTags converts a map[string]*string into a infrav1.Tags.
 func MapToTags(src map[string]*string) infrav1.Tags {
+	if src == nil {
+		return nil
+	}
+
 	tags := make(infrav1.Tags, len(src))
 
 	for k, v := range src {
@@ -34,6 +38,10 @@ func MapToTags(src map[string]*string) infrav1.Tags {
 
 // TagsToMap converts infrav1.Tags into a map[string]*string.
 func TagsToMap(src infrav1.Tags) map[string]*string {
+	if src == nil {
+		return nil
+	}
+
 	tags := make(map[string]*string, len(src))
 
 	for k, v := range src {

--- a/azure/converters/tags_test.go
+++ b/azure/converters/tags_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package converters
+
+import (
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/onsi/gomega"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+)
+
+func Test_TagsToMap(t *testing.T) {
+	cases := []struct {
+		tags   infrav1.Tags
+		expect map[string]*string
+	}{
+		{
+			tags:   nil,
+			expect: nil,
+		},
+		{
+			tags:   infrav1.Tags{},
+			expect: map[string]*string{},
+		},
+		{
+			tags:   infrav1.Tags{"env": "prod"},
+			expect: map[string]*string{"env": to.StringPtr("prod")},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run("name", func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewGomegaWithT(t)
+			result := TagsToMap(c.tags)
+			g.Expect(c.expect).To(gomega.BeEquivalentTo(result))
+		})
+	}
+}
+
+func Test_MapToTags(t *testing.T) {
+	cases := []struct {
+		tags   map[string]*string
+		expect infrav1.Tags
+	}{
+		{
+			tags:   nil,
+			expect: nil,
+		},
+		{
+			tags:   map[string]*string{},
+			expect: infrav1.Tags{},
+		},
+		{
+			tags:   map[string]*string{"env": to.StringPtr("prod")},
+			expect: infrav1.Tags{"env": "prod"},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run("name", func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewGomegaWithT(t)
+			result := MapToTags(c.tags)
+			g.Expect(c.expect).To(gomega.BeEquivalentTo(result))
+		})
+	}
+}
+
+// convert the value to map then back to tags
+// and make sure that the value we get is strictly equal
+// to the original value (ie. round trip conversion).
+func Test_TagsToMapRoundTrip(t *testing.T) {
+	cases := []struct {
+		tags   infrav1.Tags
+		expect infrav1.Tags
+	}{
+		{
+			tags:   nil,
+			expect: nil,
+		},
+		{
+			tags:   infrav1.Tags{},
+			expect: infrav1.Tags{},
+		},
+		{
+			tags:   infrav1.Tags{"env": "prod"},
+			expect: infrav1.Tags{"env": "prod"},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run("name", func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewGomegaWithT(t)
+			result := MapToTags(TagsToMap(c.tags))
+			g.Expect(c.expect).To(gomega.BeEquivalentTo(result))
+		})
+	}
+}
+
+// convert the value to tags then back to map
+// and make sure that the value we get is strictly equal
+// to the original value (ie. round trip conversion).
+func Test_MapToTagsMapRoundTrip(t *testing.T) {
+	cases := []struct {
+		tags   map[string]*string
+		expect map[string]*string
+	}{
+		{
+			tags:   nil,
+			expect: nil,
+		},
+		{
+			tags:   map[string]*string{},
+			expect: map[string]*string{},
+		},
+		{
+			tags:   map[string]*string{"env": to.StringPtr("prod")},
+			expect: map[string]*string{"env": to.StringPtr("prod")},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run("name", func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewGomegaWithT(t)
+			result := TagsToMap(MapToTags(c.tags))
+			g.Expect(c.expect).To(gomega.BeEquivalentTo(result))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2801 
/kind bug

these converter functions had a bug where the conversion of a nil source was returning an empty `map[string]*string`
this behaviour triggered bugs when doing diff operations on converted objects

This is where this problem was encountered the first time:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2745/files#r1012288112

Release notes:
```release-note
Fixed tags converters functions MapToTags and TagsToMap to return nil on nil input. Added unit tests for tag converters.
```
