### PR TITLE
Better Detect when Machines in MachinePool VMSS are not running on the latest model

### DIFF
--- a/azure/converters/vmss.go
+++ b/azure/converters/vmss.go
@@ -99,6 +99,8 @@ func SDKToVMSSVM(sdkInstance compute.VirtualMachineScaleSetVM) *azure.VMSSVM {
 		instance.AvailabilityZone = to.StringSlice(sdkInstance.Zones)[0]
 	}
 
+	instance.LatestModelApplied = *sdkInstance.LatestModelApplied
+
 	return &instance
 }
 

--- a/azure/converters/vmss_test.go
+++ b/azure/converters/vmss_test.go
@@ -63,7 +63,8 @@ func Test_SDKToVMSS(t *testing.T) {
 							Name:       to.StringPtr("vm0"),
 							Zones:      to.StringSlicePtr([]string{"zone0"}),
 							VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-								ProvisioningState: to.StringPtr(string(compute.ProvisioningState1Succeeded)),
+								ProvisioningState:  to.StringPtr(string(compute.ProvisioningState1Succeeded)),
+								LatestModelApplied: to.BoolPtr(true),
 								OsProfile: &compute.OSProfile{
 									ComputerName: to.StringPtr("instance-000000"),
 								},
@@ -75,7 +76,8 @@ func Test_SDKToVMSS(t *testing.T) {
 							Name:       to.StringPtr("vm1"),
 							Zones:      to.StringSlicePtr([]string{"zone1"}),
 							VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-								ProvisioningState: to.StringPtr(string(compute.ProvisioningState1Succeeded)),
+								ProvisioningState:  to.StringPtr(string(compute.ProvisioningState1Succeeded)),
+								LatestModelApplied: to.BoolPtr(true),
 								OsProfile: &compute.OSProfile{
 									ComputerName: to.StringPtr("instance-000001"),
 								},
@@ -99,11 +101,12 @@ func Test_SDKToVMSS(t *testing.T) {
 
 				for i := 0; i < 2; i++ {
 					expected.Instances[i] = azure.VMSSVM{
-						ID:               fmt.Sprintf("vm/%d", i),
-						InstanceID:       fmt.Sprintf("%d", i),
-						Name:             fmt.Sprintf("instance-00000%d", i),
-						AvailabilityZone: fmt.Sprintf("zone%d", i),
-						State:            "Succeeded",
+						ID:                 fmt.Sprintf("vm/%d", i),
+						InstanceID:         fmt.Sprintf("%d", i),
+						Name:               fmt.Sprintf("instance-00000%d", i),
+						AvailabilityZone:   fmt.Sprintf("zone%d", i),
+						State:              "Succeeded",
+						LatestModelApplied: true,
 					}
 				}
 				g.Expect(actual).To(gomega.Equal(&expected))

--- a/azure/scope/machinepoolmachine.go
+++ b/azure/scope/machinepoolmachine.go
@@ -523,8 +523,13 @@ func (s *MachinePoolMachineScope) hasLatestModelApplied(ctx context.Context) (bo
 		return false, errors.New("machinepoolscope image must not be nil")
 	}
 
-	// if the images match, then the VM is of the same model
-	return reflect.DeepEqual(s.instance.Image, *image), nil
+	// if the images match, then the VM is of the same model , AND with the value returned by Azure
+
+	var latestModelApplied bool
+
+	latestModelApplied = reflect.DeepEqual(s.instance.Image, *image) && s.instance.LatestModelApplied
+
+	return latestModelApplied, nil
 }
 
 func newWorkloadClusterProxy(c client.Client, cluster client.ObjectKey) *workloadClusterProxy {

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -80,10 +80,11 @@ func TestGetExistingVMSS(t *testing.T) {
 				Zones:    []string{"1", "3"},
 				Instances: []azure.VMSSVM{
 					{
-						ID:         "my-vm-id",
-						InstanceID: "my-vm-1",
-						Name:       "instance-000001",
-						State:      "Succeeded",
+						ID:                 "my-vm-id",
+						InstanceID:         "my-vm-1",
+						Name:               "instance-000001",
+						State:              "Succeeded",
+						LatestModelApplied: true,
 					},
 				},
 			},
@@ -109,7 +110,8 @@ func TestGetExistingVMSS(t *testing.T) {
 						InstanceID: to.StringPtr("my-vm-1"),
 						Name:       to.StringPtr("my-vm"),
 						VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-							ProvisioningState: to.StringPtr("Succeeded"),
+							ProvisioningState:  to.StringPtr("Succeeded"),
+							LatestModelApplied: to.BoolPtr(true),
 							OsProfile: &compute.OSProfile{
 								ComputerName: to.StringPtr("instance-000001"),
 							},
@@ -1373,7 +1375,8 @@ func newDefaultInstances() []compute.VirtualMachineScaleSetVM {
 			InstanceID: to.StringPtr("my-vm-1"),
 			Name:       to.StringPtr("my-vm"),
 			VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-				ProvisioningState: to.StringPtr("Succeeded"),
+				ProvisioningState:  to.StringPtr("Succeeded"),
+				LatestModelApplied: to.BoolPtr(true),
 				OsProfile: &compute.OSProfile{
 					ComputerName: to.StringPtr("instance-000001"),
 				},
@@ -1392,7 +1395,8 @@ func newDefaultInstances() []compute.VirtualMachineScaleSetVM {
 			InstanceID: to.StringPtr("my-vm-2"),
 			Name:       to.StringPtr("my-vm"),
 			VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-				ProvisioningState: to.StringPtr("Succeeded"),
+				ProvisioningState:  to.StringPtr("Succeeded"),
+				LatestModelApplied: to.BoolPtr(true),
 				OsProfile: &compute.OSProfile{
 					ComputerName: to.StringPtr("instance-000002"),
 				},

--- a/azure/types.go
+++ b/azure/types.go
@@ -91,12 +91,13 @@ type ExtensionSpec struct {
 type (
 	// VMSSVM defines a VM in a virtual machine scale set.
 	VMSSVM struct {
-		ID               string                    `json:"id,omitempty"`
-		InstanceID       string                    `json:"instanceID,omitempty"`
-		Image            infrav1.Image             `json:"image,omitempty"`
-		Name             string                    `json:"name,omitempty"`
-		AvailabilityZone string                    `json:"availabilityZone,omitempty"`
-		State            infrav1.ProvisioningState `json:"vmState,omitempty"`
+		ID                 string                    `json:"id,omitempty"`
+		InstanceID         string                    `json:"instanceID,omitempty"`
+		Image              infrav1.Image             `json:"image,omitempty"`
+		Name               string                    `json:"name,omitempty"`
+		AvailabilityZone   string                    `json:"availabilityZone,omitempty"`
+		State              infrav1.ProvisioningState `json:"vmState,omitempty"`
+		LatestModelApplied bool                      `json:"latestModelApplied,omitempty"`
 	}
 
 	// VMSS defines a virtual machine scale set.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Uses the value for `latestModelApplied` as returned by Azure to determine if the Machine is up-to-date or not.

Capz will Delete and replace nodes that are not running the latest mode, fixing the issue of rolling out a change to the vmSize or Kubernetes Version to a set of nodes in a machinepool. 
I think this is what we want based on the documentation [here](https://capz.sigs.k8s.io/topics/machinepools.html#safe-rolling-upgrades-and-delete-policy) which at the moment is not true ( at least in my testing )

**Which issue(s) this PR fixes** :
Fixes # https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2972

**Special notes for your reviewer**:

* I updated some tests to include the new field but i did not add any new test.
* I marked this as `feature` but maybe it should be a `bug` since at the moment the controller does not do what the docs says it should do when spec of machinepool change ? 

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improve detecting when a `azureMachinePoolMachine` is not running the `latest version` of the spec to allow CAPZ to fully refresh the nodes in a `machinePool` when change is required.  
```
