### PR TITLE
print k8s build env vars during CI

### DIFF
--- a/scripts/ci-build-kubernetes.sh
+++ b/scripts/ci-build-kubernetes.sh
@@ -57,6 +57,7 @@ setup() {
     pushd "${KUBE_ROOT}" && kube::version::get_version_vars && popd
     : "${KUBE_GIT_VERSION:?Environment variable empty or not defined.}"
     export KUBE_GIT_VERSION
+    echo "using KUBE_GIT_VERSION=${KUBE_GIT_VERSION}"
 
     # get the latest ci version for a particular release so that kubeadm is
     # able to pull existing images before being replaced by custom images
@@ -64,11 +65,14 @@ setup() {
     minor="$(echo "${KUBE_GIT_VERSION}" | ${GREP_BINARY} -Po "(?<=v${major}.)[0-9]+")"
     CI_VERSION="$(capz::util::get_latest_ci_version "${major}.${minor}")"
     export CI_VERSION
+    echo "using CI_VERSION=${CI_VERSION}"
     export KUBERNETES_VERSION="${CI_VERSION}"
+    echo "using KUBERNETES_VERSION=${KUBERNETES_VERSION}"
 
     # Docker tags cannot contain '+'
     # ref: https://github.com/kubernetes/kubernetes/blob/5491484aa91fd09a01a68042e7674bc24d42687a/build/lib/release.sh#L345-L346
     export IMAGE_TAG="${KUBE_GIT_VERSION/+/_}"
+    echo "using IMAGE_TAG=${IMAGE_TAG}"
 }
 
 main() {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR includes debug verbosity when we run CI jobs against built k8s bits.

This will help troubleshoot why upstream k/k capz conformance jobs aren't running against the correct bits.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
