### PR TITLE
mark sshPublicKey as optional, docs windows ssh

### DIFF
--- a/api/v1beta1/azuremachine_types.go
+++ b/api/v1beta1/azuremachine_types.go
@@ -81,6 +81,9 @@ type AzureMachineSpec struct {
 	// +optional
 	DataDisks []DataDisk `json:"dataDisks,omitempty"`
 
+	// SSHPublicKey is the SSH public key string, base64-encoded to add to a Virtual Machine. Linux only.
+	// Refer to documentation on how to set up SSH access on Windows instances.
+	// +optional
 	SSHPublicKey string `json:"sshPublicKey"`
 
 	// AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -1888,8 +1888,9 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                   sshPublicKey:
-                    description: SSHPublicKey is the SSH public key string base64
-                      encoded to add to a Virtual Machine
+                    description: SSHPublicKey is the SSH public key string, base64-encoded
+                      to add to a Virtual Machine. Linux only. Refer to documentation
+                      on how to set up SSH access on Windows instances.
                     type: string
                   subnetName:
                     description: 'Deprecated: SubnetName should be set in the networkInterfaces
@@ -1942,7 +1943,6 @@ spec:
                     type: string
                 required:
                 - osDisk
-                - sshPublicKey
                 - vmSize
                 type: object
               userAssignedIdentities:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -1492,6 +1492,9 @@ spec:
                     x-kubernetes-int-or-string: true
                 type: object
               sshPublicKey:
+                description: SSHPublicKey is the SSH public key string, base64-encoded
+                  to add to a Virtual Machine. Linux only. Refer to documentation
+                  on how to set up SSH access on Windows instances.
                 type: string
               subnetName:
                 description: 'Deprecated: SubnetName should be set in the networkInterfaces
@@ -1573,7 +1576,6 @@ spec:
                 type: string
             required:
             - osDisk
-            - sshPublicKey
             - vmSize
             type: object
           status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -1276,6 +1276,9 @@ spec:
                             x-kubernetes-int-or-string: true
                         type: object
                       sshPublicKey:
+                        description: SSHPublicKey is the SSH public key string, base64-encoded
+                          to add to a Virtual Machine. Linux only. Refer to documentation
+                          on how to set up SSH access on Windows instances.
                         type: string
                       subnetName:
                         description: 'Deprecated: SubnetName should be set in the
@@ -1363,7 +1366,6 @@ spec:
                         type: string
                     required:
                     - osDisk
-                    - sshPublicKey
                     - vmSize
                     type: object
                 required:

--- a/docs/book/src/topics/windows.md
+++ b/docs/book/src/topics/windows.md
@@ -101,14 +101,35 @@ When creating a cluster with `Machinepool` if the Machine Pool name is longer th
 
 ### VM password and access
 The VM password is [random generated](https://cloudbase-init.readthedocs.io/en/latest/plugins.html#setting-password-main)
-by Cloudbase-init during provisioning of the VM. For Access to the VM you can use ssh which will be configured with SSH
-public key you provided during deployment.
+by Cloudbase-init during provisioning of the VM. For Access to the VM you can use ssh, which can be configured with a
+public key you provide during deployment.
+It's required to specify the SSH key using the `users` property in the Kubeadm config template. Specifying the `sshPublicKey` on `AzureMachine` / `AzureMachinePool` resources only works with Linux instances.
+
+For example like this:
+```yaml
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+kind: KubeadmConfigTemplate
+metadata:
+  name: test1-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      ...
+      users:
+      - name: username
+        groups: Administrators
+        sshAuthorizedKeys:
+        - "ssh-rsa AAAA..."
+```
 
 To SSH:
 
 ```
 ssh -t -i .sshkey -o 'ProxyCommand ssh -i .sshkey -W %h:%p capi@<api-server-ip>' capi@<windows-ip>
 ```
+
+Refer to [SSH Access for nodes](ssh-access.md) for more instructions on how to connect using SSH.
 
 > There is also a [CAPZ kubectl plugin](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/hack/debugging/Readme.md) that automates the ssh connection using the Management cluster
 

--- a/exp/api/v1beta1/azuremachinepool_types.go
+++ b/exp/api/v1beta1/azuremachinepool_types.go
@@ -62,7 +62,9 @@ type (
 		// +optional
 		DataDisks []infrav1.DataDisk `json:"dataDisks,omitempty"`
 
-		// SSHPublicKey is the SSH public key string base64 encoded to add to a Virtual Machine
+		// SSHPublicKey is the SSH public key string, base64-encoded to add to a Virtual Machine. Linux only.
+		// Refer to documentation on how to set up SSH access on Windows instances.
+		// +optional
 		SSHPublicKey string `json:"sshPublicKey"`
 
 		// Deprecated: AcceleratedNetworking should be set in the networkInterfaces field.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
windows instances do not have the capability to set a sshPublicKey. It must be done via cloudbase-init.
This change documents this fact and marks the `sshPublicKey` as optional since it's not required and an empty string (default for string type) is sufficient.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
#3232 is relevant but only partially fixes the issue. 

**Special notes for your reviewer**:
If I remember correctly, marking a required field optional is a backwards compatible change but please do let me know if you'd like to have this handled differently.

**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
mark sshPublicKey optional because windows instances do not support it
```
