### PR TITLE
[release-1.7] Always run AKS E2E get+update as transaction

### DIFF
--- a/test/e2e/aks_autoscaler.go
+++ b/test/e2e/aks_autoscaler.go
@@ -73,24 +73,26 @@ func AKSAutoscaleSpec(ctx context.Context, inputGetter func() AKSAutoscaleSpecIn
 	}
 
 	toggleAutoscaling := func() {
-		err = mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)
-		Expect(err).NotTo(HaveOccurred())
+		Eventually(func(g Gomega) {
+			err = mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)
+			g.Expect(err).NotTo(HaveOccurred())
 
-		enabled := ammp.Spec.Scaling != nil
-		var enabling string
-		if enabled {
-			enabling = "Disabling"
-			ammp.Spec.Scaling = nil
-		} else {
-			enabling = "Enabling"
-			ammp.Spec.Scaling = &infrav1exp.ManagedMachinePoolScaling{
-				MinSize: to.Int32Ptr(1),
-				MaxSize: to.Int32Ptr(2),
+			enabled := ammp.Spec.Scaling != nil
+			var enabling string
+			if enabled {
+				enabling = "Disabling"
+				ammp.Spec.Scaling = nil
+			} else {
+				enabling = "Enabling"
+				ammp.Spec.Scaling = &infrav1exp.ManagedMachinePoolScaling{
+					MinSize: to.Int32Ptr(1),
+					MaxSize: to.Int32Ptr(2),
+				}
 			}
-		}
-		By(enabling + " autoscaling")
-		err = mgmtClient.Update(ctx, ammp)
-		Expect(err).NotTo(HaveOccurred())
+			By(enabling + " autoscaling")
+			err = mgmtClient.Update(ctx, ammp)
+			g.Expect(err).NotTo(HaveOccurred())
+		}, inputGetter().WaitIntervals...).Should(Succeed())
 	}
 
 	validateUntoggled := validateAKSAutoscaleDisabled

