### PR TITLE
[release-1.6] Bump cert-manager to v1.11.0

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -20,7 +20,7 @@ settings = {
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
     "capi_version": "v1.2.10",
-    "cert_manager_version": "v1.1.0",
+    "cert_manager_version": "v1.11.0",
     "kubernetes_version": "v1.23.9",
     "aks_kubernetes_version": "v1.23.8",
 }
@@ -396,7 +396,7 @@ include_user_tilt_files()
 load("ext://cert_manager", "deploy_cert_manager")
 
 if settings.get("deploy_cert_manager"):
-    deploy_cert_manager()
+    deploy_cert_manager(version = settings.get("cert_manager_version"))
 
 deploy_capi()
 

--- a/hack/install-cert-manager.sh
+++ b/hack/install-cert-manager.sh
@@ -52,7 +52,7 @@ KUBECTL="${REPO_ROOT}/hack/tools/bin/kubectl"
 make --directory="${REPO_ROOT}" "${KUBECTL##*/}"
 
 ## Install cert manager and wait for availability
-"${KUBECTL}" apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.0/cert-manager.yaml
+"${KUBECTL}" apply -f https://github.com/jetstack/cert-manager/releases/download/v1.11.0/cert-manager.yaml
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Manual cherry-pick of #3139.

Updates the cert-manager component to recent release v1.11.0, keeping in sync with [CAPI](https://github.com/kubernetes-sigs/cluster-api/pull/7916).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Bump cert-manager to v1.11.0
```
