### PR TITLE
Revert "ci: print git info when building from k8s source"

### DIFF
--- a/scripts/ci-build-kubernetes.sh
+++ b/scripts/ci-build-kubernetes.sh
@@ -73,9 +73,6 @@ setup() {
     # ref: https://github.com/kubernetes/kubernetes/blob/5491484aa91fd09a01a68042e7674bc24d42687a/build/lib/release.sh#L345-L346
     export IMAGE_TAG="${KUBE_GIT_VERSION/+/_}"
     echo "using IMAGE_TAG=${IMAGE_TAG}"
-    local git=(git --work-tree "${KUBE_ROOT}")
-    "${git[@]}" log -n 1
-    "${git[@]}" diff HEAD^ HEAD
 }
 
 main() {


### PR DESCRIPTION
Reverts kubernetes-sigs/cluster-api-provider-azure#2853

This didn't work, it's printing the SHA + diff for capz instead of the SHA + diff for k/k. Ref:

- https://prow.k8s.io/log?container=test&id=1598004180683853824&job=pull-kubernetes-e2e-capz-conformance