### PR TITLE
add E2E tests for AzureManagedCluster webhooks

### DIFF
--- a/exp/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/exp/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -99,13 +99,6 @@ func (m *AzureManagedControlPlane) ValidateUpdate(oldRaw runtime.Object, client 
 	old := oldRaw.(*AzureManagedControlPlane)
 
 	if err := webhookutils.ValidateImmutable(
-		field.NewPath("Name"),
-		old.Name,
-		m.Name); err != nil {
-		allErrs = append(allErrs, err)
-	}
-
-	if err := webhookutils.ValidateImmutable(
 		field.NewPath("Spec", "SubscriptionID"),
 		old.Spec.SubscriptionID,
 		m.Spec.SubscriptionID); err != nil {

--- a/exp/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/exp/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -777,31 +777,6 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "AzureManagedControlPlane Name is mutable",
-			oldAMCP: &AzureManagedControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-cluster",
-				},
-				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: to.StringPtr("192.168.0.0"),
-					Version:      "v1.18.0",
-				},
-			},
-			amcp: &AzureManagedControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "new-test-cluster",
-				},
-				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: to.StringPtr("192.168.0.0"),
-					Version:      "v1.18.0",
-					APIServerAccessProfile: &APIServerAccessProfile{
-						AuthorizedIPRanges: []string{"192.168.0.1/32"},
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
 			name: "AzureManagedControlPlane.VirtualNetwork Name is mutable",
 			oldAMCP: &AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/aks.go
+++ b/test/e2e/aks.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
@@ -207,4 +208,69 @@ func WaitForAKSSystemNodePoolMachinesToExist(ctx context.Context, input WaitForC
 
 		return false
 	}, intervals...).Should(Equal(true), "System machine pools not detected")
+}
+
+func getAzureCluster(ctx context.Context, managementClusterClient client.Client, namespace, name string) (*infrav1.AzureCluster, error) {
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	azCluster := &infrav1.AzureCluster{}
+	err := managementClusterClient.Get(ctx, key, azCluster)
+	return azCluster, err
+}
+
+func getAzureManagedControlPlane(ctx context.Context, managementClusterClient client.Client, namespace, name string) (*infrav1exp.AzureManagedControlPlane, error) {
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	azManagedControlPlane := &infrav1exp.AzureManagedControlPlane{}
+	err := managementClusterClient.Get(ctx, key, azManagedControlPlane)
+	return azManagedControlPlane, err
+}
+
+func getAzureManagedCluster(ctx context.Context, managementClusterClient client.Client, namespace, name string) (*infrav1exp.AzureManagedCluster, error) {
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+	azManagedCluster := &infrav1exp.AzureManagedCluster{}
+	err := managementClusterClient.Get(ctx, key, azManagedCluster)
+	return azManagedCluster, err
+}
+
+func getAzureMachine(ctx context.Context, managementClusterClient client.Client, m *clusterv1.Machine) (*infrav1.AzureMachine, error) {
+	key := client.ObjectKey{
+		Namespace: m.Spec.InfrastructureRef.Namespace,
+		Name:      m.Spec.InfrastructureRef.Name,
+	}
+
+	azMachine := &infrav1.AzureMachine{}
+	err := managementClusterClient.Get(ctx, key, azMachine)
+	return azMachine, err
+}
+
+func getAzureMachinePool(ctx context.Context, managementClusterClient client.Client, mp *expv1.MachinePool) (*infrav1exp.AzureMachinePool, error) {
+	key := client.ObjectKey{
+		Namespace: mp.Spec.Template.Spec.InfrastructureRef.Namespace,
+		Name:      mp.Spec.Template.Spec.InfrastructureRef.Name,
+	}
+
+	azMachinePool := &infrav1exp.AzureMachinePool{}
+	err := managementClusterClient.Get(ctx, key, azMachinePool)
+	return azMachinePool, err
+}
+
+func getAzureManagedMachinePool(ctx context.Context, managementClusterClient client.Client, mp *expv1.MachinePool) (*infrav1exp.AzureManagedMachinePool, error) {
+	key := client.ObjectKey{
+		Namespace: mp.Spec.Template.Spec.InfrastructureRef.Namespace,
+		Name:      mp.Spec.Template.Spec.InfrastructureRef.Name,
+	}
+
+	azManagedMachinePool := &infrav1exp.AzureManagedMachinePool{}
+	err := managementClusterClient.Get(ctx, key, azManagedMachinePool)
+	return azManagedMachinePool, err
 }

