### PR TITLE
Add skipLogCollection variable to all e2e test specs

### DIFF
--- a/test/e2e/azure_privatecluster.go
+++ b/test/e2e/azure_privatecluster.go
@@ -169,6 +169,7 @@ func AzurePrivateClusterSpec(ctx context.Context, inputGetter func() AzurePrivat
 			CancelWatches:          publicCancelWatches,
 			IntervalsGetter:        e2eConfig.GetIntervals,
 			SkipCleanup:            input.SkipCleanup,
+			SkipLogCollection:      skipLogCollection,
 			ArtifactFolder:         input.ArtifactFolder,
 			SkipResourceGroupCheck: true, // We don't expect the resource group to be deleted since the private cluster does not own the resource group.
 		}

--- a/test/e2e/azure_selfhosted.go
+++ b/test/e2e/azure_selfhosted.go
@@ -234,14 +234,15 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 		}
 
 		cleanInput := cleanupInput{
-			SpecName:        specName,
-			Cluster:         clusterResources.Cluster,
-			ClusterProxy:    input.BootstrapClusterProxy,
-			Namespace:       namespace,
-			CancelWatches:   cancelWatches,
-			IntervalsGetter: input.E2EConfig.GetIntervals,
-			SkipCleanup:     input.SkipCleanup,
-			ArtifactFolder:  input.ArtifactFolder,
+			SpecName:          specName,
+			Cluster:           clusterResources.Cluster,
+			ClusterProxy:      input.BootstrapClusterProxy,
+			Namespace:         namespace,
+			CancelWatches:     cancelWatches,
+			IntervalsGetter:   input.E2EConfig.GetIntervals,
+			SkipCleanup:       input.SkipCleanup,
+			SkipLogCollection: skipLogCollection,
+			ArtifactFolder:    input.ArtifactFolder,
 		}
 		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
 		dumpSpecResourcesAndCleanup(ctx, cleanInput)

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -246,14 +246,15 @@ var _ = Describe("Conformance Tests", func() {
 		CheckTestBeforeCleanup()
 
 		cleanInput := cleanupInput{
-			SpecName:        specName,
-			Cluster:         result.Cluster,
-			ClusterProxy:    bootstrapClusterProxy,
-			Namespace:       namespace,
-			CancelWatches:   cancelWatches,
-			IntervalsGetter: e2eConfig.GetIntervals,
-			SkipCleanup:     skipCleanup,
-			ArtifactFolder:  artifactFolder,
+			SpecName:          specName,
+			Cluster:           result.Cluster,
+			ClusterProxy:      bootstrapClusterProxy,
+			Namespace:         namespace,
+			CancelWatches:     cancelWatches,
+			IntervalsGetter:   e2eConfig.GetIntervals,
+			SkipCleanup:       skipCleanup,
+			SkipLogCollection: skipLogCollection,
+			ArtifactFolder:    artifactFolder,
 		}
 		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
 		dumpSpecResourcesAndCleanup(ctx, cleanInput)

--- a/test/e2e/csi_migration_test.go
+++ b/test/e2e/csi_migration_test.go
@@ -128,6 +128,7 @@ var _ = Describe("[K8s-Upgrade] Running the CSI migration tests", func() {
 			CancelWatches:     cancelWatches,
 			IntervalsGetter:   e2eConfig.GetIntervals,
 			SkipCleanup:       skipCleanup,
+			SkipLogCollection: skipLogCollection,
 			AdditionalCleanup: additionalCleanup,
 			ArtifactFolder:    artifactFolder,
 		}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Currently, the SKIP_LOG_COLLECTION environment variable is not being passed into cleanupInputs outside of `azure_test.go`. This PR fixes that issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2904 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
