### PR TITLE
don’t log MachinePool reconciliation housekeeping

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -943,7 +943,7 @@ func MachinePoolToAzureManagedControlPlaneMapFunc(ctx context.Context, c client.
 		// Return early if the GroupKind doesn't match what we expect.
 		controlPlaneGK := ref.GroupVersionKind().GroupKind()
 		if gk != controlPlaneGK {
-			log.Info("gk does not match", "gk", gk, "controlPlaneGK", controlPlaneGK)
+			// MachinePool does not correlate to a AzureManagedControlPlane, nothing to do
 			return nil
 		}
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind cleanup

**What this PR does / why we need it**:

This PR removes the regular logging of a healthy terminal outcome when evaluating whether or not a MachinePool correlates to a AzureManagedControlPlane during regular AzureManagedControlPlane reconciliation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
