### PR TITLE
missing context wrapping

### DIFF
--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -571,7 +571,7 @@ func (m *MachinePoolScope) GetBootstrapData(ctx context.Context) (string, error)
 
 // GetVMImage picks an image from the AzureMachinePool configuration, or uses a default one.
 func (m *MachinePoolScope) GetVMImage(ctx context.Context) (*infrav1.Image, error) {
-	_, log, done := tele.StartSpanWithLogger(ctx, "scope.MachinePoolScope.GetVMImage")
+	ctx, log, done := tele.StartSpanWithLogger(ctx, "scope.MachinePoolScope.GetVMImage")
 	defer done()
 
 	// Use custom Marketplace image, Image ID or a Shared Image Gallery image if provided

--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -71,7 +71,7 @@ func NewAzureClusterReconciler(client client.Client, recorder record.EventRecord
 
 // SetupWithManager initializes this controller with a manager.
 func (acr *AzureClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options Options) error {
-	_, log, done := tele.StartSpanWithLogger(ctx,
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
 		"controllers.AzureClusterReconciler.SetupWithManager",
 		tele.KVP("controller", "AzureCluster"),
 	)

--- a/controllers/azureidentity_controller.go
+++ b/controllers/azureidentity_controller.go
@@ -53,7 +53,7 @@ type AzureIdentityReconciler struct {
 
 // SetupWithManager initializes this controller with a manager.
 func (r *AzureIdentityReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
-	_, log, done := tele.StartSpanWithLogger(ctx,
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
 		"controllers.AzureIdentityReconciler.SetupWithManager",
 		tele.KVP("controller", "AzureIdentity"),
 	)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind cleanup

**What this PR does / why we need it**:

This PR addresses positively identified instances where we're not wrapping context objects w/ our logger as is the normal pattern.

@nojnhuh points out [here](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3128/files#r1091116305) that we're sort of induced by our linter to create such opportunities.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
