### PR TITLE
[Release-1.7] AzureMachinePool windows template fixes

### DIFF
--- a/templates/cluster-template-machinepool-windows.yaml
+++ b/templates/cluster-template-machinepool-windows.yaml
@@ -259,13 +259,14 @@ kind: AzureMachinePool
 metadata:
   annotations:
     runtime: containerd
+    windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
   name: ${CLUSTER_NAME}-mp-win
   namespace: default
 spec:
   location: ${AZURE_LOCATION}
   template:
     osDisk:
-      diskSizeGB: 30
+      diskSizeGB: 128
       managedDisk:
         storageAccountType: Premium_LRS
       osType: Windows
@@ -297,7 +298,7 @@ spec:
         cloud-config: c:/k/azure.json
         cloud-provider: azure
         feature-gates: WindowsHostProcessContainers=true
-        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
+        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.9
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/flavors/machinepool-windows/machine-pool-deployment-windows.yaml
+++ b/templates/flavors/machinepool-windows/machine-pool-deployment-windows.yaml
@@ -26,13 +26,14 @@ metadata:
   name: "${CLUSTER_NAME}-mp-win"
   annotations:
     runtime: containerd
+    windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
 spec:
   location: ${AZURE_LOCATION}
   template:
     vmSize: ${AZURE_NODE_MACHINE_TYPE}
     osDisk:
       osType: "Windows"
-      diskSizeGB: 30
+      diskSizeGB: 128
       managedDisk:
         storageAccountType: "Premium_LRS"
     sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
@@ -60,7 +61,7 @@ spec:
         cloud-provider: azure
         cloud-config: 'c:/k/azure.json'
         azure-container-registry-config: 'c:/k/azure.json'
-        pod-infra-container-image: "mcr.microsoft.com/oss/kubernetes/pause:3.4.1"
+        pod-infra-container-image: "mcr.microsoft.com/oss/kubernetes/pause:3.9"
         feature-gates: "WindowsHostProcessContainers=true"
   files:
   - contentFrom:

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -420,6 +420,7 @@ kind: AzureMachinePool
 metadata:
   annotations:
     runtime: containerd
+    windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
   name: ${CLUSTER_NAME}-mp-win
   namespace: default
 spec:
@@ -432,7 +433,7 @@ spec:
         sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
         version: latest
     osDisk:
-      diskSizeGB: 30
+      diskSizeGB: 128
       managedDisk:
         storageAccountType: Premium_LRS
       osType: Windows
@@ -491,7 +492,7 @@ spec:
         cloud-config: c:/k/azure.json
         cloud-provider: azure
         feature-gates: WindowsHostProcessContainers=true
-        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
+        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.9
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -274,13 +274,14 @@ kind: AzureMachinePool
 metadata:
   annotations:
     runtime: containerd
+    windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
   name: ${CLUSTER_NAME}-mp-win
   namespace: default
 spec:
   location: ${AZURE_LOCATION}
   template:
     osDisk:
-      diskSizeGB: 30
+      diskSizeGB: 128
       managedDisk:
         storageAccountType: Premium_LRS
       osType: Windows
@@ -312,7 +313,7 @@ spec:
         cloud-config: c:/k/azure.json
         cloud-provider: azure
         feature-gates: WindowsHostProcessContainers=true
-        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
+        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.9
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -367,13 +367,14 @@ kind: AzureMachinePool
 metadata:
   annotations:
     runtime: containerd
+    windowsServerVersion: ${WINDOWS_SERVER_VERSION:=""}
   name: ${CLUSTER_NAME}-mp-win
   namespace: default
 spec:
   location: ${AZURE_LOCATION}
   template:
     osDisk:
-      diskSizeGB: 30
+      diskSizeGB: 128
       managedDisk:
         storageAccountType: Premium_LRS
       osType: Windows
@@ -405,7 +406,7 @@ spec:
         cloud-config: c:/k/azure.json
         cloud-provider: azure
         feature-gates: WindowsHostProcessContainers=true
-        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
+        pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.9
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - nssm set kubelet start SERVICE_AUTO_START


### PR DESCRIPTION


 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
AzureMachinePool windows fixes to
- to set disk size to 128gb
- honor WINDOWS_SERVER_VERSION
- use newer pause image

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes for AzureMachinePool running Windows
```
