### PR TITLE
[release-1.7] Add 30s timeout to test helper SSH config

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -78,6 +78,7 @@ const (
 	retryableOperationTimeout             = 30 * time.Second
 	retryableDeleteOperationTimeout       = 3 * time.Minute
 	retryableOperationSleepBetweenRetries = 3 * time.Second
+	sshConnectionTimeout                  = 30 * time.Second
 )
 
 // deploymentsClientAdapter adapts a Deployment to work with WaitForDeploymentsAvailable.
@@ -587,6 +588,7 @@ func newSSHConfig() (*ssh.ClientConfig, error) {
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // Non-production code
 		User:            azure.DefaultUserName,
 		Auth:            []ssh.AuthMethod{pubkey},
+		Timeout:         sshConnectionTimeout,
 	}
 	return &sshConfig, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Manual cherry-pick of #3153.

Adds a 30s timeout to the `sshConfig` used in e2e test log collection. This may fix the cleanup error we have often observed with the CAPI test `Running the MachineDeployment rollout spec` in the pull-cluster-api-provider-azure-capi-e2e job.

**Which issue(s) this PR fixes**:

Refs #3108

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
