### PR TITLE
Restarts containers in post kubeadm 

### DIFF
--- a/templates/cluster-template-dual-stack.yaml
+++ b/templates/cluster-template-dual-stack.yaml
@@ -256,3 +256,4 @@ spec:
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
       - systemctl restart systemd-resolved
+      - crictl pods -q | xargs -n1 crictl stopp

--- a/templates/cluster-template-ipv6.yaml
+++ b/templates/cluster-template-ipv6.yaml
@@ -152,6 +152,7 @@ spec:
     - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
       /etc/resolv.conf
     - systemctl restart systemd-resolved
+    - crictl pods -q | xargs -n1 crictl stopp
     preKubeadmCommands: []
   machineTemplate:
     infrastructureRef:
@@ -277,3 +278,4 @@ spec:
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
       - systemctl restart systemd-resolved
+      - crictl pods -q | xargs -n1 crictl stopp

--- a/templates/flavors/dual-stack/machine-deployment.yaml
+++ b/templates/flavors/dual-stack/machine-deployment.yaml
@@ -50,6 +50,7 @@ spec:
         - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
         - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
         - systemctl restart systemd-resolved
+        - crictl pods -q | xargs -n1 crictl stopp
       joinConfiguration:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/flavors/dual-stack/patches/kubeadm-controlplane.yaml
+++ b/templates/flavors/dual-stack/patches/kubeadm-controlplane.yaml
@@ -9,6 +9,7 @@ spec:
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
       - systemctl restart systemd-resolved
+      - crictl pods -q | xargs -n1 crictl stopp
     initConfiguration:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/flavors/ipv6/machine-deployment.yaml
+++ b/templates/flavors/ipv6/machine-deployment.yaml
@@ -50,6 +50,7 @@ spec:
         - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
         - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
         - systemctl restart systemd-resolved
+        - crictl pods -q | xargs -n1 crictl stopp
       joinConfiguration:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/flavors/ipv6/patches/kubeadm-controlplane.yaml
+++ b/templates/flavors/ipv6/patches/kubeadm-controlplane.yaml
@@ -9,6 +9,7 @@ spec:
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
       - systemctl restart systemd-resolved
+      - crictl pods -q | xargs -n1 crictl stopp
     initConfiguration:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/cluster-template-prow-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-dual-stack.yaml
@@ -148,6 +148,7 @@ spec:
     - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
       /etc/resolv.conf
     - systemctl restart systemd-resolved
+    - crictl pods -q | xargs -n1 crictl stopp
     preKubeadmCommands: []
   machineTemplate:
     infrastructureRef:
@@ -267,3 +268,4 @@ spec:
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
       - systemctl restart systemd-resolved
+      - crictl pods -q | xargs -n1 crictl stopp

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -157,6 +157,7 @@ spec:
     - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
       /etc/resolv.conf
     - systemctl restart systemd-resolved
+    - crictl pods -q | xargs -n1 crictl stopp
     preKubeadmCommands: []
   machineTemplate:
     infrastructureRef:
@@ -282,3 +283,4 @@ spec:
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
       - systemctl restart systemd-resolved
+      - crictl pods -q | xargs -n1 crictl stopp


### PR DESCRIPTION
Restarts containers in post kubeadm so that /etc/host values are loaded.This is a hack for lack of Azure NLB hairpin support does not work for all hostNetwork pods

Signed-off-by: Geetika Batra <geetikab@vmware.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
