### PR TITLE
MachinePools: Fix AzureMachinePool default for SystemAssignedIdentityRole

### DIFF
--- a/api/v1beta1/azuremachine_default_test.go
+++ b/api/v1beta1/azuremachine_default_test.go
@@ -79,7 +79,10 @@ func TestAzureMachineSpec_SetIdentityDefaults(t *testing.T) {
 			DefinitionID: fakeRoleDefinitionID,
 		},
 	}}}
-
+	deprecatedRoleAssignmentNameTest := test{machine: &AzureMachine{Spec: AzureMachineSpec{
+		Identity:           VMIdentitySystemAssigned,
+		RoleAssignmentName: existingRoleAssignmentName,
+	}}}
 	emptyTest := test{machine: &AzureMachine{Spec: AzureMachineSpec{
 		Identity:                   VMIdentitySystemAssigned,
 		SystemAssignedIdentityRole: &SystemAssignedIdentityRole{},
@@ -94,6 +97,10 @@ func TestAzureMachineSpec_SetIdentityDefaults(t *testing.T) {
 	systemAssignedIdentityRoleExistTest.machine.Spec.SetIdentityDefaults(fakeSubscriptionID)
 	g.Expect(systemAssignedIdentityRoleExistTest.machine.Spec.SystemAssignedIdentityRole.Scope).To(Equal(fakeScope))
 	g.Expect(systemAssignedIdentityRoleExistTest.machine.Spec.SystemAssignedIdentityRole.DefinitionID).To(Equal(fakeRoleDefinitionID))
+
+	deprecatedRoleAssignmentNameTest.machine.Spec.SetIdentityDefaults(fakeSubscriptionID)
+	g.Expect(deprecatedRoleAssignmentNameTest.machine.Spec.SystemAssignedIdentityRole.Name).To(Equal(existingRoleAssignmentName))
+	g.Expect(deprecatedRoleAssignmentNameTest.machine.Spec.RoleAssignmentName).To(BeEmpty())
 
 	emptyTest.machine.Spec.SetIdentityDefaults(fakeSubscriptionID)
 	g.Expect(emptyTest.machine.Spec.SystemAssignedIdentityRole.Name).To(Not(BeEmpty()))

--- a/exp/api/v1beta1/azuremachinepool_default.go
+++ b/exp/api/v1beta1/azuremachinepool_default.go
@@ -72,18 +72,14 @@ func (amp *AzureMachinePool) SetIdentityDefaults(subscriptionID string) {
 		return
 	}
 	if amp.Spec.Identity == infrav1.VMIdentitySystemAssigned {
-		if amp.Spec.RoleAssignmentName == "" {
-			amp.Spec.RoleAssignmentName = string(uuid.NewUUID())
-		}
 		if amp.Spec.SystemAssignedIdentityRole == nil {
 			amp.Spec.SystemAssignedIdentityRole = &infrav1.SystemAssignedIdentityRole{}
 		}
-		if amp.Spec.SystemAssignedIdentityRole.Name == "" {
+		if amp.Spec.RoleAssignmentName != "" {
+			amp.Spec.SystemAssignedIdentityRole.Name = amp.Spec.RoleAssignmentName
+			amp.Spec.RoleAssignmentName = ""
+		} else if amp.Spec.SystemAssignedIdentityRole.Name == "" {
 			amp.Spec.SystemAssignedIdentityRole.Name = string(uuid.NewUUID())
-			if amp.Spec.RoleAssignmentName != "" {
-				amp.Spec.SystemAssignedIdentityRole.Name = amp.Spec.RoleAssignmentName
-				amp.Spec.RoleAssignmentName = ""
-			}
 		}
 		if amp.Spec.SystemAssignedIdentityRole.Scope == "" {
 			// Default scope to the subscription.

--- a/exp/api/v1beta1/azuremachinepool_default_test.go
+++ b/exp/api/v1beta1/azuremachinepool_default_test.go
@@ -75,6 +75,10 @@ func TestAzureMachinePool_SetIdentityDefaults(t *testing.T) {
 			Scope:        fakeScope,
 		},
 	}}}
+	deprecatedRoleAssignmentNameTest := test{machinePool: &AzureMachinePool{Spec: AzureMachinePoolSpec{
+		Identity:           infrav1.VMIdentitySystemAssigned,
+		RoleAssignmentName: existingRoleAssignmentName,
+	}}}
 	emptyTest := test{machinePool: &AzureMachinePool{Spec: AzureMachinePoolSpec{
 		Identity:                   infrav1.VMIdentitySystemAssigned,
 		SystemAssignedIdentityRole: &infrav1.SystemAssignedIdentityRole{},
@@ -89,6 +93,10 @@ func TestAzureMachinePool_SetIdentityDefaults(t *testing.T) {
 	systemAssignedIdentityRoleExistTest.machinePool.SetIdentityDefaults(fakeSubscriptionID)
 	g.Expect(systemAssignedIdentityRoleExistTest.machinePool.Spec.SystemAssignedIdentityRole.Scope).To(Equal(fakeScope))
 	g.Expect(systemAssignedIdentityRoleExistTest.machinePool.Spec.SystemAssignedIdentityRole.DefinitionID).To(Equal(fakeRoleDefinitionID))
+
+	deprecatedRoleAssignmentNameTest.machinePool.SetIdentityDefaults(fakeSubscriptionID)
+	g.Expect(deprecatedRoleAssignmentNameTest.machinePool.Spec.SystemAssignedIdentityRole.Name).To(Equal(existingRoleAssignmentName))
+	g.Expect(deprecatedRoleAssignmentNameTest.machinePool.Spec.RoleAssignmentName).To(BeEmpty())
 
 	emptyTest.machinePool.SetIdentityDefaults(fakeSubscriptionID)
 	g.Expect(emptyTest.machinePool.Spec.SystemAssignedIdentityRole.Name).To(Not(BeEmpty()))

--- a/exp/api/v1beta1/azuremachinepool_webhook.go
+++ b/exp/api/v1beta1/azuremachinepool_webhook.go
@@ -208,7 +208,7 @@ func (amp *AzureMachinePool) ValidateSystemAssignedIdentity(old runtime.Object) 
 // ValidateSystemAssignedIdentityRole validates the scope and roleDefinitionID for the system-assigned identity.
 func (amp *AzureMachinePool) ValidateSystemAssignedIdentityRole() error {
 	var allErrs field.ErrorList
-	if amp.Spec.RoleAssignmentName != "" && amp.Spec.SystemAssignedIdentityRole.Name != "" {
+	if amp.Spec.RoleAssignmentName != "" && amp.Spec.SystemAssignedIdentityRole != nil && amp.Spec.SystemAssignedIdentityRole.Name != "" {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("systemAssignedIdentityRole"), amp.Spec.SystemAssignedIdentityRole.Name, "cannot set both roleAssignmentName and systemAssignedIdentityRole.name"))
 	}
 	if amp.Spec.Identity == infrav1.VMIdentitySystemAssigned {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR fixes an issue with MachinePools where if the old deprecated `roleAssignmentName` field is set and the new `systemAssignedIdentityRole.Name` isn't, the defaulting webhook sets both fields, resulting in an error in the validation webhook. This is because only one of those fields should be set at a time.

This also fixes failures in the [CAPI upgrade tests](https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#capi-periodic-upgrade-main-1-23-1-24).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
