### PR TITLE
Add unit tests for AzureMachine controller

### DIFF
--- a/controllers/azuremachine_controller_test.go
+++ b/controllers/azuremachine_controller_test.go
@@ -19,47 +19,556 @@ package controllers
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/Azure/go-autorest/autorest"
-	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
-	"sigs.k8s.io/cluster-api-provider-azure/internal/test"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capierrors "sigs.k8s.io/cluster-api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-var _ = Describe("AzureMachineReconciler", func() {
-	BeforeEach(func() {})
-	AfterEach(func() {})
+type TestReconcileInput struct {
+	createAzureMachineService func(*scope.MachineScope) (*azureMachineService, error)
+	azureMachineOptions       func(am *infrav1.AzureMachine)
+	expectedErr               string
+	machineScopeFailureReason capierrors.MachineStatusError
+	ready                     bool
+	cache                     *scope.MachineCache
+	expectedResult            reconcile.Result
+}
 
-	Context("Reconcile an AzureMachine", func() {
-		It("should not error with minimal set up", func() {
-			reconciler := NewAzureMachineReconciler(testEnv, testEnv.GetEventRecorderFor("azuremachine-reconciler"), reconciler.DefaultLoopTimeout, "")
+func TestAzureMachineReconcile(t *testing.T) {
+	g := NewWithT(t)
+	scheme, err := newScheme()
+	g.Expect(err).NotTo(HaveOccurred())
 
-			By("Calling reconcile")
-			name := test.RandomName("foo", 10)
-			instance := &infrav1.AzureMachine{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}}
-			result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Namespace: instance.Namespace,
-					Name:      instance.Name,
+	defaultCluster := getFakeCluster()
+	defaultAzureCluster := getFakeAzureCluster()
+	defaultAzureMachine := getFakeAzureMachine()
+	defaultMachine := getFakeMachine(defaultAzureMachine)
+
+	cases := map[string]struct {
+		objects []runtime.Object
+		fail    bool
+		err     string
+		event   string
+	}{
+		"should reconcile normally": {
+			objects: []runtime.Object{
+				defaultCluster,
+				defaultAzureCluster,
+				defaultAzureMachine,
+				defaultMachine,
+			},
+		},
+		"should not fail if the azure machine is not found": {
+			objects: []runtime.Object{
+				defaultCluster,
+				defaultAzureCluster,
+				defaultMachine,
+			},
+		},
+		"should fail if machine is not found": {
+			objects: []runtime.Object{
+				defaultCluster,
+				defaultAzureCluster,
+				defaultAzureMachine,
+			},
+			fail: true,
+			err:  "machines.cluster.x-k8s.io \"my-machine\" not found",
+		},
+		"should return if azureMachine has not yet set ownerref": {
+			objects: []runtime.Object{
+				defaultCluster,
+				defaultAzureCluster,
+				getFakeAzureMachine(func(am *infrav1.AzureMachine) {
+					am.OwnerReferences = nil
+				}),
+				defaultMachine,
+			},
+			event: "Machine controller dependency not yet met",
+		},
+		"should return if cluster does not exist": {
+			objects: []runtime.Object{
+				defaultAzureCluster,
+				defaultAzureMachine,
+				defaultMachine,
+			},
+			event: "Unable to get cluster from metadata",
+		},
+		"should return if cluster is paused": {
+			objects: []runtime.Object{
+				getFakeCluster(func(c *clusterv1.Cluster) {
+					c.Spec.Paused = true
+				}),
+				defaultAzureCluster,
+				defaultAzureMachine,
+				defaultMachine,
+			},
+		},
+		"should return if azureCluster does not yet available": {
+			objects: []runtime.Object{
+				defaultCluster,
+				defaultAzureMachine,
+				defaultMachine,
+			},
+			event: "AzureCluster unavailable",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.objects...).Build()
+
+			reconciler := &AzureMachineReconciler{
+				Client:   client,
+				Recorder: record.NewFakeRecorder(128),
+			}
+
+			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "default",
+					Name:      "my-machine",
 				},
 			})
-
-			Expect(err).To(BeNil())
-			Expect(result.RequeueAfter).To(BeZero())
+			if tc.event != "" {
+				g.Expect(reconciler.Recorder.(*record.FakeRecorder).Events).To(Receive(ContainSubstring(tc.event)))
+			}
+			if tc.fail {
+				g.Expect(err).To(MatchError(tc.err))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
 		})
+	}
+}
+
+func TestAzureMachineReconcileNormal(t *testing.T) {
+	cases := map[string]TestReconcileInput{
+		"should reconcile normally": {
+			createAzureMachineService: getFakeAzureMachineService,
+			cache:                     &scope.MachineCache{},
+			ready:                     true,
+		},
+		"should skip reconciliation if error state is detected on azure machine": {
+			azureMachineOptions: func(am *infrav1.AzureMachine) {
+				updateError := capierrors.UpdateMachineError
+				am.Status.FailureReason = &updateError
+			},
+			createAzureMachineService: getFakeAzureMachineService,
+		},
+		"should fail if failed to initialize machine cache": {
+			createAzureMachineService: getFakeAzureMachineService,
+			cache:                     nil,
+			expectedErr:               "failed to init machine scope cache",
+		},
+		"should fail if identities are not ready": {
+			azureMachineOptions: func(am *infrav1.AzureMachine) {
+				am.Status.Conditions = clusterv1.Conditions{
+					{
+						Type:   infrav1.VMIdentitiesReadyCondition,
+						Reason: infrav1.UserAssignedIdentityMissingReason,
+						Status: corev1.ConditionFalse,
+					},
+				}
+			},
+			createAzureMachineService: getFakeAzureMachineService,
+			cache:                     &scope.MachineCache{},
+			expectedErr:               "VM identities are not ready",
+		},
+		"should fail if azure machine service creator fails": {
+			createAzureMachineService: func(*scope.MachineScope) (*azureMachineService, error) {
+				return nil, errors.New("failed to create azure machine service")
+			},
+			cache:       &scope.MachineCache{},
+			expectedErr: "failed to create azure machine service",
+		},
+		"should fail if VM is deleted": {
+			createAzureMachineService: getFakeAzureMachineServiceWithVMDeleted,
+			machineScopeFailureReason: capierrors.UpdateMachineError,
+			cache:                     &scope.MachineCache{},
+			expectedErr:               "failed to reconcile AzureMachine",
+		},
+		"should reconcile if terminal error is received": {
+			createAzureMachineService: getFakeAzureMachineServiceWithTerminalError,
+			machineScopeFailureReason: capierrors.CreateMachineError,
+			cache:                     &scope.MachineCache{},
+		},
+		"should requeue if transient error is received": {
+			createAzureMachineService: getFakeAzureMachineServiceWithTransientError,
+			cache:                     &scope.MachineCache{},
+			expectedResult:            reconcile.Result{RequeueAfter: 10 * time.Second},
+		},
+		"should return error for general failures": {
+			createAzureMachineService: getFakeAzureMachineServiceWithGeneralError,
+			cache:                     &scope.MachineCache{},
+			expectedErr:               "failed to reconcile AzureMachine",
+		},
+	}
+
+	for name, c := range cases {
+		tc := c
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			reconciler, machineScope, clusterScope, err := getReconcileInputs(tc)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			result, err := reconciler.reconcileNormal(context.Background(), machineScope, clusterScope)
+			g.Expect(result).To(Equal(tc.expectedResult))
+
+			if tc.ready {
+				g.Expect(machineScope.AzureMachine.Status.Ready).To(BeTrue())
+			}
+			if tc.machineScopeFailureReason != "" {
+				g.Expect(machineScope.AzureMachine.Status.FailureReason).ToNot(BeNil())
+				g.Expect(*machineScope.AzureMachine.Status.FailureReason).To(Equal(tc.machineScopeFailureReason))
+			}
+			if tc.expectedErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tc.expectedErr))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestAzureMachineReconcileDelete(t *testing.T) {
+	cases := map[string]TestReconcileInput{
+		"should delete successfully": {
+			createAzureMachineService: getFakeAzureMachineService,
+			cache:                     &scope.MachineCache{},
+		},
+		"should fail if failed to create azure machine service": {
+			createAzureMachineService: getFakeAzureMachineServiceWithFailure,
+			cache:                     &scope.MachineCache{},
+			expectedErr:               "failed to create AzureMachineService",
+		},
+		"should requeue if transient error is received": {
+			createAzureMachineService: getFakeAzureMachineServiceWithTransientError,
+			cache:                     &scope.MachineCache{},
+			expectedResult:            reconcile.Result{RequeueAfter: 10 * time.Second},
+		},
+		"should fail to delete for non-transient errors": {
+			createAzureMachineService: getFakeAzureMachineServiceWithGeneralError,
+			cache:                     &scope.MachineCache{},
+			expectedErr:               "error deleting AzureMachine",
+		},
+	}
+
+	for name, c := range cases {
+		tc := c
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			reconciler, machineScope, clusterScope, err := getReconcileInputs(tc)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			result, err := reconciler.reconcileDelete(context.Background(), machineScope, clusterScope)
+			g.Expect(result).To(Equal(tc.expectedResult))
+
+			if tc.expectedErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tc.expectedErr))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func getReconcileInputs(tc TestReconcileInput) (*AzureMachineReconciler, *scope.MachineScope, *scope.ClusterScope, error) {
+	scheme, err := newScheme()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var azureMachine *infrav1.AzureMachine
+	if tc.azureMachineOptions != nil {
+		azureMachine = getFakeAzureMachine(tc.azureMachineOptions)
+	} else {
+		azureMachine = getFakeAzureMachine()
+	}
+
+	cluster := getFakeCluster()
+	azureCluster := getFakeAzureCluster(func(ac *infrav1.AzureCluster) {
+		ac.Spec.Location = "westus2"
 	})
-})
+	machine := getFakeMachine(azureMachine, func(m *clusterv1.Machine) {
+		m.Spec.Bootstrap = clusterv1.Bootstrap{
+			DataSecretName: pointer.String("fooSecret"),
+		}
+	})
+
+	objects := []runtime.Object{
+		cluster,
+		azureCluster,
+		machine,
+		azureMachine,
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fooSecret",
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				"value": []byte("foo"),
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+
+	reconciler := &AzureMachineReconciler{
+		Client:                    client,
+		Recorder:                  record.NewFakeRecorder(128),
+		createAzureMachineService: tc.createAzureMachineService,
+	}
+
+	clusterScope, err := scope.NewClusterScope(context.Background(), scope.ClusterScopeParams{
+		Client:       client,
+		Cluster:      cluster,
+		AzureCluster: azureCluster,
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	machineScope, err := scope.NewMachineScope(scope.MachineScopeParams{
+		Client:       client,
+		Machine:      machine,
+		AzureMachine: azureMachine,
+		ClusterScope: clusterScope,
+		Cache:        tc.cache,
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return reconciler, machineScope, clusterScope, nil
+}
+
+func getFakeAzureMachineService(machineScope *scope.MachineScope) (*azureMachineService, error) {
+	cache, err := resourceskus.GetCache(machineScope, machineScope.Location())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating a NewCache")
+	}
+
+	return getDefaultAzureMachineService(machineScope, cache), nil
+}
+
+func getFakeAzureMachineServiceWithFailure(_ *scope.MachineScope) (*azureMachineService, error) {
+	return nil, errors.New("failed to create AzureMachineService")
+}
+
+func getFakeAzureMachineServiceWithVMDeleted(machineScope *scope.MachineScope) (*azureMachineService, error) {
+	cache, err := resourceskus.GetCache(machineScope, machineScope.Location())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating a NewCache")
+	}
+
+	ams := getDefaultAzureMachineService(machineScope, cache)
+	ams.Reconcile = func(context.Context) error {
+		return azure.VMDeletedError{}
+	}
+
+	return ams, nil
+}
+
+func getFakeAzureMachineServiceWithTerminalError(machineScope *scope.MachineScope) (*azureMachineService, error) {
+	cache, err := resourceskus.GetCache(machineScope, machineScope.Location())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating a NewCache")
+	}
+
+	ams := getDefaultAzureMachineService(machineScope, cache)
+	ams.Reconcile = func(context.Context) error {
+		return azure.WithTerminalError(errors.New("failed to reconcile AzureMachine"))
+	}
+
+	return ams, nil
+}
+
+func getFakeAzureMachineServiceWithTransientError(machineScope *scope.MachineScope) (*azureMachineService, error) {
+	cache, err := resourceskus.GetCache(machineScope, machineScope.Location())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating a NewCache")
+	}
+
+	ams := getDefaultAzureMachineService(machineScope, cache)
+	ams.Reconcile = func(context.Context) error {
+		return azure.WithTransientError(errors.New("failed to reconcile AzureMachine"), 10*time.Second)
+	}
+	ams.Delete = func(context.Context) error {
+		return azure.WithTransientError(errors.New("failed to reconcile AzureMachine"), 10*time.Second)
+	}
+
+	return ams, nil
+}
+
+func getFakeAzureMachineServiceWithGeneralError(machineScope *scope.MachineScope) (*azureMachineService, error) {
+	cache, err := resourceskus.GetCache(machineScope, machineScope.Location())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating a NewCache")
+	}
+
+	ams := getDefaultAzureMachineService(machineScope, cache)
+	ams.Reconcile = func(context.Context) error {
+		return errors.New("foo error")
+	}
+	ams.Delete = func(context.Context) error {
+		return errors.New("foo error")
+	}
+
+	return ams, nil
+}
+
+func getDefaultAzureMachineService(machineScope *scope.MachineScope, cache *resourceskus.Cache) *azureMachineService {
+	return &azureMachineService{
+		scope:    machineScope,
+		services: []azure.ServiceReconciler{},
+		skuCache: cache,
+		Reconcile: func(context.Context) error {
+			return nil
+		},
+		Delete: func(context.Context) error {
+			return nil
+		},
+	}
+}
+
+func getFakeCluster(changes ...func(*clusterv1.Cluster)) *clusterv1.Cluster {
+	input := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: "default",
+		},
+		Spec: clusterv1.ClusterSpec{
+			InfrastructureRef: &corev1.ObjectReference{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "AzureCluster",
+				Name:       "my-azure-cluster",
+			},
+		},
+		Status: clusterv1.ClusterStatus{
+			InfrastructureReady: true,
+		},
+	}
+
+	for _, change := range changes {
+		change(input)
+	}
+
+	return input
+}
+
+func getFakeAzureCluster(changes ...func(*infrav1.AzureCluster)) *infrav1.AzureCluster {
+	input := &infrav1.AzureCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-azure-cluster",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "cluster.x-k8s.io/v1beta1",
+					Kind:       "Cluster",
+					Name:       "my-cluster",
+				},
+			},
+		},
+		Spec: infrav1.AzureClusterSpec{
+			AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+				SubscriptionID: "123",
+			},
+			NetworkSpec: infrav1.NetworkSpec{
+				Subnets: infrav1.Subnets{
+					{
+						SubnetClassSpec: infrav1.SubnetClassSpec{
+							Name: "node",
+							Role: infrav1.SubnetNode,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, change := range changes {
+		change(input)
+	}
+
+	return input
+}
+
+func getFakeAzureMachine(changes ...func(*infrav1.AzureMachine)) *infrav1.AzureMachine {
+	input := &infrav1.AzureMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-machine",
+			Namespace: "default",
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel: "my-cluster",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "cluster.x-k8s.io/v1beta1",
+					Kind:       "Machine",
+					Name:       "my-machine",
+				},
+			},
+		},
+		Spec: infrav1.AzureMachineSpec{
+			VMSize: "Standard_D2s_v3",
+		},
+	}
+	for _, change := range changes {
+		change(input)
+	}
+
+	return input
+}
+
+func getFakeMachine(azureMachine *infrav1.AzureMachine, changes ...func(*clusterv1.Machine)) *clusterv1.Machine {
+	input := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-machine",
+			Namespace: "default",
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel: "my-cluster",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "cluster.x-k8s.io/v1beta1",
+			Kind:       "Machine",
+		},
+		Spec: clusterv1.MachineSpec{
+			InfrastructureRef: corev1.ObjectReference{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "AzureMachine",
+				Name:       azureMachine.Name,
+				Namespace:  azureMachine.Namespace,
+			},
+			Version: pointer.String("v1.22.0"),
+		},
+	}
+	for _, change := range changes {
+		change(input)
+	}
+
+	return input
+}
 
 func TestConditions(t *testing.T) {
 	g := NewWithT(t)

--- a/controllers/azuremachine_reconciler_test.go
+++ b/controllers/azuremachine_reconciler_test.go
@@ -93,7 +93,7 @@ func TestAzureMachineServiceReconcile(t *testing.T) {
 				skuCache: resourceskus.NewStaticCache([]compute.ResourceSku{}, ""),
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.reconcile(context.TODO())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))
@@ -160,7 +160,7 @@ func TestAzureMachineServiceDelete(t *testing.T) {
 				skuCache: resourceskus.NewStaticCache([]compute.ResourceSku{}, ""),
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.delete(context.TODO())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR adds tests for the AzureMachine controller. The added tests explicitly test `Reconcile`, `reconcileNormal`, and `reconcileDelete`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3360 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
