### PR TITLE
disable AKSPublicIPPrefixSpec in AKS E2E

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -674,6 +674,7 @@ var _ = Describe("Workload cluster creation", func() {
 				})
 			})
 
+			/* See https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/3047
 			By("creating a machine pool with public IP addresses from a prefix", func() {
 				// This test is also currently serving as the canonical
 				// "create/delete node pool" test. Eventually, that should be
@@ -685,7 +686,7 @@ var _ = Describe("Workload cluster creation", func() {
 						WaitIntervals:     e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
 					}
 				})
-			})
+			})*/
 
 			By("modifying nodepool autoscaling configuration", func() {
 				AKSAutoscaleSpec(ctx, func() AKSAutoscaleSpecInput {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR disables AKS E2E tests around public IP scenarios, until we can debug and figure out how to test this signal more reliably.

See: https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/3047

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
