### PR TITLE
include IPAMConfig CRD w/ ClusterResourceSets

### DIFF
--- a/templates/addons/windows/calico/calico.yaml
+++ b/templates/addons/windows/calico/calico.yaml
@@ -274,3 +274,61 @@ spec:
       - name: kubeadm-config
         configMap:
           name: kubeadm-config
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamconfigs.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMConfig
+    listKind: IPAMConfigList
+    plural: ipamconfigs
+    singular: ipamconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMConfigSpec contains the specification for an IPAMConfig
+              resource.
+            properties:
+              autoAllocateBlocks:
+                type: boolean
+              maxBlocksPerHost:
+                description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                  that can be affine to each host.
+                maximum: 2147483647
+                minimum: 0
+                type: integer
+              strictAffinity:
+                type: boolean
+            required:
+            - autoAllocateBlocks
+            - strictAffinity
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -755,7 +755,30 @@ data:
     \       configMap:\n          name: calico-static-rules\n      # Used to install
     CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
     \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
-    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
+    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n---\napiVersion:
+    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n
+    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMConfig\n    listKind:
+    IPAMConfigList\n    plural: ipamconfigs\n    singular: ipamconfig\n  preserveUnknownFields:
+    false\n  scope: Cluster\n  versions:\n  - name: v1\n    schema:\n      openAPIV3Schema:\n
+    \       properties:\n          apiVersion:\n            description: 'APIVersion
+    defines the versioned schema of this representation\n              of an object.
+    Servers should convert recognized schemas to the latest\n              internal
+    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
+    \           type: string\n          kind:\n            description: 'Kind is a
+    string value representing the REST resource this\n              object represents.
+    Servers may infer this from the endpoint the client\n              submits requests
+    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
+    \           type: string\n          metadata:\n            type: object\n          spec:\n
+    \           description: IPAMConfigSpec contains the specification for an IPAMConfig\n
+    \             resource.\n            properties:\n              autoAllocateBlocks:\n
+    \               type: boolean\n              maxBlocksPerHost:\n                description:
+    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                  that
+    can be affine to each host.\n                maximum: 2147483647\n                minimum:
+    0\n                type: integer\n              strictAffinity:\n                type:
+    boolean\n            required:\n            - autoAllocateBlocks\n            -
+    strictAffinity\n            type: object\n        type: object\n    served: true\n
+    \   storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
+    \ conditions: []\n  storedVersions: []\n"
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -755,7 +755,30 @@ data:
     \       configMap:\n          name: calico-static-rules\n      # Used to install
     CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
     \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
-    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
+    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n---\napiVersion:
+    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n
+    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMConfig\n    listKind:
+    IPAMConfigList\n    plural: ipamconfigs\n    singular: ipamconfig\n  preserveUnknownFields:
+    false\n  scope: Cluster\n  versions:\n  - name: v1\n    schema:\n      openAPIV3Schema:\n
+    \       properties:\n          apiVersion:\n            description: 'APIVersion
+    defines the versioned schema of this representation\n              of an object.
+    Servers should convert recognized schemas to the latest\n              internal
+    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
+    \           type: string\n          kind:\n            description: 'Kind is a
+    string value representing the REST resource this\n              object represents.
+    Servers may infer this from the endpoint the client\n              submits requests
+    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
+    \           type: string\n          metadata:\n            type: object\n          spec:\n
+    \           description: IPAMConfigSpec contains the specification for an IPAMConfig\n
+    \             resource.\n            properties:\n              autoAllocateBlocks:\n
+    \               type: boolean\n              maxBlocksPerHost:\n                description:
+    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                  that
+    can be affine to each host.\n                maximum: 2147483647\n                minimum:
+    0\n                type: integer\n              strictAffinity:\n                type:
+    boolean\n            required:\n            - autoAllocateBlocks\n            -
+    strictAffinity\n            type: object\n        type: object\n    served: true\n
+    \   storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
+    \ conditions: []\n  storedVersions: []\n"
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/ci/cluster-template-prow-intree-cloud-provider-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-intree-cloud-provider-machine-pool.yaml
@@ -521,7 +521,30 @@ data:
     \       configMap:\n          name: calico-static-rules\n      # Used to install
     CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
     \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
