### PR TITLE
Fixing panic on AzureMachinePool creation with auto-scale

### DIFF
--- a/azure/scope/managedmachinepool.go
+++ b/azure/scope/managedmachinepool.go
@@ -309,6 +309,9 @@ func (s *ManagedMachinePoolScope) SetCAPIMachinePoolReplicas(replicas *int32) {
 
 // SetCAPIMachinePoolAnnotation sets the specified annotation on the associated MachinePool.
 func (s *ManagedMachinePoolScope) SetCAPIMachinePoolAnnotation(key, value string) {
+	if s.MachinePool.Annotations == nil {
+		s.MachinePool.Annotations = make(map[string]string)
+	}
 	s.MachinePool.Annotations[key] = value
 }
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3062 

**Special notes for your reviewer**:
Did not go the route of using the helper function mentioned in the issue by @CecileRobertMichon as
that would need me to implement the interface, can be done as a separate refactor.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ X ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
