### PR TITLE
refactor agentpool test definitions

### DIFF
--- a/azure/services/agentpools/spec_test.go
+++ b/azure/services/agentpools/spec_test.go
@@ -27,19 +27,19 @@ import (
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
-var (
-	fakeAgentPoolSpecWithAutoscaling = AgentPoolSpec{
+func fakeAgentPool(changes ...func(*AgentPoolSpec)) AgentPoolSpec {
+	pool := AgentPoolSpec{
 		Name:              "fake-agent-pool-name",
 		ResourceGroup:     "fake-rg",
 		Cluster:           "fake-cluster",
 		AvailabilityZones: []string{"fake-zone"},
 		EnableAutoScaling: to.BoolPtr(true),
 		EnableUltraSSD:    to.BoolPtr(true),
+		KubeletDiskType:   (*infrav1.KubeletDiskType)(to.StringPtr("fake-kubelet-disk-type")),
 		MaxCount:          to.Int32Ptr(5),
 		MaxPods:           to.Int32Ptr(10),
 		MinCount:          to.Int32Ptr(1),
@@ -56,257 +56,73 @@ var (
 		Headers:           map[string]string{"fake-header": "fake-value"},
 		AdditionalTags:    infrav1.Tags{"fake": "tag"},
 	}
-	fakeAgentPoolSpecWithoutAutoscaling = AgentPoolSpec{
-		Name:              "fake-agent-pool-name",
-		ResourceGroup:     "fake-rg",
-		Cluster:           "fake-cluster",
-		AvailabilityZones: []string{"fake-zone"},
-		EnableAutoScaling: to.BoolPtr(true),
-		EnableUltraSSD:    to.BoolPtr(true),
-		MaxCount:          to.Int32Ptr(5),
-		MaxPods:           to.Int32Ptr(10),
-		MinCount:          to.Int32Ptr(1),
-		Mode:              "fake-mode",
-		NodeLabels:        map[string]*string{"fake-label": to.StringPtr("fake-value")},
-		NodeTaints:        []string{"fake-taint"},
-		OSDiskSizeGB:      2,
-		OsDiskType:        to.StringPtr("fake-os-disk-type"),
-		OSType:            to.StringPtr("fake-os-type"),
-		Replicas:          1,
-		SKU:               "fake-sku",
-		Version:           to.StringPtr("fake-version"),
-		VnetSubnetID:      "fake-vnet-subnet-id",
-		Headers:           map[string]string{"fake-header": "fake-value"},
-		AdditionalTags:    infrav1.Tags{"fake": "tag"},
-	}
-	fakeAgentPoolSpecWithZeroReplicas = AgentPoolSpec{
-		Name:              "fake-agent-pool-name",
-		ResourceGroup:     "fake-rg",
-		Cluster:           "fake-cluster",
-		AvailabilityZones: []string{"fake-zone"},
-		EnableAutoScaling: to.BoolPtr(false),
-		EnableUltraSSD:    to.BoolPtr(true),
-		MaxCount:          to.Int32Ptr(5),
-		MaxPods:           to.Int32Ptr(10),
-		MinCount:          to.Int32Ptr(1),
-		Mode:              "fake-mode",
-		NodeLabels:        map[string]*string{"fake-label": to.StringPtr("fake-value")},
-		NodeTaints:        []string{"fake-taint"},
-		OSDiskSizeGB:      2,
-		OsDiskType:        to.StringPtr("fake-os-disk-type"),
-		OSType:            to.StringPtr("fake-os-type"),
-		Replicas:          0,
-		SKU:               "fake-sku",
-		Version:           to.StringPtr("fake-version"),
-		VnetSubnetID:      "fake-vnet-subnet-id",
-		Headers:           map[string]string{"fake-header": "fake-value"},
-		AdditionalTags:    infrav1.Tags{"fake": "tag"},
+
+	for _, change := range changes {
+		change(&pool)
 	}
 
-	fakeAgentPoolAutoScalingOutOfDate = containerservice.AgentPool{
-		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
-			AvailabilityZones:   &[]string{"fake-zone"},
-			Count:               to.Int32Ptr(1),    // updates if changed
-			EnableAutoScaling:   to.BoolPtr(false), // updates if changed
-			EnableUltraSSD:      to.BoolPtr(true),
-			MaxCount:            to.Int32Ptr(5), // updates if changed
-			MaxPods:             to.Int32Ptr(10),
-			MinCount:            to.Int32Ptr(1),                                               // updates if changed
-			Mode:                containerservice.AgentPoolMode("fake-mode"),                  // updates if changed
-			NodeLabels:          map[string]*string{"fake-label": to.StringPtr("fake-value")}, // updates if changed
-			NodeTaints:          &[]string{"fake-taint"},                                      // updates if changed
-			OrchestratorVersion: to.StringPtr("fake-version"),                                 // updates if changed
-			OsDiskSizeGB:        to.Int32Ptr(2),
-			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
-			OsType:              containerservice.OSType("fake-os-type"),
-			ProvisioningState:   to.StringPtr("Succeeded"),
-			Tags:                map[string]*string{"fake": pointer.String("tag")},
-			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
-			VMSize:              to.StringPtr("fake-sku"),
-			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
-		},
-	}
-
-	fakeAgentPoolMaxCountOutOfDate = containerservice.AgentPool{
-		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
-			AvailabilityZones:   &[]string{"fake-zone"},
-			Count:               to.Int32Ptr(1),   // updates if changed
-			EnableAutoScaling:   to.BoolPtr(true), // updates if changed
-			EnableUltraSSD:      to.BoolPtr(true),
-			MaxCount:            to.Int32Ptr(3), // updates if changed
-			MaxPods:             to.Int32Ptr(10),
-			MinCount:            to.Int32Ptr(1),                                               // updates if changed
-			Mode:                containerservice.AgentPoolMode("fake-mode"),                  // updates if changed
-			NodeLabels:          map[string]*string{"fake-label": to.StringPtr("fake-value")}, // updates if changed
-			NodeTaints:          &[]string{"fake-taint"},                                      // updates if changed
-			OrchestratorVersion: to.StringPtr("fake-version"),                                 // updates if changed
-			OsDiskSizeGB:        to.Int32Ptr(2),
-			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
-			OsType:              containerservice.OSType("fake-os-type"),
-			ProvisioningState:   to.StringPtr("Succeeded"),
-			Tags:                map[string]*string{"fake": pointer.String("tag")},
-			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
-			VMSize:              to.StringPtr("fake-sku"),
-			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
-		},
-	}
-
-	fakeAgentPoolMinCountOutOfDate = containerservice.AgentPool{
-		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
-			AvailabilityZones:   &[]string{"fake-zone"},
-			Count:               to.Int32Ptr(1),   // updates if changed
-			EnableAutoScaling:   to.BoolPtr(true), // updates if changed
-			EnableUltraSSD:      to.BoolPtr(true),
-			MaxCount:            to.Int32Ptr(5), // updates if changed
-			MaxPods:             to.Int32Ptr(10),
-			MinCount:            to.Int32Ptr(3),                                               // updates if changed
-			Mode:                containerservice.AgentPoolMode("fake-mode"),                  // updates if changed
-			NodeLabels:          map[string]*string{"fake-label": to.StringPtr("fake-value")}, // updates if changed
-			NodeTaints:          &[]string{"fake-taint"},                                      // updates if changed
-			OrchestratorVersion: to.StringPtr("fake-version"),                                 // updates if changed
-			OsDiskSizeGB:        to.Int32Ptr(2),
-			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
-			OsType:              containerservice.OSType("fake-os-type"),
-			ProvisioningState:   to.StringPtr("Succeeded"),
-			Tags:                map[string]*string{"fake": pointer.String("tag")},
-			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
-			VMSize:              to.StringPtr("fake-sku"),
-			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
-		},
-	}
-
-	fakeAgentPoolModeOutOfDate = containerservice.AgentPool{
-		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
-			AvailabilityZones:   &[]string{"fake-zone"},
-			Count:               to.Int32Ptr(1),   // updates if changed
-			EnableAutoScaling:   to.BoolPtr(true), // updates if changed
-			EnableUltraSSD:      to.BoolPtr(true),
-			MaxCount:            to.Int32Ptr(5), // updates if changed
-			MaxPods:             to.Int32Ptr(10),
-			MinCount:            to.Int32Ptr(1),                                               // updates if changed
-			Mode:                containerservice.AgentPoolMode("fake-old-mode"),              // updates if changed
-			NodeLabels:          map[string]*string{"fake-label": to.StringPtr("fake-value")}, // updates if changed
-			NodeTaints:          &[]string{"fake-taint"},                                      // updates if changed
-			OrchestratorVersion: to.StringPtr("fake-version"),                                 // updates if changed
-			OsDiskSizeGB:        to.Int32Ptr(2),
-			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
-			OsType:              containerservice.OSType("fake-os-type"),
-			ProvisioningState:   to.StringPtr("Succeeded"),
-			Tags:                map[string]*string{"fake": pointer.String("tag")},
-			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
-			VMSize:              to.StringPtr("fake-sku"),
-			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
-		},
-	}
-
-	fakeAgentPoolNodeLabelsOutOfDate = containerservice.AgentPool{
-		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
-			AvailabilityZones: &[]string{"fake-zone"},
-			Count:             to.Int32Ptr(1),   // updates if changed
-			EnableAutoScaling: to.BoolPtr(true), // updates if changed
-			EnableUltraSSD:    to.BoolPtr(true),
-			MaxCount:          to.Int32Ptr(5), // updates if changed
-			MaxPods:           to.Int32Ptr(10),
-			MinCount:          to.Int32Ptr(1),                                  // updates if changed
-			Mode:              containerservice.AgentPoolMode("fake-old-mode"), // updates if changed
-			NodeLabels: map[string]*string{
-				"fake-label":     to.StringPtr("fake-value"),
-				"fake-old-label": to.StringPtr("fake-old-value")}, // updates if changed
-			NodeTaints:          &[]string{"fake-taint"},      // updates if changed
-			OrchestratorVersion: to.StringPtr("fake-version"), // updates if changed
-			OsDiskSizeGB:        to.Int32Ptr(2),
-			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
-			OsType:              containerservice.OSType("fake-os-type"),
-			ProvisioningState:   to.StringPtr("Succeeded"),
-			Tags:                map[string]*string{"fake": pointer.String("tag")},
-			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
-			VMSize:              to.StringPtr("fake-sku"),
-			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
-		},
-	}
-
-	fakeAgentPoolNodeTaintsOutOfDate = containerservice.AgentPool{
-		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
-			AvailabilityZones:   &[]string{"fake-zone"},
-			Count:               to.Int32Ptr(1),   // updates if changed
-			EnableAutoScaling:   to.BoolPtr(true), // updates if changed
-			EnableUltraSSD:      to.BoolPtr(true),
-			MaxCount:            to.Int32Ptr(5), // updates if changed
-			MaxPods:             to.Int32Ptr(10),
-			MinCount:            to.Int32Ptr(1),                                               // updates if changed
-			Mode:                containerservice.AgentPoolMode("fake-mode"),                  // updates if changed
-			NodeLabels:          map[string]*string{"fake-label": to.StringPtr("fake-value")}, // updates if changed
-			NodeTaints:          &[]string{"fake-old-taint"},                                  // updates if changed
-			OrchestratorVersion: to.StringPtr("fake-version"),                                 // updates if changed
-			OsDiskSizeGB:        to.Int32Ptr(2),
-			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
-			OsType:              containerservice.OSType("fake-os-type"),
-			ProvisioningState:   to.StringPtr("Succeeded"),
-			Tags:                map[string]*string{"fake": pointer.String("tag")},
-			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
-			VMSize:              to.StringPtr("fake-sku"),
-			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
-		},
-	}
-)
-
-func fakeAgentPoolWithProvisioningState(provisioningState string) containerservice.AgentPool {
-	return fakeAgentPoolWithProvisioningStateAndCountAndAutoscaling(provisioningState, 1, true)
+	return pool
 }
 
