### PR TITLE
Detect Flex from VMSS orchestration mode

### DIFF
--- a/azure/converters/vmss.go
+++ b/azure/converters/vmss.go
@@ -49,6 +49,7 @@ func SDKToVMSS(sdkvmss compute.VirtualMachineScaleSet, sdkinstances []compute.Vi
 		vmss.Instances = make([]azure.VMSSVM, len(sdkinstances))
 		for i, vm := range sdkinstances {
 			vmss.Instances[i] = *SDKToVMSSVM(vm)
+			vmss.Instances[i].OrchestrationMode = infrav1.OrchestrationModeType(sdkvmss.OrchestrationMode)
 		}
 	}
 
@@ -63,7 +64,7 @@ func SDKToVMSS(sdkvmss compute.VirtualMachineScaleSet, sdkinstances []compute.Vi
 }
 
 // SDKVMToVMSSVM converts an Azure SDK VM to a VMSS VM.
-func SDKVMToVMSSVM(sdkInstance compute.VirtualMachine) *azure.VMSSVM {
+func SDKVMToVMSSVM(sdkInstance compute.VirtualMachine, mode infrav1.OrchestrationModeType) *azure.VMSSVM {
 	instance := azure.VMSSVM{
 		ID: pointer.StringDeref(sdkInstance.ID, ""),
 	}
@@ -90,6 +91,8 @@ func SDKVMToVMSSVM(sdkInstance compute.VirtualMachine) *azure.VMSSVM {
 		// An instance should have only 1 zone, so use the first item of the slice.
 		instance.AvailabilityZone = azure.StringSlice(sdkInstance.Zones)[0]
 	}
+
+	instance.OrchestrationMode = mode
 
 	return &instance
 }

--- a/azure/converters/vmss_test.go
+++ b/azure/converters/vmss_test.go
@@ -350,7 +350,7 @@ func Test_SDKVMToVMSSVM(t *testing.T) {
 		t.Run(c.Name, func(t *testing.T) {
 			t.Parallel()
 			g := gomega.NewGomegaWithT(t)
-			subject := converters.SDKVMToVMSSVM(c.Subject)
+			subject := converters.SDKVMToVMSSVM(c.Subject, "")
 			g.Expect(subject).To(gomega.Equal(c.Expected))
 		})
 	}

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -302,7 +302,7 @@ func (m *MachinePoolScope) applyAzureMachinePoolMachines(ctx context.Context) er
 	}
 
 	// determine which machines need to be created to reflect the current state in Azure
