### PR TITLE
Update metrics-server to v0.6.3

### DIFF
--- a/templates/addons/metrics-server/kustomization.yaml
+++ b/templates/addons/metrics-server/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kube-system
 resources:
-  - https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.2/components.yaml
+  - https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.3/components.yaml
 patchesStrategicMerge:
   - patches/control-plane-toleration.yaml
 patches:

--- a/templates/addons/metrics-server/metrics-server.yaml
+++ b/templates/addons/metrics-server/metrics-server.yaml
@@ -138,7 +138,7 @@ spec:
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
         - --kubelet-insecure-tls
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.2
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -1103,7 +1103,7 @@ data:
             - --kubelet-use-node-status-port
             - --metric-resolution=15s
             - --kubelet-insecure-tls
-            image: k8s.gcr.io/metrics-server/metrics-server:v0.6.2
+            image: registry.k8s.io/metrics-server/metrics-server:v0.6.3
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 3

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -1103,7 +1103,7 @@ data:
             - --kubelet-use-node-status-port
             - --metric-resolution=15s
             - --kubelet-insecure-tls
-            image: k8s.gcr.io/metrics-server/metrics-server:v0.6.2
+            image: registry.k8s.io/metrics-server/metrics-server:v0.6.3
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 3

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -1064,7 +1064,7 @@ data:
             - --kubelet-use-node-status-port
             - --metric-resolution=15s
             - --kubelet-insecure-tls
-            image: k8s.gcr.io/metrics-server/metrics-server:v0.6.2
+            image: registry.k8s.io/metrics-server/metrics-server:v0.6.3
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 3


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates the metrics-server addon and template references to [v0.6.3](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.3), which moves the container location to registry.k8s.io.

**Which issue(s) this PR fixes**:

Fixes #3035
Closes #3184

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
