### PR TITLE
AzureMachinePool windows template fixes 

### DIFF
--- a/templates/cluster-template-machinepool-windows.yaml
+++ b/templates/cluster-template-machinepool-windows.yaml
@@ -244,13 +244,14 @@ kind: AzureMachinePool
 metadata:
   annotations:
     runtime: containerd
+    windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
   name: ${CLUSTER_NAME}-mp-win
   namespace: default
 spec:
   location: ${AZURE_LOCATION}
   template:
     osDisk:
-      diskSizeGB: 30
+      diskSizeGB: 128
       managedDisk:
         storageAccountType: Premium_LRS
       osType: Windows
@@ -281,7 +282,7 @@ spec:
         azure-container-registry-config: c:/k/azure.json
         cloud-provider: external
         feature-gates: WindowsHostProcessContainers=true
-        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
+        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.9
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/flavors/machinepool-windows/machine-pool-deployment-windows.yaml
+++ b/templates/flavors/machinepool-windows/machine-pool-deployment-windows.yaml
@@ -26,13 +26,14 @@ metadata:
   name: "${CLUSTER_NAME}-mp-win"
   annotations:
     runtime: containerd
+    windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
 spec:
   location: ${AZURE_LOCATION}
   template:
     vmSize: ${AZURE_NODE_MACHINE_TYPE}
     osDisk:
       osType: "Windows"
-      diskSizeGB: 30
+      diskSizeGB: 128
       managedDisk:
         storageAccountType: "Premium_LRS"
     sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
@@ -59,7 +60,7 @@ spec:
       kubeletExtraArgs:
         azure-container-registry-config: 'c:/k/azure.json'
         cloud-provider: external
-        pod-infra-container-image: "mcr.microsoft.com/oss/kubernetes/pause:3.4.1"
+        pod-infra-container-image: "mcr.microsoft.com/oss/kubernetes/pause:3.9"
         feature-gates: "WindowsHostProcessContainers=true"
   files:
   - contentFrom:

--- a/templates/test/ci/cluster-template-prow-intree-cloud-provider-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-intree-cloud-provider-machine-pool.yaml
@@ -274,13 +274,14 @@ kind: AzureMachinePool
 metadata:
   annotations:
     runtime: containerd
+    windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
   name: ${CLUSTER_NAME}-mp-win
   namespace: default
 spec:
   location: ${AZURE_LOCATION}
   template:
     osDisk:
-      diskSizeGB: 30
+      diskSizeGB: 128
       managedDisk:
         storageAccountType: Premium_LRS
       osType: Windows

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -403,6 +403,7 @@ kind: AzureMachinePool
 metadata:
   annotations:
     runtime: containerd
+    windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
   name: ${CLUSTER_NAME}-mp-win
   namespace: default
 spec:
@@ -415,7 +416,7 @@ spec:
         sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
         version: latest
     osDisk:
-      diskSizeGB: 30
+      diskSizeGB: 128
       managedDisk:
         storageAccountType: Premium_LRS
       osType: Windows
@@ -473,7 +474,7 @@ spec:
         azure-container-registry-config: c:/k/azure.json
         cloud-provider: external
         feature-gates: WindowsHostProcessContainers=true
-        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
+        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.9
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
@@ -259,6 +259,7 @@ kind: AzureMachinePool
 metadata:
   annotations:
     runtime: containerd
+    windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
   name: ${CLUSTER_NAME}-mp-win
   namespace: default
 spec:
@@ -271,7 +272,7 @@ spec:
     type: RollingUpdate
   template:
     osDisk:
-      diskSizeGB: 30
+      diskSizeGB: 128
       managedDisk:
         storageAccountType: Premium_LRS
       osType: Windows
@@ -302,7 +303,7 @@ spec:
         azure-container-registry-config: c:/k/azure.json
         cloud-provider: external
         feature-gates: WindowsHostProcessContainers=true
-        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
+        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.9
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -259,13 +259,14 @@ kind: AzureMachinePool
 metadata:
   annotations:
     runtime: containerd
+    windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
   name: ${CLUSTER_NAME}-mp-win
   namespace: default
 spec:
   location: ${AZURE_LOCATION}
   template:
     osDisk:
-      diskSizeGB: 30
+      diskSizeGB: 128
       managedDisk:
         storageAccountType: Premium_LRS
       osType: Windows
@@ -296,7 +297,7 @@ spec:
         azure-container-registry-config: c:/k/azure.json
         cloud-provider: external
         feature-gates: WindowsHostProcessContainers=true
-        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
+        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.9
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -363,13 +363,14 @@ kind: AzureMachinePool
 metadata:
   annotations:
     runtime: containerd
+    windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
   name: ${CLUSTER_NAME}-mp-win
   namespace: default
 spec:
   location: ${AZURE_LOCATION}
   template:
     osDisk:
-      diskSizeGB: 30
+      diskSizeGB: 128
       managedDisk:
         storageAccountType: Premium_LRS
       osType: Windows


### PR DESCRIPTION


 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
 AzureMachinePool windows fixes to
-  to set disk size to 128gb
- honor WINDOWS_SERVER_VERSION
- use newer pause image


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes for AzureMachinePool running Windows
```
