### PR TITLE
fix AKS out-of-band tag reconciliation

### DIFF
--- a/azure/const.go
+++ b/azure/const.go
@@ -29,6 +29,12 @@ const (
 	// for annotation formatting rules.
 	RGTagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-azure-last-applied-tags-rg"
 
+	// ManagedClusterTagsLastAppliedAnnotation is the key for the AzureManagedControlPlane
+	// object annotation which tracks the AdditionalTags for managed clusters.
+	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+	// for annotation formatting rules.
+	ManagedClusterTagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-azure-last-applied-tags-managedcluster"
+
 	// CustomDataHashAnnotation is the key for the machine object annotation
 	// which tracks the hash of the custom data.
 	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -422,11 +422,12 @@ func (s *ManagedControlPlaneScope) ManagedClusterAnnotations() map[string]string
 }
 
 // ManagedClusterSpec returns the managed cluster spec.
-func (s *ManagedControlPlaneScope) ManagedClusterSpec(ctx context.Context) azure.ResourceSpecGetter {
+func (s *ManagedControlPlaneScope) ManagedClusterSpec() azure.ResourceSpecGetter {
 	managedClusterSpec := managedclusters.ManagedClusterSpec{
 		Name:              s.ControlPlane.Name,
 		ResourceGroup:     s.ControlPlane.Spec.ResourceGroupName,
 		NodeResourceGroup: s.ControlPlane.Spec.NodeResourceGroupName,
+		ClusterName:       s.ClusterName(),
 		Location:          s.ControlPlane.Spec.Location,
 		Tags:              s.ControlPlane.Spec.AdditionalTags,
 		Headers:           maps.FilterByKeyPrefix(s.ManagedClusterAnnotations(), infrav1.CustomHeaderPrefix),
@@ -687,6 +688,11 @@ func (s *ManagedControlPlaneScope) TagsSpecs() []azure.TagsSpec {
 			Scope:      azure.ResourceGroupID(s.SubscriptionID(), s.ResourceGroup()),
 			Tags:       s.AdditionalTags(),
 			Annotation: azure.RGTagsLastAppliedAnnotation,
+		},
+		{
+			Scope:      azure.ManagedClusterID(s.SubscriptionID(), s.ResourceGroup(), s.ManagedClusterSpec().ResourceName()),
+			Tags:       s.AdditionalTags(),
+			Annotation: azure.ManagedClusterTagsLastAppliedAnnotation,
 		},
 	}
 }

--- a/azure/scope/managedcontrolplane_test.go
+++ b/azure/scope/managedcontrolplane_test.go
@@ -88,7 +88,7 @@ func TestManagedControlPlaneScope_OutboundType(t *testing.T) {
 			c.Input.Client = fakeClient
 			s, err := NewManagedControlPlaneScope(context.TODO(), c.Input)
 			g.Expect(err).To(Succeed())
-			managedCluster := s.ManagedClusterSpec(context.TODO())
+			managedCluster := s.ManagedClusterSpec()
 			result := managedCluster.(*managedclusters.ManagedClusterSpec).OutboundType == nil
 			g.Expect(result).To(Equal(c.Expected))
 		})
@@ -326,7 +326,7 @@ func TestManagedControlPlaneScope_AddonProfiles(t *testing.T) {
 			c.Input.Client = fakeClient
 			s, err := NewManagedControlPlaneScope(context.TODO(), c.Input)
 			g.Expect(err).To(Succeed())
-			managedCluster := s.ManagedClusterSpec(context.TODO())
+			managedCluster := s.ManagedClusterSpec()
 			g.Expect(managedCluster.(*managedclusters.ManagedClusterSpec).AddonProfiles).To(Equal(c.Expected))
 		})
 	}

