### PR TITLE
Fix scale in for VMSS Flex MachinePools

### DIFF
--- a/test/e2e/azure_machinepools.go
+++ b/test/e2e/azure_machinepools.go
@@ -117,7 +117,6 @@ func AzureMachinePoolsSpec(ctx context.Context, inputGetter func() AzureMachineP
 	}
 	wg.Wait()
 
-	/* TODO: uncomment with scale down fix for flexible mode
 	for _, mp := range machinepools {
 		goalReplicas := pointer.Int32Deref(mp.Spec.Replicas, 0) - 1
 		Byf("Scaling machine pool %s in from %d to %d", mp.Name, *mp.Spec.Replicas, goalReplicas)
@@ -135,7 +134,6 @@ func AzureMachinePoolsSpec(ctx context.Context, inputGetter func() AzureMachineP
 		}(mp)
 	}
 	wg.Wait()
-	*/
 
 	By("verifying that workload nodes are schedulable")
 	clientset := workloadClusterProxy.GetClientSet()

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -535,7 +535,7 @@ var _ = Describe("Workload cluster creation", func() {
 				withControlPlaneInterval(specName, "wait-control-plane"),
 			), result)
 
-			By("Verifying machinepool can scale out", func() {
+			By("Verifying machinepool can scale out and in", func() {
 				AzureMachinePoolsSpec(ctx, func() AzureMachinePoolsSpecInput {
 					return AzureMachinePoolsSpecInput{
 						Cluster:               result.Cluster,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Scaling in a MachinePool using `Flexible` orchestration mode fails, and a change in API response broke the previous mechanism for detecting Flex clusters.

**Which issue(s) this PR fixes**:
Fixes #3077

**Special notes for your reviewer**:

**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
 
```release-note
NONE
```
