### PR TITLE
ci: print git info when building from k8s source

### DIFF
--- a/scripts/ci-build-kubernetes.sh
+++ b/scripts/ci-build-kubernetes.sh
@@ -73,6 +73,9 @@ setup() {
     # ref: https://github.com/kubernetes/kubernetes/blob/5491484aa91fd09a01a68042e7674bc24d42687a/build/lib/release.sh#L345-L346
     export IMAGE_TAG="${KUBE_GIT_VERSION/+/_}"
     echo "using IMAGE_TAG=${IMAGE_TAG}"
+    local git=(git --work-tree "${KUBE_ROOT}")
+    "${git[@]}" log -n 1
+    "${git[@]}" diff HEAD^ HEAD
 }
 
 main() {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR prints out the details of the upstream kubernetes source git when building clusters from k/k source, to help debug scenarios where we suspect we're building from the wrong commit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
