### PR TITLE
Always run AKS E2E get+update as transaction

### DIFF
--- a/test/e2e/aks_public_ip_prefix.go
+++ b/test/e2e/aks_public_ip_prefix.go
@@ -154,11 +154,13 @@ func AKSPublicIPPrefixSpec(ctx context.Context, inputGetter func() AKSPublicIPPr
 	}, input.WaitIntervals...).Should(Succeed())
 
 	By("Scaling the MachinePool to 2 nodes")
-	err = mgmtClient.Get(ctx, client.ObjectKeyFromObject(machinePool), machinePool)
-	Expect(err).NotTo(HaveOccurred())
-	machinePool.Spec.Replicas = to.Int32Ptr(2)
-	err = mgmtClient.Update(ctx, machinePool)
-	Expect(err).NotTo(HaveOccurred())
+	Eventually(func(g Gomega) {
+		err = mgmtClient.Get(ctx, client.ObjectKeyFromObject(machinePool), machinePool)
+		g.Expect(err).NotTo(HaveOccurred())
+		machinePool.Spec.Replicas = to.Int32Ptr(2)
+		err = mgmtClient.Update(ctx, machinePool)
+		g.Expect(err).NotTo(HaveOccurred())
+	}, input.WaitIntervals...).Should(Succeed())
 
 	By("Verifying the AzureManagedMachinePool becomes ready")
 	Eventually(func(g Gomega) {

--- a/test/e2e/aks_tags.go
+++ b/test/e2e/aks_tags.go
@@ -87,10 +87,13 @@ func AKSAdditionalTagsSpec(ctx context.Context, inputGetter func() AKSAdditional
 
 		By("Deleting all tags for control plane")
 		expectedTags = nil
-		Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
-		initialTags := infraControlPlane.Spec.AdditionalTags
-		infraControlPlane.Spec.AdditionalTags = expectedTags
-		Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		var initialTags infrav1.Tags
+		Eventually(func(g Gomega) {
+			g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
+			initialTags = infraControlPlane.Spec.AdditionalTags
+			infraControlPlane.Spec.AdditionalTags = expectedTags
+			g.Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		}, inputGetter().WaitForUpdate...).Should(Succeed())
 		Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 
 		By("Creating tags for control plane")
@@ -98,25 +101,31 @@ func AKSAdditionalTagsSpec(ctx context.Context, inputGetter func() AKSAdditional
 			"test":    "tag",
 			"another": "value",
 		}
-		Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
-		infraControlPlane.Spec.AdditionalTags = expectedTags
-		Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
+			infraControlPlane.Spec.AdditionalTags = expectedTags
+			g.Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		}, inputGetter().WaitForUpdate...).Should(Succeed())
 		Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 
 		By("Updating tags for control plane")
 		expectedTags["test"] = "updated"
 		delete(expectedTags, "another")
 		expectedTags["new"] = "value"
-		Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
-		infraControlPlane.Spec.AdditionalTags = expectedTags
-		Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
+			infraControlPlane.Spec.AdditionalTags = expectedTags
+			g.Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		}, inputGetter().WaitForUpdate...).Should(Succeed())
 		Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 
 		By("Restoring initial tags for control plane")
 		expectedTags = initialTags
-		Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
-		infraControlPlane.Spec.AdditionalTags = expectedTags
-		Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
+			infraControlPlane.Spec.AdditionalTags = expectedTags
+			g.Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		}, inputGetter().WaitForUpdate...).Should(Succeed())
 		Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 	}()
 
