### PR TITLE
e2e: print number of ready daemonset pods

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -275,12 +275,12 @@ func WaitForDaemonset(ctx context.Context, input WaitForDaemonsetInput, interval
 		key := client.ObjectKey{Namespace: namespace, Name: name}
 		if err := input.Getter.Get(ctx, key, input.DaemonSet); err == nil {
 			if input.DaemonSet.Status.DesiredNumberScheduled == input.DaemonSet.Status.NumberReady {
+				Logf("%d daemonset %s/%s pods are running, took %v", input.DaemonSet.Status.NumberReady, namespace, name, time.Since(start))
 				return true
 			}
 		}
 		return false
 	}, intervals...).Should(BeTrue(), func() string { return DescribeFailedDaemonset(ctx, input) })
-	Logf("daemonset %s/%s pods are running, took %v", namespace, name, time.Since(start))
 }
 
 // GetWaitForDaemonsetAvailableInput is a convenience func to compose a WaitForDaemonsetInput


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR prints out the number of observed Ready daemonset pods when running the part of E2E tests that wait for required system components (e.g., calico).

I'm wondering if we're running these tests before Windows nodes have come online, which is allowing the test to pass w/ a `DesiredNumberScheduled == NumberReady` when the value of both is zero.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