-    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
+    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n---\napiVersion:
+    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n
+    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMConfig\n    listKind:
+    IPAMConfigList\n    plural: ipamconfigs\n    singular: ipamconfig\n  preserveUnknownFields:
+    false\n  scope: Cluster\n  versions:\n  - name: v1\n    schema:\n      openAPIV3Schema:\n
+    \       properties:\n          apiVersion:\n            description: 'APIVersion
+    defines the versioned schema of this representation\n              of an object.
+    Servers should convert recognized schemas to the latest\n              internal
+    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
+    \           type: string\n          kind:\n            description: 'Kind is a
+    string value representing the REST resource this\n              object represents.
+    Servers may infer this from the endpoint the client\n              submits requests
+    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
+    \           type: string\n          metadata:\n            type: object\n          spec:\n
+    \           description: IPAMConfigSpec contains the specification for an IPAMConfig\n
+    \             resource.\n            properties:\n              autoAllocateBlocks:\n
+    \               type: boolean\n              maxBlocksPerHost:\n                description:
+    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                  that
+    can be affine to each host.\n                maximum: 2147483647\n                minimum:
+    0\n                type: integer\n              strictAffinity:\n                type:
+    boolean\n            required:\n            - autoAllocateBlocks\n            -
+    strictAffinity\n            type: object\n        type: object\n    served: true\n
+    \   storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
+    \ conditions: []\n  storedVersions: []\n"
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/ci/cluster-template-prow-intree-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-intree-cloud-provider.yaml
@@ -583,7 +583,30 @@ data:
     \       configMap:\n          name: calico-static-rules\n      # Used to install
     CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
     \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
-    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
+    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n---\napiVersion:
+    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n
+    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMConfig\n    listKind:
+    IPAMConfigList\n    plural: ipamconfigs\n    singular: ipamconfig\n  preserveUnknownFields:
+    false\n  scope: Cluster\n  versions:\n  - name: v1\n    schema:\n      openAPIV3Schema:\n
+    \       properties:\n          apiVersion:\n            description: 'APIVersion
+    defines the versioned schema of this representation\n              of an object.
+    Servers should convert recognized schemas to the latest\n              internal
+    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
+    \           type: string\n          kind:\n            description: 'Kind is a
+    string value representing the REST resource this\n              object represents.
+    Servers may infer this from the endpoint the client\n              submits requests
+    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
+    \           type: string\n          metadata:\n            type: object\n          spec:\n
+    \           description: IPAMConfigSpec contains the specification for an IPAMConfig\n
+    \             resource.\n            properties:\n              autoAllocateBlocks:\n
+    \               type: boolean\n              maxBlocksPerHost:\n                description:
+    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                  that
+    can be affine to each host.\n                maximum: 2147483647\n                minimum:
+    0\n                type: integer\n              strictAffinity:\n                type:
+    boolean\n            required:\n            - autoAllocateBlocks\n            -
+    strictAffinity\n            type: object\n        type: object\n    served: true\n
+    \   storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
+    \ conditions: []\n  storedVersions: []\n"
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -691,7 +691,30 @@ data:
     \       configMap:\n          name: calico-static-rules\n      # Used to install
     CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
     \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
