### PR TITLE
log diffs for agentpools

### DIFF
--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
 // KubeletConfig defines the set of kubelet configurations for nodes in pools.
@@ -160,6 +161,9 @@ func (s *AgentPoolSpec) CustomHeaders() map[string]string {
 
 // Parameters returns the parameters for the agent pool.
 func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
+	_, log, done := tele.StartSpanWithLogger(ctx, "agentpools.Service.Parameters")
+	defer done()
+
 	nodeLabels := s.NodeLabels
 	if existing != nil {
 		existingPool, ok := existing.(containerservice.AgentPool)
@@ -234,8 +238,10 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (p
 		diff := cmp.Diff(normalizedProfile, existingProfile)
 		if diff == "" {
 			// agent pool is up to date, nothing to do
+			log.V(4).Info("no changes found between user-updated spec and existing spec")
 			return nil, nil
 		}
+		log.V(4).Info("found a diff between the desired spec and the existing agentpool", "difference", diff)
 		// We do a just-in-time merge of existent kubernetes.azure.com-prefixed labels
 		// So that we don't unintentionally delete them
 		// See https://github.com/Azure/AKS/issues/3152


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR adds logging for diffs between the actual and expected AKS agent pool backing an AzureManagedMachinePool to determine why the controller is issuing a PUT against AKS during reconciliation. This will help debug cases where the controller is erroneously endlessly updating an agent pool like in #3009.

Related to #2829 which added this for managed cluster resources.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
