### PR TITLE
add AGE column to custom printcolumn

### DIFF
--- a/api/v1beta1/azurecluster_types.go
+++ b/api/v1beta1/azurecluster_types.go
@@ -85,6 +85,7 @@ type AzureClusterStatus struct {
 // +kubebuilder:printcolumn:name="SubscriptionID",type="string",priority=1,JSONPath=".spec.subscriptionID"
 // +kubebuilder:printcolumn:name="Location",type="string",priority=1,JSONPath=".spec.location"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",priority=1,JSONPath=".spec.controlPlaneEndpoint.host",description="Control Plane Endpoint"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of this AzureCluster"
 // +kubebuilder:resource:path=azureclusters,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status

--- a/api/v1beta1/azureclusteridentity_types.go
+++ b/api/v1beta1/azureclusteridentity_types.go
@@ -77,6 +77,8 @@ type AzureClusterIdentityStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type",description="Type of Azure Identity"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of this AzureClusterIdentity"
 // +kubebuilder:resource:path=azureclusteridentities,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status

--- a/api/v1beta1/azuremachine_types.go
+++ b/api/v1beta1/azuremachine_types.go
@@ -224,6 +224,7 @@ type AdditionalCapabilities struct {
 // +kubebuilder:printcolumn:name="Machine",type="string",priority=1,JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object to which this AzureMachine belongs"
 // +kubebuilder:printcolumn:name="VM ID",type="string",priority=1,JSONPath=".spec.providerID",description="Azure VM ID"
 // +kubebuilder:printcolumn:name="VM Size",type="string",priority=1,JSONPath=".spec.vmSize",description="Azure VM Size"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of this AzureMachine"
 // +kubebuilder:resource:path=azuremachines,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml
@@ -315,7 +315,16 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Type of Azure Identity
+      jsonPath: .spec.type
+      name: Type
+      type: string
+    - description: Time duration since creation of this AzureClusterIdentity
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: AzureClusterIdentity is the Schema for the azureclustersidentities

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -1272,6 +1272,10 @@ spec:
       name: Endpoint
       priority: 1
       type: string
+    - description: Time duration since creation of this AzureCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepoolmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepoolmachines.yaml
@@ -264,6 +264,10 @@ spec:
       name: VMSS VM ID
       priority: 1
       type: string
+    - description: Time duration since creation of this AzureMachinePoolMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -1326,6 +1326,10 @@ spec:
       name: VM Size
       priority: 1
       type: string
+    - description: Time duration since creation of this AzureMachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -1023,6 +1023,10 @@ spec:
       name: VM Size
       priority: 1
       type: string
+    - description: Time duration since creation of this AzureMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/exp/api/v1beta1/azuremachinepool_types.go
+++ b/exp/api/v1beta1/azuremachinepool_types.go
@@ -335,6 +335,7 @@ type (
 	// +kubebuilder:printcolumn:name="MachinePool",type="string",priority=1,JSONPath=".metadata.ownerReferences[?(@.kind==\"MachinePool\")].name",description="MachinePool object to which this AzureMachinePool belongs"
 	// +kubebuilder:printcolumn:name="VMSS ID",type="string",priority=1,JSONPath=".spec.providerID",description="Azure VMSS ID"
 	// +kubebuilder:printcolumn:name="VM Size",type="string",priority=1,JSONPath=".spec.template.vmSize",description="Azure VM Size"
+	// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of this AzureMachinePool"
 
 	// AzureMachinePool is the Schema for the azuremachinepools API.
 	AzureMachinePool struct {

--- a/exp/api/v1beta1/azuremachinepoolmachine_types.go
+++ b/exp/api/v1beta1/azuremachinepoolmachine_types.go
@@ -105,6 +105,7 @@ type (
 	// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.provisioningState",description="Azure VMSS VM provisioning state"
 	// +kubebuilder:printcolumn:name="Cluster",type="string",priority=1,JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AzureMachinePoolMachine belongs"
 	// +kubebuilder:printcolumn:name="VMSS VM ID",type="string",priority=1,JSONPath=".spec.providerID",description="Azure VMSS VM ID"
+	// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of this AzureMachinePoolMachine"
 	// +kubebuilder:storageversion
 
 	// AzureMachinePoolMachine is the Schema for the azuremachinepoolmachines API.


### PR DESCRIPTION


 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind feature

**What this PR does / why we need it**:

On all CRDs where custom printcolumns are defined, the AGE column is missing. CAPI core CRDs already have the AGE column in place.

For all CRDs where custom build-colums are defined, the `AGE` column will be introduced. 

```
k get azurecluster
NAME      CLUSTER   READY   REASON   AGE
marioc1   marioc1   True             3d23h
```

Beside the `AGE` column, for `azureclusteridentities`, the `type` will also be a separate column.

```
k get azureclusteridentities
NAME               TYPE                     AGE
cluster-identity   ManualServicePrincipal   14d
```

Signed-off-by: Mario Constanti <mario@constanti.de>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* The age of all Azureresources is now printed by running `kubectl get` (e.g. `kubectl get azurecluster`)
* `kubectl get azureclusteridentity` now prints the `type` of the Azure Identity.
```
