### PR TITLE
Use MCR registry for Calico images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,13 +479,17 @@ generate-addons: fetch-calico-manifests ## Generate metric-server, calico calico
 	$(KUSTOMIZE) build $(ADDONS_DIR)/calico-dual-stack > $(ADDONS_DIR)/calico-dual-stack.yaml
 
 # When updating this, make sure to also update the Windows image version in templates/addons/windows/calico.
-CALICO_VERSION := v3.25.0
+export CALICO_VERSION := v3.25.1
 # Where all downloaded Calico manifests are unpacked and stored.
 CALICO_RELEASES := $(ARTIFACTS)/calico
 # Path to manifests directory in a Calico release archive.
 CALICO_RELEASE_MANIFESTS_DIR := release-$(CALICO_VERSION)/manifests
 # Path where Calico manifests are stored which should be used for addons generation.
 CALICO_MANIFESTS_DIR := $(ARTIFACTS)/calico/$(CALICO_RELEASE_MANIFESTS_DIR)
+
+.PHONY: get-calico-version
+get-calico-version: ## Print the Calico version used for CNI in the repo.
+	@echo $(CALICO_VERSION)
 
 .PHONY: fetch-calico-manifests
 fetch-calico-manifests: $(CALICO_MANIFESTS_DIR) ## Get Calico release manifests and unzip them.

--- a/Tiltfile
+++ b/Tiltfile
@@ -390,7 +390,7 @@ def get_addons(flavor_name):
     else:
         calico_values = "./templates/addons/calico/values.yaml"
 
-    addon_cmd = "; " + helm_cmd + " --kubeconfig ./${CLUSTER_NAME}.kubeconfig install --repo https://docs.tigera.io/calico/charts calico tigera-operator -f " + calico_values + " --namespace tigera-operator --create-namespace"
+    addon_cmd = "; " + helm_cmd + " --kubeconfig ./${CLUSTER_NAME}.kubeconfig install --repo https://docs.tigera.io/calico/charts --version ${CALICO_VERSION} calico tigera-operator -f " + calico_values + " --namespace tigera-operator --create-namespace"
 
     if "intree-cloud-provider" not in flavor_name:
         addon_cmd += "; " + helm_cmd + " --kubeconfig ./${CLUSTER_NAME}.kubeconfig install --repo https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo cloud-provider-azure --generate-name --set infra.clusterName=${CLUSTER_NAME}"

--- a/docs/book/src/topics/addons.md
+++ b/docs/book/src/topics/addons.md
@@ -29,7 +29,7 @@ Then install the Helm chart on the workload cluster:
 
 ```bash
 helm repo add projectcalico https://docs.tigera.io/calico/charts && \
-helm install calico projectcalico/tigera-operator -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico/values.yaml --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV4_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
+helm install calico projectcalico/tigera-operator --version v3.25.1 -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico/values.yaml --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV4_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
 ```
 
 ### For IPv6 Clusters
@@ -44,7 +44,7 @@ Then install the Helm chart on the workload cluster:
 
 ```bash
 helm repo add projectcalico https://docs.tigera.io/calico/charts && \
-helm install calico projectcalico/tigera-operator -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico-ipv6/values.yaml  --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV6_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
+helm install calico projectcalico/tigera-operator --version v3.25.1 -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico-ipv6/values.yaml  --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV6_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
 ```
 
 ### For Dual-Stack Clusters
