### PR TITLE
use g.Expect when assertions are clearest

### DIFF
--- a/test/e2e/aks_public_ip_prefix.go
+++ b/test/e2e/aks_public_ip_prefix.go
@@ -77,9 +77,9 @@ func AKSPublicIPPrefixSpec(ctx context.Context, inputGetter func() AKSPublicIPPr
 	})
 	Expect(err).NotTo(HaveOccurred())
 	var publicIPPrefix network.PublicIPPrefix
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
 		publicIPPrefix, err = publicIPPrefixFuture.Result(publicIPPrefixClient)
-		return err
+		g.Expect(err).NotTo(HaveOccurred())
 	}, input.WaitIntervals...).Should(Succeed(), "failed to create public IP prefix")
 
 	By("Creating node pool with 3 nodes")
@@ -130,15 +130,15 @@ func AKSPublicIPPrefixSpec(ctx context.Context, inputGetter func() AKSPublicIPPr
 		err := mgmtClient.Delete(ctx, machinePool)
 		Expect(err).NotTo(HaveOccurred())
 
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(machinePool), &expv1.MachinePool{})
-			return apierrors.IsNotFound(err)
-		}, input.WaitIntervals...).Should(BeTrue(), "Deleted MachinePool %s/%s still exists", machinePool.Namespace, machinePool.Name)
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		}, input.WaitIntervals...).Should(Succeed(), "Deleted MachinePool %s/%s still exists", machinePool.Namespace, machinePool.Name)
 
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(infraMachinePool), &infrav1.AzureManagedMachinePool{})
-			return apierrors.IsNotFound(err)
-		}, input.WaitIntervals...).Should(BeTrue(), "Deleted AzureManagedMachinePool %s/%s still exists", infraMachinePool.Namespace, infraMachinePool.Name)
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		}, input.WaitIntervals...).Should(Succeed(), "Deleted AzureManagedMachinePool %s/%s still exists", infraMachinePool.Namespace, infraMachinePool.Name)
 	}()
 
 	By("Verifying the AzureManagedMachinePool converges to a failed ready status")

--- a/test/e2e/aks_upgrade.go
+++ b/test/e2e/aks_upgrade.go
@@ -26,7 +26,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -67,16 +66,13 @@ func AKSUpgradeSpec(ctx context.Context, inputGetter func() AKSUpgradeSpecInput)
 		g.Expect(mgmtClient.Update(ctx, infraControlPlane)).To(Succeed())
 	}, inputGetter().WaitForControlPlane...).Should(Succeed())
 
