### PR TITLE
omit benign errors in e2e logs

### DIFF
--- a/test/e2e/aks.go
+++ b/test/e2e/aks.go
@@ -578,9 +578,8 @@ func AKSPublicIPPrefixSpec(ctx context.Context, inputGetter func() AKSPublicIPPr
 	var publicIPPrefix network.PublicIPPrefix
 	Eventually(func() error {
 		publicIPPrefix, err = publicIPPrefixFuture.Result(publicIPPrefixClient)
-		Logf("Got err %v", err)
 		return err
-	}, input.WaitIntervals...).Should(Succeed())
+	}, input.WaitIntervals...).Should(Succeed(), "failed to create public IP prefix")
 
 	By("Creating node pool with 3 nodes")
 	infraMachinePool := &infrav1exp.AzureManagedMachinePool{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR removes log statements printing the error gotten from polling the publicIPPrefix future to check that the operation succeeds. This usually fails at least once with a harmless "operation not done" error before ultimately succeeding. With this change, the ultimate error if the operation fails is still logged in the test's failure message.

Follow-up from https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2745#issuecomment-1301177450

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
