### PR TITLE
Add logging for empty RoleAssignmentName

### DIFF
--- a/azure/services/roleassignments/roleassignments.go
+++ b/azure/services/roleassignments/roleassignments.go
@@ -103,6 +103,9 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 	for _, roleAssignmentSpec := range s.Scope.RoleAssignmentSpecs(principalID) {
 		log.V(2).Info("Creating role assignment")
+		if roleAssignmentSpec.ResourceName() == "" {
+			log.V(2).Info("RoleAssignmentName is empty. This is not expected and will cause this System Assigned Identity to have no permissions.")
+		}
 		_, err := s.CreateOrUpdateResource(ctx, roleAssignmentSpec, serviceName)
 		if err != nil {
 			return errors.Wrapf(err, "cannot assign role to %s system assigned identity", resourceType)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

If, due to mistakes in webhook resource filtering or value specified in the AzureMachineTemplate , the `RoleAssignmentName` is empty with the identity set to `SystemAssigned` the logs
are not very clear and will just say that a given assignment already exist but in reality the Identity will get no role assigned 

See https://kubernetes.slack.com/archives/CEX9HENG7/p1669988608773479 

This PR is just adding an extra Log event when this happens to help users troubleshoot the issue.

_Should this actually be an Erorr_ rather than a log event ? 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
Add Log event when `RoleAssignmentName` for a `SystemAssigned` Identity AzureMachine is empty
```
