### PR TITLE
replace xargs with for loop in gen-flavors.sh

### DIFF
--- a/hack/common-vars.sh
+++ b/hack/common-vars.sh
@@ -13,11 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [[ -z "$REPO_ROOT" ]]; then
-  echo >&2 "REPO_ROOT must be set"
-  exit 1
-fi
-
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 # shellcheck disable=SC2034
 KUBECTL="${REPO_ROOT}/hack/tools/bin/kubectl"
 # shellcheck disable=SC2034


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: As a follow-up to #2879, this PR removes the use of xargs for constructing and running the kustomize commands used to generate the flavor templates. This will let the script be more flexible without having to worry about the default 255-character limit when using replacement strings in xargs on macOS. The behavior with this change should stay the same.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
