### PR TITLE
fix unnecessary reconciles on AKS node taints

### DIFF
--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -204,6 +204,9 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (p
 				Tags:                converters.TagsToMap(s.AdditionalTags),
 			},
 		}
+		if len(*normalizedProfile.NodeTaints) == 0 {
+			normalizedProfile.NodeTaints = nil
+		}
 
 		if s.KubeletConfig != nil {
 			normalizedProfile.KubeletConfig = &containerservice.KubeletConfig{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Fixes a bug where AKS node taints were constantly being reconciled when they were not defined on AzureManagedMachinePool because of a nil/empty discrepancy. More details: https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/3047#issuecomment-1386071049


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3047

**Special notes for your reviewer**: I will try to add a unit test for this after #3006.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
