### PR TITLE
Switch ipv6 template to external cloud-provider

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -371,7 +371,7 @@ def deploy_worker_templates(template, substitutions):
     else:
         calico_values = "./templates/addons/calico/values.yaml"
     flavor_cmd += "; " + helm_cmd + " repo add projectcalico https://docs.tigera.io/calico/charts; " + helm_cmd + " --kubeconfig ./${CLUSTER_NAME}.kubeconfig install calico projectcalico/tigera-operator -f " + calico_values + " --namespace tigera-operator --create-namespace"
-    if "intree-cloud-provider" not in flavor_name and "ipv6" not in flavor_name:  # TODO: remove ipv6 once https://github.com/kubernetes-sigs/cloud-provider-azure/issues/3401 is fixed.
+    if "intree-cloud-provider" not in flavor_name:
         flavor_cmd += "; " + helm_cmd + " --kubeconfig ./${CLUSTER_NAME}.kubeconfig install --repo https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo cloud-provider-azure --generate-name --set infra.clusterName=${CLUSTER_NAME}"
     local_resource(
         name = flavor_name,

--- a/templates/cluster-template-ipv6.yaml
+++ b/templates/cluster-template-ipv6.yaml
@@ -62,28 +62,16 @@ spec:
       apiServer:
         extraArgs:
           bind-address: '::'
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
-        extraVolumes:
-        - hostPath: /etc/kubernetes/azure.json
-          mountPath: /etc/kubernetes/azure.json
-          name: cloud-config
-          readOnly: true
+          cloud-provider: external
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
           allocate-node-cidrs: "true"
           bind-address: '::'
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
+          cloud-provider: external
           cluster-cidr: 2001:1234:5678:9a40::/58
           cluster-name: ${CLUSTER_NAME}
           configure-cloud-routes: "true"
-        extraVolumes:
-        - hostPath: /etc/kubernetes/azure.json
-          mountPath: /etc/kubernetes/azure.json
-          name: cloud-config
-          readOnly: true
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
@@ -124,10 +112,8 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
+          cloud-provider: external
           cluster-dns: fd00::10
-          node-ip: '::'
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       controlPlane:
@@ -137,10 +123,8 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
+          cloud-provider: external
           cluster-dns: fd00::10
-          node-ip: '::'
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -265,10 +249,8 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
+            cloud-provider: external
             cluster-dns: '[fd00::10]'
-            node-ip: '::'
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf

--- a/templates/flavors/ipv6/kustomization.yaml
+++ b/templates/flavors/ipv6/kustomization.yaml
@@ -6,8 +6,6 @@ resources:
 
 patchesStrategicMerge:
   - ../../azure-cluster-identity/azurecluster-identity-ref.yaml
-  - ../../test/ci/prow-intree-cloud-provider/patches/intree-cp.yaml # TODO: enable CCM for ipv6, see https://github.com/kubernetes-sigs/cloud-provider-azure/issues/3401.
-  - ../../test/ci/prow-intree-cloud-provider/patches/intree-md-0.yaml # TODO: enable CCM for ipv6, see https://github.com/kubernetes-sigs/cloud-provider-azure/issues/3401.
   - patches/ipv6.yaml
   - patches/kubeadm-controlplane.yaml
   - patches/controlplane-azuremachinetemplate.yaml

--- a/templates/flavors/ipv6/machine-deployment.yaml
+++ b/templates/flavors/ipv6/machine-deployment.yaml
@@ -55,7 +55,7 @@ spec:
           name: '{{ ds.meta_data["local_hostname"] }}'
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            node-ip: "::"
+            cloud-provider: external
             cluster-dns: "[fd00::10]"
       clusterConfiguration:
         apiServer:

--- a/templates/flavors/ipv6/patches/kubeadm-controlplane.yaml
+++ b/templates/flavors/ipv6/patches/kubeadm-controlplane.yaml
@@ -13,7 +13,6 @@ spec:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'
         kubeletExtraArgs:
-          node-ip: "::"
           cluster-dns: "fd00::10"
       localAPIEndpoint:
         advertiseAddress: "::"
@@ -22,7 +21,6 @@ spec:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'
         kubeletExtraArgs:
-          node-ip: "::"
           cluster-dns: "fd00::10"
       controlPlane:
         localAPIEndpoint:

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -66,29 +66,17 @@ spec:
       apiServer:
         extraArgs:
           bind-address: '::'
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
-        extraVolumes:
-        - hostPath: /etc/kubernetes/azure.json
-          mountPath: /etc/kubernetes/azure.json
-          name: cloud-config
-          readOnly: true
+          cloud-provider: external
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
           allocate-node-cidrs: "true"
           bind-address: '::'
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
+          cloud-provider: external
           cluster-cidr: 2001:1234:5678:9a40::/58
           cluster-name: ${CLUSTER_NAME}
           configure-cloud-routes: "true"
           v: "4"
-        extraVolumes:
-        - hostPath: /etc/kubernetes/azure.json
-          mountPath: /etc/kubernetes/azure.json
-          name: cloud-config
-          readOnly: true
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
@@ -129,10 +117,8 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
+          cloud-provider: external
           cluster-dns: fd00::10
-          node-ip: '::'
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       controlPlane:
@@ -142,10 +128,8 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
+          cloud-provider: external
           cluster-dns: fd00::10
-          node-ip: '::'
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -270,10 +254,8 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
+            cloud-provider: external
             cluster-dns: '[fd00::10]'
-            node-ip: '::'
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Follow up on #3105 to switch the ipv6 template to out of tree. It was previously blocked due to https://github.com/kubernetes-sigs/cloud-provider-azure/issues/3401.  Root cause can be found here: https://github.com/kubernetes-sigs/cloud-provider-azure/issues/3401#issuecomment-1480540832. The fix is to remove the `--node-ip` flag from kubelet.

> For IPv6, --node-ip should not be set either since it is actually a dual-stack cluster as for Nodes. When someday the cluster is truly IPv6 only, this option should be set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Switch ipv6 template to external cloud-provider
```
