### PR TITLE
log ManagedCluster spec changes at higher verbosity

### DIFF
--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -115,7 +115,7 @@ type ResourceSpecGetter interface {
 	// Parameters takes the existing resource and returns the desired parameters of the resource.
 	// If the resource does not exist, or we do not care about existing parameters to update the resource, existing should be nil.
 	// If no update is needed on the resource, Parameters should return nil.
-	Parameters(existing interface{}) (params interface{}, err error)
+	Parameters(ctx context.Context, existing interface{}) (params interface{}, err error)
 }
 
 // ResourceSpecGetterWithHeaders is a ResourceSpecGetter that can return custom headers to be added to API calls.

--- a/azure/mock_azure/azure_mock.go
+++ b/azure/mock_azure/azure_mock.go
@@ -1611,18 +1611,18 @@ func (mr *MockResourceSpecGetterMockRecorder) OwnerResourceName() *gomock.Call {
 }
 
 // Parameters mocks base method.
-func (m *MockResourceSpecGetter) Parameters(existing interface{}) (interface{}, error) {
+func (m *MockResourceSpecGetter) Parameters(ctx context.Context, existing interface{}) (interface{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Parameters", existing)
+	ret := m.ctrl.Call(m, "Parameters", ctx, existing)
 	ret0, _ := ret[0].(interface{})
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Parameters indicates an expected call of Parameters.
-func (mr *MockResourceSpecGetterMockRecorder) Parameters(existing interface{}) *gomock.Call {
+func (mr *MockResourceSpecGetterMockRecorder) Parameters(ctx, existing interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parameters", reflect.TypeOf((*MockResourceSpecGetter)(nil).Parameters), existing)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parameters", reflect.TypeOf((*MockResourceSpecGetter)(nil).Parameters), ctx, existing)
 }
 
 // ResourceGroupName mocks base method.
@@ -1705,18 +1705,18 @@ func (mr *MockResourceSpecGetterWithHeadersMockRecorder) OwnerResourceName() *go
 }
 
 // Parameters mocks base method.
-func (m *MockResourceSpecGetterWithHeaders) Parameters(existing interface{}) (interface{}, error) {
+func (m *MockResourceSpecGetterWithHeaders) Parameters(ctx context.Context, existing interface{}) (interface{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Parameters", existing)
+	ret := m.ctrl.Call(m, "Parameters", ctx, existing)
 	ret0, _ := ret[0].(interface{})
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Parameters indicates an expected call of Parameters.
-func (mr *MockResourceSpecGetterWithHeadersMockRecorder) Parameters(existing interface{}) *gomock.Call {
+func (mr *MockResourceSpecGetterWithHeadersMockRecorder) Parameters(ctx, existing interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parameters", reflect.TypeOf((*MockResourceSpecGetterWithHeaders)(nil).Parameters), existing)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parameters", reflect.TypeOf((*MockResourceSpecGetterWithHeaders)(nil).Parameters), ctx, existing)
 }
 
 // ResourceGroupName mocks base method.

--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -17,6 +17,7 @@ limitations under the License.
 package agentpools
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -155,7 +156,7 @@ func (s *AgentPoolSpec) CustomHeaders() map[string]string {
 }
 
 // Parameters returns the parameters for the agent pool.
-func (s *AgentPoolSpec) Parameters(existing interface{}) (params interface{}, err error) {
+func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	nodeLabels := s.NodeLabels
 	if existing != nil {
 		existingPool, ok := existing.(containerservice.AgentPool)

--- a/azure/services/agentpools/spec_test.go
+++ b/azure/services/agentpools/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package agentpools
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -399,7 +400,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(tc.existing)
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
 			if tc.expectedError != nil {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/async/async.go
+++ b/azure/services/async/async.go
@@ -123,7 +123,7 @@ func (s *Service) CreateOrUpdateResource(ctx context.Context, spec azure.Resourc
 	}
 
 	// Construct parameters using the resource spec and information from the existing resource, if there is one.
-	parameters, err := spec.Parameters(existingResource)
+	parameters, err := spec.Parameters(ctx, existingResource)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get desired parameters for resource %s/%s (service: %s)", rgName, resourceName, serviceName)
 	} else if parameters == nil {

--- a/azure/services/async/async_test.go
+++ b/azure/services/async/async_test.go
@@ -235,7 +235,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 				r.ResourceGroupName().Return("test-group")
 				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.PutFuture).Return(nil)
 				c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(&fakeExistingResource, nil)
-				r.Parameters(&fakeExistingResource).Return(&fakeResourceParameters, nil)
+				r.Parameters(gomockinternal.AContext(), &fakeExistingResource).Return(&fakeResourceParameters, nil)
 				c.CreateOrUpdateAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{}), &fakeResourceParameters).Return("test-resource", nil, nil)
 			},
 		},
@@ -260,7 +260,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 				r.ResourceGroupName().Return("test-group")
 				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.PutFuture).Return(nil)
 				c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(nil, fakeNotFoundError)
-				r.Parameters(nil).Return(&fakeResourceParameters, nil)
+				r.Parameters(gomockinternal.AContext(), nil).Return(&fakeResourceParameters, nil)
 				c.CreateOrUpdateAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{}), &fakeResourceParameters).Return(&fakeExistingResource, nil, nil)
 			},
 		},
