### PR TITLE
Fix unbound CIDR1 in ci-entrypoint when testing CCM

### DIFF
--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -194,7 +194,7 @@ install_cloud_provider_azure() {
     fi
 
     CCM_CLUSTER_CIDR="${CIDR0}"
-    if [[ -n "${CIDR1}" ]]; then
+    if [[ -n "${CIDR1:-}" ]]; then
         CCM_CLUSTER_CIDR="${CIDR0}\,${CIDR1}"
     fi
     echo "CCM cluster CIDR: ${CCM_CLUSTER_CIDR:-}"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: #3148 introduced an unbound variable error which only gets triggered with the "TEST_CCM" option set to true. Found while testing #3105. Needs to merge before https://github.com/kubernetes/test-infra/pull/28725.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
