### PR TITLE
Fix Windows external CI version template to use OOT

### DIFF
--- a/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider-ci-version.yaml
@@ -523,8 +523,8 @@ spec:
           kubeletExtraArgs:
             azure-container-registry-config: c:/k/azure.json
             cloud-config: c:/k/azure.json
-            cloud-provider: azure
-            feature-gates: WindowsHostProcessContainers=true
+            cloud-provider: external
+            feature-gates: WindowsHostProcessContainers=true,CSIMigrationAzureDisk=true
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/prow-external-cloud-provider-ci-version/kustomization.yaml
+++ b/templates/test/ci/prow-external-cloud-provider-ci-version/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ../prow-ci-version
 patchesStrategicMerge:
   - ../../../flavors/external-cloud-provider/patches/external-cloud-provider.yaml
+  - patches/external-cloud-provider-windows.yaml

--- a/templates/test/ci/prow-external-cloud-provider-ci-version/patches/external-cloud-provider-windows.yaml
+++ b/templates/test/ci/prow-external-cloud-provider-ci-version/patches/external-cloud-provider-windows.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-win
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
+            feature-gates: WindowsHostProcessContainers=true,CSIMigrationAzureDisk=true


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: The external cloud provider CI version template has a bug as the windows deployment is not using external cloud-provider so it's actually testing in-tree for windows.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
