### PR TITLE
Standardize autorest/azure import alias as azureautorest

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -103,6 +103,9 @@ linters-settings:
         alias: infrav1exp
       - pkg: sigs.k8s.io/cluster-api-provider-azure/util/webhook
         alias: webhookutils
+      # Azure
+      - pkg: github.com/Azure/go-autorest/autorest/azure
+        alias: azureautorest
   gocritic:
     enabled-tags:
       - "experimental"

--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	"sigs.k8s.io/cluster-api-provider-azure/version"
 )
@@ -303,7 +303,7 @@ func ManagedClusterID(subscriptionID, resourceGroup, managedClusterName string) 
 // Its role is to detect and report Kubernetes bootstrap failure or success.
 func GetBootstrappingVMExtension(osType string, cloud string, vmName string) *ExtensionSpec {
 	// currently, the bootstrap extension is only available in AzurePublicCloud.
-	if osType == LinuxOS && cloud == azure.PublicCloud.Name {
+	if osType == LinuxOS && cloud == azureautorest.PublicCloud.Name {
 		// The command checks for the existence of the bootstrapSentinelFile on the machine, with retries and sleep between retries.
 		return &ExtensionSpec{
 			Name:      "CAPZ.Linux.Bootstrapping",
@@ -314,7 +314,7 @@ func GetBootstrappingVMExtension(osType string, cloud string, vmName string) *Ex
 				"commandToExecute": LinuxBootstrapExtensionCommand,
 			},
 		}
-	} else if osType == WindowsOS && cloud == azure.PublicCloud.Name {
+	} else if osType == WindowsOS && cloud == azureautorest.PublicCloud.Name {
 		// This command for the existence of the bootstrapSentinelFile on the machine, with retries and sleep between reties.
 		// If the file is not present after the retries are exhausted the extension fails with return code '-2' - ERROR_FILE_NOT_FOUND.
 		return &ExtensionSpec{

--- a/azure/errors.go
+++ b/azure/errors.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -31,7 +31,7 @@ const codeResourceGroupNotFound = "ResourceGroupNotFound"
 // ResourceGroupNotFound parses the error to check if it's a resource group not found error.
 func ResourceGroupNotFound(err error) bool {
 	derr := autorest.DetailedError{}
-	serr := &azure.ServiceError{}
+	serr := &azureautorest.ServiceError{}
 	return errors.As(err, &derr) && errors.As(derr.Original, &serr) && serr.Code == codeResourceGroupNotFound
 }
 

--- a/azure/scope/clients.go
+++ b/azure/scope/clients.go
@@ -25,9 +25,8 @@ import (
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
-
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 )
 
@@ -154,9 +153,9 @@ func (c *AzureClients) getSettingsFromEnvironment(environmentName string) (s aut
 	setValue(s, auth.Password)
 	setValue(s, auth.Resource)
 	if v := s.Values[auth.EnvironmentName]; v == "" {
-		s.Environment = azure.PublicCloud
+		s.Environment = azureautorest.PublicCloud
 	} else {
-		s.Environment, err = azure.EnvironmentFromName(v)
+		s.Environment, err = azureautorest.EnvironmentFromName(v)
 	}
 	if s.Values[auth.Resource] == "" {
 		s.Values[auth.Resource] = s.Environment.ResourceManagerEndpoint

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	autorestazure "github.com/Azure/go-autorest/autorest/azure"
+	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
@@ -513,8 +513,8 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 				ClusterScoper: &ClusterScope{
 					AzureClients: AzureClients{
 						EnvironmentSettings: auth.EnvironmentSettings{
-							Environment: autorestazure.Environment{
-								Name: autorestazure.PublicCloud.Name,
+							Environment: azureautorest.Environment{
+								Name: azureautorest.PublicCloud.Name,
 							},
 						},
 					},
@@ -561,8 +561,8 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 				ClusterScoper: &ClusterScope{
 					AzureClients: AzureClients{
 						EnvironmentSettings: auth.EnvironmentSettings{
-							Environment: autorestazure.Environment{
-								Name: autorestazure.USGovernmentCloud.Name,
+							Environment: azureautorest.Environment{
+								Name: azureautorest.USGovernmentCloud.Name,
 							},
 						},
 					},
@@ -595,8 +595,8 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 				ClusterScoper: &ClusterScope{
 					AzureClients: AzureClients{
 						EnvironmentSettings: auth.EnvironmentSettings{
-							Environment: autorestazure.Environment{
-								Name: autorestazure.PublicCloud.Name,
+							Environment: azureautorest.Environment{
+								Name: azureautorest.PublicCloud.Name,
 							},
 						},
 					},
@@ -643,8 +643,8 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 				ClusterScoper: &ClusterScope{
 					AzureClients: AzureClients{
 						EnvironmentSettings: auth.EnvironmentSettings{
-							Environment: autorestazure.Environment{
-								Name: autorestazure.USGovernmentCloud.Name,
+							Environment: azureautorest.Environment{
+								Name: azureautorest.USGovernmentCloud.Name,
 							},
 						},
 					},
@@ -677,8 +677,8 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 				ClusterScoper: &ClusterScope{
 					AzureClients: AzureClients{
 						EnvironmentSettings: auth.EnvironmentSettings{
-							Environment: autorestazure.Environment{
-								Name: autorestazure.PublicCloud.Name,
+							Environment: azureautorest.Environment{
+								Name: azureautorest.PublicCloud.Name,
 							},
 						},
 					},
@@ -711,8 +711,8 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 				ClusterScoper: &ClusterScope{
 					AzureClients: AzureClients{
 						EnvironmentSettings: auth.EnvironmentSettings{
-							Environment: autorestazure.Environment{
-								Name: autorestazure.USGovernmentCloud.Name,
+							Environment: azureautorest.Environment{
+								Name: azureautorest.USGovernmentCloud.Name,
 							},
 						},
 					},
@@ -758,8 +758,8 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 				ClusterScoper: &ClusterScope{
 					AzureClients: AzureClients{
 						EnvironmentSettings: auth.EnvironmentSettings{
-							Environment: autorestazure.Environment{
-								Name: autorestazure.PublicCloud.Name,
+							Environment: azureautorest.Environment{
+								Name: azureautorest.PublicCloud.Name,
 							},
 						},
 					},

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"testing"
 
-	autorestazure "github.com/Azure/go-autorest/autorest/azure"
+	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
@@ -665,8 +665,8 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 				ClusterScoper: &ClusterScope{
 					AzureClients: AzureClients{
 						EnvironmentSettings: auth.EnvironmentSettings{
-							Environment: autorestazure.Environment{
-								Name: autorestazure.PublicCloud.Name,
+							Environment: azureautorest.Environment{
+								Name: azureautorest.PublicCloud.Name,
 							},
 						},
 					},
@@ -711,8 +711,8 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 				ClusterScoper: &ClusterScope{
 					AzureClients: AzureClients{
 						EnvironmentSettings: auth.EnvironmentSettings{
-							Environment: autorestazure.Environment{
-								Name: autorestazure.USGovernmentCloud.Name,
+							Environment: azureautorest.Environment{
+								Name: azureautorest.USGovernmentCloud.Name,
 							},
 						},
 					},
@@ -745,8 +745,8 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 				ClusterScoper: &ClusterScope{
 					AzureClients: AzureClients{
 						EnvironmentSettings: auth.EnvironmentSettings{
-							Environment: autorestazure.Environment{
-								Name: autorestazure.PublicCloud.Name,
+							Environment: azureautorest.Environment{
+								Name: azureautorest.PublicCloud.Name,
 							},
 						},
 					},
@@ -792,8 +792,8 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 				ClusterScoper: &ClusterScope{
 					AzureClients: AzureClients{
 						EnvironmentSettings: auth.EnvironmentSettings{
-							Environment: autorestazure.Environment{
-								Name: autorestazure.USGovernmentCloud.Name,
+							Environment: azureautorest.Environment{
+								Name: azureautorest.USGovernmentCloud.Name,
 							},
 						},
 					},
@@ -825,8 +825,8 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 				ClusterScoper: &ClusterScope{
 					AzureClients: AzureClients{
 						EnvironmentSettings: auth.EnvironmentSettings{
-							Environment: autorestazure.Environment{
-								Name: autorestazure.PublicCloud.Name,
+							Environment: azureautorest.Environment{
+								Name: azureautorest.PublicCloud.Name,
 							},
 						},
 					},
@@ -858,8 +858,8 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 				ClusterScoper: &ClusterScope{
 					AzureClients: AzureClients{
 						EnvironmentSettings: auth.EnvironmentSettings{
-							Environment: autorestazure.Environment{
-								Name: autorestazure.USGovernmentCloud.Name,
+							Environment: azureautorest.Environment{
+								Name: azureautorest.USGovernmentCloud.Name,
 							},
 						},
 					},
@@ -904,8 +904,8 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 				ClusterScoper: &ClusterScope{
 					AzureClients: AzureClients{
 						EnvironmentSettings: auth.EnvironmentSettings{
-							Environment: autorestazure.Environment{
-								Name: autorestazure.PublicCloud.Name,
+							Environment: azureautorest.Environment{
+								Name: azureautorest.PublicCloud.Name,
 							},
 						},
 					},

--- a/azure/services/identities/client.go
+++ b/azure/services/identities/client.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/msi/mgmt/2018-11-30/msi"
 	"github.com/Azure/go-autorest/autorest"
-	azuresdk "github.com/Azure/go-autorest/autorest/azure"
+	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
@@ -63,7 +63,7 @@ func (ac *AzureClient) GetClientID(ctx context.Context, providerID string) (stri
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "identities.GetClientID")
 	defer done()
 
-	parsed, err := azuresdk.ParseResourceID(providerID)
+	parsed, err := azureautorest.ParseResourceID(providerID)
 	if err != nil {
 		return "", err
 	}

--- a/azure/services/natgateways/spec.go
+++ b/azure/services/natgateways/spec.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	autorest "github.com/Azure/go-autorest/autorest/azure"
+	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -97,7 +97,7 @@ func hasPublicIP(natGateway network.NatGateway, publicIPName string) bool {
 	}
 
 	for _, publicIP := range *natGateway.PublicIPAddresses {
-		resource, err := autorest.ParseResourceID(*publicIP.ID)
+		resource, err := azureautorest.ParseResourceID(*publicIP.ID)
 		if err != nil {
 			continue
 		}

--- a/test/e2e/aks_versions.go
+++ b/test/e2e/aks_versions.go
@@ -28,11 +28,10 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
+	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 )
 
 // GetAKSKubernetesVersion gets the kubernetes version for AKS clusters as specified by the environment variable defined by versionVar.

--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
-	autorest "github.com/Azure/go-autorest/autorest/azure"
+	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -398,7 +398,7 @@ func collectVMBootLog(ctx context.Context, am *infrav1.AzureMachine, outputPath 
 	}
 
 	resourceID := strings.TrimPrefix(*am.Spec.ProviderID, azure.ProviderIDPrefix)
-	resource, err := autorest.ParseResourceID(resourceID)
+	resource, err := azureautorest.ParseResourceID(resourceID)
 	if err != nil {
 		return errors.Wrap(err, "failed to parse resource id")
 	}
@@ -428,7 +428,7 @@ func collectVMSSBootLog(ctx context.Context, providerID string, outputPath strin
 	v := strings.Split(resourceID, "/")
 	instanceID := v[len(v)-1]
 	resourceID = strings.TrimSuffix(resourceID, "/virtualMachines/"+instanceID)
-	resource, err := autorest.ParseResourceID(resourceID)
+	resource, err := azureautorest.ParseResourceID(resourceID)
 	if err != nil {
 		return errors.Wrap(err, "failed to parse resource id")
 	}

--- a/test/e2e/azure_privatecluster.go
+++ b/test/e2e/azure_privatecluster.go
@@ -31,7 +31,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
-	azuresdk "github.com/Azure/go-autorest/autorest/azure"
+	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo/v2"
@@ -429,7 +429,7 @@ func SetupExistingVNet(ctx context.Context, vnetCidr string, cpSubnetCidrs, node
 }
 
 func getAPIVersion(resourceID string) (string, error) {
-	parsed, err := azuresdk.ParseResourceID(resourceID)
+	parsed, err := azureautorest.ParseResourceID(resourceID)
 	if err != nil {
 		return "", errors.Wrap(err, fmt.Sprintf("unable to parse resource ID %q", resourceID))
 	}
@@ -463,7 +463,7 @@ func getClientIDforMSI(resourceID string) string {
 	msiClient := msi.NewUserAssignedIdentitiesClient(subscriptionID)
 	msiClient.Authorizer = authorizer
 
-	parsed, err := azuresdk.ParseResourceID(resourceID)
+	parsed, err := azureautorest.ParseResourceID(resourceID)
 	Expect(err).NotTo(HaveOccurred())
 
 	id, err := msiClient.Get(context.TODO(), parsed.ResourceGroup, parsed.ResourceName)

--- a/test/e2e/azure_vmextensions.go
+++ b/test/e2e/azure_vmextensions.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
-	autorest "github.com/Azure/go-autorest/autorest/azure"
+	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -99,7 +99,7 @@ func AzureVMExtensionsSpec(ctx context.Context, inputGetter func() AzureVMExtens
 
 		// get the resource group name
 		resourceID := strings.TrimPrefix(*machineList.Items[0].Spec.ProviderID, azure.ProviderIDPrefix)
-		resource, err := autorest.ParseResourceID(resourceID)
+		resource, err := azureautorest.ParseResourceID(resourceID)
 		Expect(err).NotTo(HaveOccurred())
 
 		vmListResults, err := vmClient.List(ctx, resource.ResourceGroup, "")
@@ -147,7 +147,7 @@ func AzureVMExtensionsSpec(ctx context.Context, inputGetter func() AzureVMExtens
 
 		// get the resource group name
 		resourceID := strings.TrimPrefix(machinePoolList.Items[0].Spec.ProviderID, azure.ProviderIDPrefix)
-		resource, err := autorest.ParseResourceID(resourceID)
+		resource, err := azureautorest.ParseResourceID(resourceID)
 		Expect(err).NotTo(HaveOccurred())
 
 		vmssListResults, err := vmssClient.List(ctx, resource.ResourceGroup)

--- a/util/azure/azure.go
+++ b/util/azure/azure.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/jongio/azidext/go/azidext"
 )
@@ -37,7 +37,7 @@ func IsAzureSystemNodeLabelKey(labelKey string) bool {
 	return strings.HasPrefix(labelKey, AzureSystemNodeLabelPrefix)
 }
 
-func getCloudConfig(environment azure.Environment) cloud.Configuration {
+func getCloudConfig(environment azureautorest.Environment) cloud.Configuration {
 	var config cloud.Configuration
 	switch environment.Name {
 	case "AzureStackCloud":
@@ -60,7 +60,7 @@ func getCloudConfig(environment azure.Environment) cloud.Configuration {
 	return config
 }
 
-// GetAuthorizer returns an autorest.Authorizer-compatible object from MSAL
+// GetAuthorizer returns an autorest.Authorizer-compatible object from MSAL.
 func GetAuthorizer(settings auth.EnvironmentSettings) (autorest.Authorizer, error) {
 	// azidentity uses different envvars for certificate authentication:
 	//  azidentity: AZURE_CLIENT_CERTIFICATE_{PATH,PASSWORD}


### PR DESCRIPTION
**What type of PR is this?**:

/kind cleanup

**What this PR does / why we need it**:

Adds this import alias to those enforced by the linter:

```go
import azureautorest "github.com/Azure/go-autorest/autorest/azure"
```

**Which issue(s) this PR fixes**:

See [this comment](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2813#discussion_r1038642488) for the inspiration.

**Special notes for your reviewer**:

See also #2974 

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