-    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
+    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n---\napiVersion:
+    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n
+    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMConfig\n    listKind:
+    IPAMConfigList\n    plural: ipamconfigs\n    singular: ipamconfig\n  preserveUnknownFields:
+    false\n  scope: Cluster\n  versions:\n  - name: v1\n    schema:\n      openAPIV3Schema:\n
+    \       properties:\n          apiVersion:\n            description: 'APIVersion
+    defines the versioned schema of this representation\n              of an object.
+    Servers should convert recognized schemas to the latest\n              internal
+    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
+    \           type: string\n          kind:\n            description: 'Kind is a
+    string value representing the REST resource this\n              object represents.
+    Servers may infer this from the endpoint the client\n              submits requests
+    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
+    \           type: string\n          metadata:\n            type: object\n          spec:\n
+    \           description: IPAMConfigSpec contains the specification for an IPAMConfig\n
+    \             resource.\n            properties:\n              autoAllocateBlocks:\n
+    \               type: boolean\n              maxBlocksPerHost:\n                description:
+    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                  that
+    can be affine to each host.\n                maximum: 2147483647\n                minimum:
+    0\n                type: integer\n              strictAffinity:\n                type:
+    boolean\n            required:\n            - autoAllocateBlocks\n            -
+    strictAffinity\n            type: object\n        type: object\n    served: true\n
+    \   storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
+    \ conditions: []\n  storedVersions: []\n"
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
@@ -511,7 +511,30 @@ data:
     \       configMap:\n          name: calico-static-rules\n      # Used to install
     CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
     \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
-    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
+    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n---\napiVersion:
+    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n
+    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMConfig\n    listKind:
+    IPAMConfigList\n    plural: ipamconfigs\n    singular: ipamconfig\n  preserveUnknownFields:
+    false\n  scope: Cluster\n  versions:\n  - name: v1\n    schema:\n      openAPIV3Schema:\n
+    \       properties:\n          apiVersion:\n            description: 'APIVersion
+    defines the versioned schema of this representation\n              of an object.
+    Servers should convert recognized schemas to the latest\n              internal
+    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
+    \           type: string\n          kind:\n            description: 'Kind is a
+    string value representing the REST resource this\n              object represents.
+    Servers may infer this from the endpoint the client\n              submits requests
+    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
+    \           type: string\n          metadata:\n            type: object\n          spec:\n
+    \           description: IPAMConfigSpec contains the specification for an IPAMConfig\n
+    \             resource.\n            properties:\n              autoAllocateBlocks:\n
+    \               type: boolean\n              maxBlocksPerHost:\n                description:
+    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                  that
+    can be affine to each host.\n                maximum: 2147483647\n                minimum:
+    0\n                type: integer\n              strictAffinity:\n                type:
+    boolean\n            required:\n            - autoAllocateBlocks\n            -
+    strictAffinity\n            type: object\n        type: object\n    served: true\n
+    \   storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
+    \ conditions: []\n  storedVersions: []\n"
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -505,7 +505,30 @@ data:
     \       configMap:\n          name: calico-static-rules\n      # Used to install
     CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
     \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
-    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
+    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n---\napiVersion:
+    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n
+    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMConfig\n    listKind:
+    IPAMConfigList\n    plural: ipamconfigs\n    singular: ipamconfig\n  preserveUnknownFields:
+    false\n  scope: Cluster\n  versions:\n  - name: v1\n    schema:\n      openAPIV3Schema:\n
+    \       properties:\n          apiVersion:\n            description: 'APIVersion
+    defines the versioned schema of this representation\n              of an object.
+    Servers should convert recognized schemas to the latest\n              internal
+    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
+    \           type: string\n          kind:\n            description: 'Kind is a
+    string value representing the REST resource this\n              object represents.
+    Servers may infer this from the endpoint the client\n              submits requests
+    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
+    \           type: string\n          metadata:\n            type: object\n          spec:\n
+    \           description: IPAMConfigSpec contains the specification for an IPAMConfig\n
+    \             resource.\n            properties:\n              autoAllocateBlocks:\n
+    \               type: boolean\n              maxBlocksPerHost:\n                description:
+    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                  that
+    can be affine to each host.\n                maximum: 2147483647\n                minimum:
+    0\n                type: integer\n              strictAffinity:\n                type:
+    boolean\n            required:\n            - autoAllocateBlocks\n            -
+    strictAffinity\n            type: object\n        type: object\n    served: true\n
+    \   storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
+    \ conditions: []\n  storedVersions: []\n"
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/ci/cluster-template-prow-topology.yaml
+++ b/templates/test/ci/cluster-template-prow-topology.yaml
@@ -232,7 +232,30 @@ data:
     \       configMap:\n          name: calico-static-rules\n      # Used to install
     CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
     \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