--- a/test/e2e/aks_azure_cluster_autoscaler.go
+++ b/test/e2e/aks_azure_cluster_autoscaler.go
@@ -50,46 +50,61 @@ func AKSAzureClusterAutoscalerSettingsSpec(ctx context.Context, inputGetter func
 	containerserviceClient := containerservice.NewManagedClustersClient(subscriptionID)
 	containerserviceClient.Authorizer = auth
 
-	amcp := &infrav1exp.AzureManagedControlPlane{}
-	err = mgmtClient.Get(ctx, types.NamespacedName{
-		Namespace: input.Cluster.Spec.ControlPlaneRef.Namespace,
-		Name:      input.Cluster.Spec.ControlPlaneRef.Name,
-	}, amcp)
-	Expect(err).NotTo(HaveOccurred())
-	amcpInitialAutoScalerProfile := amcp.Spec.AutoScalerProfile
-
-	aks, err := containerserviceClient.Get(ctx, amcp.Spec.ResourceGroupName, amcp.Name)
-	Expect(err).NotTo(HaveOccurred())
-	aksInitialAutoScalerProfile := aks.AutoScalerProfile
-
 	var expectedAksExpander containerservice.Expander
 	var newExpanderValue infrav1exp.Expander
-	// Conditional is based off of the actual AKS settings not the AzureManagedControlPlane
-	if aksInitialAutoScalerProfile == nil {
-		expectedAksExpander = containerservice.ExpanderLeastWaste
-		newExpanderValue = infrav1exp.ExpanderLeastWaste
-	} else if aksInitialAutoScalerProfile.Expander == containerservice.ExpanderLeastWaste {
-		expectedAksExpander = containerservice.ExpanderMostPods
-		newExpanderValue = infrav1exp.ExpanderMostPods
-	}
+	var amcpInitialAutoScalerProfile = &infrav1exp.AutoScalerProfile{}
+	amcp := &infrav1exp.AzureManagedControlPlane{}
 
-	amcp.Spec.AutoScalerProfile = nil
-	Expect(mgmtClient.Update(ctx, amcp)).To(Succeed())
 	Eventually(func(g Gomega) {
-		amcp := &infrav1exp.AzureManagedControlPlane{}
 		err = mgmtClient.Get(ctx, types.NamespacedName{
 			Namespace: input.Cluster.Spec.ControlPlaneRef.Namespace,
 			Name:      input.Cluster.Spec.ControlPlaneRef.Name,
 		}, amcp)
-		Expect(err).NotTo(HaveOccurred())
+		g.Expect(err).NotTo(HaveOccurred())
+		amcpInitialAutoScalerProfile = amcp.Spec.AutoScalerProfile
+
+		aks, err := containerserviceClient.Get(ctx, amcp.Spec.ResourceGroupName, amcp.Name)
+		g.Expect(err).NotTo(HaveOccurred())
+		aksInitialAutoScalerProfile := aks.AutoScalerProfile
+
+		// Conditional is based off of the actual AKS settings not the AzureManagedControlPlane
+		if aksInitialAutoScalerProfile == nil {
+			expectedAksExpander = containerservice.ExpanderLeastWaste
+			newExpanderValue = infrav1exp.ExpanderLeastWaste
+		} else if aksInitialAutoScalerProfile.Expander == containerservice.ExpanderLeastWaste {
+			expectedAksExpander = containerservice.ExpanderMostPods
+			newExpanderValue = infrav1exp.ExpanderMostPods
+		}
+
+		amcp.Spec.AutoScalerProfile = nil
+		err = mgmtClient.Get(ctx, types.NamespacedName{
+			Namespace: input.Cluster.Spec.ControlPlaneRef.Namespace,
+			Name:      input.Cluster.Spec.ControlPlaneRef.Name,
+		}, amcp)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(mgmtClient.Update(ctx, amcp)).To(Succeed())
+	}, input.WaitIntervals...).Should(Succeed())
+	Eventually(func(g Gomega) {
+		err = mgmtClient.Get(ctx, types.NamespacedName{
+			Namespace: input.Cluster.Spec.ControlPlaneRef.Namespace,
+			Name:      input.Cluster.Spec.ControlPlaneRef.Name,
+		}, amcp)
+		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(amcp.Spec.AutoScalerProfile).To(BeNil())
 	}, input.WaitIntervals...).Should(Succeed())
 
 	// Now set to the new value
-	amcp.Spec.AutoScalerProfile = &infrav1exp.AutoScalerProfile{
-		Expander: (*infrav1exp.Expander)(to.StringPtr(string(newExpanderValue))),
-	}
-	Expect(mgmtClient.Update(ctx, amcp)).To(Succeed())
+	Eventually(func(g Gomega) {
+		err = mgmtClient.Get(ctx, types.NamespacedName{
+			Namespace: input.Cluster.Spec.ControlPlaneRef.Namespace,
+			Name:      input.Cluster.Spec.ControlPlaneRef.Name,
+		}, amcp)
+		g.Expect(err).NotTo(HaveOccurred())
+		amcp.Spec.AutoScalerProfile = &infrav1exp.AutoScalerProfile{
+			Expander: (*infrav1exp.Expander)(to.StringPtr(string(newExpanderValue))),
+		}
+		g.Expect(mgmtClient.Update(ctx, amcp)).To(Succeed())
+	}, input.WaitIntervals...).Should(Succeed())
 	By("Verifying the cluster-autoscaler settings have changed")
 	Eventually(func(g Gomega) {
 		// Check that the autoscaler settings have been sync'd to AKS
@@ -99,21 +114,21 @@ func AKSAzureClusterAutoscalerSettingsSpec(ctx context.Context, inputGetter func
 		g.Expect(aks.AutoScalerProfile.Expander).To(Equal(expectedAksExpander))
 	}, input.WaitIntervals...).Should(Succeed())
 
-	amcp = &infrav1exp.AzureManagedControlPlane{}
-	err = mgmtClient.Get(ctx, types.NamespacedName{
-		Namespace: input.Cluster.Spec.ControlPlaneRef.Namespace,
-		Name:      input.Cluster.Spec.ControlPlaneRef.Name,
-	}, amcp)
-	Expect(err).NotTo(HaveOccurred())
-	amcp.Spec.AutoScalerProfile = amcpInitialAutoScalerProfile
-
-	Expect(mgmtClient.Update(ctx, amcp)).To(Succeed())
 	Eventually(func(g Gomega) {
-		amcp := &infrav1exp.AzureManagedControlPlane{}
 		err = mgmtClient.Get(ctx, types.NamespacedName{
 			Namespace: input.Cluster.Spec.ControlPlaneRef.Namespace,
 			Name:      input.Cluster.Spec.ControlPlaneRef.Name,
 		}, amcp)
+		g.Expect(err).NotTo(HaveOccurred())
+		amcp.Spec.AutoScalerProfile = amcpInitialAutoScalerProfile
+		g.Expect(mgmtClient.Update(ctx, amcp)).To(Succeed())
+	}, input.WaitIntervals...).Should(Succeed())
+	Eventually(func(g Gomega) {
+		err = mgmtClient.Get(ctx, types.NamespacedName{
+			Namespace: input.Cluster.Spec.ControlPlaneRef.Namespace,
+			Name:      input.Cluster.Spec.ControlPlaneRef.Name,
+		}, amcp)
+		g.Expect(err).NotTo(HaveOccurred())
 		Expect(err).NotTo(HaveOccurred())
 		g.Expect(amcp.Spec.AutoScalerProfile).To(Equal(amcpInitialAutoScalerProfile))
 	}, input.WaitIntervals...).Should(Succeed())

--- a/test/e2e/aks_public_ip_prefix.go
+++ b/test/e2e/aks_public_ip_prefix.go
@@ -155,11 +155,13 @@ func AKSPublicIPPrefixSpec(ctx context.Context, inputGetter func() AKSPublicIPPr
 	}, input.WaitIntervals...).Should(Succeed())
 
 	By("Scaling the MachinePool to 2 nodes")
-	err = mgmtClient.Get(ctx, client.ObjectKeyFromObject(machinePool), machinePool)
-	Expect(err).NotTo(HaveOccurred())
-	machinePool.Spec.Replicas = to.Int32Ptr(2)
-	err = mgmtClient.Update(ctx, machinePool)
-	Expect(err).NotTo(HaveOccurred())
+	Eventually(func(g Gomega) {
+		err = mgmtClient.Get(ctx, client.ObjectKeyFromObject(machinePool), machinePool)
+		g.Expect(err).NotTo(HaveOccurred())
+		machinePool.Spec.Replicas = to.Int32Ptr(2)
+		err = mgmtClient.Update(ctx, machinePool)
+		g.Expect(err).NotTo(HaveOccurred())
+	}, input.WaitIntervals...).Should(Succeed())
 
 	By("Verifying the AzureManagedMachinePool becomes ready")
 	Eventually(func(g Gomega) {

--- a/test/e2e/aks_tags.go
+++ b/test/e2e/aks_tags.go
@@ -88,10 +88,13 @@ func AKSAdditionalTagsSpec(ctx context.Context, inputGetter func() AKSAdditional
 
 		By("Deleting all tags for control plane")
 		expectedTags = nil
-		Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
-		initialTags := infraControlPlane.Spec.AdditionalTags
-		infraControlPlane.Spec.AdditionalTags = expectedTags
-		Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		var initialTags infrav1.Tags
+		Eventually(func(g Gomega) {
+			g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
+			initialTags = infraControlPlane.Spec.AdditionalTags
+			infraControlPlane.Spec.AdditionalTags = expectedTags
+			g.Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		}, inputGetter().WaitForUpdate...).Should(Succeed())
 		Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 
 		By("Creating tags for control plane")
@@ -99,25 +102,31 @@ func AKSAdditionalTagsSpec(ctx context.Context, inputGetter func() AKSAdditional
 			"test":    "tag",
 			"another": "value",
 		}
-		Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
-		infraControlPlane.Spec.AdditionalTags = expectedTags
-		Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
+			infraControlPlane.Spec.AdditionalTags = expectedTags
+			g.Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		}, inputGetter().WaitForUpdate...).Should(Succeed())
 		Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 
 		By("Updating tags for control plane")
 		expectedTags["test"] = "updated"
 		delete(expectedTags, "another")
 		expectedTags["new"] = "value"
-		Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
-		infraControlPlane.Spec.AdditionalTags = expectedTags
-		Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
+			infraControlPlane.Spec.AdditionalTags = expectedTags
+			g.Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		}, inputGetter().WaitForUpdate...).Should(Succeed())
 		Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 
 		By("Restoring initial tags for control plane")
 		expectedTags = initialTags
