### PR TITLE
fix deleting all tags on AKS resources

### DIFF
--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -294,7 +294,7 @@ func (s *AgentPoolSpec) Parameters(existing interface{}) (params interface{}, er
 			VnetSubnetID:         vnetSubnetID,
 			EnableNodePublicIP:   s.EnableNodePublicIP,
 			NodePublicIPPrefixID: s.NodePublicIPPrefixID,
-			Tags:                 converters.TagsToMap(s.AdditionalTags),
+			Tags:                 *to.StringMapPtr(s.AdditionalTags),
 		},
 	}
 

--- a/azure/services/agentpools/spec_test.go
+++ b/azure/services/agentpools/spec_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
@@ -51,6 +52,7 @@ var (
 		Version:           to.StringPtr("fake-version"),
 		VnetSubnetID:      "fake-vnet-subnet-id",
 		Headers:           map[string]string{"fake-header": "fake-value"},
+		AdditionalTags:    infrav1.Tags{"fake": "tag"},
 	}
 	fakeAgentPoolSpecWithoutAutoscaling = AgentPoolSpec{
 		Name:              "fake-agent-pool-name",
@@ -73,6 +75,7 @@ var (
 		Version:           to.StringPtr("fake-version"),
 		VnetSubnetID:      "fake-vnet-subnet-id",
 		Headers:           map[string]string{"fake-header": "fake-value"},
+		AdditionalTags:    infrav1.Tags{"fake": "tag"},
 	}
 	fakeAgentPoolSpecWithZeroReplicas = AgentPoolSpec{
 		Name:              "fake-agent-pool-name",
@@ -95,6 +98,7 @@ var (
 		Version:           to.StringPtr("fake-version"),
 		VnetSubnetID:      "fake-vnet-subnet-id",
 		Headers:           map[string]string{"fake-header": "fake-value"},
+		AdditionalTags:    infrav1.Tags{"fake": "tag"},
 	}
 
 	fakeAgentPoolAutoScalingOutOfDate = containerservice.AgentPool{
@@ -241,6 +245,7 @@ func fakeAgentPoolWithProvisioningStateAndCountAndAutoscaling(provisioningState 
 			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
 			OsType:              containerservice.OSType("fake-os-type"),
 			ProvisioningState:   state,
+			Tags:                map[string]*string{"fake": to.StringPtr("tag")},
 			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
 			VMSize:              to.StringPtr("fake-sku"),
 			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
@@ -266,6 +271,7 @@ func fakeAgentPoolWithAutoscalingAndCount(enableAutoScaling bool, count int32) c
 			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
 			OsType:              containerservice.OSType("fake-os-type"),
 			ProvisioningState:   to.StringPtr("Succeeded"),
+			Tags:                map[string]*string{"fake": to.StringPtr("tag")},
 			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
 			VMSize:              to.StringPtr("fake-sku"),
 			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),

--- a/azure/services/managedclusters/spec_test.go
+++ b/azure/services/managedclusters/spec_test.go
@@ -134,6 +134,19 @@ func TestParameters(t *testing.T) {
 				g.Expect(result.(containerservice.ManagedCluster).KubernetesVersion).To(Equal(to.StringPtr("v1.22.99")))
 			},
 		},
+		{
+			name:     "delete all tags",
+			existing: getExistingCluster(),
+			spec: &ManagedClusterSpec{
+				Tags: nil,
+			},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(containerservice.ManagedCluster{}))
+				tags := result.(containerservice.ManagedCluster).Tags
+				g.Expect(tags).NotTo(BeNil())
+				g.Expect(tags).To(BeEmpty())
+			},
+		},
 	}
 	for _, tc := range testcases {
 		tc := tc


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: When `spec.additionalTags` are defined on `AzureManagedControlPlane` or `AzureManagedMachinePool` resources, setting them to `null` or empty does not delete all tags because the resulting `PUT` request specifies `null` tags which seems to be interpreted by AKS as "do not change the tags." This change ensures that if the tags are specified in the CAPZ resources as `null`, then a non-nil, empty set of tags are sent to the AKS API to express "please delete all of the existing tags."

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: I came across this issue while implementing an e2e test covering this scenario (currently drafted in #2917). Those tests verify this new behavior for me locally. Additional context in https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2745#discussion_r1016508287 and https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2802.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug preventing `spec.additionalTags` from being deleted entirely on AzureManagedControlPlane
```
Note: `spec.additionalTags` is not yet implemented for AzureManagedMachinePools in any tagged release