-    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
+    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n---\napiVersion:
+    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n
+    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMConfig\n    listKind:
+    IPAMConfigList\n    plural: ipamconfigs\n    singular: ipamconfig\n  preserveUnknownFields:
+    false\n  scope: Cluster\n  versions:\n  - name: v1\n    schema:\n      openAPIV3Schema:\n
+    \       properties:\n          apiVersion:\n            description: 'APIVersion
+    defines the versioned schema of this representation\n              of an object.
+    Servers should convert recognized schemas to the latest\n              internal
+    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
+    \           type: string\n          kind:\n            description: 'Kind is a
+    string value representing the REST resource this\n              object represents.
+    Servers may infer this from the endpoint the client\n              submits requests
+    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
+    \           type: string\n          metadata:\n            type: object\n          spec:\n
+    \           description: IPAMConfigSpec contains the specification for an IPAMConfig\n
+    \             resource.\n            properties:\n              autoAllocateBlocks:\n
+    \               type: boolean\n              maxBlocksPerHost:\n                description:
+    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                  that
+    can be affine to each host.\n                maximum: 2147483647\n                minimum:
+    0\n                type: integer\n              strictAffinity:\n                type:
+    boolean\n            required:\n            - autoAllocateBlocks\n            -
+    strictAffinity\n            type: object\n        type: object\n    served: true\n
+    \   storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
+    \ conditions: []\n  storedVersions: []\n"
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -567,7 +567,30 @@ data:
     \       configMap:\n          name: calico-static-rules\n      # Used to install
     CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
     \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
-    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
+    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n---\napiVersion:
+    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n
+    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMConfig\n    listKind:
+    IPAMConfigList\n    plural: ipamconfigs\n    singular: ipamconfig\n  preserveUnknownFields:
+    false\n  scope: Cluster\n  versions:\n  - name: v1\n    schema:\n      openAPIV3Schema:\n
+    \       properties:\n          apiVersion:\n            description: 'APIVersion
+    defines the versioned schema of this representation\n              of an object.
+    Servers should convert recognized schemas to the latest\n              internal
+    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
+    \           type: string\n          kind:\n            description: 'Kind is a
+    string value representing the REST resource this\n              object represents.
+    Servers may infer this from the endpoint the client\n              submits requests
+    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
+    \           type: string\n          metadata:\n            type: object\n          spec:\n
+    \           description: IPAMConfigSpec contains the specification for an IPAMConfig\n
+    \             resource.\n            properties:\n              autoAllocateBlocks:\n
+    \               type: boolean\n              maxBlocksPerHost:\n                description:
+    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                  that
+    can be affine to each host.\n                maximum: 2147483647\n                minimum:
+    0\n                type: integer\n              strictAffinity:\n                type:
+    boolean\n            required:\n            - autoAllocateBlocks\n            -
+    strictAffinity\n            type: object\n        type: object\n    served: true\n
+    \   storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
+    \ conditions: []\n  storedVersions: []\n"
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -610,7 +610,30 @@ data:
     \       configMap:\n          name: calico-static-rules\n      # Used to install
     CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
     \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
