### PR TITLE
Set build time GOARCH to the one reported by go env

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -34,6 +34,8 @@ settings.update(read_yaml(
     default = {},
 ))
 
+os_arch = str(local("go env GOARCH")).rstrip("\n")
+
 if settings.get("trigger_mode") == "manual":
     trigger_mode(TRIGGER_MODE_MANUAL)
 
@@ -197,12 +199,18 @@ def capz():
             yaml = str(encode_yaml_stream(yaml_dict))
             yaml = fixup_yaml_empty_arrays(yaml)
 
-    ldflags = str(local("hack/version.sh"))
+    # Forge the build command
+    ldflags = "-extldflags \"-static\" " + str(local("hack/version.sh")).rstrip("\n")
+    build_env = "CGO_ENABLED=0 GOOS=linux GOARCH={arch}".format(arch = os_arch)
+    build_cmd = "{build_env} go build -ldflags '{ldflags}' -o .tiltbuild/manager".format(
+        build_env = build_env,
+        ldflags = ldflags,
+    )
 
     # Set up a local_resource build of the provider's manager binary.
     local_resource(
         "manager",
-        cmd = 'mkdir -p .tiltbuild;CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags  \'-extldflags "-static" ' + ldflags + "' -o .tiltbuild/manager",
+        cmd = "mkdir -p .tiltbuild; " + build_cmd,
         deps = ["api", "azure", "config", "controllers", "exp", "feature", "pkg", "util", "go.mod", "go.sum", "main.go"],
         labels = ["cluster-api"],
     )


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Avoid cross-compiling and therefore subsequent `qemu` emulation.

**Special notes for your reviewer**:
I am running this on Apple Silicon (`arm64`):

Before:
```
k --context kind-capz -n capz-system exec -t deployments/capz-controller-manager -- ps auxf
PID   USER     TIME  COMMAND
    1 root      0:00 sh /start.sh /manager azure --metrics-bind-addr=:8080 --leader-elect --feature-gates=MachinePool=true,AKS=true,AKSResourceHealth=false --enable-tracing --feature-gates=MachinePool=true,AKS=true
   11 root      0:02 {manager} /usr/bin/qemu-x86_64 /manager /manager azure --metrics-bind-addr=:8080 --leader-elect --feature-gates=MachinePool=true,AKS=true,AKSResourceHealth=false --enable-tracing --feature-gates=MachinePool=true,AKS=true
   59 root      0:00 ps auxf
```

After:
```
k --context kind-capz -n capz-system exec -t deployments/capz-controller-manager -- ps auxf
PID   USER     TIME  COMMAND
    1 root      0:00 sh /start.sh /manager azure --metrics-bind-addr=:8080 --leader-elect --feature-gates=MachinePool=true,AKS=true,AKSResourceHealth=false --enable-tracing --feature-gates=MachinePool=true,AKS=true
   11 root      0:01 /manager azure --metrics-bind-addr=:8080 --leader-elect --feature-gates=MachinePool=true,AKS=true,AKSResourceHealth=false --enable-tracing --feature-gates=MachinePool=true,AKS=true
   22 root      0:00 ps auxf
```

Note that in the second case no emulation is required because the binary has been compiled with the native architecture.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updated `Tiltfile` to honour the `GOARCH` reported by the OS.
```
