### PR TITLE
return 1 in ci-entrypoint func’s when necessary

### DIFF
--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -102,7 +102,7 @@ setup() {
     export CCM_COUNT="${CCM_COUNT:-1}"
     export WORKER_MACHINE_COUNT="${WORKER_MACHINE_COUNT:-2}"
     export EXP_CLUSTER_RESOURCE_SET="true"
-    
+
     # TODO figure out a better way to account for expected Windows node count
     if [[ -n "${TEST_WINDOWS:-}" ]]; then
         export WINDOWS_WORKER_MACHINE_COUNT="${WINDOWS_WORKER_MACHINE_COUNT:-2}"
@@ -142,11 +142,11 @@ create_cluster() {
 # and any statement must be idempotent so that subsequent retry attempts can make forward progress.
 get_cidrs() {
     # Get cluster CIDRs from Cluster object
-    CIDR0=$(${KUBECTL} --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" get cluster "${CLUSTER_NAME}" -o=jsonpath='{.spec.clusterNetwork.pods.cidrBlocks[0]}')
+    CIDR0=$(${KUBECTL} --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" get cluster "${CLUSTER_NAME}" -o=jsonpath='{.spec.clusterNetwork.pods.cidrBlocks[0]}') || return 1
     export CIDR0
-    CIDR_LENGTH=$(${KUBECTL} --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" get cluster "${CLUSTER_NAME}" -o=jsonpath='{.spec.clusterNetwork.pods.cidrBlocks}' | jq '. | length')
+    CIDR_LENGTH=$(${KUBECTL} --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" get cluster "${CLUSTER_NAME}" -o=jsonpath='{.spec.clusterNetwork.pods.cidrBlocks}' | jq '. | length') || return 1
     if [[ "${CIDR_LENGTH}" == "2" ]]; then
-        CIDR1=$(${KUBECTL} get cluster --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" "${CLUSTER_NAME}" -o=jsonpath='{.spec.clusterNetwork.pods.cidrBlocks[1]}')
+        CIDR1=$(${KUBECTL} get cluster --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" "${CLUSTER_NAME}" -o=jsonpath='{.spec.clusterNetwork.pods.cidrBlocks[1]}') || return 1
         export CIDR1
     fi
 }
@@ -156,7 +156,7 @@ get_cidrs() {
 # retry it using a `until get_cloud_provider; do sleep 5; done` pattern;
 # and any statement must be idempotent so that subsequent retry attempts can make forward progress.
 get_cloud_provider() {
-    CLOUD_PROVIDER=$("${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" get kubeadmcontrolplane -l cluster.x-k8s.io/cluster-name="${CLUSTER_NAME}" -o=jsonpath='{.items[0].spec.kubeadmConfigSpec.clusterConfiguration.controllerManager.extraArgs.cloud-provider}')
+    CLOUD_PROVIDER=$("${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" get kubeadmcontrolplane -l cluster.x-k8s.io/cluster-name="${CLUSTER_NAME}" -o=jsonpath='{.items[0].spec.kubeadmConfigSpec.clusterConfiguration.controllerManager.extraArgs.cloud-provider}') || return 1
     if [[ "${CLOUD_PROVIDER:-}" = "azure" ]]; then
         IN_TREE="true"
         export IN_TREE
@@ -171,9 +171,11 @@ install_calico() {
     # Copy the kubeadm configmap to the calico-system namespace.
     # This is a workaround needed for the calico-node-windows daemonset
     # to be able to run in the calico-system namespace.
-    "${KUBECTL}" create namespace calico-system --dry-run=client -o yaml | kubectl apply -f -
+    # First, validate that the kubeadm-config configmap has been created.
+    "${KUBECTL}" get configmap kubeadm-config --namespace=kube-system -o yaml || return 1
+    "${KUBECTL}" create namespace calico-system --dry-run=client -o yaml | kubectl apply -f - || return 1
     if ! "${KUBECTL}" get configmap kubeadm-config --namespace=calico-system; then
-        "${KUBECTL}" get configmap kubeadm-config --namespace=kube-system -o yaml | sed 's/namespace: kube-system/namespace: calico-system/' | "${KUBECTL}" apply -f -
+        "${KUBECTL}" get configmap kubeadm-config --namespace=kube-system -o yaml | sed 's/namespace: kube-system/namespace: calico-system/' | "${KUBECTL}" apply -f - || return 1
     fi
     # install Calico CNI
     echo "Installing Calico CNI via helm"
@@ -190,7 +192,7 @@ install_calico() {
         CALICO_VALUES_FILE="${REPO_ROOT}/templates/addons/calico/values.yaml"
         CIDR_STRING_VALUES="installation.calicoNetwork.ipPools[0].cidr=${CIDR0}"
     fi
-    "${HELM}" upgrade calico --install --repo https://docs.tigera.io/calico/charts tigera-operator -f "${CALICO_VALUES_FILE}" --set-string "${CIDR_STRING_VALUES}" --namespace calico-system
+    "${HELM}" upgrade calico --install --repo https://docs.tigera.io/calico/charts tigera-operator -f "${CALICO_VALUES_FILE}" --set-string "${CIDR_STRING_VALUES}" --namespace calico-system || return 1
 }
 
 # install_cloud_provider_azure installs OOT cloud-provider-azure componentry onto the Cluster.
@@ -205,7 +207,7 @@ install_cloud_provider_azure() {
         CLOUD_CONFIG=""
         CONFIG_SECRET_NAME="azure-cloud-provider"
         ENABLE_DYNAMIC_RELOADING=true
-        copy_secret
+        copy_secret || return 1
     fi
 
     CCM_CLUSTER_CIDR="${CIDR0}"
@@ -223,7 +225,7 @@ install_cloud_provider_azure() {
         --set cloudControllerManager.cloudConfig="${CLOUD_CONFIG}" \
         --set cloudControllerManager.cloudConfigSecretName="${CONFIG_SECRET_NAME}" \
         --set cloudControllerManager.logVerbosity="${CCM_LOG_VERBOSITY}" \
-        --set-string cloudControllerManager.clusterCIDR="${CCM_CLUSTER_CIDR}" "${CCM_IMG_ARGS[@]}"
+        --set-string cloudControllerManager.clusterCIDR="${CCM_CLUSTER_CIDR}" "${CCM_IMG_ARGS[@]}" || return 1
 }
 
 # wait_for_nodes returns when all nodes in the workload cluster are Ready.
@@ -291,11 +293,11 @@ install_addons() {
 
 copy_secret() {
     # point at the management cluster
-    "${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" get secret "${CLUSTER_NAME}-control-plane-azure-json" -o jsonpath='{.data.control-plane-azure\.json}' | base64 --decode >azure_json
+    "${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" get secret "${CLUSTER_NAME}-control-plane-azure-json" -o jsonpath='{.data.control-plane-azure\.json}' | base64 --decode >azure_json || return 1
 
     # create the secret on the workload cluster
     "${KUBECTL}" create secret generic "${CONFIG_SECRET_NAME}" -n kube-system \
-        --from-file=cloud-config=azure_json
+        --from-file=cloud-config=azure_json || return 1
     rm azure_json
 }
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind flake

**What this PR does / why we need it**:

This PR adds necessary per-command return statements inside `ci-entrypoint.sh` functions to fulfill the "retry until success contract" of those functions.

The following bash snippet demonstrates the way that not doing so can produce functions that do not retry after one of the commands fails, which in `ci-entrypoint.sh` will have the side-effect of leaving a functional gap in the set of required steps during cluster bootstrapping.

```bash
#!/bin/bash
set -o errexit
set -o nounset
set -o pipefail

pathology_one() {
    echo "entering pathology_one"
    if ! false; then
        ls does-not-exist
    fi
    echo "exiting pathology_one"
}

pathology_two() {
    echo "entering pathology_two"
    RET=$(ls does-not-exist)
    export RET
    echo "exiting pathology_two"
}

pathology_three() {
    echo "entering pathology_three"
    ls does-not-exist
    echo "exiting pathology_three"
}

until pathology_one; do
    echo "pathology_one failed"
    sleep 1
done


until pathology_two; do
    echo "pathology_two failed"
    sleep 1
done

until pathology_three; do
    echo "pathology_three failed"
    sleep 1
done
```

The above script reflects the current approach of `ci-entrypoint.sh`, and we would expect that the script should hang forever during the `until pathology_one` function call as the `ls does-not-exist` statement returns non-zero. Instead command proceeds immediately afterwards, and the same thing happens for the next two functions that wrap non-successful command statements:

```sh
$ ./test.sh 
entering pathology_one
ls: does-not-exist: No such file or directory
exiting pathology_one
entering pathology_two
ls: does-not-exist: No such file or directory
exiting pathology_two
entering pathology_three
ls: does-not-exist: No such file or directory
exiting pathology_three
$ echo $?
0
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
