### PR TITLE
test managed machine pool delete in e2e

### DIFF
--- a/test/e2e/aks.go
+++ b/test/e2e/aks.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -624,6 +625,22 @@ func AKSPublicIPPrefixSpec(ctx context.Context, inputGetter func() AKSPublicIPPr
 	}
 	err = mgmtClient.Create(ctx, machinePool)
 	Expect(err).NotTo(HaveOccurred())
+
+	defer func() {
+		By("Deleting the node pool")
+		err := mgmtClient.Delete(ctx, machinePool)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() bool {
+			err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(machinePool), &expv1.MachinePool{})
+			return apierrors.IsNotFound(err)
+		}, input.WaitIntervals...).Should(BeTrue(), "Deleted MachinePool %s/%s still exists", machinePool.Namespace, machinePool.Name)
+
+		Eventually(func() bool {
+			err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraMachinePool), &infrav1exp.AzureManagedMachinePool{})
+			return apierrors.IsNotFound(err)
+		}, input.WaitIntervals...).Should(BeTrue(), "Deleted AzureManagedMachinePool %s/%s still exists", infraMachinePool.Namespace, infraMachinePool.Name)
+	}()
 
 	By("Verifying the AzureManagedMachinePool converges to a failed ready status")
 	Eventually(func(g Gomega) {

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -592,6 +592,9 @@ var _ = Describe("Workload cluster creation", func() {
 			})
 
 			By("creating a machine pool with public IP addresses from a prefix", func() {
+				// This test is also currently serving as the canonical
+				// "create/delete node pool" test. Eventually, that should be
+				// made more distinct from this public IP prefix test.
 				AKSPublicIPPrefixSpec(ctx, func() AKSPublicIPPrefixSpecInput {
 					return AKSPublicIPPrefixSpecInput{
 						Cluster:           result.Cluster,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR adds new e2e test coverage testing that a MachinePool can be successfully deleted from a managed cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