@@ -60,7 +60,7 @@ Then install the Helm chart on the workload cluster:
 
 ```bash
 helm repo add projectcalico https://docs.tigera.io/calico/charts && \
-helm install calico projectcalico/tigera-operator -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico-dual-stack/values.yaml --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV4_CIDR_BLOCK}","installation.calicoNetwork.ipPools[1].cidr=${IPV6_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
+helm install calico projectcalico/tigera-operator --version v3.25.1 -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico-dual-stack/values.yaml --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV4_CIDR_BLOCK}","installation.calicoNetwork.ipPools[1].cidr=${IPV6_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
 ```
 
 <aside class="note">

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -71,7 +71,9 @@ export AZURE_LOCATION_GPU="${AZURE_LOCATION_GPU:-$(capz::util::get_random_region
 export AZURE_LOCATION_EDGEZONE="${AZURE_LOCATION_EDGEZONE:-$(capz::util::get_random_region_edgezone)}"
 export AZURE_CONTROL_PLANE_MACHINE_TYPE="${AZURE_CONTROL_PLANE_MACHINE_TYPE:-"Standard_B2s"}"
 export AZURE_NODE_MACHINE_TYPE="${AZURE_NODE_MACHINE_TYPE:-"Standard_B2s"}"
-export KIND_EXPERIMENTAL_DOCKER_NETWORK="bridge"
+CALICO_VERSION=$(make get-calico-version)
+export CALICO_VERSION
+
 
 capz::util::generate_ssh_key
 

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -178,7 +178,8 @@ install_calico() {
         "${KUBECTL}" get configmap kubeadm-config --namespace=kube-system -o yaml | sed 's/namespace: kube-system/namespace: calico-system/' | "${KUBECTL}" apply -f - || return 1
     fi
     # install Calico CNI
-    echo "Installing Calico CNI via helm"
+    CALICO_VERSION=$(make get-calico-version)
+    echo "Installing Calico CNI ${CALICO_VERSION} via helm"
     if [[ "${CIDR0:-}" =~ .*:.* ]]; then
         echo "Cluster CIDR is IPv6"
         CALICO_VALUES_FILE="${REPO_ROOT}/templates/addons/calico-ipv6/values.yaml"
@@ -192,7 +193,7 @@ install_calico() {
         CALICO_VALUES_FILE="${REPO_ROOT}/templates/addons/calico/values.yaml"
         CIDR_STRING_VALUES="installation.calicoNetwork.ipPools[0].cidr=${CIDR0}"
     fi
-    "${HELM}" upgrade calico --install --repo https://docs.tigera.io/calico/charts tigera-operator -f "${CALICO_VALUES_FILE}" --set-string "${CIDR_STRING_VALUES}" --namespace calico-system || return 1
+    "${HELM}" upgrade calico --install --repo https://docs.tigera.io/calico/charts --version "${CALICO_VERSION}" tigera-operator -f "${CALICO_VALUES_FILE}" --set-string "${CIDR_STRING_VALUES}" --namespace calico-system || return 1
 }
 
 # install_cloud_provider_azure installs OOT cloud-provider-azure componentry onto the Cluster.

--- a/templates/addons/calico-dual-stack.yaml
+++ b/templates/addons/calico-dual-stack.yaml
@@ -4351,7 +4351,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.25.0
+        image: docker.io/calico/kube-controllers:v3.25.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -4428,7 +4428,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/typha:v3.25.0
+        image: docker.io/calico/typha:v3.25.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -4546,7 +4546,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.25.0
+        image: docker.io/calico/node:v3.25.1
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4621,7 +4621,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.25.0
+        image: docker.io/calico/cni:v3.25.1
         imagePullPolicy: IfNotPresent
         name: install-cni
         securityContext:
@@ -4635,7 +4635,7 @@ spec:
         - calico-node
         - -init
         - -best-effort
-        image: docker.io/calico/node:v3.25.0
+        image: docker.io/calico/node:v3.25.1
         imagePullPolicy: IfNotPresent
         name: mount-bpffs
         securityContext:

--- a/templates/addons/calico-dual-stack/values.yaml
+++ b/templates/addons/calico-dual-stack/values.yaml
@@ -18,12 +18,9 @@ installation:
       natOutgoing: Enabled
       nodeSelector: all()
   registry: mcr.microsoft.com/oss
-  tag: v3.25.1
 # Image and registry configuration for the tigera/operator pod.
 tigeraOperator:
   image: tigera/operator
   registry: mcr.microsoft.com/oss
-  tag: v1.29.3
 calicoctl:
   image: mcr.microsoft.com/oss/calico/ctl
-  tag: v3.25.1

--- a/templates/addons/calico-dual-stack/values.yaml
+++ b/templates/addons/calico-dual-stack/values.yaml
@@ -17,3 +17,13 @@ installation:
       encapsulation: None
       natOutgoing: Enabled
       nodeSelector: all()
+  registry: mcr.microsoft.com/oss
+  tag: v3.25.1
+# Image and registry configuration for the tigera/operator pod.
+tigeraOperator:
+  image: tigera/operator
+  registry: mcr.microsoft.com/oss
+  tag: v1.29.3
+calicoctl:
+  image: mcr.microsoft.com/oss/calico/ctl
+  tag: v3.25.1

--- a/templates/addons/calico-ipv6.yaml
+++ b/templates/addons/calico-ipv6.yaml
@@ -4340,7 +4340,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.25.0
+        image: docker.io/calico/kube-controllers:v3.25.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -4417,7 +4417,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/typha:v3.25.0
+        image: docker.io/calico/typha:v3.25.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -4535,7 +4535,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.25.0
+        image: docker.io/calico/node:v3.25.1
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4610,7 +4610,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.25.0
+        image: docker.io/calico/cni:v3.25.1
         imagePullPolicy: IfNotPresent
         name: install-cni
         securityContext:
@@ -4624,7 +4624,7 @@ spec:
         - calico-node
         - -init
         - -best-effort
-        image: docker.io/calico/node:v3.25.0
+        image: docker.io/calico/node:v3.25.1
         imagePullPolicy: IfNotPresent
         name: mount-bpffs
         securityContext:

--- a/templates/addons/calico-ipv6/calico-policy-only.yaml
+++ b/templates/addons/calico-ipv6/calico-policy-only.yaml
@@ -4441,7 +4441,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.25.0
+          image: docker.io/calico/cni:v3.25.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4478,7 +4478,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.25.0
+          image: docker.io/calico/node:v3.25.1
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4504,7 +4504,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.25.0
+          image: docker.io/calico/node:v3.25.1
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4692,7 +4692,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.25.0
+          image: docker.io/calico/kube-controllers:v3.25.1
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.
@@ -4776,7 +4776,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: docker.io/calico/typha:v3.25.0
+      - image: docker.io/calico/typha:v3.25.1
         imagePullPolicy: IfNotPresent
         name: calico-typha
         ports:

--- a/templates/addons/calico-ipv6/values.yaml
+++ b/templates/addons/calico-ipv6/values.yaml
@@ -12,3 +12,13 @@ installation:
       encapsulation: None
       natOutgoing: Enabled
       nodeSelector: all()
+  registry: mcr.microsoft.com/oss
+  tag: v3.25.1
+# Image and registry configuration for the tigera/operator pod.
+tigeraOperator:
+  image: tigera/operator
+  registry: mcr.microsoft.com/oss
+  tag: v1.29.3
+calicoctl:
+  image: mcr.microsoft.com/oss/calico/ctl
+  tag: v3.25.1

--- a/templates/addons/calico-ipv6/values.yaml
+++ b/templates/addons/calico-ipv6/values.yaml
@@ -13,12 +13,9 @@ installation:
       natOutgoing: Enabled
       nodeSelector: all()
   registry: mcr.microsoft.com/oss
-  tag: v3.25.1
 # Image and registry configuration for the tigera/operator pod.
 tigeraOperator:
   image: tigera/operator
   registry: mcr.microsoft.com/oss
-  tag: v1.29.3
 calicoctl:
   image: mcr.microsoft.com/oss/calico/ctl
-  tag: v3.25.1

--- a/templates/addons/calico.yaml
+++ b/templates/addons/calico.yaml
@@ -4355,7 +4355,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.25.0
+        image: docker.io/calico/kube-controllers:v3.25.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -4468,7 +4468,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.25.0
+        image: docker.io/calico/node:v3.25.1
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4540,7 +4540,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.25.0
+        image: docker.io/calico/cni:v3.25.1
         imagePullPolicy: IfNotPresent
         name: upgrade-ipam
         securityContext:
@@ -4575,7 +4575,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.25.0
+        image: docker.io/calico/cni:v3.25.1
         imagePullPolicy: IfNotPresent
         name: install-cni
         securityContext:
@@ -4589,7 +4589,7 @@ spec:
         - calico-node
         - -init
         - -best-effort
-        image: docker.io/calico/node:v3.25.0
+        image: docker.io/calico/node:v3.25.1
         imagePullPolicy: IfNotPresent
         name: mount-bpffs
         securityContext:

--- a/templates/addons/calico/calico-vxlan.yaml
+++ b/templates/addons/calico/calico-vxlan.yaml
@@ -4440,7 +4440,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.25.0
+          image: docker.io/calico/cni:v3.25.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4468,7 +4468,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.25.0
+          image: docker.io/calico/cni:v3.25.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4511,7 +4511,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.25.0
+          image: docker.io/calico/node:v3.25.1
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4537,7 +4537,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.25.0
+          image: docker.io/calico/node:v3.25.1
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4752,7 +4752,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.25.0
+          image: docker.io/calico/kube-controllers:v3.25.1
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/templates/addons/calico/values.yaml
+++ b/templates/addons/calico/values.yaml
@@ -8,12 +8,9 @@ installation:
     - cidr: 192.168.0.0/16
       encapsulation: VXLAN
   registry: mcr.microsoft.com/oss
-  tag: v3.25.1
 # Image and registry configuration for the tigera/operator pod.
 tigeraOperator:
   image: tigera/operator
-  tag: v1.29.3
   registry: mcr.microsoft.com/oss
 calicoctl:
   image: mcr.microsoft.com/oss/calico/ctl
-  tag: v3.25.1

--- a/templates/addons/calico/values.yaml
+++ b/templates/addons/calico/values.yaml
@@ -7,3 +7,13 @@ installation:
     ipPools:
     - cidr: 192.168.0.0/16
       encapsulation: VXLAN
+  registry: mcr.microsoft.com/oss
+  tag: v3.25.1
+# Image and registry configuration for the tigera/operator pod.
+tigeraOperator:
+  image: tigera/operator
+  tag: v1.29.3
+  registry: mcr.microsoft.com/oss
+calicoctl:
+  image: mcr.microsoft.com/oss/calico/ctl
+  tag: v3.25.1

--- a/templates/addons/windows/calico/calico.yaml
+++ b/templates/addons/windows/calico/calico.yaml
@@ -163,7 +163,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: sigwindowstools/calico-install:v3.25.0-hostprocess
+          image: sigwindowstools/calico-install:v3.25.1-hostprocess
           args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1"]
           imagePullPolicy: Always
           env:
@@ -205,7 +205,7 @@ spec:
               runAsUserName: "NT AUTHORITY\\system"
       containers:
       - name: calico-node-startup
-        image: sigwindowstools/calico-node:v3.25.0-hostprocess
+        image: sigwindowstools/calico-node:v3.25.1-hostprocess
         args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1"]
         workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/"
         imagePullPolicy: Always
@@ -232,7 +232,7 @@ spec:
         - name: VXLAN_VNI
           value: "4096"
       - name: calico-node-felix
-        image: sigwindowstools/calico-node:v3.25.0-hostprocess
+        image: sigwindowstools/calico-node:v3.25.1-hostprocess
         args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1"]
         imagePullPolicy: Always
         workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/"

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -710,7 +710,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -729,7 +729,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -740,7 +740,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-intree-cloud-provider-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-intree-cloud-provider-machine-pool.yaml
@@ -472,7 +472,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -491,7 +491,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -502,7 +502,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-intree-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-intree-cloud-provider.yaml
@@ -536,7 +536,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -555,7 +555,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -566,7 +566,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -644,7 +644,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -663,7 +663,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -674,7 +674,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
@@ -462,7 +462,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -481,7 +481,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -492,7 +492,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -456,7 +456,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -475,7 +475,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -486,7 +486,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -4643,7 +4643,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.25.0
+            image: docker.io/calico/kube-controllers:v3.25.1
             imagePullPolicy: IfNotPresent
             livenessProbe:
               exec:
@@ -4756,7 +4756,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.25.0
+            image: docker.io/calico/node:v3.25.1
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -4828,7 +4828,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.25.0
+            image: docker.io/calico/cni:v3.25.1
             imagePullPolicy: IfNotPresent
             name: upgrade-ipam
             securityContext:
@@ -4863,7 +4863,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.25.0
+            image: docker.io/calico/cni:v3.25.1
             imagePullPolicy: IfNotPresent
             name: install-cni
             securityContext:
@@ -4877,7 +4877,7 @@ data:
             - calico-node
             - -init
             - -best-effort
-            image: docker.io/calico/node:v3.25.0
+            image: docker.io/calico/node:v3.25.1
             imagePullPolicy: IfNotPresent
             name: mount-bpffs
             securityContext:

--- a/templates/test/ci/cluster-template-prow-topology.yaml
+++ b/templates/test/ci/cluster-template-prow-topology.yaml
@@ -187,7 +187,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -206,7 +206,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -217,7 +217,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -520,7 +520,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -539,7 +539,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -550,7 +550,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -592,7 +592,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -611,7 +611,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -622,7 +622,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -657,7 +657,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -676,7 +676,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -687,7 +687,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/test/e2e/cloud-provider-azure.go
+++ b/test/e2e/cloud-provider-azure.go
@@ -66,7 +66,7 @@ func InstallCalicoAndCloudProviderAzureHelmChart(ctx context.Context, input clus
 	}
 
 	clusterProxy := input.ClusterProxy.GetWorkloadCluster(ctx, input.ConfigCluster.Namespace, input.ConfigCluster.ClusterName)
-	InstallHelmChart(ctx, clusterProxy, defaultNamespace, cloudProviderAzureHelmRepoURL, cloudProviderAzureChartName, cloudProviderAzureHelmReleaseName, options)
+	InstallHelmChart(ctx, clusterProxy, defaultNamespace, cloudProviderAzureHelmRepoURL, cloudProviderAzureChartName, cloudProviderAzureHelmReleaseName, options, "")
 
 	// Install Calico CNI Helm Chart. We do this before waiting for the pods to be ready because there is a co-dependency between CNI (nodes ready) and cloud-provider being initialized.
 	InstallCalicoHelmChart(ctx, input, cidrBlocks, hasWindows)
@@ -90,7 +90,7 @@ func InstallAzureDiskCSIDriverHelmChart(ctx context.Context, input clusterctl.Ap
 		options.Values = append(options.Values, "windows.useHostProcessContainers=true")
 	}
 	clusterProxy := input.ClusterProxy.GetWorkloadCluster(ctx, input.ConfigCluster.Namespace, input.ConfigCluster.ClusterName)
-	InstallHelmChart(ctx, clusterProxy, kubesystem, azureDiskCSIDriverHelmRepoURL, azureDiskCSIDriverChartName, azureDiskCSIDriverHelmReleaseName, options)
+	InstallHelmChart(ctx, clusterProxy, kubesystem, azureDiskCSIDriverHelmRepoURL, azureDiskCSIDriverChartName, azureDiskCSIDriverHelmReleaseName, options, "")
 	By("Waiting for Ready csi-azuredisk-controller deployment pods")
 	for _, d := range []string{"csi-azuredisk-controller"} {
 		waitInput := GetWaitForDeploymentsAvailableInput(ctx, clusterProxy, d, kubesystem, specName)

--- a/test/e2e/cni.go
+++ b/test/e2e/cni.go
@@ -22,6 +22,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -49,7 +50,7 @@ func InstallCalicoHelmChart(ctx context.Context, input clusterctl.ApplyClusterTe
 	By("Installing Calico CNI via helm")
 	values := getCalicoValues(cidrBlocks)
 	clusterProxy := input.ClusterProxy.GetWorkloadCluster(ctx, input.ConfigCluster.Namespace, input.ConfigCluster.ClusterName)
-	InstallHelmChart(ctx, clusterProxy, calicoOperatorNamespace, calicoHelmChartRepoURL, calicoHelmChartName, calicoHelmReleaseName, values)
+	InstallHelmChart(ctx, clusterProxy, calicoOperatorNamespace, calicoHelmChartRepoURL, calicoHelmChartName, calicoHelmReleaseName, values, os.Getenv(CalicoVersion))
 	workloadClusterClient := clusterProxy.GetClient()
 
 	// Copy the kubeadm configmap to the calico-system namespace. This is a workaround needed for the calico-node-windows daemonset to be able to run in the calico-system namespace.

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -84,6 +84,7 @@ const (
 	FlatcarVersion                  = "FLATCAR_VERSION"
 	SecurityScanFailThreshold       = "SECURITY_SCAN_FAIL_THRESHOLD"
 	SecurityScanContainer           = "SECURITY_SCAN_CONTAINER"
+	CalicoVersion                   = "CALICO_VERSION"
 	ManagedClustersResourceType     = "managedClusters"
 	capiImagePublisher              = "cncf-upstream"
 	capiOfferName                   = "capi"

--- a/test/e2e/gpu_operator.go
+++ b/test/e2e/gpu_operator.go
@@ -64,5 +64,5 @@ func InstallGPUOperator(ctx context.Context, inputGetter func() GPUOperatorSpecI
 func InstallNvidiaGPUOperatorChart(ctx context.Context, clusterProxy framework.ClusterProxy) {
 	By("Installing nvidia/gpu-operator via helm")
 	values := &helmVals.Options{}
-	InstallHelmChart(ctx, clusterProxy, nvidiaGPUOperatorNamespace, nvidiaHelmChartRepoURL, nvidiaGPUOperatorHelmChartName, nvidiaGPUOperatorHelmReleaseName, values)
+	InstallHelmChart(ctx, clusterProxy, nvidiaGPUOperatorNamespace, nvidiaHelmChartRepoURL, nvidiaGPUOperatorHelmChartName, nvidiaGPUOperatorHelmReleaseName, values, "")
 }

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -936,7 +936,7 @@ func getPodLogs(ctx context.Context, clientset *kubernetes.Clientset, pod corev1
 }
 
 // InstallHelmChart takes a helm repo URL, a chart name, and release name, and installs a helm release onto the E2E workload cluster.
-func InstallHelmChart(ctx context.Context, clusterProxy framework.ClusterProxy, namespace, repoURL, chartName, releaseName string, options *helmVals.Options) {
+func InstallHelmChart(ctx context.Context, clusterProxy framework.ClusterProxy, namespace, repoURL, chartName, releaseName string, options *helmVals.Options, version string) {
 	kubeConfigPath := clusterProxy.GetKubeconfigPath()
 	settings := helmCli.New()
 	settings.KubeConfig = kubeConfigPath
@@ -968,6 +968,7 @@ func InstallHelmChart(ctx context.Context, clusterProxy framework.ClusterProxy, 
 		}
 		i.ReleaseName = releaseName
 		i.Namespace = namespace
+		i.Version = version
 		i.CreateNamespace = true
 		Eventually(func(g Gomega) {
 			cp, err := i.ChartPathOptions.LocateChart(chartName, helmCli.New())


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR changes the image registry used to install Calico in examples and test scripts to MCR to allow testing scale without running into docker.io throttling. It also pins the Calico version to v3.25.1 so we can bump the Calico after the sig-windows tools and the MCR images become available whenever there is a new release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3323 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use MCR registry for Calico images and bump Calico to v3.25.1
```
