### PR TITLE
Bug_fix: validate non-nil AzureMachine.Spec.Diagnostic when upgrading to v1beta1

### DIFF
--- a/api/v1beta1/azuremachine_webhook.go
+++ b/api/v1beta1/azuremachine_webhook.go
@@ -143,11 +143,13 @@ func (m *AzureMachine) ValidateUpdate(oldRaw runtime.Object) error {
 		allErrs = append(allErrs, err)
 	}
 
-	if err := webhookutils.ValidateImmutable(
-		field.NewPath("Spec", "Diagnostics"),
-		old.Spec.Diagnostics,
-		m.Spec.Diagnostics); err != nil {
-		allErrs = append(allErrs, err)
+	if old.Spec.Diagnostics != nil {
+		if err := webhookutils.ValidateImmutable(
+			field.NewPath("Spec", "Diagnostics"),
+			old.Spec.Diagnostics,
+			m.Spec.Diagnostics); err != nil {
+			allErrs = append(allErrs, err)
+		}
 	}
 
 	if len(allErrs) == 0 {

--- a/api/v1beta1/azuremachine_webhook_test.go
+++ b/api/v1beta1/azuremachine_webhook_test.go
@@ -562,6 +562,48 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "validTest: azuremachine.spec.Diagnostics should not error on updating nil diagnostics",
+			oldMachine: &AzureMachine{
+				Spec: AzureMachineSpec{},
+			},
+			newMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					Diagnostics: &Diagnostics{Boot: &BootDiagnostics{StorageAccountType: ManagedDiagnosticsStorage}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalidTest: azuremachine.spec.Diagnostics is immutable",
+			oldMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					Diagnostics: &Diagnostics{},
+				},
+			},
+			newMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					Diagnostics: &Diagnostics{Boot: &BootDiagnostics{StorageAccountType: ManagedDiagnosticsStorage}},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalidTest: azuremachine.spec.Diagnostics is immutable",
+			oldMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					Diagnostics: &Diagnostics{
+						Boot: &BootDiagnostics{},
+					},
+				},
+			},
+			newMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					Diagnostics: &Diagnostics{Boot: &BootDiagnostics{StorageAccountType: ManagedDiagnosticsStorage}},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2952 

**Special notes for your reviewer**:
- When upgrading from v1alpha4 -> v1beta1, AzureMachine CR gets updated upon cluster upgrade via the defaulter.
This upgrade updates AzureMachine.Spec.Diagnostics to "Managed", matching the existing behavior as implemented in https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/901.
- Without this fix, the validator webhook would not allow updating the AzureMachine.Spec.
- This PR enables upgrading nil AzureMachine.Spec.Diagnostic to "Managed" and unblocks v1alpha4 -> v1beta1 upgrades.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
