### PR TITLE
Fix wrong LB idletimeout for node outbound

### DIFF
--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -242,7 +242,7 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 			FrontendIPConfigs:    s.APIServerLB().FrontendIPs,
 			APIServerPort:        s.APIServerPort(),
 			Type:                 s.APIServerLB().Type,
-			SKU:                  infrav1.SKUStandard,
+			SKU:                  s.APIServerLB().SKU,
 			Role:                 infrav1.APIServerRole,
 			BackendPoolName:      s.APIServerLB().BackendPool.Name,
 			IdleTimeoutInMinutes: s.APIServerLB().IdleTimeoutInMinutes,
@@ -284,7 +284,7 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 			Type:                 s.ControlPlaneOutboundLB().Type,
 			SKU:                  s.ControlPlaneOutboundLB().SKU,
 			BackendPoolName:      s.ControlPlaneOutboundLB().BackendPool.Name,
-			IdleTimeoutInMinutes: s.NodeOutboundLB().IdleTimeoutInMinutes,
+			IdleTimeoutInMinutes: s.ControlPlaneOutboundLB().IdleTimeoutInMinutes,
 			Role:                 infrav1.ControlPlaneOutboundRole,
 			AdditionalTags:       s.AdditionalTags(),
 		})

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -2674,3 +2674,284 @@ func TestFailureDomains(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterScope_LBSpecs(t *testing.T) {
+	tests := []struct {
+		name         string
+		azureCluster *infrav1.AzureCluster
+		want         []azure.ResourceSpecGetter
+	}{
+		{
+			name: "API Server LB, Control Plane Oubound LB, and Node Outbound LB",
+			azureCluster: &infrav1.AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-cluster",
+				},
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+						AdditionalTags: infrav1.Tags{
+							"foo": "bar",
+						},
+						SubscriptionID: "123",
+						Location:       "westus2",
+					},
+					ResourceGroup: "my-rg",
+					NetworkSpec: infrav1.NetworkSpec{
+						Vnet: infrav1.VnetSpec{
+							Name:          "my-vnet",
+							ResourceGroup: "my-rg",
+						},
+						Subnets: []infrav1.SubnetSpec{
+							{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Name: "cp-subnet",
+									Role: infrav1.SubnetControlPlane,
+								},
+							},
+							{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Name: "node-subnet",
+									Role: infrav1.SubnetNode,
+								},
+							},
+						},
+						APIServerLB: infrav1.LoadBalancerSpec{
+							Name: "api-server-lb",
+							BackendPool: infrav1.BackendPool{
+								Name: "api-server-lb-backend-pool",
+							},
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type:                 infrav1.Public,
+								IdleTimeoutInMinutes: pointer.Int32(30),
+								SKU:                  infrav1.SKUStandard,
+							},
+							FrontendIPs: []infrav1.FrontendIP{
+								{
+									Name: "api-server-lb-frontend-ip",
+									PublicIP: &infrav1.PublicIPSpec{
+										Name: "api-server-lb-frontend-ip",
+									},
+								},
+							},
+						},
+						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
+							Name: "cp-outbound-lb",
+							BackendPool: infrav1.BackendPool{
+								Name: "cp-outbound-backend-pool",
+							},
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type:                 infrav1.Public,
+								IdleTimeoutInMinutes: pointer.Int32(15),
+								SKU:                  infrav1.SKUStandard,
+							},
+							FrontendIPs: []infrav1.FrontendIP{
+								{
+									Name: "cp-outbound-lb-frontend-ip",
+									PublicIP: &infrav1.PublicIPSpec{
+										Name: "cp-outbound-lb-frontend-ip",
+									},
+								},
+							},
+						},
+						NodeOutboundLB: &infrav1.LoadBalancerSpec{
+							Name: "node-outbound-lb",
+							BackendPool: infrav1.BackendPool{
+								Name: "node-outbound-backend-pool",
+							},
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type:                 infrav1.Public,
+								IdleTimeoutInMinutes: pointer.Int32(50),
+								SKU:                  infrav1.SKUStandard,
+							},
+							FrontendIPs: []infrav1.FrontendIP{
+								{
+									Name: "node-outbound-lb-frontend-ip",
+									PublicIP: &infrav1.PublicIPSpec{
+										Name: "node-outbound-lb-frontend-ip",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []azure.ResourceSpecGetter{
+				&loadbalancers.LBSpec{
+					Name:              "api-server-lb",
+					ResourceGroup:     "my-rg",
+					SubscriptionID:    "123",
+					ClusterName:       "my-cluster",
+					Location:          "westus2",
+					VNetName:          "my-vnet",
+					VNetResourceGroup: "my-rg",
+					SubnetName:        "cp-subnet",
+					FrontendIPConfigs: []infrav1.FrontendIP{
+						{
+							Name: "api-server-lb-frontend-ip",
+							PublicIP: &infrav1.PublicIPSpec{
+								Name: "api-server-lb-frontend-ip",
+							},
+						},
+					},
+					APIServerPort:        6443,
+					Type:                 infrav1.Public,
+					SKU:                  infrav1.SKUStandard,
+					Role:                 infrav1.APIServerRole,
+					BackendPoolName:      "api-server-lb-backend-pool",
+					IdleTimeoutInMinutes: pointer.Int32(30),
+					AdditionalTags: infrav1.Tags{
+						"foo": "bar",
+					},
+				},
+				&loadbalancers.LBSpec{
+					Name:              "node-outbound-lb",
+					ResourceGroup:     "my-rg",
+					SubscriptionID:    "123",
+					ClusterName:       "my-cluster",
+					Location:          "westus2",
+					VNetName:          "my-vnet",
+					VNetResourceGroup: "my-rg",
+					FrontendIPConfigs: []infrav1.FrontendIP{
+						{
+							Name: "node-outbound-lb-frontend-ip",
+							PublicIP: &infrav1.PublicIPSpec{
+								Name: "node-outbound-lb-frontend-ip",
+							},
+						},
+					},
+					Type:                 infrav1.Public,
+					SKU:                  infrav1.SKUStandard,
+					Role:                 infrav1.NodeOutboundRole,
+					BackendPoolName:      "node-outbound-backend-pool",
+					IdleTimeoutInMinutes: pointer.Int32(50),
+					AdditionalTags: infrav1.Tags{
+						"foo": "bar",
+					},
+				},
+				&loadbalancers.LBSpec{
+					Name:              "cp-outbound-lb",
+					ResourceGroup:     "my-rg",
+					SubscriptionID:    "123",
+					ClusterName:       "my-cluster",
+					Location:          "westus2",
+					VNetName:          "my-vnet",
+					VNetResourceGroup: "my-rg",
+					FrontendIPConfigs: []infrav1.FrontendIP{
+						{
+							Name: "cp-outbound-lb-frontend-ip",
+							PublicIP: &infrav1.PublicIPSpec{
+								Name: "cp-outbound-lb-frontend-ip",
+							},
+						},
+					},
+					Type:                 infrav1.Public,
+					SKU:                  infrav1.SKUStandard,
+					BackendPoolName:      "cp-outbound-backend-pool",
+					IdleTimeoutInMinutes: pointer.Int32(15),
+					Role:                 infrav1.ControlPlaneOutboundRole,
+					AdditionalTags: infrav1.Tags{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "Private API Server LB",
+			azureCluster: &infrav1.AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-cluster",
+				},
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+						SubscriptionID: "123",
+						Location:       "westus2",
+					},
+					ResourceGroup: "my-rg",
+					NetworkSpec: infrav1.NetworkSpec{
+						Vnet: infrav1.VnetSpec{
+							Name:          "my-vnet",
+							ResourceGroup: "my-rg",
+						},
+						Subnets: []infrav1.SubnetSpec{
+							{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Name: "cp-subnet",
+									Role: infrav1.SubnetControlPlane,
+								},
+							},
+							{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Name: "node-subnet",
+									Role: infrav1.SubnetNode,
+								},
+							},
+						},
+						APIServerLB: infrav1.LoadBalancerSpec{
+							Name: "api-server-lb",
+							BackendPool: infrav1.BackendPool{
+								Name: "api-server-lb-backend-pool",
+							},
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type:                 infrav1.Internal,
+								IdleTimeoutInMinutes: pointer.Int32(30),
+								SKU:                  infrav1.SKUStandard,
+							},
+						},
+					},
+				},
+			},
+			want: []azure.ResourceSpecGetter{
+				&loadbalancers.LBSpec{
+					Name:                 "api-server-lb",
+					ResourceGroup:        "my-rg",
+					SubscriptionID:       "123",
+					ClusterName:          "my-cluster",
+					Location:             "westus2",
+					VNetName:             "my-vnet",
+					VNetResourceGroup:    "my-rg",
+					SubnetName:           "cp-subnet",
+					APIServerPort:        6443,
+					Type:                 infrav1.Internal,
+					SKU:                  infrav1.SKUStandard,
+					Role:                 infrav1.APIServerRole,
+					BackendPoolName:      "api-server-lb-backend-pool",
+					IdleTimeoutInMinutes: pointer.Int32(30),
+					AdditionalTags:       infrav1.Tags{},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			scheme := runtime.NewScheme()
+			_ = infrav1.AddToScheme(scheme)
+			_ = clusterv1.AddToScheme(scheme)
+
+			cluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tc.azureCluster.Name,
+					Namespace: "default",
+				},
+			}
+
+			initObjects := []runtime.Object{cluster, tc.azureCluster}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
+
+			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
+				AzureClients: AzureClients{
+					Authorizer: autorest.NullAuthorizer{},
+				},
+				Cluster:      cluster,
+				AzureCluster: tc.azureCluster,
+				Client:       fakeClient,
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			if got := clusterScope.LBSpecs(); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("LBSpecs() diff between expected result and actual result (%v): %s", got, cmp.Diff(tc.want, got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: In cluster scope, when reading Control Plane outbound LB specs, IdleTimeoutInMinutes is read from node outbound LB spec instead from control plane outbound spec https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/4964920c7467073ff445e6d971e78d98bc60f177/azure/scope/cluster.go#L287, so this can cause a panic on the mentioned line in cluster scope when node outbound LB is nil.

Adds unit tests for the LBSpecs() func.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix idleTimeoutInMinutes for Control Plane Outbound LB to use the right LB spec
```
