### PR TITLE
Exclude generated and untestable files from codecov report

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '^1.19'
+        go-version: '1.19'
     - run: "PATH=/usr/local/go/bin:$PATH make test-cover"
     - uses: codecov/codecov-action@v3
       with:

--- a/Makefile
+++ b/Makefile
@@ -654,6 +654,7 @@ go-test: $(SETUP_ENVTEST) ## Run go tests.
 test-cover: TEST_ARGS+= -coverprofile coverage.out
 test-cover: test ## Run tests with code coverage and generate reports.
 	go tool cover -func=coverage.out -o coverage.txt
+	./hack/codecov-ignore.sh
 	go tool cover -html=coverage.out -o coverage.html
 
 .PHONY: test-e2e-run

--- a/hack/codecov-ignore.sh
+++ b/hack/codecov-ignore.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3
+sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4
+sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3
+sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha4" > codecov-ignore.txt
+
+{
+  find api/v1beta1 -regex '.*_conversion\.go' -exec echo sigs.k8s.io/cluster-api-provider-azure/{} \;
+  find api/v1beta1 -regex '.*zz_generated.*\.go' -exec echo sigs.k8s.io/cluster-api-provider-azure/{} \;
+  find exp/api/v1beta1 -regex '.*_conversion\.go' -exec echo sigs.k8s.io/cluster-api-provider-azure/{} \;
+  find exp/api/v1beta1 -regex '.*zz_generated.*\.go' -exec echo sigs.k8s.io/cluster-api-provider-azure/{} \;
+} >> codecov-ignore.txt
+
+while read -r p || [ -n "$p" ] 
+do
+if [[ "${OSTYPE}" == "darwin"* ]]; then
+  sed -i '' "/${p//\//\\/}/d" ./coverage.out
+else
+  sed -i "/${p//\//\\/}/d" ./coverage.out
+fi
+done < ./codecov-ignore.txt


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR adds a script to the `make test-cover` target to remove any generated files or old API versions from the codecov report, resulting in a more accurate number being reported.

**Note:** This PR also fixes a reoccurring issue where the codecov test is being killed during the make lint step. This is caused by the most recent Go version, and the issue is fixed by setting the Go version for the GitHub action to 1.19.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3258

**Special notes for your reviewer**:
Codecov report before changes: https://app.codecov.io/github/kubernetes-sigs/cluster-api-provider-azure
Codecov report after changes: https://app.codecov.io/github/willie-yao/cluster-api-provider-azure/commit/903bf7a6b702f7207af8471fc34c98519f57f609/tree

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
