### PR TITLE
mark context canceled or exceeded as transient failures

### DIFF
--- a/azure/errors.go
+++ b/azure/errors.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -152,4 +153,13 @@ func IsOperationNotDoneError(target error) bool {
 		return IsOperationNotDoneError(reconcileErr.error)
 	}
 	return errors.As(target, &OperationNotDoneError{})
+}
+
+// IsContextDeadlineExceededOrCanceledError checks if it's a context deadline
+// exceeded or canceled error.
+func IsContextDeadlineExceededOrCanceledError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
 }

--- a/azure/errors_test.go
+++ b/azure/errors_test.go
@@ -1,0 +1,53 @@
+package azure
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func TestIsContextDeadlineExceededOrCanceled(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+		err  error
+	}{
+		{
+			name: "Context deadline exceeded error",
+			err: func() error {
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-7*time.Hour))
+				defer cancel()
+				return ctx.Err()
+			}(),
+			want: true,
+		},
+		{
+			name: "Context canceled exceeded error",
+			err: func() error {
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(1*time.Hour))
+				cancel()
+				return ctx.Err()
+			}(),
+			want: true,
+		},
+		{
+			name: "Nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "Error other than context deadline exceeded or canceled error",
+			err:  errors.New("dummy error"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsContextDeadlineExceededOrCanceledError(tt.err); got != tt.want {
+				t.Errorf("IsContextDeadlineExceededOrCanceled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION


 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
This PR adds code to mark the `context deadline exceeded or canceled` as a transient failure. 
<!--
Add one of the following kinds:
/kind bug
-->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2976 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Mark context canceled or exceeded as transient failures
```
