### PR TITLE
[release-1.5] update latest-1.21 to latest-1.25

### DIFF
--- a/docs/book/src/developers/development.md
+++ b/docs/book/src/developers/development.md
@@ -523,7 +523,7 @@ With the following environment variables defined, you can build a CAPZ cluster f
 | Environment Variable | Value  |
 |----------------------|--------|
 | `E2E_ARGS`           | `-kubetest.use-ci-artifacts` |
-| `KUBERNETES_VERSION` | `latest` - extract Kubernetes version from https://dl.k8s.io/ci/latest.txt (main's HEAD)<br>`latest-1.21` - extract Kubernetes version from https://dl.k8s.io/ci/latest-1.21.txt (release branch's HEAD) |
+| `KUBERNETES_VERSION` | `latest` - extract Kubernetes version from https://dl.k8s.io/ci/latest.txt (main's HEAD)<br>`latest-1.25` - extract Kubernetes version from https://dl.k8s.io/ci/latest-1.25.txt (release branch's HEAD) |
 | `WINDOWS_FLAVOR`     | Optional, can be `containerd` or `containerd-2022`, when not specified dockershim is used |
 | `KUBETEST_WINDOWS_CONFIG`     | Optional, can be `upstream-windows-serial-slow.yaml`, when not specified `upstream-windows.yaml` is used |
 | `WINDOWS_CONTAINERD_URL`     | Optional, can be any url to a `tar.gz` file containing binaries for containerd in the same format as upstream package |

--- a/docs/book/src/topics/custom-images.md
+++ b/docs/book/src/topics/custom-images.md
@@ -57,7 +57,7 @@ To upgrade to a new Kubernetes release with custom images requires this preparat
 - create the new `AzureMachineTemplate` on the management cluster
 - modify the existing `KubeadmControlPlane` and `MachineDeployment` to reference the new `AzureMachineTemplate` and update the `version:` field to match
 
-See [Upgrading workload clusters][upgrading-workload-clusters] for more details.
+See [Upgrading clusters][upgrading-clusters] for more details.
 
 ## Creating a cluster from a custom image
 
@@ -231,4 +231,4 @@ In the case of a third party image, you must accept the license terms with the [
 [replication-recommendations]: https://docs.microsoft.com/azure/virtual-machines/linux/shared-image-galleries#scaling
 [supported-capi]: https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions
 [supported-k8s]: https://kubernetes.io/releases/version-skew-policy/#supported-versions
-[upgrading-workload-clusters]: https://cluster-api.sigs.k8s.io/tasks/kubeadm-control-plane.html#upgrading-workload-clusters
+[upgrading-clusters]: https://cluster-api.sigs.k8s.io/tasks/upgrading-clusters.html


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR fixes two broken links in the `release-1.5` branch:

- Kubernetes 1.21 has been deprecated and the 1.21-latest links appear to be broken. This PR updates those links to 1.25, which is active, and matches main branch.
- a link to cluster-api upgrade docs is a 404, updates to a working link

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
