### PR TITLE
Build CCM when using k8s version latest in ci-entrypoint

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -42,10 +42,16 @@ capz::util::should_build_kubernetes() {
 }
 
 capz::util::should_build_ccm() {
+    # TEST_CCM is an environment variable set by a prow job to indicate that the CCM should be built and tested.
     if [[ -n "${TEST_CCM:-}" ]]; then
         echo "true" && return
     fi
+    # If conformance is being tested with CI artifacts, CCM should be built.
     if [[ "${E2E_ARGS:-}" == "-kubetest.use-ci-artifacts" ]]; then
+        echo "true" && return
+    fi
+    # If the Kubernetes version contains "latest", CCM should be built.
+    if [[ "${KUBERNETES_VERSION:-}" =~ "latest" ]]; then
         echo "true" && return
     fi
     echo "false"

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -50,7 +50,7 @@ setup() {
     # setup REGISTRY for custom images.
     : "${REGISTRY:?Environment variable empty or not defined.}"
     "${REPO_ROOT}/hack/ensure-acr-login.sh"
-    if [[ -n "${TEST_CCM:-}" ]]; then
+    if [[ "$(capz::util::should_build_ccm)" == "true" ]]; then
         # shellcheck source=scripts/ci-build-azure-ccm.sh
         source "${REPO_ROOT}/scripts/ci-build-azure-ccm.sh"
         echo "Will use the ${IMAGE_REGISTRY}/${CCM_IMAGE_NAME}:${IMAGE_TAG} cloud-controller-manager image for external cloud-provider-cluster"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Fixes regression from #3105 where CCM is not getting built for CSI driver tests that use ci-entrypoint but don't test CCM: https://testgrid.k8s.io/provider-azure-master-signal#capz-azure-disk, resulting in an invalid Helm image version as the k8s version doesn't exist.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
