### PR TITLE
add missing create verb to AzureManagedCluster, AzureManagedMachinePool webhooks

### DIFF
--- a/api/v1beta1/azuremanagedcluster_webhook.go
+++ b/api/v1beta1/azuremanagedcluster_webhook.go
@@ -38,7 +38,7 @@ func (r *AzureManagedCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcluster,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=azuremanagedclusters,versions=v1beta1,name=validation.azuremanagedclusters.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcluster,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=azuremanagedclusters,versions=v1beta1,name=validation.azuremanagedclusters.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 var _ webhook.Validator = &AzureManagedCluster{}
 

--- a/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -81,7 +81,7 @@ func (mw *azureManagedMachinePoolWebhook) Default(ctx context.Context, obj runti
 	return nil
 }
 
-//+kubebuilder:webhook:verbs=update;delete,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedmachinepool,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=azuremanagedmachinepools,versions=v1beta1,name=validation.azuremanagedmachinepools.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+//+kubebuilder:webhook:verbs=create;update;delete,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedmachinepool,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=azuremanagedmachinepools,versions=v1beta1,name=validation.azuremanagedmachinepools.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (mw *azureManagedMachinePoolWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
@@ -347,13 +347,12 @@ func (m *AzureManagedMachinePool) validateOSType() error {
 }
 
 func (m *AzureManagedMachinePool) validateName() error {
-	if m.Spec.OSType != nil && *m.Spec.OSType == WindowsOS {
-		if len(m.Name) > 6 {
-			return field.Invalid(
-				field.NewPath("Name"),
-				m.Name,
-				"Windows agent pool name can not be longer than 6 characters.")
-		}
+	if m.Spec.OSType != nil && *m.Spec.OSType == WindowsOS &&
+		m.Spec.Name != nil && len(*m.Spec.Name) > 6 {
+		return field.Invalid(
+			field.NewPath("Spec", "Name"),
+			m.Spec.Name,
+			"Windows agent pool name can not be longer than 6 characters.")
 	}
 
 	return nil

--- a/api/v1beta1/azuremanagedmachinepool_webhook_test.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook_test.go
@@ -651,10 +651,8 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		{
 			name: "Windows clusters with more than 6char names are not allowed",
 			ammp: &AzureManagedMachinePool{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pool0-name-too-long",
-				},
 				Spec: AzureManagedMachinePoolSpec{
+					Name:   pointer.String("pool0-name-too-long"),
 					Mode:   "User",
 					OSType: pointer.String(WindowsOS),
 				},

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -290,6 +290,7 @@ webhooks:
     apiVersions:
     - v1beta1
     operations:
+    - CREATE
     - UPDATE
     resources:
     - azuremanagedclusters
@@ -332,6 +333,7 @@ webhooks:
     apiVersions:
     - v1beta1
     operations:
+    - CREATE
     - UPDATE
     - DELETE
     resources:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
I noticed the validating webhooks for AzureManagedCluster and AzureManagedMachinePool resources were never getting invoked when those resources were created. This PR adds the missing kubebuilder annotation to fix that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: I took a look through all the types to see if any others were missing and these were the only 2 I found.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug causing validating webhooks for AzureManagedCluster and AzureManagedMachinePool not to be invoked on create
```
