### PR TITLE
standardize curl retries in scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -783,7 +783,7 @@ $(KUBECTL): ## Build kubectl from tools folder.
 $(HELM): ## Put helm into tools folder.
 	mkdir -p $(TOOLS_BIN_DIR)
 	rm -f "$(TOOLS_BIN_DIR)/$(HELM_BIN)*"
-	curl -fsSL -o $(TOOLS_BIN_DIR)/get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+	curl --retry $(CURL_RETRIES) -fsSL -o $(TOOLS_BIN_DIR)/get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 	chmod 700 $(TOOLS_BIN_DIR)/get_helm.sh
 	USE_SUDO=false HELM_INSTALL_DIR=$(TOOLS_BIN_DIR) DESIRED_VERSION=$(HELM_VER) BINARY_NAME=$(HELM_BIN)-$(HELM_VER) $(TOOLS_BIN_DIR)/get_helm.sh
 	ln -sf $(HELM) $(TOOLS_BIN_DIR)/$(HELM_BIN)

--- a/Tiltfile
+++ b/Tiltfile
@@ -50,7 +50,7 @@ if "default_registry" in settings:
 def deploy_capi():
     version = settings.get("capi_version")
     capi_uri = "https://github.com/kubernetes-sigs/cluster-api/releases/download/{}/cluster-api-components.yaml".format(version)
-    cmd = "curl -sSL {} | {} | {} apply -f -".format(capi_uri, envsubst_cmd, kubectl_cmd)
+    cmd = "curl --retry 3 -sSL {} | {} | {} apply -f -".format(capi_uri, envsubst_cmd, kubectl_cmd)
     local(cmd, quiet = True)
     if settings.get("extra_args"):
         extra_args = settings.get("extra_args")

--- a/docs/book/install-and-build.sh
+++ b/docs/book/install-and-build.sh
@@ -57,7 +57,7 @@ esac
 # we hardcode linux/amd64 since rust uses a different naming scheme
 echo "downloading mdBook-${mdBookVersion}-${arch}-${target}.${ext}"
 set -x
-curl -sL -o /tmp/mdbook.${ext} "https://github.com/rust-lang-nursery/mdBook/releases/download/${mdBookVersion}/mdBook-${mdBookVersion}-${arch}-${target}.${ext}"
+curl --retry 3 -sL -o /tmp/mdbook.${ext} "https://github.com/rust-lang-nursery/mdBook/releases/download/${mdBookVersion}/mdBook-${mdBookVersion}-${arch}-${target}.${ext}"
 ${cmd} /tmp/mdbook.${ext}
 chmod +x /tmp/mdbook
 

--- a/hack/create-custom-cloud-provider-config.sh
+++ b/hack/create-custom-cloud-provider-config.sh
@@ -26,7 +26,7 @@ source "${REPO_ROOT}/hack/common-vars.sh"
 make --directory="${REPO_ROOT}" "${KUBECTL##*/}"
 
 if [[ -n "${CUSTOM_CLOUD_PROVIDER_CONFIG:-}" ]]; then
-  curl -sL -o tmp_azure_json "${CUSTOM_CLOUD_PROVIDER_CONFIG}"
+  curl --retry 3 -sL -o tmp_azure_json "${CUSTOM_CLOUD_PROVIDER_CONFIG}"
   envsubst < tmp_azure_json > azure_json
   kubectl create secret generic "${CLUSTER_NAME}-control-plane-azure-json" \
     --from-file=control-plane-azure.json=azure_json \

--- a/hack/ensure-azcli.sh
+++ b/hack/ensure-azcli.sh
@@ -21,7 +21,7 @@ set -o pipefail
 if [[ -z "$(command -v az)" ]]; then
   echo "installing Azure CLI"
   apt-get update && apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
-  curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+  curl --retry 3 -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
   AZ_REPO=$(lsb_release -cs)
   echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ ${AZ_REPO} main" | tee /etc/apt/sources.list.d/azure-cli.list
   apt-get update && apt-get install -y azure-cli

--- a/hack/observability/prometheus/fetch-prometheus-resources.sh
+++ b/hack/observability/prometheus/fetch-prometheus-resources.sh
@@ -20,4 +20,4 @@ set -o pipefail
 
 RESOURCES_ROOT=$(dirname "${BASH_SOURCE[0]}")/resources
 
-curl -s https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml > "${RESOURCES_ROOT}/bundle.yaml"
+curl --retry 3 -s https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml > "${RESOURCES_ROOT}/bundle.yaml"

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -18,13 +18,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+CURL_RETRIES=3
+
 capz::util::get_latest_ci_version() {
     release="${1}"
     ci_version_url="https://dl.k8s.io/ci/latest-${release}.txt"
-    if ! curl -fL "${ci_version_url}" > /dev/null; then
+    if ! curl --retry "${CURL_RETRIES}" -fL "${ci_version_url}" > /dev/null; then
         ci_version_url="https://dl.k8s.io/ci/latest.txt"
     fi
-    curl -sSL "${ci_version_url}"
+    curl --retry "${CURL_RETRIES}" -sSL "${ci_version_url}"
 }
 
 capz::util::should_build_kubernetes() {

--- a/hack/verify-starlark.sh
+++ b/hack/verify-starlark.sh
@@ -59,7 +59,7 @@ BUILDIFIER="${SCRIPT_DIR}/tools/bin/buildifier/${VERSION}/buildifier"
 if [ ! -f "$BUILDIFIER" ]; then
   # install buildifier
   cd "${TMP_DIR}" || exit
-  curl -L "https://github.com/bazelbuild/buildtools/releases/download/${VERSION}/${BINARY}" -o "${TMP_DIR}/buildifier"
+  curl --retry 3 -L "https://github.com/bazelbuild/buildtools/releases/download/${VERSION}/${BINARY}" -o "${TMP_DIR}/buildifier"
   chmod +x "${TMP_DIR}/buildifier"
   cd "${ROOT_PATH}"
   mkdir -p "$(dirname "$0")/tools/bin/buildifier/${VERSION}"

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -64,7 +64,7 @@ setup() {
 
     if [[ "${KUBERNETES_VERSION:-}" =~ "latest" ]]; then
         CI_VERSION_URL="https://dl.k8s.io/ci/${KUBERNETES_VERSION}.txt"
-        export CI_VERSION="${CI_VERSION:-$(curl -sSL "${CI_VERSION_URL}")}"
+        export CI_VERSION="${CI_VERSION:-$(curl --retry 3 -sSL "${CI_VERSION_URL}")}"
     fi
     if [[ -n "${CI_VERSION:-}" ]]; then
         echo "Using CI_VERSION ${CI_VERSION}"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind flake

**What this PR does / why we need it**:

This PR standardizes our usage of curl in dev and CI scripts to retry 3 times in order to overcome transient I/O errors.

See here for an example of a flake:

- https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/3075/pull-cluster-api-provider-azure-ci-entrypoint/1617649166840762368

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
