### PR TITLE
use explicit kind kubeconfig in ci-entrypoint

### DIFF
--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -29,6 +29,8 @@ HELM="${REPO_ROOT}/hack/tools/bin/helm"
 KIND="${REPO_ROOT}/hack/tools/bin/kind"
 KUSTOMIZE="${REPO_ROOT}/hack/tools/bin/kustomize"
 make --directory="${REPO_ROOT}" "${KUBECTL##*/}" "${HELM##*/}" "${KIND##*/}" "${KUSTOMIZE##*/}"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-capz}"
+export KIND_CLUSTER_NAME
 # export the variables so they are available in bash -c wait_for_nodes below
 export KUBECTL
 export HELM
@@ -129,6 +131,10 @@ select_cluster_template() {
 
 create_cluster() {
     "${REPO_ROOT}/hack/create-dev-cluster.sh"
+    if [ ! -f "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" ]; then
+        echo "Unable to find kubeconfig for kind mgmt cluster ${KIND_CLUSTER_NAME}"
+        exit 1
+    fi
 }
 
 # get_cidrs derives the CIDR from the Cluster's '.spec.clusterNetwork.pods.cidrBlocks' metadata
@@ -279,11 +285,9 @@ install_addons() {
 
 copy_secret() {
     # point at the management cluster
-    unset KUBECONFIG
-    "${KUBECTL}" get secret "${CLUSTER_NAME}-control-plane-azure-json" -o jsonpath='{.data.control-plane-azure\.json}' | base64 --decode >azure_json
+    "${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" get secret "${CLUSTER_NAME}-control-plane-azure-json" -o jsonpath='{.data.control-plane-azure\.json}' | base64 --decode >azure_json
 
-    # set KUBECONFIG back to the workload cluster
-    export KUBECONFIG="${KUBECONFIG:-${PWD}/kubeconfig}"
+    # create the secret on the workload cluster
     "${KUBECTL}" create secret generic "${CONFIG_SECRET_NAME}" -n kube-system \
         --from-file=cloud-config=azure_json
     rm azure_json
@@ -291,11 +295,12 @@ copy_secret() {
 
 # cleanup all resources we use
 cleanup() {
-    timeout 1800 "${KUBECTL}" delete cluster "${CLUSTER_NAME}" || true
-    make kind-reset || true
+    timeout 1800 "${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" delete cluster "${CLUSTER_NAME}" || true
+    make --directory="${REPO_ROOT}" kind-reset || true
 }
 
 on_exit() {
+    cd ${REPO_ROOT}
     if [[ -n ${KUBECONFIG:-} ]]; then
         "${KUBECTL}" get nodes -o wide || echo "Unable to get nodes"
         "${KUBECTL}" get pods -A -o wide || echo "Unable to get pods"
@@ -304,7 +309,7 @@ on_exit() {
     # we want to be pointing at the management cluster (kind in this case)
     unset KUBECONFIG
     go run -tags e2e "${REPO_ROOT}"/test/logger.go --name "${CLUSTER_NAME}" --namespace default
-    "${REPO_ROOT}/hack/log/redact.sh" || true
+    #"${REPO_ROOT}/hack/log/redact.sh" || true
     # cleanup
     if [[ -z "${SKIP_CLEANUP:-}" ]]; then
         cleanup

--- a/scripts/kind-with-registry.sh
+++ b/scripts/kind-with-registry.sh
@@ -25,6 +25,7 @@ make --directory="${REPO_ROOT}" "${KUBECTL##*/}" "${KIND##*/}"
 
 # desired cluster name; default is "kind"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-capz}"
+export KIND_CLUSTER_NAME
 
 if [[ "$("${KIND}" get clusters)" =~ .*"${KIND_CLUSTER_NAME}".* ]]; then
   echo "cluster already exists, moving on"
@@ -54,9 +55,11 @@ EOF
 # (the network may already be connected)
 docker network connect "kind" "${reg_name}" || true
 
+kind get kubeconfig -n "${KIND_CLUSTER_NAME}" > "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig"
+
 # Document the local registry
 # https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
-cat <<EOF | kubectl apply -f -
+cat <<EOF | "${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" apply -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -68,4 +71,4 @@ data:
     help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
 EOF
 
-"${KUBECTL}" wait node "${KIND_CLUSTER_NAME}-control-plane" --for=condition=ready --timeout=90s
+"${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" wait node "${KIND_CLUSTER_NAME}-control-plane" --for=condition=ready --timeout=90s


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR persists a kubeconfig file in a well-known location so that downstream scripts can explicitly reference it, rather than rely upon their implicit kubeconfig context pointing at the right place.

This PR updates ci-entrypoint.sh so that it uses that explicit kubeconfig file during its lifecycle when it needs to point to the mgmt cluster. Other capz CI scripts may benefit from this in the future, but this change is scoped to address observed issues w/ usages of ci-entrypoint.sh

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
