### PR TITLE
fix/ diff for authorized ip ranges

### DIFF
--- a/api/v1alpha3/conversion_test.go
+++ b/api/v1alpha3/conversion_test.go
@@ -70,9 +70,10 @@ func TestFuzzyConversion(t *testing.T) {
 	}))
 
 	t.Run("for AzureManagedControlPlane", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
-		Scheme: scheme,
-		Hub:    &infrav1.AzureManagedControlPlane{},
-		Spoke:  &AzureManagedControlPlane{},
+		Scheme:      scheme,
+		Hub:         &infrav1.AzureManagedControlPlane{},
+		Spoke:       &AzureManagedControlPlane{},
+		FuzzerFuncs: []fuzzer.FuzzerFuncs{overrideAPIServerAccessProfileFunc},
 	}))
 
 	t.Run("for AzureManagedMachinePool", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
@@ -108,6 +109,15 @@ func overrideOutboundLBFunc(codecs runtimeserializer.CodecFactory) []interface{}
 			networkSpec.NodeOutboundLB = &infrav1.LoadBalancerSpec{
 				FrontendIPsCount: pointer.Int32(1),
 			}
+		},
+	}
+}
+
+func overrideAPIServerAccessProfileFunc(codecs runtimeserializer.CodecFactory) []interface{} {
+	authIPRange := []string{}
+	return []interface{}{
+		func(apiServerAccessProfile *infrav1.APIServerAccessProfile, c fuzz.Continue) {
+			apiServerAccessProfile.AuthorizedIPRanges = &authIPRange
 		},
 	}
 }

