### PR TITLE
[release-1.6] Bump CAPI to v1.2.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	./hack/create-custom-cloud-provider-config.sh
 
 	# Deploy CAPI
-	curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.8/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -
+	curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.9/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -
 
 	# Deploy CAPZ
 	$(KIND) load docker-image $(CONTROLLER_IMG)-$(ARCH):$(TAG) --name=capz

--- a/Tiltfile
+++ b/Tiltfile
@@ -19,7 +19,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
-    "capi_version": "v1.2.8",
+    "capi_version": "v1.2.9",
     "cert_manager_version": "v1.1.0",
     "kubernetes_version": "v1.23.9",
     "aks_kubernetes_version": "v1.23.8",

--- a/go.mod
+++ b/go.mod
@@ -44,8 +44,8 @@ require (
 	k8s.io/klog/v2 v2.60.1
 	k8s.io/kubectl v0.24.0
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
-	sigs.k8s.io/cluster-api v1.2.8
-	sigs.k8s.io/cluster-api/test v1.2.8
+	sigs.k8s.io/cluster-api v1.2.9
+	sigs.k8s.io/cluster-api/test v1.2.9
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/kind v0.14.0
 )
@@ -211,4 +211,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.8
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.9

--- a/go.sum
+++ b/go.sum
@@ -1392,10 +1392,10 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
-sigs.k8s.io/cluster-api v1.2.8 h1:O0ZGyxGBeJaSWVptM7U0vTArAVlxCE5OtQItZ4OS2Y4=
-sigs.k8s.io/cluster-api v1.2.8/go.mod h1:HmxYwjLGHia5yjFoMY8I03Ha4kXAB+VTJnHFhAmPVig=
-sigs.k8s.io/cluster-api/test v1.2.8 h1:kYziHLSV+KqBoQXg7STGU4ZQpClayqIyw+BTYGx71uE=
-sigs.k8s.io/cluster-api/test v1.2.8/go.mod h1:55r564Dm7/eO7LH76SRE8whfg4yUnsLz5akqqej4Q+8=
+sigs.k8s.io/cluster-api v1.2.9 h1:8Q+gVLJUsuPixfgjKInNnA7xbgESLWGq26STfRkBqdc=
+sigs.k8s.io/cluster-api v1.2.9/go.mod h1:ZuiH8az7bIv0D6AzkbOrPUtiRAnKH9U1YnFC6nrk72I=
+sigs.k8s.io/cluster-api/test v1.2.9 h1:URMCZ4GHPmgIvH7vIVSItne0iEK0SBiHiyFZa9O1oXU=
+sigs.k8s.io/cluster-api/test v1.2.9/go.mod h1:/bOh2uQ+sbK8Iy0GM6wYq52z867klX95NHgtOG29PEU=
 sigs.k8s.io/controller-runtime v0.12.3 h1:FCM8xeY/FI8hoAfh/V4XbbYMY20gElh9yh+A98usMio=
 sigs.k8s.io/controller-runtime v0.12.3/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -3,11 +3,11 @@ managementClusterName: capz-e2e
 images:
   - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.2.8
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.2.9
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.2.8
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.2.9
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.2.8
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.2.9
     loadBehavior: tryLoad
 
 providers:
@@ -23,8 +23,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
-    - name: v1.2.8
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.8/core-components.yaml
+    - name: v1.2.9
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.9/core-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -46,8 +46,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
-    - name: v1.2.8
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.8/bootstrap-components.yaml
+    - name: v1.2.9
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.9/bootstrap-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -68,8 +68,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
-    - name: v1.2.8
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.8/control-plane-components.yaml
+    - name: v1.2.9
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.9/control-plane-components.yaml
       type: url
       contract: v1beta1
       files:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This fixes issues with the new k8s registry: 

https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.2.9

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
