### PR TITLE
Allow user to specify AZURE_CLOUD_PROVIDER_ROOT when running ci-entrypoint locally

### DIFF
--- a/scripts/ci-build-azure-ccm.sh
+++ b/scripts/ci-build-azure-ccm.sh
@@ -38,12 +38,18 @@ export CNM_IMAGE_NAME=azure-cloud-node-manager
 export WINDOWS_IMAGE_VERSION=1809
 declare -a IMAGES=("${CCM_IMAGE_NAME}" "${CNM_IMAGE_NAME}")
 
+
 setup() {
-    AZURE_CLOUD_PROVIDER_ROOT="$(go env GOPATH)/src/sigs.k8s.io/cloud-provider-azure"
-    export AZURE_CLOUD_PROVIDER_ROOT
+    AZURE_CLOUD_PROVIDER_ROOT="${AZURE_CLOUD_PROVIDER_ROOT:-""}"
+    if [[ -z "${AZURE_CLOUD_PROVIDER_ROOT}" ]]; then
+        AZURE_CLOUD_PROVIDER_ROOT="$(go env GOPATH)/src/sigs.k8s.io/cloud-provider-azure"
+        export AZURE_CLOUD_PROVIDER_ROOT
+    fi
+
     # the azure-cloud-provider repo expects IMAGE_REGISTRY.
     export IMAGE_REGISTRY=${REGISTRY}
     pushd "${AZURE_CLOUD_PROVIDER_ROOT}" && IMAGE_TAG=$(git rev-parse --short=7 HEAD) && export IMAGE_TAG && popd
+    echo "Image registry is ${REGISTRY}"
     echo "Image Tag is ${IMAGE_TAG}"
 
     if [[ -n "${WINDOWS_SERVER_VERSION:-}" ]]; then


### PR DESCRIPTION
…

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Let  user specify AZURE_CLOUD_PROVIDER_ROOT env var when running ci-entrypoint locally

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
