### PR TITLE
Default Ubuntu to 22.04 for new k8s versions

### DIFF
--- a/azure/services/virtualmachineimages/images.go
+++ b/azure/services/virtualmachineimages/images.go
@@ -180,14 +180,17 @@ func (s *Service) getSKUAndVersion(ctx context.Context, location, publisher, off
 
 // getUbuntuOSVersion returns the default Ubuntu OS version for the given Kubernetes version.
 func getUbuntuOSVersion(major, minor, patch uint64) string {
-	// Default to Ubuntu 20.04 LTS, except for k8s versions which have only 18.04 reference images.
-	osVersion := "2004"
-	if (major == 1 && minor == 21 && patch < 2) ||
-		(major == 1 && minor == 20 && patch < 8) ||
-		(major == 1 && minor == 19 && patch < 12) ||
-		(major == 1 && minor == 18 && patch < 20) ||
-		(major == 1 && minor < 18) {
+	// Default to Ubuntu 22.04 LTS for Kubernetes v1.25.3 and later.
+	osVersion := "2204"
+	if major == 1 && minor == 21 && patch < 2 ||
+		major == 1 && minor == 20 && patch < 8 ||
+		major == 1 && minor == 19 && patch < 12 ||
+		major == 1 && minor == 18 && patch < 20 ||
+		major == 1 && minor < 18 {
 		osVersion = "1804"
+	} else if major == 1 && minor == 25 && patch < 3 ||
+		major == 1 && minor < 25 {
+		osVersion = "2004"
 	}
 	return osVersion
 }

--- a/azure/services/virtualmachineimages/images_test.go
+++ b/azure/services/virtualmachineimages/images_test.go
@@ -116,6 +116,16 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			},
 		},
 		{
+			k8sVersion:      "v1.22.16",
+			expectedSKU:     "ubuntu-2004-gen1",
+			expectedVersion: "122.16.20221117",
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
+					{Name: to.StringPtr("122.16.20221117")},
+				},
+			},
+		},
+		{
 			k8sVersion:      "v1.23.6",
 			expectedSKU:     "k8s-1dot23dot6-ubuntu-2004",
 			expectedVersion: "latest",
@@ -140,6 +150,66 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
 					{Name: to.StringPtr("124.0.20220512")},
+				},
+			},
+		},
+		{
+			k8sVersion:      "v1.23.12",
+			expectedSKU:     "ubuntu-2004-gen1",
+			expectedVersion: "123.12.20220921",
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
+					{Name: to.StringPtr("123.12.20220921")},
+				},
+			},
+		},
+		{
+			k8sVersion:      "v1.23.13",
+			expectedSKU:     "ubuntu-2004-gen1",
+			expectedVersion: "123.13.20221014",
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
+					{Name: to.StringPtr("123.13.20221014")},
+				},
+			},
+		},
+		{
+			k8sVersion:      "v1.24.6",
+			expectedSKU:     "ubuntu-2004-gen1",
+			expectedVersion: "124.6.20220921",
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
+					{Name: to.StringPtr("124.6.20220921")},
+				},
+			},
+		},
+		{
+			k8sVersion:      "v1.24.7",
+			expectedSKU:     "ubuntu-2004-gen1",
+			expectedVersion: "124.7.20221014",
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
+					{Name: to.StringPtr("124.7.20221014")},
+				},
+			},
+		},
+		{
+			k8sVersion:      "v1.25.2",
+			expectedSKU:     "ubuntu-2004-gen1",
+			expectedVersion: "125.2.20220921",
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
+					{Name: to.StringPtr("125.2.20220921")},
+				},
+			},
+		},
+		{
+			k8sVersion:      "v1.25.3",
+			expectedSKU:     "ubuntu-2204-gen1",
+			expectedVersion: "125.3.20221014",
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
+					{Name: to.StringPtr("125.3.20221014")},
 				},
 			},
 		},
@@ -393,11 +463,37 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			osAndVersion:    "ubuntu-2004",
 		},
 		{
-			k8sVersion:      "v1.23.13",
-			expectedSKU:     "ubuntu-2004-gen1",
-			expectedVersion: "123.13.20220524",
+			k8sVersion:      "v1.22.0",
+			expectedSKU:     "k8s-1dot22dot0-ubuntu-2004",
+			expectedVersion: "latest",
 			expectedError:   false,
 			osAndVersion:    "ubuntu-2004",
+		},
+		{
+			k8sVersion:      "v1.22.9",
+			expectedSKU:     "k8s-1dot22dot9-ubuntu-2004",
+			expectedVersion: "latest",
+			expectedError:   false,
+			osAndVersion:    "ubuntu-2004",
+		},
+		{
+			k8sVersion:      "v1.23.12",
+			expectedSKU:     "ubuntu-2004-gen1",
+			expectedVersion: "123.12.20220921",
+			expectedError:   false,
+			osAndVersion:    "ubuntu-2004",
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
+					{Name: to.StringPtr("123.12.20220921")},
+				},
+			},
+		},
+		{
+			k8sVersion:      "v1.23.13",
+			expectedSKU:     "ubuntu-2204-gen1",
+			expectedVersion: "123.13.20220524",
+			expectedError:   false,
+			osAndVersion:    "ubuntu-2204",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
 					{Name: to.StringPtr("123.13.20220524")},
@@ -443,6 +539,18 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
 					{Name: to.StringPtr("124.0.20220606")},
+				},
+			},
+		},
+		{
+			k8sVersion:      "v1.25.4",
+			expectedSKU:     "ubuntu-2204-gen1",
+			expectedVersion: "125.4.20221011",
+			expectedError:   false,
+			osAndVersion:    "ubuntu-2204",
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
+					{Name: to.StringPtr("125.4.20221011")},
 				},
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Updates the default Ubuntu version to 22.04 LTS for newer Kubernetes versions that have published reference images to Azure Marketplace for it.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**TODOs**:


- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Default Ubuntu to 22.04 for new k8s versions
```
