### PR TITLE
prefer CAPI replicas-managed-by annotation for AKS autoscaler

### DIFF
--- a/azure/const.go
+++ b/azure/const.go
@@ -28,8 +28,4 @@ const (
 	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 	// for annotation formatting rules.
 	RGTagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-azure-last-applied-tags-rg"
-
-	// ReplicasManagedByAutoscalerAnnotation is set to true in the corresponding capi machine pool
-	// when an external autoscaler manages the node count of the associated machine pool.
-	ReplicasManagedByAutoscalerAnnotation = "cluster.x-k8s.io/replicas-managed-by-autoscaler"
 )

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -735,7 +736,7 @@ func (m *MachinePoolScope) UpdateCAPIMachinePoolReplicas(ctx context.Context, re
 
 // HasReplicasExternallyManaged returns true if the externally managed annotation is set on the CAPI MachinePool resource.
 func (m *MachinePoolScope) HasReplicasExternallyManaged(ctx context.Context) bool {
-	return m.MachinePool.Annotations[azure.ReplicasManagedByAutoscalerAnnotation] == "true"
+	return annotations.ReplicasManagedByExternalAutoscaler(m.MachinePool)
 }
 
 // ReconcileReplicas ensures MachinePool replicas match VMSS capacity if replicas are externally managed by an autoscaler.

--- a/azure/services/agentpools/agentpools.go
+++ b/azure/services/agentpools/agentpools.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const serviceName = "agentpools"
@@ -84,10 +85,10 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			}
 			// When autoscaling is set, add the annotation to the machine pool and update the replica count.
 			if to.Bool(agentPool.EnableAutoScaling) {
-				s.scope.SetCAPIMachinePoolAnnotation(azure.ReplicasManagedByAutoscalerAnnotation, "true")
+				s.scope.SetCAPIMachinePoolAnnotation(clusterv1.ReplicasManagedByAnnotation, "true")
 				s.scope.SetCAPIMachinePoolReplicas(agentPool.Count)
 			} else { // Otherwise, remove the annotation.
-				s.scope.RemoveCAPIMachinePoolAnnotation(azure.ReplicasManagedByAutoscalerAnnotation)
+				s.scope.RemoveCAPIMachinePoolAnnotation(clusterv1.ReplicasManagedByAnnotation)
 			}
 		}
 	} else {

--- a/azure/services/agentpools/agentpools_test.go
+++ b/azure/services/agentpools/agentpools_test.go
@@ -26,11 +26,11 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/agentpools/mock_agentpools"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 var (
@@ -73,7 +73,7 @@ func TestReconcileAgentPools(t *testing.T) {
 			expect: func(s *mock_agentpools.MockAgentPoolScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				s.AgentPoolSpec().Return(&fakeAgentPoolSpec)
 				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeAgentPoolSpec, serviceName).Return(fakeAgentPoolWithAutoscalingAndCount(true, 1), nil)
-				s.SetCAPIMachinePoolAnnotation(azure.ReplicasManagedByAutoscalerAnnotation, "true")
+				s.SetCAPIMachinePoolAnnotation(clusterv1.ReplicasManagedByAnnotation, "true")
 				s.SetCAPIMachinePoolReplicas(fakeAgentPoolWithAutoscalingAndCount(true, 1).Count)
 				s.UpdatePutStatus(infrav1.AgentPoolsReadyCondition, serviceName, nil)
 			},
@@ -84,7 +84,7 @@ func TestReconcileAgentPools(t *testing.T) {
 			expect: func(s *mock_agentpools.MockAgentPoolScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				s.AgentPoolSpec().Return(&fakeAgentPoolSpec)
 				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeAgentPoolSpec, serviceName).Return(fakeAgentPoolWithAutoscalingAndCount(false, 1), nil)
-				s.RemoveCAPIMachinePoolAnnotation(azure.ReplicasManagedByAutoscalerAnnotation)
+				s.RemoveCAPIMachinePoolAnnotation(clusterv1.ReplicasManagedByAnnotation)
 
 				s.UpdatePutStatus(infrav1.AgentPoolsReadyCondition, serviceName, nil)
 			},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR changes the annotation that we add to AKS node pools to the CAPI-defined `"cluster.x-k8s.io/replicas-managed-by"` annotation.

See:

- https://github.com/kubernetes-sigs/cluster-api/pull/7107

This PR also deprecates the CAPZ-defined `"cluster.x-k8s.io/replicas-managed-by-autoscaler"` annotation. We include a fallback support for this during MachinePool reconciliation, to aid forward-compatibility for existing clusters using the previous annotation.

I've decided not to worry about cleaning up the legacy annotation: upon the first reconciliation of the AKS node pool, CAPZ will assign the new, CAPI annotation. This seems simpler than worry about checking for existence of the old annotation on each reconcile loop, and deleting it if it's affected. The additional fallback code that supports the legacy annotation is not a maintenance burden, IMO.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2993

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
prefer CAPI replicas-managed-by annotation for AKS autoscaler
```
