### PR TITLE
don’t default to AKS networkPolicy=calico

### DIFF
--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -62,7 +62,7 @@ type ManagedClusterSpec struct {
 	// NetworkPlugin used for building Kubernetes network. Possible values include: 'azure', 'kubenet'. Defaults to azure.
 	NetworkPlugin string
 
-	// NetworkPolicy used for building Kubernetes network. Possible values include: 'calico', 'azure'. Defaults to azure.
+	// NetworkPolicy used for building Kubernetes network. Possible values include: 'calico', 'azure'.
 	NetworkPolicy string
 
 	// SSHPublicKey is a string literal containing an ssh public key. Will autogenerate and discard if not provided.

--- a/exp/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/exp/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -61,10 +61,6 @@ func (m *AzureManagedControlPlane) Default(_ client.Client) {
 		loadBalancerSKU := "Standard"
 		m.Spec.LoadBalancerSKU = &loadBalancerSKU
 	}
-	if m.Spec.NetworkPolicy == nil {
-		NetworkPolicy := "calico"
-		m.Spec.NetworkPolicy = &NetworkPolicy
-	}
 
 	if m.Spec.Version != "" && !strings.HasPrefix(m.Spec.Version, "v") {
 		normalizedVersion := "v" + m.Spec.Version

--- a/exp/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/exp/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -45,7 +45,6 @@ func TestDefaultingWebhook(t *testing.T) {
 	amcp.Default(nil)
 	g.Expect(*amcp.Spec.NetworkPlugin).To(Equal("azure"))
 	g.Expect(*amcp.Spec.LoadBalancerSKU).To(Equal("Standard"))
-	g.Expect(*amcp.Spec.NetworkPolicy).To(Equal("calico"))
 	g.Expect(amcp.Spec.Version).To(Equal("v1.17.5"))
 	g.Expect(amcp.Spec.SSHPublicKey).NotTo(BeEmpty())
 	g.Expect(amcp.Spec.NodeResourceGroupName).To(Equal("MC_fooRg_fooName_fooLocation"))


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind flake
/kind feature

**What this PR does / why we need it**:

This PR removes an opinionated default for AKS clusters to use the calico NetworkPolicy feature.

I was unaware that this default configuration enforcement existed. It is not documented anywhere I can see, and I'm not aware of any justification to include this opinionated cluster configuration for CAPZ-originating AKS clusters: we should let the user decide whether or not to include the installation of either calico or azure NetworkPolicy, as either requires additional operational overhead and other considerations that aren't suitable for choosing one or the other as a default (IMO).

Feature support for calico and azure NetworkPolicy remain unchanged.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
don’t default to AKS networkPolicy=calico
```
