### PR TITLE
Update windows kube-proxy to deploy to kube-system

### DIFF
--- a/templates/addons/windows/calico/kube-proxy-windows.yaml
+++ b/templates/addons/windows/calico/kube-proxy-windows.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     k8s-app: kube-proxy
   name: kube-proxy-windows
-  namespace: calico-system
+  namespace: kube-system
 spec:
   selector:
     matchLabels:

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -629,7 +629,7 @@ data:
       labels:
         k8s-app: kube-proxy
       name: kube-proxy-windows
-      namespace: calico-system
+      namespace: kube-system
     spec:
       selector:
         matchLabels:

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -629,7 +629,7 @@ data:
       labels:
         k8s-app: kube-proxy
       name: kube-proxy-windows
-      namespace: calico-system
+      namespace: kube-system
     spec:
       selector:
         matchLabels:

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
@@ -633,7 +633,7 @@ data:
       labels:
         k8s-app: kube-proxy
       name: kube-proxy-windows
-      namespace: calico-system
+      namespace: kube-system
     spec:
       selector:
         matchLabels:

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -536,7 +536,7 @@ data:
       labels:
         k8s-app: kube-proxy
       name: kube-proxy-windows
-      namespace: calico-system
+      namespace: kube-system
     spec:
       selector:
         matchLabels:

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -348,7 +348,7 @@ data:
       labels:
         k8s-app: kube-proxy
       name: kube-proxy-windows
-      namespace: calico-system
+      namespace: kube-system
     spec:
       selector:
         matchLabels:

--- a/templates/test/ci/cluster-template-prow-topology.yaml
+++ b/templates/test/ci/cluster-template-prow-topology.yaml
@@ -88,7 +88,7 @@ data:
       labels:
         k8s-app: kube-proxy
       name: kube-proxy-windows
-      namespace: calico-system
+      namespace: kube-system
     spec:
       selector:
         matchLabels:

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -439,7 +439,7 @@ data:
       labels:
         k8s-app: kube-proxy
       name: kube-proxy-windows
-      namespace: calico-system
+      namespace: kube-system
     spec:
       selector:
         matchLabels:

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -439,7 +439,7 @@ data:
       labels:
         k8s-app: kube-proxy
       name: kube-proxy-windows
-      namespace: calico-system
+      namespace: kube-system
     spec:
       selector:
         matchLabels:

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -574,7 +574,7 @@ data:
       labels:
         k8s-app: kube-proxy
       name: kube-proxy-windows
-      namespace: calico-system
+      namespace: kube-system
     spec:
       selector:
         matchLabels:

--- a/test/e2e/cni.go
+++ b/test/e2e/cni.go
@@ -89,8 +89,14 @@ func InstallCalicoHelmChart(ctx context.Context, input clusterctl.ApplyClusterTe
 	// TODO: enable this for all clusters once calico for windows is part of the helm chart.
 	if hasWindows {
 		By("Waiting for Ready calico windows pods")
-		for _, ds := range []string{"calico-node-windows", "kube-proxy-windows"} {
+		for _, ds := range []string{"calico-node-windows"} {
 			waitInput := GetWaitForDaemonsetAvailableInput(ctx, clusterProxy, ds, CalicoSystemNamespace, specName)
+			WaitForDaemonset(ctx, waitInput, e2eConfig.GetIntervals(specName, "wait-daemonset")...)
+		}
+
+		By("Waiting for Ready calico windows pods")
+		for _, ds := range []string{"kube-proxy-windows"} {
+			waitInput := GetWaitForDaemonsetAvailableInput(ctx, clusterProxy, ds, kubesystem, specName)
 			WaitForDaemonset(ctx, waitInput, e2eConfig.GetIntervals(specName, "wait-daemonset")...)
 		}
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

When introducing the Calico HelmChart the Windows kube-proxy was moved into the calico namespace.  This causes

```
Warning  FailedCreate  8m49s (x18 over 19m)  daemonset-controller  Error creating: pods "kube-proxy-windows-" is forbidden: error looking up service account calico-system/kube-proxy: serviceaccount "kube-proxy" not found
```

This wasn't caught since the test doesn't really verify the number of pods running in the DS:

https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/c0f81b0b89e6640ccd6c9eee35aadac05ec36417/test/e2e/helpers.go#L276-L279

you can see this in the logs of the e2e tests, notice the log doesn't have the number of pods running

```
[1mSTEP[0m: waiting for daemonset calico-system/calico-node to be complete
Nov 29 21:42:44.456: INFO: waiting for daemonset calico-system/calico-node to be complete
Nov 29 21:42:44.489: INFO: daemonset calico-system/calico-node pods are running, took 33.187202ms
[1mSTEP[0m: Waiting for Ready calico windows pods
[1mSTEP[0m: waiting for daemonset calico-system/calico-node-windows to be complete
Nov 29 21:42:44.659: INFO: waiting for daemonset calico-system/calico-node-windows to be complete
Nov 29 21:42:44.691: INFO: daemonset calico-system/calico-node-windows pods are running, took 32.541702ms
[1mSTEP[0m: waiting for daemonset calico-system/kube-proxy-windows to be complete
Nov 29 21:42:44.831: INFO: waiting for daemonset calico-system/kube-proxy-windows to be complete
Nov 29 21:42:44.864: INFO: daemonset calico-system/kube-proxy-windows pods are running, took 32.690035ms
``` 

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