-	azureMachinesByProviderID := m.vmssState.InstancesByProviderID()
+	azureMachinesByProviderID := m.vmssState.InstancesByProviderID(m.AzureMachinePool.Spec.OrchestrationMode)
 	for key, val := range azureMachinesByProviderID {
 		if _, ok := existingMachinesByProviderID[key]; !ok {
 			log.V(4).Info("creating AzureMachinePoolMachine", "providerID", key)

--- a/azure/scope/machinepoolmachine.go
+++ b/azure/scope/machinepoolmachine.go
@@ -163,6 +163,11 @@ func (s *MachinePoolMachineScope) ScaleSetName() string {
 	return s.MachinePoolScope.Name()
 }
 
+// OrchestrationMode is the VMSS orchestration mode, either Uniform or Flexible.
+func (s *MachinePoolMachineScope) OrchestrationMode() infrav1.OrchestrationModeType {
+	return s.AzureMachinePool.Spec.OrchestrationMode
+}
+
 // SetLongRunningOperationState will set the future on the AzureMachinePoolMachine status to allow the resource to continue
 // in the next reconciliation.
 func (s *MachinePoolMachineScope) SetLongRunningOperationState(future *infrav1.Future) {
@@ -259,6 +264,7 @@ func (s *MachinePoolMachineScope) PatchObject(ctx context.Context) error {
 		patch.WithOwnedConditions{Conditions: []clusterv1.ConditionType{
 			clusterv1.ReadyCondition,
 			clusterv1.MachineNodeHealthyCondition,
+			clusterv1.DrainingSucceededCondition,
 		}})
 }
 

--- a/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy.go
+++ b/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy.go
@@ -158,13 +158,7 @@ func (rollingUpdateStrategy rollingUpdateStrategy) SelectMachinesToDelete(ctx co
 		return append(failedMachines, deletingMachines...), nil
 	}
 
-	// if we have failed machines, remove them
-	if len(failedMachines) > 0 {
-		log.Info("failed machines", "desiredReplicaCount", desiredReplicaCount, "maxUnavailable", maxUnavailable, "failedMachines", getProviderIDs(failedMachines))
-		return failedMachines, nil
-	}
-
-	// if we have not yet reached our desired count, don't try to delete anything but failed machines
+	// if we have not yet reached our desired count, don't try to delete anything
 	if len(readyMachines) < int(desiredReplicaCount) {
 		log.Info("not enough ready machines", "desiredReplicaCount", desiredReplicaCount, "readyMachinesCount", len(readyMachines), "machinesByProviderID", len(machinesByProviderID))
 		return []infrav1exp.AzureMachinePoolMachine{}, nil

--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -277,13 +277,7 @@ func (s *Service) patchVMSSIfNeeded(ctx context.Context, infraVMSS *azure.VMSS) 
 	}
 
 	hasModelChanges := hasModelModifyingDifferences(infraVMSS, vmss)
-	var isFlex bool
-	for _, instance := range infraVMSS.Instances {
-		if instance.IsFlex() {
-			isFlex = true
-			break
-		}
-	}
+	isFlex := s.Scope.ScaleSetSpec().OrchestrationMode == infrav1.FlexibleOrchestrationMode
 	updated := true
 	if !isFlex {
 		updated = infraVMSS.HasEnoughLatestModelOrNotMixedModel()

--- a/azure/services/scalesetvms/mock_scalesetvms/scalesetvms_mock.go
+++ b/azure/services/scalesetvms/mock_scalesetvms/scalesetvms_mock.go
@@ -261,6 +261,20 @@ func (mr *MockScaleSetVMScopeMockRecorder) Location() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Location", reflect.TypeOf((*MockScaleSetVMScope)(nil).Location))
 }
 
+// OrchestrationMode mocks base method.
+func (m *MockScaleSetVMScope) OrchestrationMode() v1beta1.OrchestrationModeType {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OrchestrationMode")
+	ret0, _ := ret[0].(v1beta1.OrchestrationModeType)
+	return ret0
+}
+
+// OrchestrationMode indicates an expected call of OrchestrationMode.
+func (mr *MockScaleSetVMScopeMockRecorder) OrchestrationMode() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OrchestrationMode", reflect.TypeOf((*MockScaleSetVMScope)(nil).OrchestrationMode))
+}
+
 // ProviderID mocks base method.
 func (m *MockScaleSetVMScope) ProviderID() string {
 	m.ctrl.T.Helper()

--- a/azure/services/scalesetvms/scalesetvms_test.go
+++ b/azure/services/scalesetvms/scalesetvms_test.go
@@ -150,6 +150,7 @@ func TestService_Reconcile(t *testing.T) {
 			scopeMock.EXPECT().SubscriptionID().Return("subID").AnyTimes()
 			scopeMock.EXPECT().BaseURI().Return("https://localhost/").AnyTimes()
 			scopeMock.EXPECT().Authorizer().Return(nil).AnyTimes()
+			scopeMock.EXPECT().OrchestrationMode().Return(infrav1.UniformOrchestrationMode).AnyTimes()
 
 			service := NewService(scopeMock)
 			service.Client = clientMock
@@ -268,6 +269,7 @@ func TestService_Delete(t *testing.T) {
 			scopeMock.EXPECT().SubscriptionID().Return("subID").AnyTimes()
 			scopeMock.EXPECT().BaseURI().Return("https://localhost/").AnyTimes()
 			scopeMock.EXPECT().Authorizer().Return(nil).AnyTimes()
+			scopeMock.EXPECT().OrchestrationMode().Return(infrav1.UniformOrchestrationMode).AnyTimes()
 
 			service := NewService(scopeMock)
 			service.Client = clientMock

--- a/azure/types_test.go
+++ b/azure/types_test.go
@@ -163,35 +163,3 @@ func getDefaultVMSSForModelTesting() VMSS {
 		},
 	}
 }
-
-func TestIsFlex(t *testing.T) {
-	cases := []struct {
-		Name   string
-		VM     VMSSVM
-		IsFlex bool
-	}{
-		{
-			Name:   "default empty VMSSVM",
-			VM:     VMSSVM{},
-			IsFlex: true,
-		},
-		{
-			Name:   "VMSSVM with an instance ID",
-			VM:     VMSSVM{InstanceID: "instance-id"},
-			IsFlex: false,
-		},
-		{
-			Name:   "VMSSVM with empty instance ID",
-			VM:     VMSSVM{InstanceID: ""},
-			IsFlex: true,
-		},
-	}
-
-	for _, c := range cases {
-		c := c
-		t.Run(c.Name, func(t *testing.T) {
-			g := NewWithT(t)
-			g.Expect(c.VM.IsFlex()).To(Equal(c.IsFlex))
-		})
-	}
-}

--- a/test/e2e/azure_machinepools.go
+++ b/test/e2e/azure_machinepools.go
@@ -21,13 +21,21 @@ package e2e
 
 import (
 	"context"
+	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -41,30 +49,38 @@ const (
 // AzureMachinePoolsSpecInput is the input for AzureMachinePoolsSpec.
 type (
 	AzureMachinePoolsSpecInput struct {
+		Cluster               *clusterv1.Cluster
 		BootstrapClusterProxy framework.ClusterProxy
 		Namespace             *corev1.Namespace
 		ClusterName           string
+		WaitIntervals         []interface{}
 	}
 )
 
 // AzureMachinePoolsSpec tests that the expected machinepool resources exist.
 func AzureMachinePoolsSpec(ctx context.Context, inputGetter func() AzureMachinePoolsSpecInput) {
 	input := inputGetter()
+	Expect(input.Cluster).NotTo(BeNil(), "Invalid argument. input.Cluster can't be nil when calling %s spec", AzureMachinePoolsSpecName)
 	Expect(input.BootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", AzureMachinePoolsSpecName)
 	Expect(input.Namespace).NotTo(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", AzureMachinePoolsSpecName)
 	Expect(input.ClusterName).NotTo(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", AzureMachinePoolsSpecName)
+	Expect(input.WaitIntervals).NotTo(BeEmpty(), "Invalid argument. input.WaitIntervals can't be empty when calling %s spec", AzureMachinePoolsSpecName)
 
 	var (
 		bootstrapClusterProxy = input.BootstrapClusterProxy
 		workloadClusterProxy  = bootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
-		labels                = map[string]string{clusterv1.ClusterLabelName: workloadClusterProxy.GetName()}
+		clusterLabels         = map[string]string{clusterv1.ClusterLabelName: workloadClusterProxy.GetName()}
 	)
 
 	Expect(workloadClusterProxy).NotTo(BeNil())
+	mgmtClient := bootstrapClusterProxy.GetClient()
+	Expect(mgmtClient).NotTo(BeNil())
 
 	Byf("listing AzureMachinePools for cluster %s in namespace %s", input.ClusterName, input.Namespace.Name)
 	ampList := &infrav1exp.AzureMachinePoolList{}
-	Expect(bootstrapClusterProxy.GetClient().List(ctx, ampList, client.InNamespace(input.Namespace.Name), client.MatchingLabels(labels))).To(Succeed())
+	Expect(mgmtClient.List(ctx, ampList, client.InNamespace(input.Namespace.Name), client.MatchingLabels(clusterLabels))).To(Succeed())
+	Expect(ampList.Items).NotTo(BeEmpty())
+	machinepools := []*expv1.MachinePool{}
 	for _, amp := range ampList.Items {
 		Byf("checking AzureMachinePool %s in %s orchestration mode", amp.Name, amp.Spec.OrchestrationMode)
 		Expect(amp.Status.Replicas).To(BeNumerically("==", len(amp.Spec.ProviderIDList)))
@@ -75,6 +91,66 @@ func AzureMachinePoolsSpec(ctx context.Context, inputGetter func() AzureMachineP
 			default:
 				Expect(providerID).To(MatchRegexp(regexpUniformInstance))
 			}
+		}
+		mp, err := azure.FindParentMachinePool(amp.Name, bootstrapClusterProxy.GetClient())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mp).NotTo(BeNil())
+		machinepools = append(machinepools, mp)
+	}
+
+	var wg sync.WaitGroup
+	for _, mp := range machinepools {
+		goalReplicas := pointer.Int32Deref(mp.Spec.Replicas, 0) + 1
+		Byf("Scaling machine pool %s out from %d to %d", mp.Name, *mp.Spec.Replicas, goalReplicas)
+		wg.Add(1)
+		go func(mp *expv1.MachinePool) {
+			defer GinkgoRecover()
+			defer wg.Done()
+			framework.ScaleMachinePoolAndWait(ctx, framework.ScaleMachinePoolAndWaitInput{
+				ClusterProxy:              bootstrapClusterProxy,
+				Cluster:                   input.Cluster,
+				Replicas:                  goalReplicas,
+				MachinePools:              []*expv1.MachinePool{mp},
+				WaitForMachinePoolToScale: input.WaitIntervals,
+			})
+		}(mp)
+	}
+	wg.Wait()
+
+	/* TODO: uncomment with scale down fix for flexible mode
+	for _, mp := range machinepools {
+		goalReplicas := pointer.Int32Deref(mp.Spec.Replicas, 0) - 1
+		Byf("Scaling machine pool %s in from %d to %d", mp.Name, *mp.Spec.Replicas, goalReplicas)
+		wg.Add(1)
+		go func(mp *expv1.MachinePool) {
+			defer GinkgoRecover()
+			defer wg.Done()
+			framework.ScaleMachinePoolAndWait(ctx, framework.ScaleMachinePoolAndWaitInput{
+				ClusterProxy:              bootstrapClusterProxy,
+				Cluster:                   input.Cluster,
+				Replicas:                  goalReplicas,
+				MachinePools:              []*expv1.MachinePool{mp},
+				WaitForMachinePoolToScale: input.WaitIntervals,
+			})
+		}(mp)
+	}
+	wg.Wait()
+	*/
+
+	By("verifying that workload nodes are schedulable")
+	clientset := workloadClusterProxy.GetClientSet()
+	Expect(clientset).NotTo(BeNil())
+	workloadNodeRequirement, err := labels.NewRequirement("node-role.kubernetes.io/control-plane", selection.DoesNotExist, nil)
+	Expect(err).NotTo(HaveOccurred())
+	selector := labels.NewSelector().Add(*workloadNodeRequirement)
+	nodeList, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(nodeList.Items)).NotTo(BeZero())
+	for _, node := range nodeList.Items {
+		for _, taint := range node.Spec.Taints {
+			Expect(taint.Effect).NotTo(BeElementOf(
+				corev1.TaintEffectNoSchedule, corev1.TaintEffectPreferNoSchedule, corev1.TaintEffectNoExecute),
+				"node %s has %s taint", node.Name, taint.Effect)
 		}
 	}
 }

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -517,7 +517,6 @@ var _ = Describe("Workload cluster creation", func() {
 	// resource group. Override these defaults by setting the USER_IDENTITY and CI_RG environment variables.
 	Context("Creating a cluster that uses the external cloud provider and machinepools [OPTIONAL]", func() {
 		It("with 1 control plane node and 1 machinepool", func() {
-			Skip("VMSS Flex test disabled pending fix for API changes")
 			By("using user-assigned identity")
 			clusterName = getClusterName(clusterNamePrefix, "flex")
 			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(
@@ -527,7 +526,7 @@ var _ = Describe("Workload cluster creation", func() {
 				withClusterName(clusterName),
 				withControlPlaneMachineCount(1),
 				withWorkerMachineCount(1),
-				withKubernetesVersion("v1.26.0"),
+				withKubernetesVersion("v1.26.1"),
 				withMachineDeploymentInterval(specName, ""),
 				withControlPlaneWaiters(clusterctl.ControlPlaneWaiters{
 					WaitForControlPlaneInitialized: EnsureControlPlaneInitialized,
@@ -536,12 +535,14 @@ var _ = Describe("Workload cluster creation", func() {
 				withControlPlaneInterval(specName, "wait-control-plane"),
 			), result)
 
-			By("Verifying machinepool resources", func() {
+			By("Verifying machinepool can scale out", func() {
 				AzureMachinePoolsSpec(ctx, func() AzureMachinePoolsSpecInput {
 					return AzureMachinePoolsSpecInput{
+						Cluster:               result.Cluster,
 						BootstrapClusterProxy: bootstrapClusterProxy,
 						Namespace:             namespace,
 						ClusterName:           clusterName,
+						WaitIntervals:         e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
 					}
 				})
 			})


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

A recent change to responses from the VMSS API in flexible orchestration mode broke some assumptions in CAPZ code. This changes the code to rely on the `AzureMachinePool.Spec.OrchestrationMode` rather than infer the orchestrator from the instanceID field. It also restores the e2e test we started skipping in #3165.

**Which issue(s) this PR fixes**:

Refs #3077

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
