### PR TITLE
[release-1.6]use outboundlb name as the lb name in cloud config

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -259,6 +259,7 @@ func newCloudProviderConfig(d azure.ClusterScoper) (controlPlaneConfig *CloudPro
 			SubnetName:                   subnet.Name,
 			RouteTableName:               subnet.RouteTable.Name,
 			LoadBalancerSku:              "Standard",
+			LoadBalancerName:             d.OutboundLBName(infrav1.Node),
 			MaximumLoadBalancerRuleCount: 250,
 			UseManagedIdentityExtension:  false,
 			UseInstanceMetadata:          true,
@@ -279,6 +280,7 @@ func newCloudProviderConfig(d azure.ClusterScoper) (controlPlaneConfig *CloudPro
 			SubnetName:                   subnet.Name,
 			RouteTableName:               subnet.RouteTable.Name,
 			LoadBalancerSku:              "Standard",
+			LoadBalancerName:             d.OutboundLBName(infrav1.Node),
 			MaximumLoadBalancerRuleCount: 250,
 			UseManagedIdentityExtension:  false,
 			UseInstanceMetadata:          true,
@@ -312,6 +314,7 @@ type CloudProviderConfig struct {
 	SubnetName                   string `json:"subnetName"`
 	RouteTableName               string `json:"routeTableName"`
 	LoadBalancerSku              string `json:"loadBalancerSku"`
+	LoadBalancerName             string `json:"loadBalancerName"`
 	MaximumLoadBalancerRuleCount int    `json:"maximumLoadBalancerRuleCount"`
 	UseManagedIdentityExtension  bool   `json:"useManagedIdentityExtension"`
 	UseInstanceMetadata          bool   `json:"useInstanceMetadata"`

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -461,6 +461,7 @@ const (
     "subnetName": "foo-node-subnet",
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
+    "loadBalancerName": "foo",
     "maximumLoadBalancerRuleCount": 250,
     "useManagedIdentityExtension": false,
     "useInstanceMetadata": true
@@ -482,6 +483,7 @@ const (
     "subnetName": "foo-node-subnet",
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
+    "loadBalancerName": "foo",
     "maximumLoadBalancerRuleCount": 250,
     "useManagedIdentityExtension": false,
     "useInstanceMetadata": true
@@ -501,6 +503,7 @@ const (
     "subnetName": "foo-node-subnet",
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
+    "loadBalancerName": "foo",
     "maximumLoadBalancerRuleCount": 250,
     "useManagedIdentityExtension": true,
     "useInstanceMetadata": true
@@ -519,6 +522,7 @@ const (
     "subnetName": "foo-node-subnet",
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
+    "loadBalancerName": "foo",
     "maximumLoadBalancerRuleCount": 250,
     "useManagedIdentityExtension": true,
     "useInstanceMetadata": true
@@ -538,6 +542,7 @@ const (
     "subnetName": "foo-node-subnet",
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
+    "loadBalancerName": "foo",
     "maximumLoadBalancerRuleCount": 250,
     "useManagedIdentityExtension": true,
     "useInstanceMetadata": true,
@@ -557,6 +562,7 @@ const (
     "subnetName": "foo-node-subnet",
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
+    "loadBalancerName": "foo",
     "maximumLoadBalancerRuleCount": 250,
     "useManagedIdentityExtension": true,
     "useInstanceMetadata": true,
@@ -578,6 +584,7 @@ const (
     "subnetName": "foo-node-subnet",
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
+    "loadBalancerName": "foo",
     "maximumLoadBalancerRuleCount": 250,
     "useManagedIdentityExtension": false,
     "useInstanceMetadata": true
@@ -598,6 +605,7 @@ const (
     "subnetName": "foo-node-subnet",
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
+    "loadBalancerName": "foo",
     "maximumLoadBalancerRuleCount": 250,
     "useManagedIdentityExtension": false,
     "useInstanceMetadata": true
@@ -618,6 +626,7 @@ const (
     "subnetName": "foo-node-subnet",
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
+    "loadBalancerName": "foo",
     "maximumLoadBalancerRuleCount": 250,
     "useManagedIdentityExtension": false,
     "useInstanceMetadata": true,
@@ -643,6 +652,7 @@ const (
     "subnetName": "foo-node-subnet",
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
+    "loadBalancerName": "foo",
     "maximumLoadBalancerRuleCount": 250,
     "useManagedIdentityExtension": false,
     "useInstanceMetadata": true,
@@ -668,6 +678,7 @@ const (
     "subnetName": "foo-node-subnet",
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
+    "loadBalancerName": "foo",
     "maximumLoadBalancerRuleCount": 250,
     "useManagedIdentityExtension": false,
     "useInstanceMetadata": true,


### PR DESCRIPTION
Signed-off-by: Ashutosh Kumar <sonasingh46@gmail.com>

This is  cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3059

```release-note
Fixes not routable issue of service type of load balancer when AzureClusterName and ClusterName are different.
```
