### PR TITLE
fix tag delete following resource create

### DIFF
--- a/azure/services/tags/tags.go
+++ b/azure/services/tags/tags.go
@@ -105,12 +105,13 @@ func (s *Service) Reconcile(ctx context.Context) error {
 					return errors.Wrap(err, "cannot update tags")
 				}
 			}
-
-			// We also need to update the annotation if anything changed.
-			if err := s.Scope.UpdateAnnotationJSON(tagsSpec.Annotation, newAnnotation); err != nil {
-				return err
-			}
 			log.V(2).Info("successfully updated tags")
+		}
+
+		// We also need to update the annotation even if nothing changed to
+		// ensure it's set immediately following resource creation.
+		if err := s.Scope.UpdateAnnotationJSON(tagsSpec.Annotation, newAnnotation); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/azure/services/tags/tags_test.go
+++ b/azure/services/tags/tags_test.go
@@ -218,6 +218,7 @@ func TestReconcileTags(t *testing.T) {
 					},
 				}}, nil)
 				s.AnnotationJSON("my-annotation").Return(map[string]interface{}{"key": "value"}, nil)
+				s.UpdateAnnotationJSON("my-annotation", map[string]interface{}{"key": "value"})
 			},
 		},
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Fixes an issue where deleting any values from an AzureCluster's or AzureManagedCluster's `spec.additionalTags` before making any other changes to that field never takes effect on the Azure resource group because the `last-applied-tags` annotation is not applied initially. This change ensures the annotation is set on each reconciliation loop, whether or not the tags need to be updated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3185

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