--- a/api/v1alpha4/azuremanagedcontrolplane_types.go
+++ b/api/v1alpha4/azuremanagedcontrolplane_types.go
@@ -157,7 +157,7 @@ type LoadBalancerProfile struct {
 type APIServerAccessProfile struct {
 	// AuthorizedIPRanges - Authorized IP Ranges to kubernetes API server.
 	// +optional
-	AuthorizedIPRanges []string `json:"authorizedIPRanges,omitempty"`
+	AuthorizedIPRanges *[]string `json:"authorizedIPRanges,omitempty"`
 	// EnablePrivateCluster - Whether to create the cluster as a private cluster or not.
 	// +optional
 	EnablePrivateCluster *bool `json:"enablePrivateCluster,omitempty"`

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -738,7 +738,7 @@ func Convert_v1beta1_AKSSku_To_v1alpha4_AKSSku(in *v1beta1.AKSSku, out *AKSSku, 
 }
 
 func autoConvert_v1alpha4_APIServerAccessProfile_To_v1beta1_APIServerAccessProfile(in *APIServerAccessProfile, out *v1beta1.APIServerAccessProfile, s conversion.Scope) error {
-	out.AuthorizedIPRanges = *(*[]string)(unsafe.Pointer(&in.AuthorizedIPRanges))
+	out.AuthorizedIPRanges = (*[]string)(unsafe.Pointer(in.AuthorizedIPRanges))
 	out.EnablePrivateCluster = (*bool)(unsafe.Pointer(in.EnablePrivateCluster))
 	out.PrivateDNSZone = (*string)(unsafe.Pointer(in.PrivateDNSZone))
 	out.EnablePrivateClusterPublicFQDN = (*bool)(unsafe.Pointer(in.EnablePrivateClusterPublicFQDN))
@@ -751,7 +751,7 @@ func Convert_v1alpha4_APIServerAccessProfile_To_v1beta1_APIServerAccessProfile(i
 }
 
 func autoConvert_v1beta1_APIServerAccessProfile_To_v1alpha4_APIServerAccessProfile(in *v1beta1.APIServerAccessProfile, out *APIServerAccessProfile, s conversion.Scope) error {
-	out.AuthorizedIPRanges = *(*[]string)(unsafe.Pointer(&in.AuthorizedIPRanges))
+	out.AuthorizedIPRanges = (*[]string)(unsafe.Pointer(in.AuthorizedIPRanges))
 	out.EnablePrivateCluster = (*bool)(unsafe.Pointer(in.EnablePrivateCluster))
 	out.PrivateDNSZone = (*string)(unsafe.Pointer(in.PrivateDNSZone))
 	out.EnablePrivateClusterPublicFQDN = (*bool)(unsafe.Pointer(in.EnablePrivateClusterPublicFQDN))

--- a/api/v1alpha4/zz_generated.deepcopy.go
+++ b/api/v1alpha4/zz_generated.deepcopy.go
@@ -69,8 +69,12 @@ func (in *APIServerAccessProfile) DeepCopyInto(out *APIServerAccessProfile) {
 	*out = *in
 	if in.AuthorizedIPRanges != nil {
 		in, out := &in.AuthorizedIPRanges, &out.AuthorizedIPRanges
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		}
 	}
 	if in.EnablePrivateCluster != nil {
 		in, out := &in.EnablePrivateCluster, &out.EnablePrivateCluster

--- a/api/v1beta1/azuremanagedcontrolplane_types.go
+++ b/api/v1beta1/azuremanagedcontrolplane_types.go
@@ -213,7 +213,7 @@ type LoadBalancerProfile struct {
 type APIServerAccessProfile struct {
 	// AuthorizedIPRanges - Authorized IP Ranges to kubernetes API server.
 	// +optional
-	AuthorizedIPRanges []string `json:"authorizedIPRanges,omitempty"`
+	AuthorizedIPRanges *[]string `json:"authorizedIPRanges,omitempty"`
 	// EnablePrivateCluster - Whether to create the cluster as a private cluster or not.
 	// +optional
 	EnablePrivateCluster *bool `json:"enablePrivateCluster,omitempty"`

--- a/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -363,7 +363,7 @@ func (m *AzureManagedControlPlane) validateLoadBalancerProfile(_ client.Client) 
 func (m *AzureManagedControlPlane) validateAPIServerAccessProfile(_ client.Client) error {
 	if m.Spec.APIServerAccessProfile != nil {
 		var allErrs field.ErrorList
-		for _, ipRange := range m.Spec.APIServerAccessProfile.AuthorizedIPRanges {
+		for _, ipRange := range *m.Spec.APIServerAccessProfile.AuthorizedIPRanges {
 			if _, _, err := net.ParseCIDR(ipRange); err != nil {
 				allErrs = append(allErrs, field.Invalid(field.NewPath("Spec", "APIServerAccessProfile", "AuthorizedIPRanges"), ipRange, "invalid CIDR format"))
 			}

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -234,7 +234,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.21.2",
 					APIServerAccessProfile: &APIServerAccessProfile{
-						AuthorizedIPRanges: []string{"1.2.3.400/32"},
+						AuthorizedIPRanges: &[]string{"1.2.3.400/32"},
 					},
 				},
 			},
@@ -1116,7 +1116,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					DNSServiceIP: pointer.String("192.168.0.0"),
 					Version:      "v1.18.0",
 					APIServerAccessProfile: &APIServerAccessProfile{
-						AuthorizedIPRanges: []string{"192.168.0.1/32"},
+						AuthorizedIPRanges: &[]string{"192.168.0.1/32"},
 					},
 				},
 			},

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -69,8 +69,12 @@ func (in *APIServerAccessProfile) DeepCopyInto(out *APIServerAccessProfile) {
 	*out = *in
 	if in.AuthorizedIPRanges != nil {
 		in, out := &in.AuthorizedIPRanges, &out.AuthorizedIPRanges
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		}
 	}
 	if in.EnablePrivateCluster != nil {
 		in, out := &in.EnablePrivateCluster, &out.EnablePrivateCluster

--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -156,7 +156,7 @@ type LoadBalancerProfile struct {
 // APIServerAccessProfile is the access profile for AKS API server.
 type APIServerAccessProfile struct {
 	// AuthorizedIPRanges are the authorized IP Ranges to kubernetes API server.
-	AuthorizedIPRanges []string
+	AuthorizedIPRanges *[]string
 	// EnablePrivateCluster defines hether to create the cluster as a private cluster or not.
 	EnablePrivateCluster *bool
 	// PrivateDNSZone is the private dns zone for private clusters.
@@ -373,7 +373,7 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existing interface{
 
 	if s.APIServerAccessProfile != nil {
 		managedCluster.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
-			AuthorizedIPRanges:             &s.APIServerAccessProfile.AuthorizedIPRanges,
+			AuthorizedIPRanges:             s.APIServerAccessProfile.AuthorizedIPRanges,
 			EnablePrivateCluster:           s.APIServerAccessProfile.EnablePrivateCluster,
 			PrivateDNSZone:                 s.APIServerAccessProfile.PrivateDNSZone,
 			EnablePrivateClusterPublicFQDN: s.APIServerAccessProfile.EnablePrivateClusterPublicFQDN,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Fixes a reconcile loop bug for the Managed Control Plane in the AuthorizedIPRanges.

Current Behaviour:
Show below, this a diff bug that causes an unending reconcile loop, effectively putting the AKS cluster in a perpetual "updating" state.

<img width="517" alt="image" src="https://user-images.githubusercontent.com/37879183/213000645-e608cd3a-99db-46cd-bb5d-903a07933e4d.png">

New Behaviour:
Updated the spec `AuthorizedIPRanges` field to a pointer field (`*[]string`) much like other similar fields. This solves the diff issue, causing the cluster reconcile loop to stabilize properly.

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
fix AuthorizedIPRanges diff reconcile loop.
```
