### PR TITLE
Convert resourceGroup name in ID for VMSS vms to lower case to keep it compatible with the rest of capz

### DIFF
--- a/azure/converters/vmss.go
+++ b/azure/converters/vmss.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 )
 
 // SDKToVMSS converts an Azure SDK VirtualMachineScaleSet to the AzureMachinePool type.
@@ -63,8 +64,15 @@ func SDKToVMSS(sdkvmss compute.VirtualMachineScaleSet, sdkinstances []compute.Vi
 
 // SDKToVMSSVM converts an Azure SDK VirtualMachineScaleSetVM into an infrav1exp.VMSSVM.
 func SDKToVMSSVM(sdkInstance compute.VirtualMachineScaleSetVM) *azure.VMSSVM {
+	// Convert resourceGroup Name ID ( ProviderID in capz objects )
+	var convertedID string
+	convertedID, err := azureutil.ConvertResourceGroupNameToLower(to.String(sdkInstance.ID))
+	if err != nil {
+		convertedID = to.String(sdkInstance.ID)
+	}
+
 	instance := azure.VMSSVM{
-		ID:         to.String(sdkInstance.ID),
+		ID:         convertedID,
 		InstanceID: to.String(sdkInstance.InstanceID),
 	}
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR is alternative to https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2821 and only one of them should be merged. 

In this PR the conversion of the ResourceGroup Name happens when the VM instance is returned from Azure SDK and the AzureMachinePoolMachine is created rather than at read time.

If for any reason the conversion fail the original string is used. 



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2817

**Special notes for your reviewer**:


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
fix machinepool reconciliation by converting the resourceGroup name in the AzureMachinePoolMachine object providerID to lowercase to match the providerID defined in the kubernetes Node Object on the workload cluster.

This fix only apply to _new azuremachinepoolmachine_ objects so if any existing machinepool with resourceGroup name with capital letter already exist , the controller with this patch will not manage to fix the azuremachinepoolmachines in it and it will still fail to reconcile the pool until the pool is deleted. 
```