@@ -146,10 +155,13 @@ func AKSAdditionalTagsSpec(ctx context.Context, inputGetter func() AKSAdditional
 
 			Byf("Deleting all tags for machine pool %s", mp.Name)
 			expectedTags = nil
-			Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
-			initialTags := ammp.Spec.AdditionalTags
-			ammp.Spec.AdditionalTags = expectedTags
-			Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			var initialTags infrav1.Tags
+			Eventually(func(g Gomega) {
+				g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
+				initialTags = ammp.Spec.AdditionalTags
+				ammp.Spec.AdditionalTags = expectedTags
+				g.Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			}, inputGetter().WaitForUpdate...).Should(Succeed())
 			Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 
 			Byf("Creating tags for machine pool %s", mp.Name)
@@ -157,25 +169,31 @@ func AKSAdditionalTagsSpec(ctx context.Context, inputGetter func() AKSAdditional
 				"test":    "tag",
 				"another": "value",
 			}
-			Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
-			ammp.Spec.AdditionalTags = expectedTags
-			Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
+				ammp.Spec.AdditionalTags = expectedTags
+				g.Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			}, inputGetter().WaitForUpdate...).Should(Succeed())
 			Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 
 			Byf("Updating tags for machine pool %s", mp.Name)
 			expectedTags["test"] = "updated"
 			delete(expectedTags, "another")
 			expectedTags["new"] = "value"
-			Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
-			ammp.Spec.AdditionalTags = expectedTags
-			Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
+				ammp.Spec.AdditionalTags = expectedTags
+				g.Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			}, inputGetter().WaitForUpdate...).Should(Succeed())
 			Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 
 			Byf("Restoring initial tags for machine pool %s", mp.Name)
 			expectedTags = initialTags
-			Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
-			ammp.Spec.AdditionalTags = expectedTags
-			Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
+				ammp.Spec.AdditionalTags = expectedTags
+				g.Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			}, inputGetter().WaitForUpdate...).Should(Succeed())
 			Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 		}(mp)
 	}

--- a/test/e2e/aks_upgrade.go
+++ b/test/e2e/aks_upgrade.go
@@ -58,13 +58,14 @@ func AKSUpgradeSpec(ctx context.Context, inputGetter func() AKSUpgradeSpecInput)
 	mgmtClient := bootstrapClusterProxy.GetClient()
 	Expect(mgmtClient).NotTo(BeNil())
 
-	infraControlPlane := &infrav1.AzureManagedControlPlane{}
-	err = mgmtClient.Get(ctx, client.ObjectKey{Namespace: input.Cluster.Spec.ControlPlaneRef.Namespace, Name: input.Cluster.Spec.ControlPlaneRef.Name}, infraControlPlane)
-	Expect(err).NotTo(HaveOccurred())
-
 	By("Upgrading the control plane")
-	infraControlPlane.Spec.Version = input.KubernetesVersionUpgradeTo
-	Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+	var infraControlPlane = &infrav1.AzureManagedControlPlane{}
+	Eventually(func(g Gomega) {
+		err = mgmtClient.Get(ctx, client.ObjectKey{Namespace: input.Cluster.Spec.ControlPlaneRef.Namespace, Name: input.Cluster.Spec.ControlPlaneRef.Name}, infraControlPlane)
+		g.Expect(err).NotTo(HaveOccurred())
+		infraControlPlane.Spec.Version = input.KubernetesVersionUpgradeTo
+		g.Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+	}, inputGetter().WaitForControlPlane...).Should(Succeed())
 
 	Eventually(func() (string, error) {
 		aksCluster, err := managedClustersClient.Get(ctx, infraControlPlane.Spec.ResourceGroupName, infraControlPlane.Name)

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -176,13 +176,11 @@ func labelNodesWithMachinePoolName(ctx context.Context, workloadClient client.Cl
 			}, n)
 			if err != nil {
 				LogWarning(err.Error())
+				return err
 			}
-			return err
-		}, waitforResourceOperationTimeout, 3*time.Second).Should(Succeed())
-		n.Labels[clusterv1.OwnerKindAnnotation] = "MachinePool"
-		n.Labels[clusterv1.OwnerNameAnnotation] = mpName
-		Eventually(func() error {
-			err := workloadClient.Update(ctx, n)
+			n.Labels[clusterv1.OwnerKindAnnotation] = "MachinePool"
+			n.Labels[clusterv1.OwnerNameAnnotation] = mpName
+			err = workloadClient.Update(ctx, n)
 			if err != nil {
 				LogWarning(err.Error())
 			}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind flake

**What this PR does / why we need it**:

This PR updates our AKS E2E code flows so that all resource updates occur in a common retry loop w/ the resource GET. This is in response to observed flakes when we attempt to update a resource that has changed since the original GET occured in the flow of E2E.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