@@ -273,7 +273,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 				r.ResourceGroupName().Return("test-group")
 				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.PutFuture).Return(nil)
 				c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(&fakeExistingResource, nil)
-				r.Parameters(&fakeExistingResource).Return(nil, fakeInternalError)
+				r.Parameters(gomockinternal.AContext(), &fakeExistingResource).Return(nil, fakeInternalError)
 			},
 		},
 		{
@@ -286,7 +286,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 				r.ResourceGroupName().Return("test-group")
 				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.PutFuture).Return(nil)
 				c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(&fakeExistingResource, nil)
-				r.Parameters(&fakeExistingResource).Return(nil, nil)
+				r.Parameters(gomockinternal.AContext(), &fakeExistingResource).Return(nil, nil)
 			},
 		},
 		{
@@ -298,7 +298,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 				r.ResourceGroupName().Return("test-group")
 				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.PutFuture).Return(nil)
 				c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(&fakeExistingResource, nil)
-				r.Parameters(&fakeExistingResource).Return(&fakeResourceParameters, nil)
+				r.Parameters(gomockinternal.AContext(), &fakeExistingResource).Return(&fakeResourceParameters, nil)
 				c.CreateOrUpdateAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{}), &fakeResourceParameters).Return(nil, nil, fakeInternalError)
 			},
 		},
@@ -311,7 +311,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 				r.ResourceGroupName().Return("test-group")
 				s.GetLongRunningOperationState("test-resource", "test-service", infrav1.PutFuture).Return(nil)
 				c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{})).Return(&fakeExistingResource, nil)
-				r.Parameters(&fakeExistingResource).Return(&fakeResourceParameters, nil)
+				r.Parameters(gomockinternal.AContext(), &fakeExistingResource).Return(&fakeResourceParameters, nil)
 				c.CreateOrUpdateAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(&mock_azure.MockResourceSpecGetter{}), &fakeResourceParameters).Return(nil, &azureautorest.Future{}, errCtxExceeded)
 				s.SetLongRunningOperationState(gomock.AssignableToTypeOf(&infrav1.Future{}))
 			},

