### PR TITLE
Run codecov job on every PR with threshold of 1%

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true

--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -2,6 +2,7 @@
 
 name: codecov
 on:
+  pull_request:
   push:
     branches:
     - main


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR enables the codecov job to run on every PR. If the PR decreases the overall code coverage by more than 1%, the coverage report will not pass. The test will still be green even if the code coverage difference is above 1%. This is done to make it visible enough for the author to pay attention to how much code coverage is being decreased without blocking the PR.

This is part of a larger effort to improve code coverage in CAPZ.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3312

**Special notes for your reviewer**:
This test PR on my fork of CAPZ shows an example code coverage report on a PR: https://github.com/willie-yao/cluster-api-provider-azure/pull/1

**Important**: This PR requires the GitHub codecov app to be added to CAPZ https://github.com/apps/codecov

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