-		Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
-		infraControlPlane.Spec.AdditionalTags = expectedTags
-		Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraControlPlane), infraControlPlane)).To(Succeed())
+			infraControlPlane.Spec.AdditionalTags = expectedTags
+			g.Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
+		}, inputGetter().WaitForUpdate...).Should(Succeed())
 		Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 	}()
 
@@ -147,10 +156,13 @@ func AKSAdditionalTagsSpec(ctx context.Context, inputGetter func() AKSAdditional
 
 			Byf("Deleting all tags for machine pool %s", mp.Name)
 			expectedTags = nil
-			Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
-			initialTags := ammp.Spec.AdditionalTags
-			ammp.Spec.AdditionalTags = expectedTags
-			Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			var initialTags infrav1.Tags
+			Eventually(func(g Gomega) {
+				g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
+				initialTags = ammp.Spec.AdditionalTags
+				ammp.Spec.AdditionalTags = expectedTags
+				g.Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			}, inputGetter().WaitForUpdate...).Should(Succeed())
 			Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 
 			Byf("Creating tags for machine pool %s", mp.Name)
@@ -158,25 +170,31 @@ func AKSAdditionalTagsSpec(ctx context.Context, inputGetter func() AKSAdditional
 				"test":    "tag",
 				"another": "value",
 			}
-			Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
-			ammp.Spec.AdditionalTags = expectedTags
-			Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
+				ammp.Spec.AdditionalTags = expectedTags
+				g.Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			}, inputGetter().WaitForUpdate...).Should(Succeed())
 			Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 
 			Byf("Updating tags for machine pool %s", mp.Name)
 			expectedTags["test"] = "updated"
 			delete(expectedTags, "another")
 			expectedTags["new"] = "value"
