### PR TITLE
Decouple the LB front port with backend port

### DIFF
--- a/azure/services/loadbalancers/loadbalancers.go
+++ b/azure/services/loadbalancers/loadbalancers.go
@@ -37,7 +37,7 @@ const (
 type LBScope interface {
 	azure.ClusterScoper
 	azure.AsyncStatusUpdater
-	LBSpecs() []azure.ResourceSpecGetter
+	LBSpecs() ([]azure.ResourceSpecGetter, error)
 }
 
 // Service provides operations on Azure resources.
@@ -68,7 +68,10 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
 	defer cancel()
 
-	specs := s.Scope.LBSpecs()
+	specs, err := s.Scope.LBSpecs()
+	if err != nil {
+		return err
+	}
 	if len(specs) == 0 {
 		return nil
 	}
@@ -97,7 +100,10 @@ func (s *Service) Delete(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
 	defer cancel()
 
-	specs := s.Scope.LBSpecs()
+	specs, err := s.Scope.LBSpecs()
+	if err != nil {
+		return err
+	}
 	if len(specs) == 0 {
 		return nil
 	}

--- a/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
+++ b/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
@@ -402,11 +402,12 @@ func (mr *MockLBScopeMockRecorder) IsVnetManaged() *gomock.Call {
 }
 
 // LBSpecs mocks base method.
-func (m *MockLBScope) LBSpecs() []azure.ResourceSpecGetter {
+func (m *MockLBScope) LBSpecs() ([]azure.ResourceSpecGetter, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LBSpecs")
 	ret0, _ := ret[0].([]azure.ResourceSpecGetter)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // LBSpecs indicates an expected call of LBSpecs.

--- a/azure/services/loadbalancers/spec.go
+++ b/azure/services/loadbalancers/spec.go
@@ -29,23 +29,24 @@ import (
 
 // LBSpec defines the specification for a Load Balancer.
 type LBSpec struct {
-	Name                 string
-	ResourceGroup        string
-	SubscriptionID       string
-	ClusterName          string
-	Location             string
-	ExtendedLocation     *infrav1.ExtendedLocationSpec
-	Role                 string
-	Type                 infrav1.LBType
-	SKU                  infrav1.SKU
-	VNetName             string
-	VNetResourceGroup    string
-	SubnetName           string
-	BackendPoolName      string
-	FrontendIPConfigs    []infrav1.FrontendIP
-	APIServerPort        int32
-	IdleTimeoutInMinutes *int32
-	AdditionalTags       map[string]string
+	Name                  string
+	ResourceGroup         string
+	SubscriptionID        string
+	ClusterName           string
+	Location              string
+	ExtendedLocation      *infrav1.ExtendedLocationSpec
+	Role                  string
+	Type                  infrav1.LBType
+	SKU                   infrav1.SKU
+	VNetName              string
+	VNetResourceGroup     string
+	SubnetName            string
+	BackendPoolName       string
+	FrontendIPConfigs     []infrav1.FrontendIP
+	APIServerFrontendPort int32
+	APIServerBackendPort  int32
+	IdleTimeoutInMinutes  *int32
+	AdditionalTags        map[string]string
 }
 
 // ResourceName returns the name of the load balancer.
@@ -226,8 +227,8 @@ func getLoadBalancingRules(lbSpec LBSpec, frontendIDs []network.SubResource) []n
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 					DisableOutboundSnat:     pointer.Bool(true),
 					Protocol:                network.TransportProtocolTCP,
-					FrontendPort:            pointer.Int32(lbSpec.APIServerPort),
-					BackendPort:             pointer.Int32(lbSpec.APIServerPort),
+					FrontendPort:            pointer.Int32(lbSpec.APIServerFrontendPort),
+					BackendPort:             pointer.Int32(lbSpec.APIServerBackendPort),
 					IdleTimeoutInMinutes:    lbSpec.IdleTimeoutInMinutes,
 					EnableFloatingIP:        pointer.Bool(false),
 					LoadDistribution:        network.LoadDistributionDefault,
@@ -260,7 +261,7 @@ func getProbes(lbSpec LBSpec) []network.Probe {
 				Name: pointer.String(tcpProbe),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
 					Protocol:          network.ProbeProtocolTCP,
-					Port:              pointer.Int32(lbSpec.APIServerPort),
+					Port:              pointer.Int32(lbSpec.APIServerFrontendPort),
 					IntervalInSeconds: pointer.Int32(15),
 					NumberOfProbes:    pointer.Int32(4),
 				},

--- a/azure/services/loadbalancers/spec_test.go
+++ b/azure/services/loadbalancers/spec_test.go
@@ -264,7 +264,7 @@ func newSamplePublicAPIServerLB(verifyFrontendIP bool, verifyBackendAddressPools
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 						DisableOutboundSnat:  pointer.Bool(true),
 						Protocol:             network.TransportProtocolTCP,
-						FrontendPort:         pointer.Int32(6443),
+						FrontendPort:         pointer.Int32(443),
 						BackendPort:          pointer.Int32(6443),
 						IdleTimeoutInMinutes: pointer.Int32(4),
 						EnableFloatingIP:     enableFloatingIP, // Add to verify that LoadBalancingRules aren't overwritten on update
@@ -286,7 +286,7 @@ func newSamplePublicAPIServerLB(verifyFrontendIP bool, verifyBackendAddressPools
 					Name: pointer.String(tcpProbe),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
 						Protocol:          network.ProbeProtocolTCP,
-						Port:              pointer.Int32(6443),
+						Port:              pointer.Int32(443),
 						IntervalInSeconds: pointer.Int32(15),
 						NumberOfProbes:    numProbes, // Add to verify that Probes aren't overwritten on update
 					},
@@ -343,7 +343,7 @@ func newDefaultInternalAPIServerLB() network.LoadBalancer {
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 						DisableOutboundSnat:  pointer.Bool(true),
 						Protocol:             network.TransportProtocolTCP,
-						FrontendPort:         pointer.Int32(6443),
+						FrontendPort:         pointer.Int32(443),
 						BackendPort:          pointer.Int32(6443),
 						IdleTimeoutInMinutes: pointer.Int32(4),
 						EnableFloatingIP:     pointer.Bool(false),
@@ -366,7 +366,7 @@ func newDefaultInternalAPIServerLB() network.LoadBalancer {
 					Name: pointer.String(tcpProbe),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
 						Protocol:          network.ProbeProtocolTCP,
-						Port:              pointer.Int32(6443),
+						Port:              pointer.Int32(443),
 						IntervalInSeconds: pointer.Int32(15),
 						NumberOfProbes:    pointer.Int32(4),
 					},

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -92,6 +92,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - kubeadmcontrolplanes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - nodes

--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -111,6 +111,7 @@ func (acr *AzureClusterReconciler) SetupWithManager(ctx context.Context, mgr ctr
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=azuremachinetemplates;azuremachinetemplates/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=azureclusteridentities;azureclusteridentities/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;
+// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=kubeadmcontrolplanes,verbs=get;list;watch;
 
 // Reconcile idempotently gets, creates, and updates a cluster.
 func (acr *AzureClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
@@ -246,7 +247,7 @@ func (acr *AzureClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 		azureCluster.Spec.ControlPlaneEndpoint.Host = clusterScope.APIServerHost()
 	}
 	if azureCluster.Spec.ControlPlaneEndpoint.Port == 0 {
-		azureCluster.Spec.ControlPlaneEndpoint.Port = clusterScope.APIServerPort()
+		azureCluster.Spec.ControlPlaneEndpoint.Port = clusterScope.APIServerFrontendPort()
 	}
 
 	// No errors, so mark us ready so the Cluster API Cluster Controller can pull it

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ import (
 	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	kubeadmcontrolplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	expv1alpha4 "sigs.k8s.io/cluster-api/exp/api/v1alpha4"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	capifeature "sigs.k8s.io/cluster-api/feature"
@@ -82,6 +83,7 @@ func init() {
 	_ = clusterv1.AddToScheme(scheme)
 	_ = expv1.AddToScheme(scheme)
 	_ = kubeadmv1.AddToScheme(scheme)
+	_ = kubeadmcontrolplanev1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 
 	// Add aadpodidentity v1 to the scheme.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1808 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kube-apiserver port can be configured via KubeadmControlPlane's LocalAPIEndpoint
```
