### PR TITLE
fix nil pointer for VMSS boot diagnostics

### DIFF
--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -401,7 +401,7 @@ func (s *Service) validateSpec(ctx context.Context) error {
 	}
 
 	// Validate DiagnosticProfile spec
-	if spec.DiagnosticsProfile.Boot != nil {
+	if spec.DiagnosticsProfile != nil && spec.DiagnosticsProfile.Boot != nil {
 		if spec.DiagnosticsProfile.Boot.StorageAccountType == infrav1.UserManagedDiagnosticsStorage {
 			if spec.DiagnosticsProfile.Boot.UserManaged == nil {
 				return azure.WithTerminalError(fmt.Errorf("userManaged must be specified when storageAccountType is '%s'", infrav1.UserManagedDiagnosticsStorage))

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -800,6 +800,27 @@ func TestReconcileVMSS(t *testing.T) {
 				s.HasReplicasExternallyManaged(gomockinternal.AContext()).Return(false)
 			},
 		},
+		{
+			name:          "should not panic when DiagnosticsProfile is nil",
+			expectedError: "",
+			expect: func(g *WithT, s *mock_scalesets.MockScaleSetScopeMockRecorder, m *mock_scalesets.MockClientMockRecorder) {
+				spec := newDefaultVMSSSpec()
+				spec.DiagnosticsProfile = nil
+				s.ScaleSetSpec().Return(spec).AnyTimes()
+
+				vmss := newDefaultVMSS("VM_SIZE")
+				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.DiagnosticsProfile = nil
+
+				instances := newDefaultInstances()
+
+				setupDefaultVMSSInProgressOperationDoneExpectations(s, m, vmss, instances)
+				s.DeleteLongRunningOperationState(spec.Name, serviceName, infrav1.PutFuture)
+				s.DeleteLongRunningOperationState(spec.Name, serviceName, infrav1.PatchFuture)
+				s.UpdatePutStatus(infrav1.BootstrapSucceededCondition, serviceName, nil)
+				s.Location().AnyTimes().Return("test-location")
+				s.HasReplicasExternallyManaged(gomockinternal.AContext()).Return(false)
+			},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:
fixes nil pointer as described in #3200

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3200

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fixes nil pointer when reconciling VMSS scalesets with no boot diagnostics enabled
```
