### PR TITLE
Fetch Calico Helm chart from new URL

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -363,7 +363,7 @@ def deploy_worker_templates(template, substitutions):
         calico_values = "./templates/addons/calico-dual-stack/values.yaml"
     else:
         calico_values = "./templates/addons/calico/values.yaml"
-    flavor_cmd += "; " + helm_cmd + " repo add projectcalico https://projectcalico.docs.tigera.io/charts; " + helm_cmd + " --kubeconfig ./${CLUSTER_NAME}.kubeconfig install calico projectcalico/tigera-operator -f " + calico_values + " --namespace tigera-operator --create-namespace"
+    flavor_cmd += "; " + helm_cmd + " repo add projectcalico https://docs.tigera.io/calico/charts; " + helm_cmd + " --kubeconfig ./${CLUSTER_NAME}.kubeconfig install calico projectcalico/tigera-operator -f " + calico_values + " --namespace tigera-operator --create-namespace"
     if "external-cloud-provider" in flavor_name:
         flavor_cmd += "; " + helm_cmd + " --kubeconfig ./${CLUSTER_NAME}.kubeconfig install --repo https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo cloud-provider-azure --generate-name --set infra.clusterName=${CLUSTER_NAME}"
     local_resource(

--- a/docs/book/src/topics/addons.md
+++ b/docs/book/src/topics/addons.md
@@ -28,7 +28,7 @@ export IPV4_CIDR_BLOCK=$(kubectl get cluster "${CLUSTER_NAME}" -o=jsonpath='{.sp
 Then install the Helm chart on the workload cluster:
 
 ```bash
-helm repo add projectcalico https://projectcalico.docs.tigera.io/charts && \
+helm repo add projectcalico https://docs.tigera.io/calico/charts && \
 helm install calico projectcalico/tigera-operator -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico/values.yaml --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV4_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
 ```
 
@@ -43,7 +43,7 @@ export IPV6_CIDR_BLOCK=$(kubectl get cluster "${CLUSTER_NAME}" -o=jsonpath='{.sp
 Then install the Helm chart on the workload cluster:
 
 ```bash
-helm repo add projectcalico https://projectcalico.docs.tigera.io/charts && \
+helm repo add projectcalico https://docs.tigera.io/calico/charts && \
 helm install calico projectcalico/tigera-operator -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico-ipv6/values.yaml  --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV6_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
 ```
 
@@ -59,7 +59,7 @@ export IPV6_CIDR_BLOCK=$(kubectl get cluster "${CLUSTER_NAME}" -o=jsonpath='{.sp
 Then install the Helm chart on the workload cluster:
 
 ```bash
-helm repo add projectcalico https://projectcalico.docs.tigera.io/charts && \
+helm repo add projectcalico https://docs.tigera.io/calico/charts && \
 helm install calico projectcalico/tigera-operator -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico-dual-stack/values.yaml --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV4_CIDR_BLOCK}","installation.calicoNetwork.ipPools[1].cidr=${IPV6_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
 ```
 

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -175,7 +175,7 @@ install_calico() {
         CALICO_VALUES_FILE="${REPO_ROOT}/templates/addons/calico/values.yaml"
         CIDR_STRING_VALUES="installation.calicoNetwork.ipPools[0].cidr=${CIDR0}"
     fi
-    "${HELM}" upgrade calico --install --repo https://projectcalico.docs.tigera.io/charts tigera-operator -f "${CALICO_VALUES_FILE}" --set-string "${CIDR_STRING_VALUES}" --namespace calico-system
+    "${HELM}" upgrade calico --install --repo https://docs.tigera.io/calico/charts tigera-operator -f "${CALICO_VALUES_FILE}" --set-string "${CIDR_STRING_VALUES}" --namespace calico-system
 }
 
 # install_cloud_provider_azure installs OOT cloud-provider-azure componentry onto the Cluster.

--- a/test/e2e/cni.go
+++ b/test/e2e/cni.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	calicoHelmChartRepoURL   string = "https://projectcalico.docs.tigera.io/charts"
+	calicoHelmChartRepoURL   string = "https://docs.tigera.io/calico/charts"
 	calicoOperatorNamespace  string = "tigera-operator"
 	CalicoSystemNamespace    string = "calico-system"
 	CalicoAPIServerNamespace string = "calico-apiserver"


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test


**What this PR does / why we need it**:

Tigera changed the location of the Calico chart from https://projectcalico.docs.tigera.io/charts to https://docs.tigera.io/calico/charts.

**Which issue(s) this PR fixes**:

See also #3142.

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
