### PR TITLE
make AzureManagedMachinePool spec.name immutable

### DIFF
--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -581,6 +581,7 @@ Following is the list of immutable fields for managed clusters:
 | AzureManagedControlPlane  | .spec.apiServerAccessProfile | except AuthorizedIPRanges |
 | AzureManagedControlPlane  | .spec.virtualNetwork         |                           |
 | AzureManagedControlPlane  | .spec.virtualNetwork.subnet  | except serviceEndpoints   |
+| AzureManagedMachinePool   | .spec.name                   |                           |
 | AzureManagedMachinePool   | .spec.sku                    |                           |
 | AzureManagedMachinePool   | .spec.osDiskSizeGB           |                           |
 | AzureManagedMachinePool   | .spec.osDiskType             |                           |

--- a/exp/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/exp/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -95,6 +95,13 @@ func (m *AzureManagedMachinePool) ValidateUpdate(oldRaw runtime.Object, client c
 	old := oldRaw.(*AzureManagedMachinePool)
 	var allErrs field.ErrorList
 
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "Name"),
+		old.Spec.Name,
+		m.Spec.Name); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
 	if err := m.validateNodeLabels(); err != nil {
 		allErrs = append(allErrs,
 			field.Invalid(

--- a/exp/api/v1beta1/azuremanagedmachinepool_webhook_test.go
+++ b/exp/api/v1beta1/azuremanagedmachinepool_webhook_test.go
@@ -83,6 +83,20 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "Cannot change Name of the agentpool",
+			new: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					Name: to.StringPtr("pool-new"),
+				},
+			},
+			old: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					Name: to.StringPtr("pool-old"),
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "Cannot change SKU of the agentpool",
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This change adds enforcement that AzureManagedMachinePool's `spec.name` is immutable. The AKS API doesn't expose a way to modify the name of a node pool and changing it on the CAPZ resource results in [unexpected behavior](https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2856#issuecomment-1372483302).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
AzureManagedMachinePool spec.name is now immutable
```
