### PR TITLE
feat/ add outboundType support

### DIFF
--- a/api/v1alpha3/azuremanagedcontrolplane_conversion.go
+++ b/api/v1alpha3/azuremanagedcontrolplane_conversion.go
@@ -44,6 +44,7 @@ func (src *AzureManagedControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.VirtualNetwork.ResourceGroup = restored.Spec.VirtualNetwork.ResourceGroup
 	dst.Spec.VirtualNetwork.Subnet.ServiceEndpoints = restored.Spec.VirtualNetwork.Subnet.ServiceEndpoints
 	dst.Spec.AutoScalerProfile = restored.Spec.AutoScalerProfile
+	dst.Spec.OutboundType = restored.Spec.OutboundType
 
 	dst.Status.LongRunningOperationStates = restored.Status.LongRunningOperationStates
 	dst.Status.Conditions = restored.Status.Conditions

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -1488,6 +1488,7 @@ func autoConvert_v1beta1_AzureManagedControlPlaneSpec_To_v1alpha3_AzureManagedCo
 	out.AdditionalTags = *(*Tags)(unsafe.Pointer(&in.AdditionalTags))
 	out.NetworkPlugin = (*string)(unsafe.Pointer(in.NetworkPlugin))
 	out.NetworkPolicy = (*string)(unsafe.Pointer(in.NetworkPolicy))
+	// WARNING: in.OutboundType requires manual conversion: does not exist in peer-type
 	out.SSHPublicKey = in.SSHPublicKey
 	out.DNSServiceIP = (*string)(unsafe.Pointer(in.DNSServiceIP))
 	out.LoadBalancerSKU = (*string)(unsafe.Pointer(in.LoadBalancerSKU))

--- a/api/v1alpha4/azuremanagedcontrolplane_conversion.go
+++ b/api/v1alpha4/azuremanagedcontrolplane_conversion.go
@@ -41,6 +41,7 @@ func (src *AzureManagedControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.VirtualNetwork.ResourceGroup = restored.Spec.VirtualNetwork.ResourceGroup
 	dst.Spec.VirtualNetwork.Subnet.ServiceEndpoints = restored.Spec.VirtualNetwork.Subnet.ServiceEndpoints
 	dst.Spec.AutoScalerProfile = restored.Spec.AutoScalerProfile
+	dst.Spec.OutboundType = restored.Spec.OutboundType
 
 	return nil
 }

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -1726,6 +1726,7 @@ func autoConvert_v1beta1_AzureManagedControlPlaneSpec_To_v1alpha4_AzureManagedCo
 	out.AdditionalTags = *(*Tags)(unsafe.Pointer(&in.AdditionalTags))
 	out.NetworkPlugin = (*string)(unsafe.Pointer(in.NetworkPlugin))
 	out.NetworkPolicy = (*string)(unsafe.Pointer(in.NetworkPolicy))
+	// WARNING: in.OutboundType requires manual conversion: does not exist in peer-type
 	out.SSHPublicKey = in.SSHPublicKey
 	out.DNSServiceIP = (*string)(unsafe.Pointer(in.DNSServiceIP))
 	out.LoadBalancerSKU = (*string)(unsafe.Pointer(in.LoadBalancerSKU))

--- a/api/v1beta1/azuremanagedcontrolplane_types.go
+++ b/api/v1beta1/azuremanagedcontrolplane_types.go
@@ -34,6 +34,20 @@ const (
 	PrivateDNSZoneModeNone string = "None"
 )
 
+// ManagedControlPlaneOutboundType enumerates the values for the managed control plane OutboundType.
+type ManagedControlPlaneOutboundType string
+
+const (
+	// ManagedControlPlaneOutboundTypeLoadBalancer ...
+	ManagedControlPlaneOutboundTypeLoadBalancer ManagedControlPlaneOutboundType = "loadBalancer"
+	// ManagedControlPlaneOutboundTypeManagedNATGateway ...
+	ManagedControlPlaneOutboundTypeManagedNATGateway ManagedControlPlaneOutboundType = "managedNATGateway"
+	// ManagedControlPlaneOutboundTypeUserAssignedNATGateway ...
+	ManagedControlPlaneOutboundTypeUserAssignedNATGateway ManagedControlPlaneOutboundType = "userAssignedNATGateway"
+	// ManagedControlPlaneOutboundTypeUserDefinedRouting ...
+	ManagedControlPlaneOutboundTypeUserDefinedRouting ManagedControlPlaneOutboundType = "userDefinedRouting"
+)
+
 // AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane.
 type AzureManagedControlPlaneSpec struct {
 	// Version defines the desired Kubernetes version.
@@ -78,6 +92,11 @@ type AzureManagedControlPlaneSpec struct {
 	// +kubebuilder:validation:Enum=azure;calico
 	// +optional
 	NetworkPolicy *string `json:"networkPolicy,omitempty"`
+
+	// Outbound configuration used by Nodes.
+	// +kubebuilder:validation:Enum=loadBalancer;managedNATGateway;userAssignedNATGateway;userDefinedRouting
+	// +optional
+	OutboundType *ManagedControlPlaneOutboundType `json:"outboundType,omitempty"`
 
 	// SSHPublicKey is a string literal containing an ssh public key base64 encoded.
 	SSHPublicKey string `json:"sshPublicKey"`

--- a/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -225,6 +225,16 @@ func (m *AzureManagedControlPlane) ValidateUpdate(oldRaw runtime.Object, client 
 		}
 	}
 
+	// Consider removing this once moves out of preview
+	// Updating outboundType after cluster creation (PREVIEW)
+	// https://learn.microsoft.com/en-us/azure/aks/egress-outboundtype#updating-outboundtype-after-cluster-creation-preview
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "OutboundType"),
+		old.Spec.OutboundType,
+		m.Spec.OutboundType); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
 	if errs := m.validateVirtualNetworkUpdate(old); len(errs) > 0 {
 		allErrs = append(allErrs, errs...)
 	}

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -1300,6 +1300,26 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "OutboundType update",
+			oldAMCP: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					OutboundType: (*ManagedControlPlaneOutboundType)(to.StringPtr(string(ManagedControlPlaneOutboundTypeUserDefinedRouting))),
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					OutboundType: (*ManagedControlPlaneOutboundType)(to.StringPtr(string(ManagedControlPlaneOutboundTypeLoadBalancer))),
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1160,6 +1160,11 @@ func (in *AzureManagedControlPlaneSpec) DeepCopyInto(out *AzureManagedControlPla
 		*out = new(string)
 		**out = **in
 	}
