### PR TITLE
add control plane tolerations to aad pod identity

### DIFF
--- a/config/default/aad-pod-identity-deployment.yaml
+++ b/config/default/aad-pod-identity-deployment.yaml
@@ -263,6 +263,11 @@ spec:
         component: nmi
         tier: node
     spec:
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
       serviceAccountName: manager
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
Signed-off-by: Ashutosh Kumar <sonasingh46@gmail.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
/kind bug
-->

**What this PR does / why we need it**:

Adds control plane tolerations to aad pod identity. The capz manager pod has already this tolerations. The toleration is needed on aad pod identity as well otherwise for situations when capz pod gets scheduled on control plane node, the authentication to azure cloud will fails as the capz-nmi(aad pod identity) pod is not present on the control plane node due to taint policy. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add tolerations to aad pod identity
```
