### PR TITLE
Make e2e Helm install idempotent

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-10-01/resources"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/blang/semver"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -260,7 +261,13 @@ func EnsureControlPlaneInitialized(ctx context.Context, input clusterctl.ApplyCl
 		InstallCalicoHelmChart(ctx, input, cluster.Spec.ClusterNetwork.Pods.CIDRBlocks, hasWindows)
 	}
 	controlPlane := discoveryAndWaitForControlPlaneInitialized(ctx, input, result)
-	InstallAzureDiskCSIDriverHelmChart(ctx, input)
+	v, err := semver.ParseTolerant(input.ConfigCluster.KubernetesVersion)
+	Expect(err).NotTo(HaveOccurred())
+	if v.GTE(semver.MustParse("1.23.0")) {
+		InstallAzureDiskCSIDriverHelmChart(ctx, input, hasWindows)
+	} else {
+		Logf("Skipping Azure Disk CSI Driver installation for Kubernetes version %s", input.ConfigCluster.KubernetesVersion)
+	}
 	result.ControlPlane = controlPlane
 }
 

--- a/test/e2e/csi_migration_test.go
+++ b/test/e2e/csi_migration_test.go
@@ -140,9 +140,6 @@ var _ = Describe("[K8s-Upgrade] Running the CSI migration tests", func() {
 		Expect(os.Unsetenv(ClusterIdentitySecretName)).To(Succeed())
 		Expect(os.Unsetenv(ClusterIdentitySecretNamespace)).To(Succeed())
 
-		Expect(os.Unsetenv("WINDOWS_WORKER_MACHINE_COUNT")).To(Succeed())
-		Expect(os.Unsetenv("K8S_FEATURE_GATES")).To(Succeed())
-
 		logCheckpoint(specTimes)
 	})
 
@@ -243,7 +240,7 @@ var _ = Describe("[K8s-Upgrade] Running the CSI migration tests", func() {
 				configCluster.KubernetesVersion = postCSIKubernetesVersion
 				// This flavour uses external csi driver and in tree cloud provider
 				configCluster.Flavor = "external-azurediskcsi-driver"
-				upgradedCluster, kcp := createClusterWithControlPlaneWaiters(ctx, configCluster, clusterctl.ControlPlaneWaiters{}, result)
+				upgradedCluster, kcp := createClusterWithControlPlaneWaiters(ctx, configCluster, clusterctl.ControlPlaneWaiters{WaitForControlPlaneInitialized: EnsureControlPlaneInitialized}, result)
 				// Wait for control plane to be upgraded successfully
 				By("Waiting for control-plane machines to have the upgraded kubernetes version")
 				framework.WaitForControlPlaneMachinesToBeUpgraded(ctx, framework.WaitForControlPlaneMachinesToBeUpgradedInput{
@@ -276,7 +273,7 @@ var _ = Describe("[K8s-Upgrade] Running the CSI migration tests", func() {
 		})
 
 		Context("CSI=external CCM=external AzureDiskCSIMigration=true: upgrade to v1.23", func() {
-			It("should create volumes dynamically with intree cloud provider", func() {
+			It("should create volumes dynamically with out-of-tree cloud provider", func() {
 				By("Creating workload cluster v1.22 using user-assigned identity")
 				clusterName = getClusterName(clusterNamePrefix, "external-providers")
 				configCluster := defaultConfigCluster(clusterName, namespace.Name)
@@ -301,7 +298,7 @@ var _ = Describe("[K8s-Upgrade] Running the CSI migration tests", func() {
 				By("Upgrade the workload cluster to v1.23")
 				configCluster.KubernetesVersion = postCSIKubernetesVersion
 				configCluster.Flavor = "external-cloud-provider"
-				upgradedCluster, kcp := createClusterWithControlPlaneWaiters(ctx, configCluster, clusterctl.ControlPlaneWaiters{}, result)
+				upgradedCluster, kcp := createClusterWithControlPlaneWaiters(ctx, configCluster, clusterctl.ControlPlaneWaiters{WaitForControlPlaneInitialized: EnsureControlPlaneInitialized}, result)
 
 				// Wait for control plane to be upgraded successfully
 				By("Waiting for control-plane machines to have the upgraded kubernetes version")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: In order to fix CSI migration test errors (https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#capi-periodic-upgrade-main-1-22-1-23) that started after #2495 merged, we need to make the Helm install idempotent for Calico and cloud provider. Also fixed the errors in the test by not installing CSI drivers before k8s 1.22 and not adding the HostProcess feature flag for windows when windows is not enabled on the template (and the right feature flags aren't in place).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
