### PR TITLE
templates/flavors/flatcar: fix mounting etcd disk

### DIFF
--- a/templates/cluster-template-flatcar.yaml
+++ b/templates/cluster-template-flatcar.yaml
@@ -64,7 +64,14 @@ spec:
           extraArgs:
             quota-backend-bytes: "8589934592"
     diskSetup:
-      filesystems: []
+      filesystems:
+      - device: /dev/disk/azure/scsi1/lun0
+        extraOpts:
+        - -E
+        - lazy_itable_init=1,lazy_journal_init=1
+        filesystem: ext4
+        label: etcd_disk
+        overwrite: false
       partitions: []
     files:
     - contentFrom:
@@ -92,15 +99,6 @@ spec:
             - device: /dev/disk/azure/scsi1/lun0
               partitions:
               - number: 1
-            filesystems:
-            - name: etcd_disk
-              mount:
-                device: /dev/disk/azure/scsi1/lun0
-                format: ext4
-                label: etcd_disk
-                options:
-                - -E
-                - lazy_itable_init=1,lazy_journal_init=1
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:

--- a/templates/flavors/flatcar/patches/kubeadm-controlplane.yaml
+++ b/templates/flavors/flatcar/patches/kubeadm-controlplane.yaml
@@ -5,9 +5,16 @@ metadata:
   name: ${CLUSTER_NAME}-control-plane
 spec:
   kubeadmConfigSpec:
-    # Workaround for https://github.com/kubernetes-sigs/cluster-api/issues/7679.
     diskSetup:
-      filesystems: []
+      filesystems:
+      - device: /dev/disk/azure/scsi1/lun0
+        extraOpts:
+        - -E
+        - lazy_itable_init=1,lazy_journal_init=1
+        filesystem: ext4
+        label: etcd_disk
+        overwrite: false
+      # Workaround for https://github.com/kubernetes-sigs/cluster-api/issues/7679.
       partitions: []
     format: ignition
     ignition:
@@ -27,15 +34,6 @@ spec:
             - device: /dev/disk/azure/scsi1/lun0
               partitions:
               - number: 1
-            filesystems:
-            - name: etcd_disk
-              mount:
-                device: /dev/disk/azure/scsi1/lun0
-                format: ext4
-                label: etcd_disk
-                options:
-                - -E
-                - lazy_itable_init=1,lazy_journal_init=1
     initConfiguration:
       nodeRegistration:
         name: '@@HOSTNAME@@'

--- a/templates/test/ci/cluster-template-prow-flatcar.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar.yaml
@@ -69,7 +69,14 @@ spec:
           extraArgs:
             quota-backend-bytes: "8589934592"
     diskSetup:
-      filesystems: []
+      filesystems:
+      - device: /dev/disk/azure/scsi1/lun0
+        extraOpts:
+        - -E
+        - lazy_itable_init=1,lazy_journal_init=1
+        filesystem: ext4
+        label: etcd_disk
+        overwrite: false
       partitions: []
     files:
     - contentFrom:
@@ -97,15 +104,6 @@ spec:
             - device: /dev/disk/azure/scsi1/lun0
               partitions:
               - number: 1
-            filesystems:
-            - name: etcd_disk
-              mount:
-                device: /dev/disk/azure/scsi1/lun0
-                format: ext4
-                label: etcd_disk
-                options:
-                - -E
-                - lazy_itable_init=1,lazy_journal_init=1
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:


### PR DESCRIPTION
Workaround for a CABPK bug with conversion of Ignition v2 to v3 as described in https://github.com/kubernetes-sigs/cluster-api/issues/7679 has been added while Flatcar templates were still in development.

While it boots and does not produce any errors, it turns out that the disk does not actually get mounted. This is because at the moment 'mounts' CABPK field requires 'diskSetup.filesystems' to be populated for mapping disk names to device path.

This commit fixes missing mount.
 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Workaround for a CABPK bug with conversion of Ignition v2 to v3 as
described in https://github.com/kubernetes-sigs/cluster-api/issues/7679
has been added while Flatcar templates were still in development.

While it boots and does not produce any errors, it turns out that the
disk does not actually get mounted. This is because at the moment 'mounts'
CABPK field requires 'diskSetup.filesystems' to be populated for mapping
disk names to device path.

This PR fixes missing mount.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I wonder if it would make sense to have some host-level test to verify that the mount is in place or that the etcd data is being persisted, so we can detect this kind of issues.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed missing etcd disk mount in Flatcar flavor
```