--- a/test/e2e/aks_webhooks.go
+++ b/test/e2e/aks_webhooks.go
@@ -1,0 +1,384 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-05-01/containerservice"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+)
+
+type AKSWebhooksSpecInput struct {
+	Cluster      *clusterv1.Cluster
+	MachinePools []*expv1.MachinePool
+}
+
+func AKSWebhooksSpec(ctx context.Context, inputGetter func() AKSWebhooksSpecInput) {
+	input := inputGetter()
+
+	settings, err := auth.GetSettingsFromEnvironment()
+	Expect(err).NotTo(HaveOccurred())
+	subscriptionID := settings.GetSubscriptionID()
+	auth, err := settings.GetAuthorizer()
+	Expect(err).NotTo(HaveOccurred())
+	agentpoolClient := containerservice.NewAgentPoolsClient(subscriptionID)
+	agentpoolClient.Authorizer = auth
+	mgmtClient := bootstrapClusterProxy.GetClient()
+	Expect(mgmtClient).NotTo(BeNil())
+
+	By("Validating that AzureManagedCluster webhooks are working")
+	amc, err := getAzureManagedCluster(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+
+	disallowedPrefix := azure.CustomHeaderPrefix + "foo"
+	By(fmt.Sprintf("Validating that we can't manually add an annotation to AzureManagedCluster with a prefix of '%s'", disallowedPrefix))
+	amc.ObjectMeta.Annotations[disallowedPrefix] = "bar"
+	err = mgmtClient.Update(ctx, amc)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	By("Validating that AzureManagedControlPlane webhooks are working")
+
+	By("Getting the existing AzureManagedControlPlane resource")
+	amcp, err := getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.SubscriptionID")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	amcp.Spec.SubscriptionID += "123"
+	err = mgmtClient.Update(ctx, amcp)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.ResourceGroupName")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	amcp.Spec.ResourceGroupName = amcp.Spec.ResourceGroupName + "foo"
+	err = mgmtClient.Update(ctx, amcp)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.NodeResourceGroupName")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	amcp.Spec.NodeResourceGroupName = amcp.Spec.NodeResourceGroupName + "foo"
+	err = mgmtClient.Update(ctx, amcp)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.Location")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	amcp.Spec.Location = "notavalidregion"
+	err = mgmtClient.Update(ctx, amcp)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.SSHPublicKey")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	amcp.Spec.SSHPublicKey = amcp.Spec.SSHPublicKey + "foo"
+	err = mgmtClient.Update(ctx, amcp)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.DNSServiceIP")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	amcp.Spec.DNSServiceIP = to.StringPtr("256.256.256.256")
+	err = mgmtClient.Update(ctx, amcp)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.NetworkPlugin")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	if to.String(amcp.Spec.NetworkPlugin) == "azure" {
+		amcp.Spec.NetworkPlugin = to.StringPtr("kubenet")
+	} else {
+		amcp.Spec.NetworkPlugin = to.StringPtr("azure")
+	}
+	err = mgmtClient.Update(ctx, amcp)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.NetworkPolicy")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	if to.String(amcp.Spec.NetworkPolicy) == "azure" {
+		amcp.Spec.NetworkPolicy = to.StringPtr("calico")
+	} else {
+		amcp.Spec.NetworkPolicy = to.StringPtr("azure")
+	}
+	err = mgmtClient.Update(ctx, amcp)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.LoadBalancerSKU")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	if to.String(amcp.Spec.LoadBalancerSKU) == "Standard" {
+		amcp.Spec.LoadBalancerSKU = to.StringPtr("Basic")
+	} else {
+		amcp.Spec.LoadBalancerSKU = to.StringPtr("Standard")
+	}
+	err = mgmtClient.Update(ctx, amcp)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.AADProfile")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	if amcp.Spec.AADProfile != nil {
+		aadProfile := &infrav1exp.AADProfile{}
+		if amcp.Spec.AADProfile.Managed {
+			aadProfile.Managed = false
+		} else {
+			aadProfile.Managed = true
+		}
+		amcp.Spec.AADProfile = aadProfile
+		err = mgmtClient.Update(ctx, amcp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+	}
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.VirtualNetwork.Name")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	amcp.Spec.VirtualNetwork.Name = amcp.Spec.VirtualNetwork.Name + "foo"
+	err = mgmtClient.Update(ctx, amcp)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.VirtualNetwork.CIDRBlock")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	amcp.Spec.VirtualNetwork.CIDRBlock = amcp.Spec.VirtualNetwork.CIDRBlock + "123"
+	err = mgmtClient.Update(ctx, amcp)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.VirtualNetwork.Subnet.Name")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	amcp.Spec.VirtualNetwork.Subnet.Name = amcp.Spec.VirtualNetwork.Subnet.Name + "foo"
+	err = mgmtClient.Update(ctx, amcp)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.VirtualNetwork.ResourceGroup")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	amcp.Spec.VirtualNetwork.ResourceGroup = amcp.Spec.VirtualNetwork.ResourceGroup + "foo"
+	err = mgmtClient.Update(ctx, amcp)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	By("Validating that we can't update AzureManagedControlPlane.Spec.APIServerAccessProfile")
+	amcp, err = getAzureManagedControlPlane(ctx, mgmtClient, input.Cluster.Namespace, input.Cluster.Name)
+	Expect(err).NotTo(HaveOccurred())
+	if amcp.Spec.APIServerAccessProfile != nil {
+		apiServerAccessProfile := &infrav1exp.APIServerAccessProfile{}
+		if to.Bool(amcp.Spec.APIServerAccessProfile.EnablePrivateCluster) {
+			apiServerAccessProfile.EnablePrivateCluster = to.BoolPtr(false)
+		} else {
+			apiServerAccessProfile.EnablePrivateCluster = to.BoolPtr(true)
+		}
+		amcp.Spec.APIServerAccessProfile = apiServerAccessProfile
+		err = mgmtClient.Update(ctx, amcp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+	}
+
+	By("Validating that AzureManagedMachinePool webhooks are working")
+	var nodePoolModeToUserError error
+	for _, mp := range input.MachinePools {
+		ammp, err := getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		By(fmt.Sprintf("Validating webhooks against AzureManagedMachinePool %s", ammp.Name))
+
+		By("Validating that we can't add a node label using the reserved 'kubernetes.azure.com/' prefix")
+		if ammp.Spec.NodeLabels == nil {
+			ammp.Spec.NodeLabels = map[string]string{}
+		}
+		ammp.Spec.NodeLabels[azureutil.AzureSystemNodeLabelPrefix+"/foo"] = "bar"
+		err = mgmtClient.Update(ctx, ammp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+		By("Validating that we can't update AzureManagedMachinePool.Spec.OSType")
+		ammp, err = getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		if to.String(ammp.Spec.OSType) == "Linux" {
+			ammp.Spec.OSType = to.StringPtr("Windows")
+		} else {
+			ammp.Spec.OSType = to.StringPtr("Linux")
+		}
+		err = mgmtClient.Update(ctx, ammp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+		By("Validating that we can't update AzureManagedMachinePool.Spec.SKU")
+		ammp, err = getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		ammp.Spec.SKU = ammp.Spec.SKU + "_vInvalid"
+		err = mgmtClient.Update(ctx, ammp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+		By("Validating that we can't update AzureManagedMachinePool.Spec.OSDiskSizeGB")
+		ammp, err = getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		ammp.Spec.OSDiskSizeGB = to.Int32Ptr(to.Int32(ammp.Spec.OSDiskSizeGB) + 1)
+		err = mgmtClient.Update(ctx, ammp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+		By("Validating that we can't add a new 'infrastructure.cluster.x-k8s.io/custom-header-' Annotation")
+		ammp, err = getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		if ammp.ObjectMeta.Annotations == nil {
+			ammp.ObjectMeta.Annotations = map[string]string{}
+		}
+		ammp.ObjectMeta.Annotations[azure.CustomHeaderPrefix+"foo"] = "bar"
+		err = mgmtClient.Update(ctx, ammp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+		By("Validating that we can't add or remove from AzureManagedMachinePool.Spec.AvailabilityZones")
+		ammp, err = getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		ammp.Spec.AvailabilityZones = append(ammp.Spec.AvailabilityZones, "99")
+		err = mgmtClient.Update(ctx, ammp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+		ammp, err = getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		if len(ammp.Spec.AvailabilityZones) > 0 {
+			ammp.Spec.AvailabilityZones = ammp.Spec.AvailabilityZones[1:]
+			err = mgmtClient.Update(ctx, ammp)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsInvalid(err)).To(BeTrue())
+		}
+
+		By("Validating that we can't update AzureManagedMachinePool.Spec.MaxPods")
+		ammp, err = getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		ammp.Spec.MaxPods = to.Int32Ptr(to.Int32(ammp.Spec.MaxPods) + 1)
+		err = mgmtClient.Update(ctx, ammp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+		By("Validating that we can't update AzureManagedMachinePool.Spec.OsDiskType")
+		ammp, err = getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		if to.String(ammp.Spec.OsDiskType) == "Ephemeral" {
+			ammp.Spec.OsDiskType = to.StringPtr("Managed")
+		} else {
+			ammp.Spec.OsDiskType = to.StringPtr("Ephemeral")
+		}
+		err = mgmtClient.Update(ctx, ammp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+		By("Validating that we can't update AzureManagedMachinePool.Spec.ScaleSetPriority")
+		ammp, err = getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		if to.String(ammp.Spec.ScaleSetPriority) == "Regular" {
+			ammp.Spec.ScaleSetPriority = to.StringPtr("Spot")
+		} else {
+			ammp.Spec.ScaleSetPriority = to.StringPtr("Regular")
+		}
+		err = mgmtClient.Update(ctx, ammp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+		By("Validating that we can't update AzureManagedMachinePool.Spec.EnableUltraSSD")
+		ammp, err = getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		ammp.Spec.EnableUltraSSD = to.BoolPtr(!to.Bool(ammp.Spec.EnableUltraSSD))
+		err = mgmtClient.Update(ctx, ammp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+		By("Validating that we can't update AzureManagedMachinePool.Spec.EnableNodePublicIP")
+		ammp, err = getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		if to.Bool(ammp.Spec.EnableNodePublicIP) {
+			ammp.Spec.EnableNodePublicIP = to.BoolPtr(false)
+		} else {
+			ammp.Spec.EnableNodePublicIP = to.BoolPtr(true)
+		}
+		err = mgmtClient.Update(ctx, ammp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+		By("Validating that we can't update AzureManagedMachinePool.Spec.NodePublicIPPrefixID")
+		ammp, err = getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		if to.String(ammp.Spec.NodePublicIPPrefixID) != "" {
+			ammp.Spec.NodePublicIPPrefixID = to.StringPtr(to.String(ammp.Spec.NodePublicIPPrefixID) + "foo")
+		} else {
+			ammp.Spec.NodePublicIPPrefixID = to.StringPtr("foo")
+		}
+		err = mgmtClient.Update(ctx, ammp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+		By("Validating that we can't update AzureManagedMachinePool.Spec.KubeletConfig")
+		ammp, err = getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		if ammp.Spec.KubeletConfig != nil {
+			ammp.Spec.KubeletConfig.FailSwapOn = to.BoolPtr(!to.Bool(ammp.Spec.KubeletConfig.FailSwapOn))
+		} else {
+			ammp.Spec.KubeletConfig = &infrav1exp.KubeletConfig{
+				FailSwapOn: to.BoolPtr(true),
+			}
+		}
+		err = mgmtClient.Update(ctx, ammp)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+		By(fmt.Sprintf("Changing AzureManagedMachinePool %s mode to User", ammp.Name))
+		ammp, err = getAzureManagedMachinePool(ctx, mgmtClient, mp)
+		Expect(err).NotTo(HaveOccurred())
+		ammp.Spec.Mode = "User"
+		err = mgmtClient.Update(ctx, ammp)
+		if err != nil {
+			nodePoolModeToUserError = err
+		}
+	}
+	By("Validating that we got a AzureManagedMachinePool 'must have at least one system node pool' error")
+	Expect(nodePoolModeToUserError).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(nodePoolModeToUserError)).To(BeTrue())
+}

--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -35,7 +35,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
-	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
@@ -176,61 +175,6 @@ func getHostname(m *clusterv1.Machine, isWindows bool) string {
 		}
 	}
 	return hostname
-}
-
-func getAzureCluster(ctx context.Context, managementClusterClient client.Client, namespace, name string) (*infrav1.AzureCluster, error) {
-	key := client.ObjectKey{
-		Namespace: namespace,
-		Name:      name,
-	}
-
-	azCluster := &infrav1.AzureCluster{}
-	err := managementClusterClient.Get(ctx, key, azCluster)
-	return azCluster, err
-}
-
-func getAzureManagedControlPlane(ctx context.Context, managementClusterClient client.Client, namespace, name string) (*infrav1exp.AzureManagedControlPlane, error) {
-	key := client.ObjectKey{
-		Namespace: namespace,
-		Name:      name,
-	}
-
-	azManagedControlPlane := &infrav1exp.AzureManagedControlPlane{}
-	err := managementClusterClient.Get(ctx, key, azManagedControlPlane)
-	return azManagedControlPlane, err
-}
-
-func getAzureMachine(ctx context.Context, managementClusterClient client.Client, m *clusterv1.Machine) (*infrav1.AzureMachine, error) {
-	key := client.ObjectKey{
-		Namespace: m.Spec.InfrastructureRef.Namespace,
-		Name:      m.Spec.InfrastructureRef.Name,
-	}
-
-	azMachine := &infrav1.AzureMachine{}
-	err := managementClusterClient.Get(ctx, key, azMachine)
-	return azMachine, err
-}
-
-func getAzureMachinePool(ctx context.Context, managementClusterClient client.Client, mp *expv1.MachinePool) (*infrav1exp.AzureMachinePool, error) {
-	key := client.ObjectKey{
-		Namespace: mp.Spec.Template.Spec.InfrastructureRef.Namespace,
-		Name:      mp.Spec.Template.Spec.InfrastructureRef.Name,
-	}
-
-	azMachinePool := &infrav1exp.AzureMachinePool{}
-	err := managementClusterClient.Get(ctx, key, azMachinePool)
-	return azMachinePool, err
-}
-
-func getAzureManagedMachinePool(ctx context.Context, managementClusterClient client.Client, mp *expv1.MachinePool) (*infrav1exp.AzureManagedMachinePool, error) {
-	key := client.ObjectKey{
-		Namespace: mp.Spec.Template.Spec.InfrastructureRef.Namespace,
-		Name:      mp.Spec.Template.Spec.InfrastructureRef.Name,
-	}
-
-	azManagedMachinePool := &infrav1exp.AzureManagedMachinePool{}
-	err := managementClusterClient.Get(ctx, key, azManagedMachinePool)
-	return azManagedMachinePool, err
 }
 
 func linuxLogs(execToPathFn func(outputFileName string, command string, args ...string) func() error) []func() error {

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -589,6 +589,15 @@ var _ = Describe("Workload cluster creation", func() {
 				},
 			}, result)
 
+			By("Validating that webhooks are working as expected", func() {
+				AKSWebhooksSpec(ctx, func() AKSWebhooksSpecInput {
+					return AKSWebhooksSpecInput{
+						Cluster:      result.Cluster,
+						MachinePools: result.MachinePools,
+					}
+				})
+			})
+
 			By("Upgrading the Kubernetes version of the cluster", func() {
 				AKSUpgradeSpec(ctx, func() AKSUpgradeSpecInput {
 					return AKSUpgradeSpecInput{

--- a/util/azure/azure_test.go
+++ b/util/azure/azure_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestIsAzureSystemNodeLabelKey(t *testing.T) {
+	tests := []struct {
+		desc     string
+		labelKey string
+		expected bool
+	}{
+		{
+			desc:     "system prefix as key should report an error",
+			labelKey: AzureSystemNodeLabelPrefix,
+			expected: true,
+		},
+		{
+			desc:     "system prefix in key should report an error",
+			labelKey: AzureSystemNodeLabelPrefix + "/foo",
+			expected: true,
+		},
+		{
+			desc:     "empty string should not report error",
+			labelKey: "",
+			expected: false,
+		},
+		{
+			desc:     "string without system prefix should not report error",
+			labelKey: "foo",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			ret := IsAzureSystemNodeLabelKey(test.labelKey)
+			g.Expect(ret).To(Equal(test.expected))
+		})
+	}
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind feature

**What this PR does / why we need it**:

This PR adds E2E tests for the full set of webhook update rules for AKS. We don't fully test every invalid permutation across all properties (or properties of properties, i.e., structs), but rather include a working "negative" E2E test case for every `AzureManagedCluster`, `AzureManagedControlPlane`, and `AzureManagedMachinePool` webhook.

This process uncovered an unnecessary webhook for the `AzureManagedControlPlane.Name` property — the `.Name` field is the unique ID for these k8s Object.Meta resources, and updates to `.Name` violate rules that prevent the webhooks from ever being reached (in practice I observed `409` conflict errors). That webhook (and its related UT) are removed in this PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
