### PR TITLE
fix agentpool taints diff check

### DIFF
--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -200,7 +200,7 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (p
 				MinCount:            s.MinCount,
 				MaxCount:            s.MaxCount,
 				NodeLabels:          s.NodeLabels,
-				NodeTaints:          existingPool.NodeTaints,
+				NodeTaints:          &s.NodeTaints,
 				Tags:                converters.TagsToMap(s.AdditionalTags),
 			},
 		}

--- a/azure/services/agentpools/spec_test.go
+++ b/azure/services/agentpools/spec_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
@@ -113,12 +114,13 @@ var (
 			MinCount:            to.Int32Ptr(1),                                               // updates if changed
 			Mode:                containerservice.AgentPoolMode("fake-mode"),                  // updates if changed
 			NodeLabels:          map[string]*string{"fake-label": to.StringPtr("fake-value")}, // updates if changed
-			NodeTaints:          &[]string{"fake-taint"},
-			OrchestratorVersion: to.StringPtr("fake-version"), // updates if changed
+			NodeTaints:          &[]string{"fake-taint"},                                      // updates if changed
+			OrchestratorVersion: to.StringPtr("fake-version"),                                 // updates if changed
 			OsDiskSizeGB:        to.Int32Ptr(2),
 			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
 			OsType:              containerservice.OSType("fake-os-type"),
 			ProvisioningState:   to.StringPtr("Succeeded"),
+			Tags:                map[string]*string{"fake": pointer.String("tag")},
 			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
 			VMSize:              to.StringPtr("fake-sku"),
 			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
@@ -136,12 +138,13 @@ var (
 			MinCount:            to.Int32Ptr(1),                                               // updates if changed
 			Mode:                containerservice.AgentPoolMode("fake-mode"),                  // updates if changed
 			NodeLabels:          map[string]*string{"fake-label": to.StringPtr("fake-value")}, // updates if changed
-			NodeTaints:          &[]string{"fake-taint"},
-			OrchestratorVersion: to.StringPtr("fake-version"), // updates if changed
+			NodeTaints:          &[]string{"fake-taint"},                                      // updates if changed
+			OrchestratorVersion: to.StringPtr("fake-version"),                                 // updates if changed
 			OsDiskSizeGB:        to.Int32Ptr(2),
 			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
 			OsType:              containerservice.OSType("fake-os-type"),
 			ProvisioningState:   to.StringPtr("Succeeded"),
+			Tags:                map[string]*string{"fake": pointer.String("tag")},
 			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
 			VMSize:              to.StringPtr("fake-sku"),
 			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
@@ -159,12 +162,13 @@ var (
 			MinCount:            to.Int32Ptr(3),                                               // updates if changed
 			Mode:                containerservice.AgentPoolMode("fake-mode"),                  // updates if changed
 			NodeLabels:          map[string]*string{"fake-label": to.StringPtr("fake-value")}, // updates if changed
-			NodeTaints:          &[]string{"fake-taint"},
-			OrchestratorVersion: to.StringPtr("fake-version"), // updates if changed
+			NodeTaints:          &[]string{"fake-taint"},                                      // updates if changed
+			OrchestratorVersion: to.StringPtr("fake-version"),                                 // updates if changed
 			OsDiskSizeGB:        to.Int32Ptr(2),
 			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
 			OsType:              containerservice.OSType("fake-os-type"),
 			ProvisioningState:   to.StringPtr("Succeeded"),
+			Tags:                map[string]*string{"fake": pointer.String("tag")},
 			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
 			VMSize:              to.StringPtr("fake-sku"),
 			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
@@ -179,15 +183,16 @@ var (
 			EnableUltraSSD:      to.BoolPtr(true),
 			MaxCount:            to.Int32Ptr(5), // updates if changed
 			MaxPods:             to.Int32Ptr(10),
-			MinCount:            to.Int32Ptr(3),                                               // updates if changed
+			MinCount:            to.Int32Ptr(1),                                               // updates if changed
 			Mode:                containerservice.AgentPoolMode("fake-old-mode"),              // updates if changed
 			NodeLabels:          map[string]*string{"fake-label": to.StringPtr("fake-value")}, // updates if changed
-			NodeTaints:          &[]string{"fake-taint"},
-			OrchestratorVersion: to.StringPtr("fake-version"), // updates if changed
+			NodeTaints:          &[]string{"fake-taint"},                                      // updates if changed
+			OrchestratorVersion: to.StringPtr("fake-version"),                                 // updates if changed
 			OsDiskSizeGB:        to.Int32Ptr(2),
 			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
 			OsType:              containerservice.OSType("fake-os-type"),
 			ProvisioningState:   to.StringPtr("Succeeded"),
+			Tags:                map[string]*string{"fake": pointer.String("tag")},
 			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
 			VMSize:              to.StringPtr("fake-sku"),
 			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
@@ -202,17 +207,42 @@ var (
 			EnableUltraSSD:    to.BoolPtr(true),
 			MaxCount:          to.Int32Ptr(5), // updates if changed
 			MaxPods:           to.Int32Ptr(10),
-			MinCount:          to.Int32Ptr(3),                                  // updates if changed
+			MinCount:          to.Int32Ptr(1),                                  // updates if changed
 			Mode:              containerservice.AgentPoolMode("fake-old-mode"), // updates if changed
 			NodeLabels: map[string]*string{
 				"fake-label":     to.StringPtr("fake-value"),
 				"fake-old-label": to.StringPtr("fake-old-value")}, // updates if changed
-			NodeTaints:          &[]string{"fake-taint"},
+			NodeTaints:          &[]string{"fake-taint"},      // updates if changed
 			OrchestratorVersion: to.StringPtr("fake-version"), // updates if changed
 			OsDiskSizeGB:        to.Int32Ptr(2),
 			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
 			OsType:              containerservice.OSType("fake-os-type"),
 			ProvisioningState:   to.StringPtr("Succeeded"),
+			Tags:                map[string]*string{"fake": pointer.String("tag")},
+			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
+			VMSize:              to.StringPtr("fake-sku"),
+			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
+		},
+	}
+
+	fakeAgentPoolNodeTaintsOutOfDate = containerservice.AgentPool{
+		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
+			AvailabilityZones:   &[]string{"fake-zone"},
+			Count:               to.Int32Ptr(1),   // updates if changed
+			EnableAutoScaling:   to.BoolPtr(true), // updates if changed
+			EnableUltraSSD:      to.BoolPtr(true),
+			MaxCount:            to.Int32Ptr(5), // updates if changed
+			MaxPods:             to.Int32Ptr(10),
+			MinCount:            to.Int32Ptr(1),                                               // updates if changed
+			Mode:                containerservice.AgentPoolMode("fake-mode"),                  // updates if changed
+			NodeLabels:          map[string]*string{"fake-label": to.StringPtr("fake-value")}, // updates if changed
+			NodeTaints:          &[]string{"fake-old-taint"},                                  // updates if changed
+			OrchestratorVersion: to.StringPtr("fake-version"),                                 // updates if changed
+			OsDiskSizeGB:        to.Int32Ptr(2),
+			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
+			OsType:              containerservice.OSType("fake-os-type"),
+			ProvisioningState:   to.StringPtr("Succeeded"),
+			Tags:                map[string]*string{"fake": pointer.String("tag")},
 			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
 			VMSize:              to.StringPtr("fake-sku"),
 			VnetSubnetID:        to.StringPtr("fake-vnet-subnet-id"),
@@ -383,6 +413,13 @@ func TestParameters(t *testing.T) {
 			name:          "parameters with an existing agent pool and update needed on node labels",
 			spec:          fakeAgentPoolSpecWithAutoscaling,
 			existing:      fakeAgentPoolNodeLabelsOutOfDate,
+			expected:      fakeAgentPoolWithProvisioningState(""),
+			expectedError: nil,
+		},
+		{
+			name:          "parameters with an existing agent pool and update needed on node taints",
+			spec:          fakeAgentPoolSpecWithAutoscaling,
+			existing:      fakeAgentPoolNodeTaintsOutOfDate,
 			expected:      fakeAgentPoolWithProvisioningState(""),
 			expectedError: nil,
 		},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
/area managedclusters

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Currently the diff between the current and desired agent pool definitions to determine whether an update is necessary or not uses the same value for node taints, so an update to an AzureManagedMachinePool's `spec.taints` would not trigger an update.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug preventing changes to AzureManagedMachinePool's `spec.taints` from taking effect.
```