-			Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
-			ammp.Spec.AdditionalTags = expectedTags
-			Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
+				ammp.Spec.AdditionalTags = expectedTags
+				g.Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			}, inputGetter().WaitForUpdate...).Should(Succeed())
 			Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 
 			Byf("Restoring initial tags for machine pool %s", mp.Name)
 			expectedTags = initialTags
-			Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
-			ammp.Spec.AdditionalTags = expectedTags
-			Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
+				ammp.Spec.AdditionalTags = expectedTags
+				g.Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			}, inputGetter().WaitForUpdate...).Should(Succeed())
 			Eventually(checkTags, input.WaitForUpdate...).Should(Succeed())
 		}(mp)
 	}

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -176,13 +176,11 @@ func labelNodesWithMachinePoolName(ctx context.Context, workloadClient client.Cl
 			}, n)
 			if err != nil {
 				LogWarning(err.Error())
+				return err
 			}
-			return err
-		}, waitforResourceOperationTimeout, 3*time.Second).Should(Succeed())
-		n.Labels[clusterv1.OwnerKindAnnotation] = "MachinePool"
-		n.Labels[clusterv1.OwnerNameAnnotation] = mpName
-		Eventually(func() error {
-			err := workloadClient.Update(ctx, n)
+			n.Labels[clusterv1.OwnerKindAnnotation] = "MachinePool"
+			n.Labels[clusterv1.OwnerNameAnnotation] = mpName
+			err = workloadClient.Update(ctx, n)
 			if err != nil {
 				LogWarning(err.Error())
 			}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind flake

**What this PR does / why we need it**:

This is a manual cherry-pick of #3058 to release-1.7.

I'm seeing this flake in periodic tests for this branch. E.g.:

- https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-azure-e2e-aks-v1beta1/1617580985807802368

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
