### PR TITLE
[release-1.6] Bump CAPI to v1.2.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	./hack/create-custom-cloud-provider-config.sh
 
 	# Deploy CAPI
-	curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.9/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -
+	curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.10/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -
 
 	# Deploy CAPZ
 	$(KIND) load docker-image $(CONTROLLER_IMG)-$(ARCH):$(TAG) --name=capz
@@ -671,7 +671,7 @@ test-e2e-local: ## Run "docker-build" rule then run e2e tests.
 	GINKGO_ARGS='$(LOCAL_GINKGO_ARGS)' \
 	test-e2e-run
 
-CONFORMANCE_FLAVOR ?= 
+CONFORMANCE_FLAVOR ?=
 CONFORMANCE_E2E_ARGS ?= -kubetest.config-file=$(KUBETEST_CONF_PATH)
 CONFORMANCE_E2E_ARGS += $(E2E_ARGS)
 .PHONY: test-conformance

--- a/Tiltfile
+++ b/Tiltfile
@@ -19,7 +19,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
-    "capi_version": "v1.2.9",
+    "capi_version": "v1.2.10",
     "cert_manager_version": "v1.1.0",
     "kubernetes_version": "v1.23.9",
     "aks_kubernetes_version": "v1.23.8",

--- a/go.mod
+++ b/go.mod
@@ -44,8 +44,8 @@ require (
 	k8s.io/klog/v2 v2.60.1
 	k8s.io/kubectl v0.24.0
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
-	sigs.k8s.io/cluster-api v1.2.9
-	sigs.k8s.io/cluster-api/test v1.2.9
+	sigs.k8s.io/cluster-api v1.2.10
+	sigs.k8s.io/cluster-api/test v1.2.10
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/kind v0.14.0
 )
@@ -211,4 +211,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.9
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.10

--- a/go.sum
+++ b/go.sum
@@ -1392,10 +1392,10 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
-sigs.k8s.io/cluster-api v1.2.9 h1:8Q+gVLJUsuPixfgjKInNnA7xbgESLWGq26STfRkBqdc=
-sigs.k8s.io/cluster-api v1.2.9/go.mod h1:ZuiH8az7bIv0D6AzkbOrPUtiRAnKH9U1YnFC6nrk72I=
-sigs.k8s.io/cluster-api/test v1.2.9 h1:URMCZ4GHPmgIvH7vIVSItne0iEK0SBiHiyFZa9O1oXU=
-sigs.k8s.io/cluster-api/test v1.2.9/go.mod h1:/bOh2uQ+sbK8Iy0GM6wYq52z867klX95NHgtOG29PEU=
+sigs.k8s.io/cluster-api v1.2.10 h1:EzNMSZ+6BJ46HGNhCP2CxmJjwfD1u/DMjpBh90mejyg=
+sigs.k8s.io/cluster-api v1.2.10/go.mod h1:ZuiH8az7bIv0D6AzkbOrPUtiRAnKH9U1YnFC6nrk72I=
+sigs.k8s.io/cluster-api/test v1.2.10 h1:O6b/R1qZFThm9uII/SjxjcRPED6xvSCJSMKw3YIOwG0=
+sigs.k8s.io/cluster-api/test v1.2.10/go.mod h1:/bOh2uQ+sbK8Iy0GM6wYq52z867klX95NHgtOG29PEU=
 sigs.k8s.io/controller-runtime v0.12.3 h1:FCM8xeY/FI8hoAfh/V4XbbYMY20gElh9yh+A98usMio=
 sigs.k8s.io/controller-runtime v0.12.3/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -3,11 +3,11 @@ managementClusterName: capz-e2e
 images:
   - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.2.9
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.2.10
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.2.9
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.2.10
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.2.9
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.2.10
     loadBehavior: tryLoad
 
 providers:
@@ -23,8 +23,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
-    - name: v1.2.9
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.9/core-components.yaml
+    - name: v1.2.10
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.10/core-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -46,8 +46,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
-    - name: v1.2.9
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.9/bootstrap-components.yaml
+    - name: v1.2.10
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.10/bootstrap-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -68,8 +68,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
-    - name: v1.2.9
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.9/control-plane-components.yaml
+    - name: v1.2.10
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.10/control-plane-components.yaml
       type: url
       contract: v1beta1
       files:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

CAPI v1.2.10 adds support for Kubernetes v1.26 and fixes some issues:
https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.2.10

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:


**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Bump CAPI to v1.2.10
```