--- a/azure/services/managedclusters/managedclusters.go
+++ b/azure/services/managedclusters/managedclusters.go
@@ -37,7 +37,7 @@ const serviceName = "managedcluster"
 type ManagedClusterScope interface {
 	azure.Authorizer
 	azure.AsyncStatusUpdater
-	ManagedClusterSpec(context.Context) azure.ResourceSpecGetter
+	ManagedClusterSpec() azure.ResourceSpecGetter
 	SetControlPlaneEndpoint(clusterv1.APIEndpoint)
 	MakeEmptyKubeConfigSecret() corev1.Secret
 	GetKubeConfigData() []byte
@@ -74,7 +74,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
 	defer cancel()
 
-	managedClusterSpec := s.Scope.ManagedClusterSpec(ctx)
+	managedClusterSpec := s.Scope.ManagedClusterSpec()
 	if managedClusterSpec == nil {
 		return nil
 	}
@@ -112,7 +112,7 @@ func (s *Service) Delete(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
 	defer cancel()
 
-	managedClusterSpec := s.Scope.ManagedClusterSpec(ctx)
+	managedClusterSpec := s.Scope.ManagedClusterSpec()
 	if managedClusterSpec == nil {
 		return nil
 	}

--- a/azure/services/managedclusters/managedclusters_test.go
+++ b/azure/services/managedclusters/managedclusters_test.go
@@ -44,14 +44,14 @@ func TestReconcile(t *testing.T) {
 			name:          "noop if managedcluster spec is nil",
 			expectedError: "",
 			expect: func(m *mock_managedclusters.MockCredentialGetterMockRecorder, s *mock_managedclusters.MockManagedClusterScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.ManagedClusterSpec(gomockinternal.AContext()).Return(nil)
+				s.ManagedClusterSpec().Return(nil)
 			},
 		},
 		{
 			name:          "create managed cluster returns an error",
 			expectedError: "some unexpected error occurred",
 			expect: func(m *mock_managedclusters.MockCredentialGetterMockRecorder, s *mock_managedclusters.MockManagedClusterScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.ManagedClusterSpec(gomockinternal.AContext()).Return(fakeManagedClusterSpec)
+				s.ManagedClusterSpec().Return(fakeManagedClusterSpec)
 				r.CreateOrUpdateResource(gomockinternal.AContext(), fakeManagedClusterSpec, serviceName).Return(nil, errors.New("some unexpected error occurred"))
 				s.UpdatePutStatus(infrav1.ManagedClusterRunningCondition, serviceName, errors.New("some unexpected error occurred"))
 			},
@@ -60,7 +60,7 @@ func TestReconcile(t *testing.T) {
 			name:          "create managed cluster succeeds",
 			expectedError: "",
 			expect: func(m *mock_managedclusters.MockCredentialGetterMockRecorder, s *mock_managedclusters.MockManagedClusterScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.ManagedClusterSpec(gomockinternal.AContext()).Return(fakeManagedClusterSpec)
+				s.ManagedClusterSpec().Return(fakeManagedClusterSpec)
 				r.CreateOrUpdateResource(gomockinternal.AContext(), fakeManagedClusterSpec, serviceName).Return(containerservice.ManagedCluster{
 					ManagedClusterProperties: &containerservice.ManagedClusterProperties{
 						Fqdn:              pointer.String("my-managedcluster-fqdn"),
@@ -80,7 +80,7 @@ func TestReconcile(t *testing.T) {
 			name:          "fail to get managed cluster credentials",
 			expectedError: "failed to get credentials for managed cluster: internal server error",
 			expect: func(m *mock_managedclusters.MockCredentialGetterMockRecorder, s *mock_managedclusters.MockManagedClusterScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.ManagedClusterSpec(gomockinternal.AContext()).Return(fakeManagedClusterSpec)
+				s.ManagedClusterSpec().Return(fakeManagedClusterSpec)
 				r.CreateOrUpdateResource(gomockinternal.AContext(), fakeManagedClusterSpec, serviceName).Return(containerservice.ManagedCluster{
 					ManagedClusterProperties: &containerservice.ManagedClusterProperties{
 						Fqdn:              pointer.String("my-managedcluster-fqdn"),
@@ -136,14 +136,14 @@ func TestDelete(t *testing.T) {
 			name:          "noop if no managed cluster spec is found",
 			expectedError: "",
 			expect: func(s *mock_managedclusters.MockManagedClusterScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.ManagedClusterSpec(gomockinternal.AContext()).Return(nil)
+				s.ManagedClusterSpec().Return(nil)
 			},
 		},
 		{
 			name:          "successfully delete an existing managed cluster",
 			expectedError: "",
 			expect: func(s *mock_managedclusters.MockManagedClusterScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.ManagedClusterSpec(gomockinternal.AContext()).Return(fakeManagedClusterSpec)
+				s.ManagedClusterSpec().Return(fakeManagedClusterSpec)
 				r.DeleteResource(gomockinternal.AContext(), fakeManagedClusterSpec, serviceName).Return(nil)
 				s.UpdateDeleteStatus(infrav1.ManagedClusterRunningCondition, serviceName, nil)
 			},
@@ -152,7 +152,7 @@ func TestDelete(t *testing.T) {
 			name:          "managed cluster deletion fails",
 			expectedError: "internal error",
 			expect: func(s *mock_managedclusters.MockManagedClusterScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
-				s.ManagedClusterSpec(gomockinternal.AContext()).Return(fakeManagedClusterSpec)
+				s.ManagedClusterSpec().Return(fakeManagedClusterSpec)
 				r.DeleteResource(gomockinternal.AContext(), fakeManagedClusterSpec, serviceName).Return(errors.New("internal error"))
 				s.UpdateDeleteStatus(infrav1.ManagedClusterRunningCondition, serviceName, errors.New("internal error"))
 			},

--- a/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
+++ b/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
@@ -21,7 +21,6 @@ limitations under the License.
 package mock_managedclusters
 
 import (
-	context "context"
 	reflect "reflect"
 
 	autorest "github.com/Azure/go-autorest/autorest"
@@ -194,17 +193,17 @@ func (mr *MockManagedClusterScopeMockRecorder) MakeEmptyKubeConfigSecret() *gomo
 }
 
 // ManagedClusterSpec mocks base method.
-func (m *MockManagedClusterScope) ManagedClusterSpec(arg0 context.Context) azure.ResourceSpecGetter {
+func (m *MockManagedClusterScope) ManagedClusterSpec() azure.ResourceSpecGetter {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ManagedClusterSpec", arg0)
+	ret := m.ctrl.Call(m, "ManagedClusterSpec")
 	ret0, _ := ret[0].(azure.ResourceSpecGetter)
 	return ret0
 }
 
 // ManagedClusterSpec indicates an expected call of ManagedClusterSpec.
-func (mr *MockManagedClusterScopeMockRecorder) ManagedClusterSpec(arg0 interface{}) *gomock.Call {
+func (mr *MockManagedClusterScopeMockRecorder) ManagedClusterSpec() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagedClusterSpec", reflect.TypeOf((*MockManagedClusterScope)(nil).ManagedClusterSpec), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagedClusterSpec", reflect.TypeOf((*MockManagedClusterScope)(nil).ManagedClusterSpec))
 }
 
 // SetControlPlaneEndpoint mocks base method.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Tags applied to managed cluster resources in Azure out-of-band with CAPZ conflict with the AzureManagedControlPlane's `spec.additionalTags`. If something like an Azure Policy enforces tags to exist on the resource that are not defined in the CAPZ resource, then CAPZ will constantly fight against the Azure Policy and it will almost always remain in an updating state.

This change removes tags from the rest of the managed cluster service and uses the `azure/services/tags` package to update tags on it instead which is aware of tags not added by CAPZ.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3009

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug causing CAPZ to overwrite tags applied to managed clusters out-of-band
```
