### PR TITLE
E2E: don’t stop/start kubelet before kubeadm runs

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -166,7 +166,6 @@ spec:
               $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
             done
           fi
-          systemctl restart kubelet
         fi
         echo "* checking binary versions"
         echo "ctr version: " $(ctr version)
@@ -354,7 +353,6 @@ spec:
                 $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
               done
             fi
-            systemctl restart kubelet
           fi
           echo "* checking binary versions"
           echo "ctr version: " $(ctr version)

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -166,7 +166,6 @@ spec:
               $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
             done
           fi
-          systemctl restart kubelet
         fi
         echo "* checking binary versions"
         echo "ctr version: " $(ctr version)
@@ -354,7 +353,6 @@ spec:
                 $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
               done
             fi
-            systemctl restart kubelet
           fi
           echo "* checking binary versions"
           echo "ctr version: " $(ctr version)

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
@@ -167,7 +167,6 @@ spec:
               $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
             done
           fi
-          systemctl restart kubelet
         fi
         echo "* checking binary versions"
         echo "ctr version: " $(ctr version)
@@ -357,7 +356,6 @@ spec:
                 $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
               done
             fi
-            systemctl restart kubelet
           fi
           echo "* checking binary versions"
           echo "ctr version: " $(ctr version)

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -165,7 +165,6 @@ spec:
               $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
             done
           fi
-          systemctl restart kubelet
         fi
         echo "* checking binary versions"
         echo "ctr version: " $(ctr version)
@@ -349,7 +348,6 @@ spec:
             $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
           done
         fi
-        systemctl restart kubelet
       fi
       echo "* checking binary versions"
       echo "ctr version: " $(ctr version)

--- a/templates/test/ci/patches/control-plane-kubeadm-boostrap-ci-version.yaml
+++ b/templates/test/ci/patches/control-plane-kubeadm-boostrap-ci-version.yaml
@@ -54,7 +54,6 @@
             $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
           done
         fi
-        systemctl restart kubelet
       fi
       echo "* checking binary versions"
       echo "ctr version: " $(ctr version)

--- a/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap.yaml
+++ b/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap.yaml
@@ -54,7 +54,6 @@
             $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
           done
         fi
-        systemctl restart kubelet
       fi
       echo "* checking binary versions"
       echo "ctr version: " $(ctr version)

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -63,7 +63,6 @@ spec:
               $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
             done
           fi
-          systemctl restart kubelet
         fi
         echo "* checking binary versions"
         echo "ctr version: " $(ctr version)

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -114,13 +114,11 @@ spec:
         set -o pipefail
         set -o errexit
 
-        systemctl stop kubelet
         declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
         for BINARY in "$${BINARIES[@]}"; do
           echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
           curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
         done
-        systemctl restart kubelet
 
         # prepull images from gcr.io/k8s-staging-ci-images and retag it to
         # registry.k8s.io so kubeadm can fetch correct images no matter what
@@ -293,13 +291,11 @@ spec:
       set -o pipefail
       set -o errexit
 
-      systemctl stop kubelet
       declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
       for BINARY in "$${BINARIES[@]}"; do
         echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
         curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
       done
-      systemctl restart kubelet
 
       echo "kubeadm version: $(kubeadm version -o=short)"
       echo "kubectl version: $(kubectl version --client=true --short=true)"

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -122,13 +122,11 @@ spec:
         set -o pipefail
         set -o errexit
 
-        systemctl stop kubelet
         declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
         for BINARY in "$${BINARIES[@]}"; do
           echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
           curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
         done
-        systemctl restart kubelet
 
         # prepull images from gcr.io/k8s-staging-ci-images and retag it to
         # registry.k8s.io so kubeadm can fetch correct images no matter what
@@ -299,13 +297,11 @@ spec:
           set -o pipefail
           set -o errexit
 
-          systemctl stop kubelet
           declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
           for BINARY in "$${BINARIES[@]}"; do
             echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
             curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
           done
-          systemctl restart kubelet
 
           echo "kubeadm version: $(kubeadm version -o=short)"
           echo "kubectl version: $(kubectl version --client=true --short=true)"

--- a/templates/test/dev/custom-builds-machine-pool/patches/custom-builds.yaml
+++ b/templates/test/dev/custom-builds-machine-pool/patches/custom-builds.yaml
@@ -16,13 +16,11 @@ spec:
       set -o pipefail
       set -o errexit
 
-      systemctl stop kubelet
       declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
       for BINARY in "$${BINARIES[@]}"; do
         echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
         curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
       done
-      systemctl restart kubelet
 
       echo "kubeadm version: $(kubeadm version -o=short)"
       echo "kubectl version: $(kubectl version --client=true --short=true)"

--- a/templates/test/dev/custom-builds/patches/kubeadm-bootstrap.yaml
+++ b/templates/test/dev/custom-builds/patches/kubeadm-bootstrap.yaml
@@ -8,13 +8,11 @@
       set -o pipefail
       set -o errexit
 
-      systemctl stop kubelet
       declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
       for BINARY in "$${BINARIES[@]}"; do
         echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
         curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
       done
-      systemctl restart kubelet
 
       echo "kubeadm version: $(kubeadm version -o=short)"
       echo "kubectl version: $(kubectl version --client=true --short=true)"

--- a/templates/test/dev/custom-builds/patches/kubeadm-controlplane-bootstrap.yaml
+++ b/templates/test/dev/custom-builds/patches/kubeadm-controlplane-bootstrap.yaml
@@ -8,13 +8,11 @@
         set -o pipefail
         set -o errexit
 
-        systemctl stop kubelet
         declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
         for BINARY in "$${BINARIES[@]}"; do
           echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
           curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
         done
-        systemctl restart kubelet
 
         # prepull images from gcr.io/k8s-staging-ci-images and retag it to
         # registry.k8s.io so kubeadm can fetch correct images no matter what

--- a/templates/test/dev/patches/control-plane-custom-builds.yaml
+++ b/templates/test/dev/patches/control-plane-custom-builds.yaml
@@ -24,13 +24,11 @@ spec:
         set -o pipefail
         set -o errexit
 
-        systemctl stop kubelet
         declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
         for BINARY in "$${BINARIES[@]}"; do
           echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
           curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
         done
-        systemctl restart kubelet
 
         # prepull images from gcr.io/k8s-staging-ci-images and retag it to
         # registry.k8s.io so kubeadm can fetch correct images no matter what


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind cleanup

**What this PR does / why we need it**:

This PR removes kubelet stop/start during pre-kubeadm scripts, which should help eliminate unnecessary thrashing and/or systemd stress during initial node bootstrapping.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