+	if in.OutboundType != nil {
+		in, out := &in.OutboundType, &out.OutboundType
+		*out = new(ManagedControlPlaneOutboundType)
+		**out = **in
+	}
 	if in.DNSServiceIP != nil {
 		in, out := &in.DNSServiceIP, &out.DNSServiceIP
 		*out = new(string)

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -436,6 +436,7 @@ func (s *ManagedControlPlaneScope) ManagedClusterSpec(ctx context.Context) azure
 			s.ControlPlane.Spec.VirtualNetwork.Subnet.Name,
 		),
 		GetAllAgentPools: s.GetAllAgentPoolSpecs,
+		OutboundType:     s.ControlPlane.Spec.OutboundType,
 	}
 
 	if s.ControlPlane.Spec.NetworkPlugin != nil {

--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -65,6 +65,9 @@ type ManagedClusterSpec struct {
 	// NetworkPolicy used for building Kubernetes network. Possible values include: 'calico', 'azure'.
 	NetworkPolicy string
 
+	// OutboundType used for building Kubernetes network. Possible values include: 'loadBalancer', 'managedNATGateway', 'userAssignedNATGateway', 'userDefinedRouting'.
+	OutboundType *infrav1.ManagedControlPlaneOutboundType
+
 	// SSHPublicKey is a string literal containing an ssh public key. Will autogenerate and discard if not provided.
 	SSHPublicKey string
 
@@ -375,6 +378,10 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existing interface{
 			PrivateDNSZone:                 s.APIServerAccessProfile.PrivateDNSZone,
 			EnablePrivateClusterPublicFQDN: s.APIServerAccessProfile.EnablePrivateClusterPublicFQDN,
 		}
+	}
+
+	if s.OutboundType != nil {
+		managedCluster.NetworkProfile.OutboundType = containerservice.OutboundType(*s.OutboundType)
 	}
 
 	managedCluster.AutoScalerProfile = buildAutoScalerProfile(s.AutoScalerProfile)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -804,6 +804,14 @@ spec:
                   containing cluster IaaS resources. Will be populated to default
                   in webhook.
                 type: string
+              outboundType:
+                description: Outbound configuration used by Nodes.
+                enum:
+                - loadBalancer
+                - managedNATGateway
+                - userAssignedNATGateway
+                - userDefinedRouting
+                type: string
               resourceGroupName:
                 description: ResourceGroupName is the name of the Azure resource group
                   for this AKS Cluster.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Adds support for the `outboundType` in an AKS cluster. The particular use case we use is userDefinedRouting.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Did not add validation (via webhook) due to:
* requirement for LoadBalancer SKU Standard is enforced via OpenAPI Spec.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

- [X] squashed commits
- [] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
Added support for setting `outboundType` property for Managed Clusters
```