-	Eventually(func() (string, error) {
+	Eventually(func(g Gomega) {
 		aksCluster, err := managedClustersClient.Get(ctx, infraControlPlane.Spec.ResourceGroupName, infraControlPlane.Name)
-		if err != nil {
-			return "", err
-		}
-		if aksCluster.ManagedClusterProperties == nil || aksCluster.ManagedClusterProperties.KubernetesVersion == nil {
-			return "", errors.New("Kubernetes version unknown")
-		}
-		return "v" + *aksCluster.KubernetesVersion, nil
-	}, input.WaitForControlPlane...).Should(Equal(input.KubernetesVersionUpgradeTo))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(aksCluster.ManagedClusterProperties).NotTo(BeNil())
+		g.Expect(aksCluster.ManagedClusterProperties.KubernetesVersion).NotTo(BeNil())
+		g.Expect("v" + *aksCluster.KubernetesVersion).To(Equal(input.KubernetesVersionUpgradeTo))
+	}, input.WaitForControlPlane...).Should(Succeed())
 
 	By("Upgrading the machinepool instances")
 	framework.UpgradeMachinePoolAndWait(ctx, framework.UpgradeMachinePoolAndWaitInput{

--- a/test/e2e/azure_gpu.go
+++ b/test/e2e/azure_gpu.go
@@ -124,12 +124,12 @@ func getGPUOperatorPodLogs(ctx context.Context, clientset *kubernetes.Clientset)
 	podsClient := clientset.CoreV1().Pods(corev1.NamespaceAll)
 	var pods *corev1.PodList
 	var err error
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
 		pods, err = podsClient.List(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/instance=gpu-operator"})
 		if err != nil {
 			LogWarning(err.Error())
 		}
-		return err
+		g.Expect(err).NotTo(HaveOccurred())
 	}, retryableOperationTimeout, retryableOperationSleepBetweenRetries).Should(Succeed())
 	b := strings.Builder{}
 	for _, pod := range pods.Items {

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -169,22 +169,22 @@ func testMachinePoolCordonAndDrain(ctx context.Context, mgmtClusterProxy, worklo
 func labelNodesWithMachinePoolName(ctx context.Context, workloadClient client.Client, mpName string, ampms []infrav1exp.AzureMachinePoolMachine) {
 	for _, ampm := range ampms {
 		n := &corev1.Node{}
-		Eventually(func() error {
+		Eventually(func(g Gomega) {
 			err := workloadClient.Get(ctx, client.ObjectKey{
 				Name:      ampm.Status.NodeRef.Name,
 				Namespace: ampm.Status.NodeRef.Namespace,
 			}, n)
 			if err != nil {
 				LogWarning(err.Error())
-				return err
 			}
+			g.Expect(err).NotTo(HaveOccurred())
 			n.Labels[clusterv1.OwnerKindAnnotation] = "MachinePool"
 			n.Labels[clusterv1.OwnerNameAnnotation] = mpName
 			err = workloadClient.Update(ctx, n)
 			if err != nil {
 				LogWarning(err.Error())
 			}
-			return err
+			g.Expect(err).NotTo(HaveOccurred())
 		}, waitforResourceOperationTimeout, 3*time.Second).Should(Succeed())
 	}
 }
@@ -212,7 +212,7 @@ func getOwnerMachinePool(ctx context.Context, c client.Client, obj metav1.Object
 
 		if ref.Kind == "MachinePool" && gv.Group == expv1.GroupVersion.Group {
 			mp := &expv1.MachinePool{}
-			Eventually(func() error {
+			Eventually(func(g Gomega) {
 				err := c.Get(ctx, client.ObjectKey{
 					Name:      ref.Name,
 					Namespace: obj.Namespace,
@@ -220,7 +220,7 @@ func getOwnerMachinePool(ctx context.Context, c client.Client, obj metav1.Object
 				if err != nil {
 					LogWarning(err.Error())
 				}
-				return err
+				g.Expect(err).NotTo(HaveOccurred())
 			}, waitforResourceOperationTimeout, 3*time.Second).Should(Succeed())
 			return mp, err
 		}

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -958,30 +958,21 @@ func InstallHelmChart(ctx context.Context, clusterProxy framework.ClusterProxy, 
 		i.ReleaseName = releaseName
 		i.Namespace = namespace
 		i.CreateNamespace = true
-		Eventually(func() error {
+		Eventually(func(g Gomega) {
 			cp, err := i.ChartPathOptions.LocateChart(chartName, helmCli.New())
-			if err != nil {
-				return err
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 			p := helmGetter.All(settings)
 			if options == nil {
 				options = &helmVals.Options{}
 			}
 			valueOpts := options
 			vals, err := valueOpts.MergeValues(p)
-			if err != nil {
-				return err
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 			chartRequested, err := helmLoader.Load(cp)
-			if err != nil {
-				return err
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 			release, err := i.RunWithContext(ctx, chartRequested, vals)
-			if err != nil {
-				return err
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 			Logf(release.Info.Description)
-			return nil
 		}, helmInstallTimeout, retryableOperationSleepBetweenRetries).Should(Succeed())
 	}
 }

--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -148,14 +148,13 @@ func (d *Builder) AddPVC(pvcName string) *Builder {
 
 func (d *Builder) Deploy(ctx context.Context, clientset *kubernetes.Clientset) (*appsv1.Deployment, error) {
 	var deployment *appsv1.Deployment
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
 		var err error
 		deployment, err = d.Client(clientset).Create(ctx, d.deployment, metav1.CreateOptions{})
 		if err != nil {
 			log.Printf("Error trying to deploy %s in namespace %s:%s\n", d.deployment.Name, d.deployment.ObjectMeta.Namespace, err.Error())
-			return err
 		}
-		return nil
+		g.Expect(err).NotTo(HaveOccurred())
 	}, deploymentOperationTimeout, deploymentOperationSleepBetweenRetries).Should(Succeed())
 
 	return deployment, nil
@@ -171,14 +170,13 @@ func (d *Builder) GetPodsFromDeployment(ctx context.Context, clientset *kubernet
 		Limit:         100,
 	}
 	var pods *corev1.PodList
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
 		var err error
 		pods, err = clientset.CoreV1().Pods(d.deployment.GetNamespace()).List(ctx, opts)
 		if err != nil {
 			log.Printf("Error trying to get the pods from deployment %s:%s\n", d.deployment.GetName(), err.Error())
-			return err
 		}
-		return nil
+		g.Expect(err).NotTo(HaveOccurred())
 	}, deploymentOperationTimeout, deploymentOperationSleepBetweenRetries).Should(Succeed())
 	return pods.Items, nil
 }

--- a/test/e2e/kubernetes/namespace/namespace.go
+++ b/test/e2e/kubernetes/namespace/namespace.go
@@ -45,14 +45,13 @@ func Create(ctx context.Context, clientset *kubernetes.Clientset, name string, l
 	}
 
 	var namespace *corev1.Namespace
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
 		var err error
 		namespace, err = clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 		if err != nil {
 			log.Printf("failed trying to create namespace (%s):%s\n", name, err.Error())
-			return err
 		}
-		return nil
+		g.Expect(err).NotTo(HaveOccurred())
 	}, namespaceOperationTimeout, namespaceOperationSleepBetweenRetries).Should(Succeed())
 	return namespace, nil
 }

--- a/test/e2e/kubernetes/networkpolicy/networkpolicy.go
+++ b/test/e2e/kubernetes/networkpolicy/networkpolicy.go
@@ -65,13 +65,12 @@ func CreateNetworkPolicyFromFile(ctx context.Context, clientset *kubernetes.Clie
 }
 
 func createNetworkPolicyV1(ctx context.Context, clientset *kubernetes.Clientset, namespace string, networkPolicy *networkingv1.NetworkPolicy) error {
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
 		_, err := clientset.NetworkingV1().NetworkPolicies(namespace).Create(ctx, networkPolicy, metav1.CreateOptions{})
 		if err != nil {
 			log.Printf("failed trying to create NetworkPolicy (%s):%s\n", networkPolicy.Name, err.Error())
-			return err
 		}
-		return nil
+		g.Expect(err).NotTo(HaveOccurred())
 	}, networkPolicyOperationTimeout, networkPolicyOperationSleepBetweenRetries).Should(Succeed())
 	return nil
 }
@@ -79,13 +78,12 @@ func createNetworkPolicyV1(ctx context.Context, clientset *kubernetes.Clientset,
 // DeleteNetworkPolicy will create a NetworkPolicy from file with a name
 func DeleteNetworkPolicy(ctx context.Context, clientset *kubernetes.Clientset, name, namespace string) {
 	opts := metav1.DeleteOptions{}
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
 		err := clientset.NetworkingV1().NetworkPolicies(namespace).Delete(ctx, name, opts)
 		if err != nil {
 			log.Printf("failed trying to delete NetworkPolicy (%s):%s\n", name, err.Error())
-			return err
 		}
-		return nil
+		g.Expect(err).NotTo(HaveOccurred())
 	}, networkPolicyOperationTimeout, networkPolicyOperationSleepBetweenRetries).Should(Succeed())
 }
 

--- a/test/e2e/kubernetes/pvc/pvc.go
+++ b/test/e2e/kubernetes/pvc/pvc.go
@@ -110,13 +110,12 @@ func (b *Builder) WithStorageClass(scName string) *Builder {
 }
 
 func (b *Builder) DeployPVC(clientset *kubernetes.Clientset) error {
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
 		_, err := clientset.CoreV1().PersistentVolumeClaims("default").Create(context.TODO(), b.pvc, metav1.CreateOptions{})
 		if err != nil {
 			log.Printf("Error trying to deploy storage class %s in namespace %s:%s\n", b.pvc.Name, b.pvc.ObjectMeta.Namespace, err.Error())
-			return err
 		}
-		return nil
+		g.Expect(err).To(HaveOccurred())
 	}, pvcOperationTimeout, pvcOperationSleepBetweenRetries).Should(Succeed())
 
 	return nil

--- a/test/e2e/kubernetes/storageclass/storageclass.go
+++ b/test/e2e/kubernetes/storageclass/storageclass.go
@@ -109,12 +109,11 @@ func (d *Builder) WithOotParameters() *Builder {
 
 // DeployStorageClass creates a storage class on the k8s cluster.
 func (d *Builder) DeployStorageClass(clientset *kubernetes.Clientset) {
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
 		_, err := clientset.StorageV1().StorageClasses().Create(context.TODO(), d.sc, metav1.CreateOptions{})
 		if err != nil {
 			log.Printf("Error trying to deploy storage class %s in namespace %s:%s\n", d.sc.Name, d.sc.ObjectMeta.Namespace, err.Error())
-			return err
 		}
-		return nil
+		g.Expect(err).To(HaveOccurred())
 	}, scOperationTimeout, scOperationSleepBetweenRetries).Should(Succeed())
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind cleanup

**What this PR does / why we need it**:

This PR standardizes *most* of our ginkgo `Eventually` blocks in E2E code to include `g Gomega` as an argument, so that we can continue using simple assertions such as `g.Expect(err).NotTo(HaveOccurred())` inside the retry block, instead of having a strongly typed return value whose pass/fail significance needs to be manually decoded by interpreting the return type against the input flavor in the eventual `Should` block that terminates the `Eventually` func.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