-    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
+    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n---\napiVersion:
+    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n
+    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMConfig\n    listKind:
+    IPAMConfigList\n    plural: ipamconfigs\n    singular: ipamconfig\n  preserveUnknownFields:
+    false\n  scope: Cluster\n  versions:\n  - name: v1\n    schema:\n      openAPIV3Schema:\n
+    \       properties:\n          apiVersion:\n            description: 'APIVersion
+    defines the versioned schema of this representation\n              of an object.
+    Servers should convert recognized schemas to the latest\n              internal
+    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
+    \           type: string\n          kind:\n            description: 'Kind is a
+    string value representing the REST resource this\n              object represents.
+    Servers may infer this from the endpoint the client\n              submits requests
+    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
+    \           type: string\n          metadata:\n            type: object\n          spec:\n
+    \           description: IPAMConfigSpec contains the specification for an IPAMConfig\n
+    \             resource.\n            properties:\n              autoAllocateBlocks:\n
+    \               type: boolean\n              maxBlocksPerHost:\n                description:
+    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                  that
+    can be affine to each host.\n                maximum: 2147483647\n                minimum:
+    0\n                type: integer\n              strictAffinity:\n                type:
+    boolean\n            required:\n            - autoAllocateBlocks\n            -
+    strictAffinity\n            type: object\n        type: object\n    served: true\n
+    \   storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
+    \ conditions: []\n  storedVersions: []\n"
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -716,7 +716,30 @@ data:
     \       configMap:\n          name: calico-static-rules\n      # Used to install
     CNI.\n      - name: cni-bin-dir\n        hostPath:\n          path: /opt/cni/bin\n
     \     - name: cni-net-dir\n        hostPath:\n          path: /etc/cni/net.d\n
-    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n"
+    \     - name: kubeadm-config\n        configMap:\n          name: kubeadm-config\n---\napiVersion:
+    apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: ipamconfigs.crd.projectcalico.org\nspec:\n
+    \ group: crd.projectcalico.org\n  names:\n    kind: IPAMConfig\n    listKind:
+    IPAMConfigList\n    plural: ipamconfigs\n    singular: ipamconfig\n  preserveUnknownFields:
+    false\n  scope: Cluster\n  versions:\n  - name: v1\n    schema:\n      openAPIV3Schema:\n
+    \       properties:\n          apiVersion:\n            description: 'APIVersion
+    defines the versioned schema of this representation\n              of an object.
+    Servers should convert recognized schemas to the latest\n              internal
+    value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n
+    \           type: string\n          kind:\n            description: 'Kind is a
+    string value representing the REST resource this\n              object represents.
+    Servers may infer this from the endpoint the client\n              submits requests
+    to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n
+    \           type: string\n          metadata:\n            type: object\n          spec:\n
+    \           description: IPAMConfigSpec contains the specification for an IPAMConfig\n
+    \             resource.\n            properties:\n              autoAllocateBlocks:\n
+    \               type: boolean\n              maxBlocksPerHost:\n                description:
+    MaxBlocksPerHost, if non-zero, is the max number of blocks\n                  that
+    can be affine to each host.\n                maximum: 2147483647\n                minimum:
+    0\n                type: integer\n              strictAffinity:\n                type:
+    boolean\n            required:\n            - autoAllocateBlocks\n            -
+    strictAffinity\n            type: object\n        type: object\n    served: true\n
+    \   storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n
+    \ conditions: []\n  storedVersions: []\n"
 kind: ConfigMap
 metadata:
   annotations:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind bug

**What this PR does / why we need it**:

This PR adds the crd.projectcalico.org definition for `IPAMConfig` to the `ClusterResourceSet` definitions we include for test templates that require them (test templates with Windows node pools).

We already include via a `ClusterResourceSet` resource a `kind: IPAMConfig` resource in order to fulfill the required calico configuration `strictAffinity: true`. Not including the reference CRD resource has the effect of forcing the CAPI controller-manager runtime to continually retry the application of the `ClusterResourceSet` payload of `kind: IPAMConfig`, and may have the side-effect of disrupting the `strictAffinity: true` configuration during helm installation of calico.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3227

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
