### PR TITLE
[release-1.5] fix deleting all tags on AzureManagedControlPlane

### DIFF
--- a/azure/services/managedclusters/spec_test.go
+++ b/azure/services/managedclusters/spec_test.go
@@ -128,6 +128,19 @@ func TestParameters(t *testing.T) {
 				g.Expect(result.(containerservice.ManagedCluster).KubernetesVersion).To(Equal(to.StringPtr("v1.22.99")))
 			},
 		},
+		{
+			name:     "delete all tags",
+			existing: getExistingCluster(),
+			spec: &ManagedClusterSpec{
+				Tags: nil,
+			},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(containerservice.ManagedCluster{}))
+				tags := result.(containerservice.ManagedCluster).Tags
+				g.Expect(tags).NotTo(BeNil())
+				g.Expect(tags).To(BeEmpty())
+			},
+		},
 	}
 	for _, tc := range testcases {
 		tc := tc


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Manual cherry-pick of #2916 for the release-1.5 branch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug preventing `spec.additionalTags` from being deleted entirely on AzureManagedControlPlane
```
