### PR TITLE
Increase linter timeout to 10m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  deadline: 10m
   skip-files:
   - 'zz_generated\.(\w*)\.go$'
   build-tags:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Increases the `golangci-lint` timeout from 5m to 10m, because we've started to see failures in CI hitting the timeout. [CAPI also](https://github.com/kubernetes-sigs/cluster-api/blob/main/.golangci.yml#L2) has 10m as a timeout.

**Which issue(s) this PR fixes**:

Fixes #3109

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
