### PR TITLE
update dependabot-code-gen step

### DIFF
--- a/.github/workflows/dependabot-code-gen.yml
+++ b/.github/workflows/dependabot-code-gen.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # tag=v3.3.1
+      uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613 # tag=v3.4.0
       with:
         go-version: '1.19'
       id: go
     - name: Check out code into the Go module directory
-      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+      uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # tag=v3.2.0
     - uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # tag=v3.0.11
       name: Restore go cache
       with:
@@ -34,7 +34,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Update all modules
-      run: make generate-modules
+      run: make modules
     - name: Update generated code
       run: make generate
     - uses: EndBug/add-and-commit@61a88be553afe4206585b31aa72387c64295d08b # tag=v9.1.1


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
-  [`generate-modules`](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/.github/workflows/dependabot-code-gen.yml#L37) rule does not exist at CAPZ. This PR replaces `make generate-modules` with `make modules`.
- This PR also copies over SHA of `actions/setup-go` and `actions/checkout@` from [CAPI's `actions/setup-go`](https://github.com/kubernetes-sigs/cluster-api/blob/a18beb90115c55049e48fc2c64090c3e24cba04b/.github/workflows/dependabot.yml#L21) and [CAPI's `actions/checkout@` ](https://github.com/kubernetes-sigs/cluster-api/blob/a18beb90115c55049e48fc2c64090c3e24cba04b/.github/workflows/dependabot.yml#L26)
- Reference comment: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3007#issuecomment-1378130258

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
