### PR TITLE
Skip test pending fix for VMSS Flex API changes

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -517,6 +517,7 @@ var _ = Describe("Workload cluster creation", func() {
 	// resource group. Override these defaults by setting the USER_IDENTITY and CI_RG environment variables.
 	Context("Creating a cluster that uses the external cloud provider and machinepools [OPTIONAL]", func() {
 		It("with 1 control plane node and 1 machinepool", func() {
+			Skip("VMSS Flex test disabled pending fix for API changes")
 			By("using user-assigned identity")
 			clusterName = getClusterName(clusterNamePrefix, "flex")
 			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Apparently API changes for VMSS Flex around 2/5 broke provisioning of Flex clusters altogether. This skips that e2e test until we have caught up with these changes and Flex MachinePools are working again.

**Which issue(s) this PR fixes**:

Refs #3162

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
