### PR TITLE
ci: always use registry.k8s.io

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -158,10 +158,6 @@ spec:
               mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
             done
             IMAGE_REGISTRY_PREFIX=registry.k8s.io
-            # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-            if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-              IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-            fi
             for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
               echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
               wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"
@@ -350,10 +346,6 @@ spec:
                 mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
               done
               IMAGE_REGISTRY_PREFIX=registry.k8s.io
-              # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-              if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-                IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-              fi
               for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
                 echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
                 wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -158,10 +158,6 @@ spec:
               mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
             done
             IMAGE_REGISTRY_PREFIX=registry.k8s.io
-            # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-            if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-              IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-            fi
             for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
               echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
               wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"
@@ -350,10 +346,6 @@ spec:
                 mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
               done
               IMAGE_REGISTRY_PREFIX=registry.k8s.io
-              # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-              if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-                IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-              fi
               for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
                 echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
                 wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
@@ -159,10 +159,6 @@ spec:
               mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
             done
             IMAGE_REGISTRY_PREFIX=registry.k8s.io
-            # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-            if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-              IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-            fi
             for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
               echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
               wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"
@@ -353,10 +349,6 @@ spec:
                 mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
               done
               IMAGE_REGISTRY_PREFIX=registry.k8s.io
-              # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-              if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-                IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-              fi
               for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
                 echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
                 wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -156,10 +156,6 @@ spec:
               mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
             done
             IMAGE_REGISTRY_PREFIX=registry.k8s.io
-            # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-            if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-              IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-            fi
             for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
               echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
               wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"
@@ -344,10 +340,6 @@ spec:
             mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
           done
           IMAGE_REGISTRY_PREFIX=registry.k8s.io
-          # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-          if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-            IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-          fi
           for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
             echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
             wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"

--- a/templates/test/ci/patches/control-plane-kubeadm-boostrap-ci-version.yaml
+++ b/templates/test/ci/patches/control-plane-kubeadm-boostrap-ci-version.yaml
@@ -46,10 +46,6 @@
             mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
           done
           IMAGE_REGISTRY_PREFIX=registry.k8s.io
-          # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-          if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-            IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-          fi
           for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
             echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
             wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"

--- a/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap.yaml
+++ b/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap.yaml
@@ -46,10 +46,6 @@
             mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
           done
           IMAGE_REGISTRY_PREFIX=registry.k8s.io
-          # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-          if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-            IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-          fi
           for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
             echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
             wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -55,10 +55,6 @@ spec:
               mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
             done
             IMAGE_REGISTRY_PREFIX=registry.k8s.io
-            # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-            if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-              IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-            fi
             for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
               echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
               wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -126,10 +126,6 @@ spec:
         declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
         [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
         IMAGE_REGISTRY_PREFIX=registry.k8s.io
-        # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-        if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-          IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-        fi
         for IMAGE in "$${IMAGES[@]}"; do
           $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
           $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -135,10 +135,6 @@ spec:
         declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
         [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
         IMAGE_REGISTRY_PREFIX=registry.k8s.io
-        # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-        if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-          IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-        fi
         for IMAGE in "$${IMAGES[@]}"; do
           $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
           $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"

--- a/templates/test/dev/custom-builds/patches/kubeadm-controlplane-bootstrap.yaml
+++ b/templates/test/dev/custom-builds/patches/kubeadm-controlplane-bootstrap.yaml
@@ -21,10 +21,6 @@
         declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
         [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
         IMAGE_REGISTRY_PREFIX=registry.k8s.io
-        # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-        if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-          IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-        fi
         for IMAGE in "$${IMAGES[@]}"; do
           $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
           $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"

--- a/templates/test/dev/patches/control-plane-custom-builds.yaml
+++ b/templates/test/dev/patches/control-plane-custom-builds.yaml
@@ -37,10 +37,6 @@ spec:
         declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
         [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
         IMAGE_REGISTRY_PREFIX=registry.k8s.io
-        # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-        if [[ "$${CI_VERSION}" =~ ^v1\.2[0-4][\.[0-9]+ ]]; then
-          IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-        fi
         for IMAGE in "$${IMAGES[@]}"; do
           $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
           $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR updates the capz templates that are use for running custom kubernetes builds to always use `registry.k8s.io` in response to a migration to the new registry URL across all supported Kubernetes versions. E.g.:

- https://github.com/kubernetes/kubernetes/pull/113395
- https://github.com/kubernetes/kubernetes/pull/113417

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
