### PR TITLE
[release-1.7] Bump cert-manager to v1.11.0

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -20,7 +20,7 @@ settings = {
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
     "capi_version": "v1.3.1",
-    "cert_manager_version": "v1.10.0",
+    "cert_manager_version": "v1.11.0",
     "kubernetes_version": "v1.24.6",
     "aks_kubernetes_version": "v1.24.6",
 }
@@ -400,7 +400,7 @@ include_user_tilt_files()
 load("ext://cert_manager", "deploy_cert_manager")
 
 if settings.get("deploy_cert_manager"):
-    deploy_cert_manager()
+    deploy_cert_manager(version = settings.get("cert_manager_version"))
 
 deploy_capi()
 

--- a/hack/install-cert-manager.sh
+++ b/hack/install-cert-manager.sh
@@ -54,7 +54,7 @@ source "${REPO_ROOT}/hack/common-vars.sh"
 make --directory="${REPO_ROOT}" "${KUBECTL##*/}"
 
 ## Install cert manager and wait for availability
-"${KUBECTL}" apply -f https://github.com/jetstack/cert-manager/releases/download/v1.10.0/cert-manager.yaml
+"${KUBECTL}" apply -f https://github.com/jetstack/cert-manager/releases/download/v1.11.0/cert-manager.yaml
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Manual cherry-pick of #3139.

Updates the cert-manager component to recent release v1.11.0, keeping in sync with [CAPI](https://github.com/kubernetes-sigs/cluster-api/pull/7916).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Bump cert-manager to v1.11.0
```
