### PR TITLE
fix bad generated template name on Mac

### DIFF
--- a/hack/common-vars.sh
+++ b/hack/common-vars.sh
@@ -13,7 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+if [[ -z "$REPO_ROOT" ]]; then
+  echo >&2 "REPO_ROOT must be set"
+  exit 1
+fi
+
 # shellcheck disable=SC2034
 KUBECTL="${REPO_ROOT}/hack/tools/bin/kubectl"
 # shellcheck disable=SC2034

--- a/hack/gen-flavors.sh
+++ b/hack/gen-flavors.sh
@@ -28,6 +28,15 @@ flavors_dir="${REPO_ROOT}/templates/flavors/"
 ci_dir="${REPO_ROOT}/templates/test/ci/"
 dev_dir="${REPO_ROOT}/templates/test/dev/"
 
+# NOTE: On macOS, the kustomize commands run by xargs that use the -I
+# replacement string may only be 255 characters. Commands longer than that will
+# not expand the replacement string when that would go over that limit,
+# resulting in generated manifests like "templates/test/ci/cluster-template-{}".
+#
+# Currently, the longest command is *exactly* 255 characters, so making these
+# commands any longer or adding a new template with a longer name will run into
+# this problem.
+
 find "${flavors_dir}"* -maxdepth 0 -type d -print0 | xargs -0 -I {} basename {} | grep -v base | xargs -I {} sh -c "${KUSTOMIZE} build --load-restrictor LoadRestrictionsNone --reorder none ${flavors_dir}{} > ${REPO_ROOT}/templates/cluster-template-{}.yaml"
 # move the default template to the default file expected by clusterctl
 mv "${REPO_ROOT}/templates/cluster-template-default.yaml" "${REPO_ROOT}/templates/cluster-template.yaml"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR fixes an issue where `make generate-flavors` on macOS would result in a new file named `templates/test/ci/cluster-template-{}.yaml` instead of a name like `templates/test/ci/cluster-template-prow-azurediskcsi-migration-off.yaml`.

For background, one side effect of #2523 was that it made `$REPO_ROOT` longer where it gets expanded in [this command in gen-flavors.sh](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/9e97aea0e2c21ad4d140afe31e4cd2d695a71112/hack/gen-flavors.sh#L35), adding an extra `../hack/`. This was taking the command past the 255-character limit set by the Mac version of `xargs` on the length of arguments containing the replacement string defined by `-I`, so the second `{}` wouldn't be replaced as expected. The [man page](https://ss64.com/osx/xargs.html) describes this behavior on the `-I` flag. My local man page also shows a `-S` flag to change this limit, but no such flag exists on Ubuntu since I don't think it has the limit to begin with.

This change removes the `$REPO_ROOT` definition from common-vars.sh since all scripts `source`-ing that already define it themselves and its value is more concise in that case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
