### PR TITLE
Move AKS config from reference to test template

### DIFF
--- a/templates/cluster-template-aks.yaml
+++ b/templates/cluster-template-aks.yaml
@@ -65,10 +65,8 @@ metadata:
   name: ${CLUSTER_NAME}-pool0
   namespace: default
 spec:
-  enableNodePublicIP: false
   mode: System
   name: pool0
-  osDiskSizeGB: 30
   sku: ${AZURE_NODE_MACHINE_TYPE}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -97,25 +95,8 @@ metadata:
   name: ${CLUSTER_NAME}-pool1
   namespace: default
 spec:
-  enableNodePublicIP: false
-  kubeletConfig:
-    allowedUnsafeSysctls:
-    - net.*
-    - kernel.msg*
-    containerLogMaxFiles: 50
-    containerLogMaxSizeMB: 500
-    cpuCfsQuota: true
-    cpuCfsQuotaPeriod: 110ms
-    cpuManagerPolicy: static
-    failSwapOn: false
-    imageGcHighThreshold: 70
-    imageGcLowThreshold: 50
-    podMaxPids: 2048
-    topologyManagerPolicy: best-effort
   mode: User
   name: pool1
-  osDiskSizeGB: 40
-  scaleSetPriority: Regular
   sku: ${AZURE_NODE_MACHINE_TYPE}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/templates/flavors/aks/cluster-template.yaml
+++ b/templates/flavors/aks/cluster-template.yaml
@@ -64,17 +64,15 @@ spec:
         name: "${CLUSTER_NAME}-pool0"
       version: "${KUBERNETES_VERSION}"
 ---
-# The Azure-specific machine pool implementation drives the configuration of the
-# VMSS instances backing the pool.
+# This first Azure-specific machine pool implementation drives the configuration of the
+# AKS "System" node pool to schedule and run kube-system and other system pods
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
   name: "${CLUSTER_NAME}-pool0"
 spec:
   mode: System
-  osDiskSizeGB: 30
   sku: "${AZURE_NODE_MACHINE_TYPE}"
-  enableNodePublicIP: false
   name: pool0
 ---
 # Deploy a second agent pool with the same number of machines, but using potentially different infrastructure.
@@ -97,29 +95,13 @@ spec:
         name: "${CLUSTER_NAME}-pool1"
       version: "${KUBERNETES_VERSION}"
 ---
-# The infrastructure backing the second pool will use the same VM sku, but a larger OS disk.
+# This first Azure-specific machine pool implementation drives the configuration of the
+# AKS "User" node pool to schedule and run user workloads
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
   name: "${CLUSTER_NAME}-pool1"
 spec:
   mode: User
-  osDiskSizeGB: 40
   sku: "${AZURE_NODE_MACHINE_TYPE}"
-  enableNodePublicIP: false
-  scaleSetPriority: Regular
   name: pool1
-  kubeletConfig:
-    cpuManagerPolicy: "static"
-    cpuCfsQuota: true
-    cpuCfsQuotaPeriod: "110ms"
-    imageGcHighThreshold: 70
-    imageGcLowThreshold: 50
-    topologyManagerPolicy: "best-effort"
-    allowedUnsafeSysctls:
-      - "net.*"
-      - "kernel.msg*"
-    failSwapOn: false
-    containerLogMaxSizeMB: 500
-    containerLogMaxFiles: 50
-    podMaxPids: 2048

--- a/templates/test/ci/prow-aks/patches/aks-pool0.yaml
+++ b/templates/test/ci/prow-aks/patches/aks-pool0.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   maxPods: 30
   osDiskType: "Managed"
+  osDiskSizeGB: 30
+  enableNodePublicIP: false
   enableUltraSSD: true
   availabilityZones: ["1", "2"]
   name: pool0

--- a/templates/test/ci/prow-aks/patches/aks-pool1.yaml
+++ b/templates/test/ci/prow-aks/patches/aks-pool1.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   maxPods: 64
   osDiskType: "Ephemeral"
+  osDiskSizeGB: 40
+  enableNodePublicIP: false
+  scaleSetPriority: Regular
   taints:
     - effect: NoSchedule
       key: type
@@ -13,3 +16,17 @@ spec:
     "type": "shared"
   name: pool1
   sku: "${AZURE_AKS_NODE_MACHINE_TYPE:=Standard_D2s_v3}"
+  kubeletConfig:
+    cpuManagerPolicy: "static"
+    cpuCfsQuota: true
+    cpuCfsQuotaPeriod: "110ms"
+    imageGcHighThreshold: 70
+    imageGcLowThreshold: 50
+    topologyManagerPolicy: "best-effort"
+    allowedUnsafeSysctls:
+      - "net.*"
+      - "kernel.msg*"
+    failSwapOn: false
+    containerLogMaxSizeMB: 500
+    containerLogMaxFiles: 50
+    podMaxPids: 2048


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind cleanup

**What this PR does / why we need it**:

This PR moves the various `AzureManagedMachinePool` configurations that we use to validate via E2E into the test template, and cleans up the reference AKS template under `templates/` so that it delivers a "default" configuration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
