### PR TITLE
add explicit securityContexts to the controller and namespace label for privileged

### DIFF
--- a/config/default/namespace.yaml
+++ b/config/default/namespace.yaml
@@ -2,3 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: system
+  labels:
+    # this is required due to the nmi daemonset
+    pod-security.kubernetes.io/enforce: privileged

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -57,6 +57,17 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsUser: 65532
+            runAsGroup: 65532
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 10
       serviceAccountName: manager
       tolerations:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This does not really change the configuration, it just makes it explicit and enforce the defaults, except for the seccompPolicy which changes from Unconfined to RuntimeDefault. Syscalls filtered by RuntimeDefault policy are 95% namespaced and require capabilities (which we drop) in the first place, so no practical change there either.

This allows the controller to be compatible to the restricted pod security admission profile.

However, the nmi daemonset requires the privileged profile which is why this also adds the corresponding label to the namespace, to allow cluster-wide enforcement of a policy lower than privileged, while preserving privileged for the capz-system namespace. If the nmi daemonset is replaced by Azure Workload Identity (https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2205), and if  Azure Workload Identity does not require privileged, the namespace label could get removed again.

This is a recommendation in the [CAPI v1.3->1.4 upgrade guide](https://main.cluster-api.sigs.k8s.io/developer/providers/migrations/v1.3-to-v1.4.html#suggested-changes-for-providers).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Prior art:
* https://github.com/kubernetes-sigs/cluster-api/pull/7831
* https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4104

Note: this requires the v1.4 branch of CAPI for usage with tilt, because the Tiltfile then removes the securityContext for allowing it to succeed.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Explicitly set securityContexts in the manifests to comply with the restricted pod security admission profile.
```
