### PR TITLE
Don't need a repo list for Windows 1.24+

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -656,7 +656,7 @@ func latestCIVersion(label string) (string, error) {
 
 // resolveKubetestRepoListPath will set the correct repo list for Windows:
 // - if WIN_REPO_URL is set use the custom file downloaded via makefile
-// - if CI version is "latest" do not set repo list since they are not needed K8s v1.25+
+// - if CI version is "latest" do not set repo list since they are not needed K8s v1.24+
 // - if CI version is  "latest-1.xx" will compare values and use correct repoList
 // - if standard version will compare values and use correct repoList
 // - if unable to determine version falls back to using latest
@@ -675,18 +675,18 @@ func resolveKubetestRepoListPath(version string, path string) (string, error) {
 		return "", err
 	}
 
-	v125, err := semver.Make("1.25.0-alpha.0.0")
+	v124, err := semver.Make("1.24.0-alpha.0.0")
 	if err != nil {
 		return "", err
 	}
 
-	if currentVersion.GT(v125) {
+	if currentVersion.GT(v124) {
 		return "", nil
 	}
 
 	// - prior to K8s v1.21 repo-list-k8sprow.yaml should be used
 	//   since all test images need to come from k8sprow.azurecr.io
-	// - starting with K8s v1.25 repo lists repo list is not needed
+	// - starting with K8s v1.24 repo lists repo list is not needed
 	// - use repo-list.yaml for everything in between which has only
 	//   some images in k8sprow.azurecr.io
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

The 1.24 job is failing due missing the etcd image: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-capz-master-containerd-windows-1-24/1635673910743666688.  

This image was pointing to the Azure registry which was recently cleaned up.  Since this image is available in upstream 1.23+ we can use that image which doesn't require custom images: https://github.com/kubernetes/kubernetes/pull/92433/commits/c4fc9bba6c292970f7f8e82b8033afbe31f07c9a 

The etcd image using in 1.24 is https://github.com/kubernetes/kubernetes/blob/v1.24.11/test/utils/image/manifest.go#L245 3.5.6-0 which does contain windows versions for 2019 and 2022

```
 ./regctl manifest get k8s.gcr.io/etcd:3.5.6-0   
Name:      k8s.gcr.io/etcd:3.5.6-0@sha256:3ddf898c18c4c68b1ebac8ec40973d041f9afd4ab4dfc46580df189a123fdb1d
  Digest:    sha256:3ddf898c18c4c68b1ebac8ec40973d041f9afd4ab4dfc46580df189a123fdb1d
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  windows/amd64/10.0.17763.3650
  OSVersion: 10.0.17763.3650   

Name:      k8s.gcr.io/etcd:3.5.6-0@sha256:088f58efd1a4008d11a63ddf25cafc2b78132fbab18281a48673b3ab2c6c8077
  Digest:    sha256:088f58efd1a4008d11a63ddf25cafc2b78132fbab18281a48673b3ab2c6c8077
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  windows/amd64/10.0.20348.1249
  OSVersion: 10.0.20348.1249
```

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
