### PR TITLE
[release-1.7] fix: networkInterfaces IPForwarding and AcceleratedNetworking

### DIFF
--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -564,11 +564,14 @@ func (s *Service) buildVMSSFromSpec(ctx context.Context, vmssSpec azure.ScaleSet
 			nicConfig := compute.VirtualMachineScaleSetNetworkConfiguration{}
 			nicConfig.VirtualMachineScaleSetNetworkConfigurationProperties = &compute.VirtualMachineScaleSetNetworkConfigurationProperties{}
 			nicConfig.Name = to.StringPtr(vmssSpec.Name + "-" + strconv.Itoa(i))
-			if to.Bool(n.AcceleratedNetworking) {
-				nicConfig.VirtualMachineScaleSetNetworkConfigurationProperties.EnableAcceleratedNetworking = to.BoolPtr(true)
+			nicConfig.EnableIPForwarding = to.BoolPtr(true)
+
+			if n.AcceleratedNetworking == nil {
+				nicConfig.VirtualMachineScaleSetNetworkConfigurationProperties.EnableAcceleratedNetworking = vmssSpec.AcceleratedNetworking
 			} else {
-				nicConfig.VirtualMachineScaleSetNetworkConfigurationProperties.EnableAcceleratedNetworking = to.BoolPtr(false)
+				nicConfig.VirtualMachineScaleSetNetworkConfigurationProperties.EnableAcceleratedNetworking = n.AcceleratedNetworking
 			}
+
 			if n.PrivateIPConfigs == 0 {
 				nicConfig.VirtualMachineScaleSetNetworkConfigurationProperties.IPConfigurations = &[]compute.VirtualMachineScaleSetIPConfiguration{
 					{

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -261,6 +261,38 @@ func TestReconcileVMSS(t *testing.T) {
 			},
 		},
 		{
+			name:          "should start creating vmss with custom subnet when specified",
+			expectedError: "failed to get VMSS my-vmss after create or update: failed to get result from future: operation type PUT on Azure resource my-rg/my-vmss is not done",
+			expect: func(g *WithT, s *mock_scalesets.MockScaleSetScopeMockRecorder, m *mock_scalesets.MockClientMockRecorder) {
+				spec := newDefaultVMSSSpec()
+				spec.Size = "VM_SIZE_AN"
+				spec.NetworkInterfaces = []infrav1.NetworkInterface{
+					{
+						SubnetName:       "somesubnet",
+						PrivateIPConfigs: 1, // defaulter sets this to one
+					},
+				}
+				s.ScaleSetSpec().Return(spec).AnyTimes()
+				setupDefaultVMSSStartCreatingExpectations(s, m)
+				vmss := newDefaultVMSS("VM_SIZE_AN")
+				netConfigs := vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
+				(*netConfigs)[0].Name = pointer.String("my-vmss-0")
+				(*netConfigs)[0].EnableIPForwarding = pointer.Bool(true)
+				(*netConfigs)[0].EnableAcceleratedNetworking = pointer.Bool(true)
+				nic1IPConfigs := (*netConfigs)[0].IPConfigurations
+				(*nic1IPConfigs)[0].Name = pointer.String("private-ipConfig-0")
+				(*nic1IPConfigs)[0].PrivateIPAddressVersion = compute.IPVersionIPv4
+				(*nic1IPConfigs)[0].Subnet = &compute.APIEntityReference{
+					ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/somesubnet"),
+				}
+				(*netConfigs)[0].EnableAcceleratedNetworking = pointer.Bool(true)
+				(*netConfigs)[0].Primary = pointer.Bool(true)
+				m.CreateOrUpdateAsync(gomockinternal.AContext(), defaultResourceGroup, defaultVMSSName, gomockinternal.DiffEq(vmss)).
+					Return(putFuture, nil)
+				setupCreatingSucceededExpectations(s, m, newDefaultExistingVMSS("VM_SIZE_AN"), putFuture)
+			},
+		},
+		{
 			name:          "should start creating vmss with custom networking when specified",
 			expectedError: "failed to get VMSS my-vmss after create or update: failed to get result from future: operation type PUT on Azure resource my-rg/my-vmss is not done",
 			expect: func(g *WithT, s *mock_scalesets.MockScaleSetScopeMockRecorder, m *mock_scalesets.MockClientMockRecorder) {
@@ -291,7 +323,7 @@ func TestReconcileVMSS(t *testing.T) {
 				vmss.VirtualMachineScaleSetProperties.AdditionalCapabilities = &compute.AdditionalCapabilities{UltraSSDEnabled: pointer.Bool(true)}
 				netConfigs := vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
 				(*netConfigs)[0].Name = to.StringPtr("my-vmss-0")
-				(*netConfigs)[0].EnableIPForwarding = nil
+				(*netConfigs)[0].EnableIPForwarding = pointer.Bool(true)
 				nic1IPConfigs := (*netConfigs)[0].IPConfigurations
 				(*nic1IPConfigs)[0].Name = to.StringPtr("private-ipConfig-0")
 				(*nic1IPConfigs)[0].PrivateIPAddressVersion = compute.IPVersionIPv4
@@ -323,6 +355,7 @@ func TestReconcileVMSS(t *testing.T) {
 					VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 						EnableAcceleratedNetworking: to.BoolPtr(true),
 						IPConfigurations:            &vmssIPConfigs,
+						EnableIPForwarding:          pointer.Bool(true),
 					},
 				})
 				m.CreateOrUpdateAsync(gomockinternal.AContext(), defaultResourceGroup, defaultVMSSName, gomockinternal.DiffEq(vmss)).


### PR DESCRIPTION
Cherry-pick of #3243 for release 1.7

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix networking when custom Network Interfaces are specified in MachinePools
```