-func fakeAgentPoolWithProvisioningStateAndCountAndAutoscaling(provisioningState string, count int32, autoscaling bool) containerservice.AgentPool {
-	var state *string
-	if provisioningState != "" {
-		state = to.StringPtr(provisioningState)
+func withReplicas(replicas int32) func(*AgentPoolSpec) {
+	return func(pool *AgentPoolSpec) {
+		pool.Replicas = replicas
 	}
-	return containerservice.AgentPool{
+}
+
+func withAutoscaling(enabled bool) func(*AgentPoolSpec) {
+	return func(pool *AgentPoolSpec) {
+		pool.EnableAutoScaling = to.BoolPtr(enabled)
+	}
+}
+
+func sdkFakeAgentPool(changes ...func(*containerservice.AgentPool)) containerservice.AgentPool {
+	pool := containerservice.AgentPool{
 		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
 			AvailabilityZones:   &[]string{"fake-zone"},
-			Count:               to.Int32Ptr(count),
-			EnableAutoScaling:   to.BoolPtr(autoscaling),
+			Count:               to.Int32Ptr(1),   // updates if changed
+			EnableAutoScaling:   to.BoolPtr(true), // updates if changed
 			EnableUltraSSD:      to.BoolPtr(true),
-			MaxCount:            to.Int32Ptr(5),
+			KubeletDiskType:     containerservice.KubeletDiskType("fake-kubelet-disk-type"),
+			MaxCount:            to.Int32Ptr(5), // updates if changed
 			MaxPods:             to.Int32Ptr(10),
-			MinCount:            to.Int32Ptr(1),
-			Mode:                containerservice.AgentPoolMode("fake-mode"),
-			NodeLabels:          map[string]*string{"fake-label": to.StringPtr("fake-value")},
-			NodeTaints:          &[]string{"fake-taint"},
-			OrchestratorVersion: to.StringPtr("fake-version"),
+			MinCount:            to.Int32Ptr(1),                                               // updates if changed
+			Mode:                containerservice.AgentPoolMode("fake-mode"),                  // updates if changed
+			NodeLabels:          map[string]*string{"fake-label": to.StringPtr("fake-value")}, // updates if changed
+			NodeTaints:          &[]string{"fake-taint"},                                      // updates if changed
+			OrchestratorVersion: to.StringPtr("fake-version"),                                 // updates if changed
 			OsDiskSizeGB:        to.Int32Ptr(2),
 			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
 			OsType:              containerservice.OSType("fake-os-type"),
-			ProvisioningState:   state,
 			Tags:                map[string]*string{"fake": to.StringPtr("tag")},
 			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
 			VMSize:              to.StringPtr("fake-sku"),
 			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
 		},
 	}
+
+	for _, change := range changes {
+		change(&pool)
+	}
+
+	return pool
 }
 
-func fakeAgentPoolWithAutoscalingAndCount(enableAutoScaling bool, count int32) containerservice.AgentPool {
-	return containerservice.AgentPool{
-		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
-			AvailabilityZones:   &[]string{"fake-zone"},
-			Count:               to.Int32Ptr(count),
-			EnableAutoScaling:   to.BoolPtr(enableAutoScaling),
-			EnableUltraSSD:      to.BoolPtr(true),
-			MaxCount:            to.Int32Ptr(5),
-			MaxPods:             to.Int32Ptr(10),
-			MinCount:            to.Int32Ptr(1),
-			Mode:                containerservice.AgentPoolMode("fake-mode"),
-			NodeLabels:          map[string]*string{"fake-label": to.StringPtr("fake-value")},
-			NodeTaints:          &[]string{"fake-taint"},
-			OrchestratorVersion: to.StringPtr("fake-version"),
-			OsDiskSizeGB:        to.Int32Ptr(2),
-			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
-			OsType:              containerservice.OSType("fake-os-type"),
-			ProvisioningState:   to.StringPtr("Succeeded"),
-			Tags:                map[string]*string{"fake": to.StringPtr("tag")},
-			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
-			VMSize:              to.StringPtr("fake-sku"),
-			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
-		},
+func sdkWithAutoscaling(enableAutoscaling bool) func(*containerservice.AgentPool) {
+	return func(pool *containerservice.AgentPool) {
+		pool.ManagedClusterAgentPoolProfileProperties.EnableAutoScaling = to.BoolPtr(enableAutoscaling)
+	}
+}
+
+func sdkWithCount(count int32) func(*containerservice.AgentPool) {
+	return func(pool *containerservice.AgentPool) {
+		pool.ManagedClusterAgentPoolProfileProperties.Count = to.Int32Ptr(count)
+	}
+}
+
+func sdkWithProvisioningState(state string) func(*containerservice.AgentPool) {
+	return func(pool *containerservice.AgentPool) {
+		pool.ManagedClusterAgentPoolProfileProperties.ProvisioningState = to.StringPtr(state)
 	}
 }
 
@@ -320,114 +136,155 @@ func TestParameters(t *testing.T) {
 	}{
 		{
 			name:          "parameters without an existing agent pool",
-			spec:          fakeAgentPoolSpecWithAutoscaling,
+			spec:          fakeAgentPool(),
 			existing:      nil,
-			expected:      fakeAgentPoolWithProvisioningState(""),
+			expected:      sdkFakeAgentPool(),
 			expectedError: nil,
 		},
 		{
 			name:          "existing agent pool up to date with provisioning state `Succeeded` without error",
-			spec:          fakeAgentPoolSpecWithAutoscaling,
-			existing:      fakeAgentPoolWithProvisioningState("Succeeded"),
+			spec:          fakeAgentPool(),
+			existing:      sdkFakeAgentPool(sdkWithProvisioningState("Succeeded")),
 			expected:      nil,
 			expectedError: nil,
 		},
 		{
 			name:          "existing agent pool up to date with provisioning state `Canceled` without error",
-			spec:          fakeAgentPoolSpecWithAutoscaling,
-			existing:      fakeAgentPoolWithProvisioningState("Canceled"),
+			spec:          fakeAgentPool(),
+			existing:      sdkFakeAgentPool(sdkWithProvisioningState("Canceled")),
 			expected:      nil,
 			expectedError: nil,
 		},
 		{
 			name:          "existing agent pool up to date with provisioning state `Failed` without error",
-			spec:          fakeAgentPoolSpecWithAutoscaling,
-			existing:      fakeAgentPoolWithProvisioningState("Failed"),
+			spec:          fakeAgentPool(),
+			existing:      sdkFakeAgentPool(sdkWithProvisioningState("Failed")),
 			expected:      nil,
 			expectedError: nil,
 		},
 		{
 			name:          "existing agent pool up to date with non-terminal provisioning state `Deleting`",
-			spec:          fakeAgentPoolSpecWithAutoscaling,
-			existing:      fakeAgentPoolWithProvisioningState("Deleting"),
+			spec:          fakeAgentPool(),
+			existing:      sdkFakeAgentPool(sdkWithProvisioningState("Deleting")),
 			expected:      nil,
 			expectedError: azure.WithTransientError(errors.New("Unable to update existing agent pool in non terminal state. Agent pool must be in one of the following provisioning states: Canceled, Failed, or Succeeded. Actual state: Deleting"), 20*time.Second),
 		},
 		{
 			name:          "existing agent pool up to date with non-terminal provisioning state `InProgress`",
-			spec:          fakeAgentPoolSpecWithAutoscaling,
-			existing:      fakeAgentPoolWithProvisioningState("InProgress"),
+			spec:          fakeAgentPool(),
+			existing:      sdkFakeAgentPool(sdkWithProvisioningState("InProgress")),
 			expected:      nil,
 			expectedError: azure.WithTransientError(errors.New("Unable to update existing agent pool in non terminal state. Agent pool must be in one of the following provisioning states: Canceled, Failed, or Succeeded. Actual state: InProgress"), 20*time.Second),
 		},
 		{
 			name:          "existing agent pool up to date with non-terminal provisioning state `randomString`",
-			spec:          fakeAgentPoolSpecWithAutoscaling,
-			existing:      fakeAgentPoolWithProvisioningState("randomString"),
+			spec:          fakeAgentPool(),
+			existing:      sdkFakeAgentPool(sdkWithProvisioningState("randomString")),
 			expected:      nil,
 			expectedError: azure.WithTransientError(errors.New("Unable to update existing agent pool in non terminal state. Agent pool must be in one of the following provisioning states: Canceled, Failed, or Succeeded. Actual state: randomString"), 20*time.Second),
 		},
 		{
-			name:          "parameters with an existing agent pool, update when count is out of date when enableAutoScaling is false",
-			spec:          fakeAgentPoolSpecWithoutAutoscaling,
-			existing:      fakeAgentPoolWithAutoscalingAndCount(false, 5),
-			expected:      fakeAgentPoolWithProvisioningState(""),
+			name: "parameters with an existing agent pool, update when count is out of date when enableAutoScaling is false",
+			spec: fakeAgentPool(),
+			existing: sdkFakeAgentPool(
+				sdkWithAutoscaling(false),
+				sdkWithCount(5),
+				sdkWithProvisioningState("Succeeded"),
+			),
+			expected:      sdkFakeAgentPool(),
 			expectedError: nil,
 		},
 		{
-			name:          "parameters with an existing agent pool, do not update when count is out of date and enableAutoScaling is true",
-			spec:          fakeAgentPoolSpecWithAutoscaling,
-			existing:      fakeAgentPoolWithAutoscalingAndCount(true, 5),
+			name: "parameters with an existing agent pool, do not update when count is out of date and enableAutoScaling is true",
+			spec: fakeAgentPool(),
+			existing: sdkFakeAgentPool(
+				sdkWithAutoscaling(true),
+				sdkWithCount(5),
+				sdkWithProvisioningState("Succeeded"),
+			),
 			expected:      nil,
 			expectedError: nil,
 		},
 		{
-			name:          "parameters with an existing agent pool and update needed on autoscaling",
-			spec:          fakeAgentPoolSpecWithAutoscaling,
-			existing:      fakeAgentPoolAutoScalingOutOfDate,
-			expected:      fakeAgentPoolWithProvisioningState(""),
+			name: "parameters with an existing agent pool and update needed on autoscaling",
+			spec: fakeAgentPool(),
+			existing: sdkFakeAgentPool(
+				sdkWithAutoscaling(false),
+				sdkWithProvisioningState("Succeeded"),
+			),
+			expected:      sdkFakeAgentPool(),
 			expectedError: nil,
 		},
 		{
-			name:          "parameters with an existing agent pool and update needed on max count",
-			spec:          fakeAgentPoolSpecWithAutoscaling,
-			existing:      fakeAgentPoolMaxCountOutOfDate,
-			expected:      fakeAgentPoolWithProvisioningState(""),
+			name: "parameters with an existing agent pool and update needed on max count",
+			spec: fakeAgentPool(),
+			existing: sdkFakeAgentPool(
+				func(pool *containerservice.AgentPool) { pool.MaxCount = to.Int32Ptr(3) },
+				sdkWithProvisioningState("Succeeded"),
+			),
+			expected:      sdkFakeAgentPool(),
 			expectedError: nil,
 		},
 		{
-			name:          "parameters with an existing agent pool and update needed on min count",
-			spec:          fakeAgentPoolSpecWithAutoscaling,
-			existing:      fakeAgentPoolMinCountOutOfDate,
-			expected:      fakeAgentPoolWithProvisioningState(""),
+			name: "parameters with an existing agent pool and update needed on min count",
+			spec: fakeAgentPool(),
+			existing: sdkFakeAgentPool(
+				func(pool *containerservice.AgentPool) { pool.MinCount = to.Int32Ptr(3) },
+				sdkWithProvisioningState("Succeeded"),
+			),
+			expected:      sdkFakeAgentPool(),
 			expectedError: nil,
 		},
 		{
-			name:          "parameters with an existing agent pool and update needed on mode",
-			spec:          fakeAgentPoolSpecWithAutoscaling,
-			existing:      fakeAgentPoolModeOutOfDate,
-			expected:      fakeAgentPoolWithProvisioningState(""),
+			name: "parameters with an existing agent pool and update needed on mode",
+			spec: fakeAgentPool(),
+			existing: sdkFakeAgentPool(
+				func(pool *containerservice.AgentPool) { pool.Mode = "fake-old-mode" },
+				sdkWithProvisioningState("Succeeded"),
+			),
+			expected:      sdkFakeAgentPool(),
 			expectedError: nil,
 		},
 		{
-			name:          "parameters with an existing agent pool and update needed on node labels",
-			spec:          fakeAgentPoolSpecWithAutoscaling,
-			existing:      fakeAgentPoolNodeLabelsOutOfDate,
-			expected:      fakeAgentPoolWithProvisioningState(""),
+			name: "parameters with an existing agent pool and update needed on node labels",
+			spec: fakeAgentPool(),
+			existing: sdkFakeAgentPool(
+				func(pool *containerservice.AgentPool) {
+					pool.NodeLabels = map[string]*string{
+						"fake-label":     to.StringPtr("fake-value"),
+						"fake-old-label": to.StringPtr("fake-old-value"),
+					}
+				},
+				sdkWithProvisioningState("Succeeded"),
+			),
+			expected:      sdkFakeAgentPool(),
 			expectedError: nil,
 		},
 		{
-			name:          "parameters with an existing agent pool and update needed on node taints",
-			spec:          fakeAgentPoolSpecWithAutoscaling,
-			existing:      fakeAgentPoolNodeTaintsOutOfDate,
-			expected:      fakeAgentPoolWithProvisioningState(""),
+			name: "parameters with an existing agent pool and update needed on node taints",
+			spec: fakeAgentPool(),
+			existing: sdkFakeAgentPool(
+				func(pool *containerservice.AgentPool) { pool.NodeTaints = &[]string{"fake-old-taint"} },
+				sdkWithProvisioningState("Succeeded"),
+			),
+			expected:      sdkFakeAgentPool(),
 			expectedError: nil,
 		},
 		{
-			name:          "scale to zero",
-			spec:          fakeAgentPoolSpecWithZeroReplicas,
-			existing:      fakeAgentPoolWithAutoscalingAndCount(false, 1),
-			expected:      fakeAgentPoolWithProvisioningStateAndCountAndAutoscaling("", 0, false),
+			name: "scale to zero",
+			spec: fakeAgentPool(
+				withReplicas(0),
+				withAutoscaling(false),
+			),
+			existing: sdkFakeAgentPool(
+				sdkWithAutoscaling(false),
+				sdkWithCount(1),
+				sdkWithProvisioningState("Succeeded"),
+			),
+			expected: sdkFakeAgentPool(
+				sdkWithAutoscaling(false),
+				sdkWithCount(0),
+			),
 			expectedError: nil,
 		},
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR refactors the agentpools unit test definitions to be more readable and self-contained by removing the shared test fixtures and instead using flexible builder functions to construct objects for each individual test. With this change, new tests should be easier to add in the future without having to copy-paste a full fixture to change a couple of fields like in https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2751/files#diff-224617dc1cf5a3e1abbc71a49b79c42441871bef5a14e810921526267e6bde82.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
AFAICT the actual tests are exactly the same, the only difference is the syntax to define them.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/area managedclusters

cc @willie-yao in case this is useful for #3003