### PR TITLE
Fetch AzureCluster name from OwnerCluster instead of assuming ClusterName = AzureCluster.Name

### DIFF
--- a/api/v1beta1/azuremachine_default.go
+++ b/api/v1beta1/azuremachine_default.go
@@ -174,21 +174,20 @@ func (s *AzureMachineSpec) SetNetworkInterfacesDefaults() {
 	}
 }
 
-// GetSubscriptionID returns the subscription ID for the given cluster name and namespace.
-func GetSubscriptionID(cli client.Client, clusterName string, namespace string, maxAttempts int) (string, error) {
+// GetOwnerAzureClusterNameAndNamespace returns the owner azure cluster's name and namespace for the given cluster name and namespace.
+func GetOwnerAzureClusterNameAndNamespace(cli client.Client, clusterName string, namespace string, maxAttempts int) (azureClusterName string, azureClusterNamespace string, err error) {
 	ctx := context.Background()
 
-	ownerCluster := &AzureCluster{}
+	ownerCluster := &clusterv1.Cluster{}
 	key := client.ObjectKey{
 		Namespace: namespace,
 		Name:      clusterName,
 	}
 
 	for i := 1; ; i++ {
-		err := cli.Get(ctx, key, ownerCluster)
-		if err != nil {
+		if err := cli.Get(ctx, key, ownerCluster); err != nil {
 			if i > maxAttempts {
-				return "", errors.Wrapf(err, "failed to find owner cluster for %s/%s", namespace, clusterName)
+				return "", "", errors.Wrapf(err, "failed to find owner cluster for %s/%s", namespace, clusterName)
 			}
 			time.Sleep(1 * time.Second)
 			continue
@@ -196,7 +195,30 @@ func GetSubscriptionID(cli client.Client, clusterName string, namespace string, 
 		break
 	}
 
-	return ownerCluster.Spec.SubscriptionID, nil
+	return ownerCluster.Spec.InfrastructureRef.Name, ownerCluster.Spec.InfrastructureRef.Namespace, nil
+}
+
+// GetSubscriptionID returns the subscription ID for the AzureCluster given the cluster name and namespace.
+func GetSubscriptionID(cli client.Client, ownerAzureClusterName string, ownerAzureClusterNamespace string, maxAttempts int) (string, error) {
+	ctx := context.Background()
+
+	ownerAzureCluster := &AzureCluster{}
+	key := client.ObjectKey{
+		Namespace: ownerAzureClusterNamespace,
+		Name:      ownerAzureClusterName,
+	}
+	for i := 1; ; i++ {
+		if err := cli.Get(ctx, key, ownerAzureCluster); err != nil {
+			if i >= maxAttempts {
+				return "", errors.Wrapf(err, "failed to find AzureCluster for owner cluster %s/%s", ownerAzureClusterNamespace, ownerAzureClusterName)
+			}
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		break
+	}
+
+	return ownerAzureCluster.Spec.SubscriptionID, nil
 }
 
 // SetDefaults sets to the defaults for the AzureMachineSpec.
@@ -212,7 +234,12 @@ func (m *AzureMachine) SetDefaults(client client.Client) error {
 		errs = append(errs, errors.Errorf("failed to fetch ClusterName for AzureMachine %s/%s", m.Namespace, m.Name))
 	}
 
-	subscriptionID, err := GetSubscriptionID(client, clusterName, m.Namespace, 5)
+	ownerAzureClusterName, ownerAzureClusterNamespace, err := GetOwnerAzureClusterNameAndNamespace(client, clusterName, m.Namespace, 5)
+	if err != nil {
+		errs = append(errs, errors.Wrapf(err, "failed to fetch owner cluster for AzureMachine %s/%s", m.Namespace, m.Name))
+	}
+
+	subscriptionID, err := GetSubscriptionID(client, ownerAzureClusterName, ownerAzureClusterNamespace, 5)
 	if err != nil {
 		errs = append(errs, errors.Wrapf(err, "failed to fetch subscription ID for AzureMachine %s/%s", m.Namespace, m.Name))
 	}

--- a/api/v1beta1/azuremachine_webhook_test.go
+++ b/api/v1beta1/azuremachine_webhook_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -716,7 +718,17 @@ type mockDefaultClient struct {
 }
 
 func (m mockDefaultClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-	obj.(*AzureCluster).Spec.SubscriptionID = m.SubscriptionID
+	switch obj := obj.(type) {
+	case *AzureCluster:
+		obj.Spec.SubscriptionID = m.SubscriptionID
+	case *clusterv1.Cluster:
+		obj.Spec.InfrastructureRef = &corev1.ObjectReference{
+			Kind: "AzureCluster",
+			Name: "test-cluster",
+		}
+	default:
+		return errors.New("invalid object type")
+	}
 	return nil
 }
 

--- a/exp/api/v1beta1/azuremachinepool_default.go
+++ b/exp/api/v1beta1/azuremachinepool_default.go
@@ -42,7 +42,12 @@ func (amp *AzureMachinePool) SetDefaults(client client.Client) error {
 		errs = append(errs, errors.Wrap(err, "failed to find parent machine pool"))
 	}
 
-	subscriptionID, err := infrav1.GetSubscriptionID(client, machinePool.Spec.ClusterName, machinePool.Namespace, 5)
+	ownerAzureClusterName, ownerAzureClusterNamespace, err := infrav1.GetOwnerAzureClusterNameAndNamespace(client, machinePool.Spec.ClusterName, machinePool.Namespace, 5)
+	if err != nil {
+		errs = append(errs, errors.Wrap(err, "failed to get owner cluster"))
+	}
+
+	subscriptionID, err := infrav1.GetSubscriptionID(client, ownerAzureClusterName, ownerAzureClusterNamespace, 5)
 	if err != nil {
 		errs = append(errs, errors.Wrap(err, "failed to get subscription ID"))
 	}

--- a/exp/api/v1beta1/azuremachinepool_webhook_test.go
+++ b/exp/api/v1beta1/azuremachinepool_webhook_test.go
@@ -264,7 +264,17 @@ type mockDefaultClient struct {
 }
 
 func (m mockDefaultClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-	obj.(*infrav1.AzureCluster).Spec.SubscriptionID = m.SubscriptionID
+	switch obj := obj.(type) {
+	case *infrav1.AzureCluster:
+		obj.Spec.SubscriptionID = m.SubscriptionID
+	case *clusterv1.Cluster:
+		obj.Spec.InfrastructureRef = &corev1.ObjectReference{
+			Kind: "AzureCluster",
+			Name: "test-cluster",
+		}
+	default:
+		return errors.New("invalid object type")
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Recently, the clusterclass tests have been failing due to the `AzureCluster` name being different from the `ClusterName` whereas they were equal in other E2E tests. This exposed a bug in getting the subscription ID for a machine/machinepool where the code [erroneously assumed](https://github.com/willie-yao/cluster-api-provider-azure/blob/92f57d00e42f0004344cec079272d7a2e0830070/api/v1beta1/azuremachine_default.go#L184) that `Cluster.Name` is always equal to `AzureCluster.Name`. This PR fixes this issue by splitting the existing `GetSubscriptionID()` function into two steps:

1. Getting the owner cluster
2. Getting the subscription ID from the owner cluster's infrastructure ref, thus getting the correct `AzureCluster` name

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3313

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug with GetSubscriptionID where it fetched the AzureCluster object using the Cluster's name instead of the AzureCluster's name
```
