### PR TITLE
fix dependabot.yaml indentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,37 +2,35 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
-  # Dependencies listed in go.mod
-  - package-ecosystem: "gomod"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-      day: "monday"      
-    commit-message:
-      include: "scope"
-    ignore:
-      # Ignore controller-runtime as its upgraded manually.
-      - dependency-name: "sigs.k8s.io/controller-runtime"
-      # Ignore k8s and its transitives modules as they are upgraded manually
-      # together with controller-runtime.
-      - dependency-name: "k8s.io/*"
-      - dependency-name: "go.etcd.io/*"
-      - dependency-name: "google.golang.org/grpc"
-    labels:
-      - "ok-to-test"
-      - "kind/cleanup"
-      - "priority/important-soon"
-      - "wg/security-audit"
-
-
-  # Dependencies listed in .github/workflows/*.yml
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    commit-message:
-      include: "scope"
-    labels:
-      - "kind/cleanup"
-      - "ok-to-test"
+# Dependencies listed in go.mod
+- package-ecosystem: "gomod"
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "daily" ## change it to interval:"weekly" once Dependabot starts working. 
+    # day: "monday"
+  commit-message:
+    include: "scope"
+  ignore:
+    # Ignore controller-runtime as its upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+    # Ignore k8s and its transitives modules as they are upgraded manually
+    # together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "go.etcd.io/*"
+    - dependency-name: "google.golang.org/grpc"
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
+    - "priority/important-soon"
+    - "wg/security-audit"
+# Dependencies listed in .github/workflows/*.yml
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  commit-message:
+    include: "scope"
+  labels:
+    - "kind/cleanup"
+    - "ok-to-test"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- We haven't seen any dependabot activities at CAPZ.
- Comparing [CAPZ's dependabot.yml ](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/.github/dependabot.yml) with [CAPI's dependabot.yml](https://github.com/kubernetes-sigs/cluster-api/blob/main/.github/dependabot.yml) points to minor indentation difference b/w both the files.
- Let's try to merge this change to see if it enables Dependabot at CAPZ
  
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # -- 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
