### PR TITLE
Add cluster's name to MachinePool and AzureManagedMachinePool in AKS templates

### DIFF
--- a/exp/controllers/azuremanagedmachinepool_reconciler.go
+++ b/exp/controllers/azuremanagedmachinepool_reconciler.go
@@ -96,7 +96,7 @@ func (s *azureManagedMachinePoolService) Reconcile(ctx context.Context) error {
 	defer done()
 
 	log.Info("reconciling managed machine pool")
-	agentPoolName := s.scope.Name()
+	agentPoolName := s.scope.AgentPoolSpec().ResourceName()
 
 	if err := s.agentPoolsSvc.Reconcile(ctx); err != nil {
 		return errors.Wrapf(err, "failed to reconcile machine pool %s", agentPoolName)

--- a/templates/cluster-template-aks.yaml
+++ b/templates/cluster-template-aks.yaml
@@ -42,7 +42,7 @@ metadata:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: pool0
+  name: ${CLUSTER_NAME}-pool0
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
@@ -56,24 +56,25 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: pool0
+        name: ${CLUSTER_NAME}-pool0
       version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: pool0
+  name: ${CLUSTER_NAME}-pool0
   namespace: default
 spec:
   enableNodePublicIP: false
   mode: System
+  name: pool0
   osDiskSizeGB: 30
   sku: ${AZURE_NODE_MACHINE_TYPE}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: pool1
+  name: ${CLUSTER_NAME}-pool1
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
@@ -87,17 +88,18 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: pool1
+        name: ${CLUSTER_NAME}-pool1
       version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: pool1
+  name: ${CLUSTER_NAME}-pool1
   namespace: default
 spec:
   enableNodePublicIP: false
   mode: User
+  name: pool1
   osDiskSizeGB: 40
   scaleSetPriority: Regular
   sku: ${AZURE_NODE_MACHINE_TYPE}

--- a/templates/flavors/aks/cluster-template.yaml
+++ b/templates/flavors/aks/cluster-template.yaml
@@ -48,7 +48,7 @@ metadata:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: "pool0"
+  name: "${CLUSTER_NAME}-pool0"
 spec:
   clusterName: "${CLUSTER_NAME}"
   replicas: ${WORKER_MACHINE_COUNT}
@@ -61,7 +61,7 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: "pool0"
+        name: "${CLUSTER_NAME}-pool0"
       version: "${KUBERNETES_VERSION}"
 ---
 # The Azure-specific machine pool implementation drives the configuration of the
@@ -69,18 +69,19 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: "pool0"
+  name: "${CLUSTER_NAME}-pool0"
 spec:
   mode: System
   osDiskSizeGB: 30
   sku: "${AZURE_NODE_MACHINE_TYPE}"
   enableNodePublicIP: false
+  name: pool0
 ---
 # Deploy a second agent pool with the same number of machines, but using potentially different infrastructure.
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: "pool1"
+  name: "${CLUSTER_NAME}-pool1"
 spec:
   clusterName: "${CLUSTER_NAME}"
   replicas: ${WORKER_MACHINE_COUNT}
@@ -93,17 +94,18 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: "pool1"
+        name: "${CLUSTER_NAME}-pool1"
       version: "${KUBERNETES_VERSION}"
 ---
 # The infrastructure backing the second pool will use the same VM sku, but a larger OS disk.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: "pool1"
+  name: "${CLUSTER_NAME}-pool1"
 spec:
   mode: User
   osDiskSizeGB: 40
   sku: "${AZURE_NODE_MACHINE_TYPE}"
   enableNodePublicIP: false
   scaleSetPriority: Regular
+  name: pool1

--- a/templates/test/ci/cluster-template-prow-aks.yaml
+++ b/templates/test/ci/cluster-template-prow-aks.yaml
@@ -49,7 +49,7 @@ metadata:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: pool0
+  name: ${CLUSTER_NAME}-pool0
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
@@ -63,13 +63,13 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: pool0
+        name: ${CLUSTER_NAME}-pool0
       version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: pool0
+  name: ${CLUSTER_NAME}-pool0
   namespace: default
 spec:
   availabilityZones:
@@ -79,6 +79,7 @@ spec:
   enableUltraSSD: true
   maxPods: 30
   mode: System
+  name: pool0
   osDiskSizeGB: 30
   osDiskType: Managed
   sku: ${AZURE_NODE_MACHINE_TYPE}
@@ -86,7 +87,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: pool1
+  name: ${CLUSTER_NAME}-pool1
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
@@ -100,18 +101,19 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: pool1
+        name: ${CLUSTER_NAME}-pool1
       version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: pool1
+  name: ${CLUSTER_NAME}-pool1
   namespace: default
 spec:
   enableNodePublicIP: false
   maxPods: 64
   mode: User
+  name: pool1
   nodeLabels:
     type: shared
   osDiskSizeGB: 40
@@ -142,7 +144,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: pool2
+  name: ${CLUSTER_NAME}-pool2
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
@@ -156,15 +158,16 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: pool2
+        name: ${CLUSTER_NAME}-pool2
       version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: pool2
+  name: ${CLUSTER_NAME}-pool2
   namespace: default
 spec:
   mode: User
+  name: pool2
   osType: Windows
   sku: ${AZURE_NODE_MACHINE_TYPE}

--- a/templates/test/ci/prow-aks/patches/aks-pool0.yaml
+++ b/templates/test/ci/prow-aks/patches/aks-pool0.yaml
@@ -1,9 +1,10 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: "pool0"
+  name: "${CLUSTER_NAME}-pool0"
 spec:
   maxPods: 30
   osDiskType: "Managed"
   enableUltraSSD: true
   availabilityZones: ["1", "2"]
+  name: pool0

--- a/templates/test/ci/prow-aks/patches/aks-pool1.yaml
+++ b/templates/test/ci/prow-aks/patches/aks-pool1.yaml
@@ -1,7 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: "pool1"
+  name: "${CLUSTER_NAME}-pool1"
 spec:
   maxPods: 64
   osDiskType: "Ephemeral"
@@ -11,3 +11,4 @@ spec:
       value: shared
   nodeLabels:
     "type": "shared"
+  name: pool1

--- a/templates/test/ci/prow-aks/patches/aks-pool2.yaml
+++ b/templates/test/ci/prow-aks/patches/aks-pool2.yaml
@@ -2,7 +2,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: "pool2"
+  name: "${CLUSTER_NAME}-pool2"
 spec:
   clusterName: "${CLUSTER_NAME}"
   replicas: 1
@@ -15,15 +15,16 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: "pool2"
+        name: "${CLUSTER_NAME}-pool2"
       version: "${KUBERNETES_VERSION}"
 ---
 # The infrastructure backing the third pool will use the same VM SKU, which is the only required configuration
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: "pool2"
+  name: "${CLUSTER_NAME}-pool2"
 spec:
   mode: User
   sku: "${AZURE_NODE_MACHINE_TYPE}"
   osType: Windows
+  name: pool2


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Add the cluster's name to the MachinePool and AzureManagedMachinePool resources in the AKS flavor templates. The previous short names, like pool0 and pool1, are added as spec.name in AzureManagedMachinePool. This keeps the nodepool names in Azure the same as before. This will make it easier for users to generate multiple AKS templates with clusterctl and apply them to the same namespace without extra modifications.

This also fixes an issue where the reconciler can't find the node pool VMSS when the AzureManagedMachinePool `metadata.name` is different from `spec.name`. Using the example below, the reconciler would look for the nodepool with the name capi-cluster-01-pool0 instead of pool0. This has been fixed to look for pool0.

example:

```yaml
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: AzureManagedMachinePool
metadata:
  name: capi-cluster-01-pool0
  namespace: default
spec:
  enableNodePublicIP: false
  mode: System
  name: pool0
  osDiskSizeGB: 30
  sku: Standard_A2_v2
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2811

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update node pool names in AKS flavor templates to include the cluster's name

Update AzureManagedMachinePool reconciler to use spec.name to find the matching node pool VMSS
```