--- a/azure/services/availabilitysets/spec.go
+++ b/azure/services/availabilitysets/spec.go
@@ -17,6 +17,7 @@ limitations under the License.
 package availabilitysets
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
@@ -53,7 +54,7 @@ func (s *AvailabilitySetSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the availability set.
-func (s *AvailabilitySetSpec) Parameters(existing interface{}) (params interface{}, err error) {
+func (s *AvailabilitySetSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
 		if _, ok := existing.(compute.AvailabilitySet); !ok {
 			return nil, errors.Errorf("%T is not a compute.AvailabilitySet", existing)

--- a/azure/services/availabilitysets/spec_test.go
+++ b/azure/services/availabilitysets/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package availabilitysets
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
@@ -79,7 +80,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(tc.existing)
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/bastionhosts/spec.go
+++ b/azure/services/bastionhosts/spec.go
@@ -17,6 +17,7 @@ limitations under the License.
 package bastionhosts
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -60,7 +61,7 @@ func (s *AzureBastionSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the bastion host.
-func (s *AzureBastionSpec) Parameters(existing interface{}) (parameters interface{}, err error) {
+func (s *AzureBastionSpec) Parameters(ctx context.Context, existing interface{}) (parameters interface{}, err error) {
 	if existing != nil {
 		if _, ok := existing.(network.BastionHost); !ok {
 			return nil, errors.Errorf("%T is not a network.BastionHost", existing)

--- a/azure/services/disks/spec.go
+++ b/azure/services/disks/spec.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package disks
 
+import "context"
+
 // DiskSpec defines the specification for a disk.
 type DiskSpec struct {
 	Name          string
@@ -38,6 +40,6 @@ func (s *DiskSpec) OwnerResourceName() string {
 }
 
 // Parameters is a no-op for disks.
-func (s *DiskSpec) Parameters(existing interface{}) (params interface{}, err error) {
+func (s *DiskSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	return nil, nil
 }

--- a/azure/services/groups/spec.go
+++ b/azure/services/groups/spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package groups
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
 	"github.com/Azure/go-autorest/autorest/to"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -48,7 +50,7 @@ func (s *GroupSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the group.
-func (s *GroupSpec) Parameters(existing interface{}) (params interface{}, err error) {
+func (s *GroupSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
 		// rg already exists, nothing to update.
 		// Note that rg tags are updated separately using tags service.

--- a/azure/services/inboundnatrules/spec.go
+++ b/azure/services/inboundnatrules/spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package inboundnatrules
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
@@ -47,7 +49,7 @@ func (s *InboundNatSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the inbound NAT rule.
-func (s *InboundNatSpec) Parameters(existing interface{}) (parameters interface{}, err error) {
+func (s *InboundNatSpec) Parameters(ctx context.Context, existing interface{}) (parameters interface{}, err error) {
 	if existing != nil {
 		if _, ok := existing.(network.InboundNatRule); !ok {
 			return nil, errors.Errorf("%T is not a network.InboundNatRule", existing)

--- a/azure/services/loadbalancers/spec.go
+++ b/azure/services/loadbalancers/spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package loadbalancers
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
@@ -61,7 +63,7 @@ func (s *LBSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the load balancer.
-func (s *LBSpec) Parameters(existing interface{}) (parameters interface{}, err error) {
+func (s *LBSpec) Parameters(ctx context.Context, existing interface{}) (parameters interface{}, err error) {
 	var (
 		etag                *string
 		frontendIDs         []network.SubResource

--- a/azure/services/loadbalancers/spec_test.go
+++ b/azure/services/loadbalancers/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package loadbalancers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
@@ -152,7 +153,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(tc.existing)
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/managedclusters/spec_test.go
+++ b/azure/services/managedclusters/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package managedclusters
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-05-01/containerservice"
@@ -154,7 +155,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(tc.existing)
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/natgateways/spec.go
+++ b/azure/services/natgateways/spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package natgateways
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	autorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -53,7 +55,7 @@ func (s *NatGatewaySpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the NAT gateway.
-func (s *NatGatewaySpec) Parameters(existing interface{}) (params interface{}, err error) {
+func (s *NatGatewaySpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
 		existingNatGateway, ok := existing.(network.NatGateway)
 		if !ok {

--- a/azure/services/networkinterfaces/spec.go
+++ b/azure/services/networkinterfaces/spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package networkinterfaces
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
@@ -68,7 +70,7 @@ func (s *NICSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the network interface.
-func (s *NICSpec) Parameters(existing interface{}) (parameters interface{}, err error) {
+func (s *NICSpec) Parameters(ctx context.Context, existing interface{}) (parameters interface{}, err error) {
 	if existing != nil {
 		if _, ok := existing.(network.Interface); !ok {
 			return nil, errors.Errorf("%T is not a network.Interface", existing)

--- a/azure/services/networkinterfaces/spec_test.go
+++ b/azure/services/networkinterfaces/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package networkinterfaces
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
@@ -439,7 +440,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(tc.existing)
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/privatedns/link_spec.go
+++ b/azure/services/privatedns/link_spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package privatedns
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
@@ -53,7 +55,7 @@ func (s LinkSpec) ResourceGroupName() string {
 }
 
 // Parameters returns the parameters for the virtual network link.
-func (s LinkSpec) Parameters(existing interface{}) (params interface{}, err error) {
+func (s LinkSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
 		_, ok := existing.(privatedns.VirtualNetworkLink)
 		if !ok {

--- a/azure/services/privatedns/link_spec_test.go
+++ b/azure/services/privatedns/link_spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package privatedns
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
@@ -114,7 +115,7 @@ func TestLinkSpec_Parameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(tc.existing)
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/privatedns/record_spec.go
+++ b/azure/services/privatedns/record_spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package privatedns
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
@@ -47,7 +49,7 @@ func (s RecordSpec) ResourceGroupName() string {
 }
 
 // Parameters returns the parameters for a record set.
-func (s RecordSpec) Parameters(existing interface{}) (params interface{}, err error) {
+func (s RecordSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
 		if _, ok := existing.(privatedns.RecordSet); !ok {
 			return nil, errors.Errorf("%T is not a privatedns.RecordSet", existing)

--- a/azure/services/privatedns/record_spec_test.go
+++ b/azure/services/privatedns/record_spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package privatedns
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
@@ -104,7 +105,7 @@ func TestRecordSpec_Parameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(tc.existing)
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/privatedns/zone_spec.go
+++ b/azure/services/privatedns/zone_spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package privatedns
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
@@ -49,7 +51,7 @@ func (s ZoneSpec) ResourceGroupName() string {
 }
 
 // Parameters returns the parameters for the private dns zone.
-func (s ZoneSpec) Parameters(existing interface{}) (params interface{}, err error) {
+func (s ZoneSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
 		_, ok := existing.(privatedns.PrivateZone)
 		if !ok {

--- a/azure/services/privatedns/zone_spec_test.go
+++ b/azure/services/privatedns/zone_spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package privatedns
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
@@ -104,7 +105,7 @@ func TestZoneSpec_Parameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(tc.existing)
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/publicips/spec.go
+++ b/azure/services/publicips/spec.go
@@ -17,6 +17,7 @@ limitations under the License.
 package publicips
 
 import (
+	"context"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
@@ -55,7 +56,7 @@ func (s *PublicIPSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the public IP.
-func (s *PublicIPSpec) Parameters(existing interface{}) (params interface{}, err error) {
+func (s *PublicIPSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
 		if _, ok := existing.(network.PublicIPAddress); !ok {
 			return nil, errors.Errorf("%T is not a network.PublicIPAddress", existing)

--- a/azure/services/publicips/spec_test.go
+++ b/azure/services/publicips/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package publicips
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -150,7 +151,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(tc.existing)
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/roleassignments/spec.go
+++ b/azure/services/roleassignments/spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package roleassignments
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/profiles/2019-03-01/authorization/mgmt/authorization"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
@@ -50,7 +52,7 @@ func (s *RoleAssignmentSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the RoleAssignmentSpec.
-func (s *RoleAssignmentSpec) Parameters(existing interface{}) (interface{}, error) {
+func (s *RoleAssignmentSpec) Parameters(ctx context.Context, existing interface{}) (interface{}, error) {
 	if existing != nil {
 		if _, ok := existing.(authorization.RoleAssignment); !ok {
 			return nil, errors.Errorf("%T is not a authorization.RoleAssignment", existing)

--- a/azure/services/routetables/spec.go
+++ b/azure/services/routetables/spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package routetables
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
@@ -49,7 +51,7 @@ func (s *RouteTableSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the route table.
-func (s *RouteTableSpec) Parameters(existing interface{}) (params interface{}, err error) {
+func (s *RouteTableSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
 		if _, ok := existing.(network.RouteTable); !ok {
 			return nil, errors.Errorf("%T is not a network.RouteTable", existing)

--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -402,7 +402,7 @@ func (s *Service) buildVMSSFromSpec(ctx context.Context, vmssSpec azure.ScaleSet
 		vmssSpec.AcceleratedNetworking = &accelNet
 	}
 
-	extensions, err := s.generateExtensions()
+	extensions, err := s.generateExtensions(ctx)
 	if err != nil {
 		return compute.VirtualMachineScaleSet{}, err
 	}
@@ -588,11 +588,11 @@ func (s *Service) getVirtualMachineScaleSetIfDone(ctx context.Context, future *i
 	return converters.SDKToVMSS(vmss, vmssInstances), nil
 }
 
-func (s *Service) generateExtensions() ([]compute.VirtualMachineScaleSetExtension, error) {
+func (s *Service) generateExtensions(ctx context.Context) ([]compute.VirtualMachineScaleSetExtension, error) {
 	extensions := make([]compute.VirtualMachineScaleSetExtension, len(s.Scope.VMSSExtensionSpecs()))
 	for i, extensionSpec := range s.Scope.VMSSExtensionSpecs() {
 		extensionSpec := extensionSpec
-		parameters, err := extensionSpec.Parameters(nil)
+		parameters, err := extensionSpec.Parameters(ctx, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/azure/services/scalesets/vmssextension_spec.go
+++ b/azure/services/scalesets/vmssextension_spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package scalesets
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
@@ -45,7 +47,7 @@ func (s *VMSSExtensionSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the VMSS extension.
-func (s *VMSSExtensionSpec) Parameters(existing interface{}) (interface{}, error) {
+func (s *VMSSExtensionSpec) Parameters(ctx context.Context, existing interface{}) (interface{}, error) {
 	if existing != nil {
 		_, ok := existing.(compute.VirtualMachineScaleSetExtension)
 		if !ok {

--- a/azure/services/scalesets/vmssextension_spec_test.go
+++ b/azure/services/scalesets/vmssextension_spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scalesets
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
@@ -83,7 +84,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(tc.existing)
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/securitygroups/spec.go
+++ b/azure/services/securitygroups/spec.go
@@ -17,6 +17,7 @@ limitations under the License.
 package securitygroups
 
 import (
+	"context"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
@@ -52,7 +53,7 @@ func (s *NSGSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the security group.
-func (s *NSGSpec) Parameters(existing interface{}) (interface{}, error) {
+func (s *NSGSpec) Parameters(ctx context.Context, existing interface{}) (interface{}, error) {
 	securityRules := make([]network.SecurityRule, 0)
 	var etag *string
 

--- a/azure/services/securitygroups/spec_test.go
+++ b/azure/services/securitygroups/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package securitygroups
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
@@ -175,7 +176,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(tc.existing)
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/subnets/spec.go
+++ b/azure/services/subnets/spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package subnets
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/google/go-cmp/cmp"
@@ -57,7 +59,7 @@ func (s *SubnetSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the subnet.
-func (s *SubnetSpec) Parameters(existing interface{}) (parameters interface{}, err error) {
+func (s *SubnetSpec) Parameters(ctx context.Context, existing interface{}) (parameters interface{}, err error) {
 	if existing != nil {
 		existingSubnet, ok := existing.(network.Subnet)
 		if !ok {

--- a/azure/services/subnets/spec_test.go
+++ b/azure/services/subnets/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package subnets
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
@@ -174,7 +175,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(tc.existing)
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/virtualmachines/spec.go
+++ b/azure/services/virtualmachines/spec.go
@@ -17,6 +17,7 @@ limitations under the License.
 package virtualmachines
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 
@@ -72,7 +73,7 @@ func (s *VMSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the virtual machine.
-func (s *VMSpec) Parameters(existing interface{}) (params interface{}, err error) {
+func (s *VMSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
 		if _, ok := existing.(compute.VirtualMachine); !ok {
 			return nil, errors.Errorf("%T is not a compute.VirtualMachine", existing)

--- a/azure/services/virtualmachines/spec_test.go
+++ b/azure/services/virtualmachines/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package virtualmachines
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
@@ -870,7 +871,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(tc.existing)
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/virtualnetworks/spec.go
+++ b/azure/services/virtualnetworks/spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package virtualnetworks
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -49,7 +51,7 @@ func (s *VNetSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the vnet.
-func (s *VNetSpec) Parameters(existing interface{}) (interface{}, error) {
+func (s *VNetSpec) Parameters(ctx context.Context, existing interface{}) (interface{}, error) {
 	if existing != nil {
 		// vnet already exists, nothing to update.
 		return nil, nil

--- a/azure/services/vmextensions/spec.go
+++ b/azure/services/vmextensions/spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package vmextensions
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
@@ -46,7 +48,7 @@ func (s *VMExtensionSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the VM extension.
-func (s *VMExtensionSpec) Parameters(existing interface{}) (interface{}, error) {
+func (s *VMExtensionSpec) Parameters(ctx context.Context, existing interface{}) (interface{}, error) {
 	if existing != nil {
 		_, ok := existing.(compute.VirtualMachineExtension)
 		if !ok {

--- a/azure/services/vmextensions/spec_test.go
+++ b/azure/services/vmextensions/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vmextensions
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
@@ -84,7 +85,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(tc.existing)
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/vnetpeerings/spec.go
+++ b/azure/services/vnetpeerings/spec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package vnetpeerings
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
@@ -49,7 +51,7 @@ func (s *VnetPeeringSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the virtual network peering.
-func (s *VnetPeeringSpec) Parameters(existing interface{}) (params interface{}, err error) {
+func (s *VnetPeeringSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
 		if _, ok := existing.(network.VirtualNetworkPeering); !ok {
 			return nil, errors.Errorf("%T is not a network.VnetPeering", existing)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- With this PR the user will be able to see AzureManagedCluster.spec updates in the CAPZ controller manager logs at a _verbosity level 4_ or higher. 
- This PR also updates the signature of `Parameters()` interface, adding `context.Context` as one of the inputs. 
- This PR also updates references to`Parameters()` in the codebase.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2611 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
