### PR TITLE
Change default nat gateway IP name

### DIFF
--- a/api/v1beta1/azurecluster_default.go
+++ b/api/v1beta1/azurecluster_default.go
@@ -132,7 +132,7 @@ func (c *AzureCluster) setSubnetDefaults() {
 				subnet.NatGateway.Name = withIndex(generateNatGatewayName(c.ObjectMeta.Name), nodeSubnetCounter)
 			}
 			if subnet.NatGateway.NatGatewayIP.Name == "" {
-				subnet.NatGateway.NatGatewayIP.Name = generateNatGatewayIPName(c.ObjectMeta.Name, subnet.Name)
+				subnet.NatGateway.NatGatewayIP.Name = generateNatGatewayIPName(subnet.NatGateway.Name)
 			}
 		}
 
@@ -453,8 +453,8 @@ func generateNatGatewayName(clusterName string) string {
 }
 
 // generateNatGatewayIPName generates a NAT gateway IP name.
-func generateNatGatewayIPName(clusterName, subnetName string) string {
-	return fmt.Sprintf("pip-%s-%s-natgw", clusterName, subnetName)
+func generateNatGatewayIPName(natGatewayName string) string {
+	return fmt.Sprintf("pip-%s", natGatewayName)
 }
 
 // withIndex appends the index as suffix to a generated name.

--- a/api/v1beta1/azurecluster_default_test.go
+++ b/api/v1beta1/azurecluster_default_test.go
@@ -370,7 +370,7 @@ func TestSubnetDefaults(t *testing.T) {
 										Name: "foo-natgw",
 									},
 									NatGatewayIP: PublicIPSpec{
-										Name: "pip-cluster-test-my-node-subnet-natgw",
+										Name: "pip-foo-natgw",
 									},
 								},
 							},
@@ -434,7 +434,7 @@ func TestSubnetDefaults(t *testing.T) {
 										Name: "cluster-test-node-natgw-1",
 									},
 									NatGatewayIP: PublicIPSpec{
-										Name: "pip-cluster-test-cluster-test-node-subnet-natgw",
+										Name: "pip-cluster-test-node-natgw-1",
 									},
 								},
 							},
@@ -500,7 +500,7 @@ func TestSubnetDefaults(t *testing.T) {
 										Name: "cluster-test-node-natgw-1",
 									},
 									NatGatewayIP: PublicIPSpec{
-										Name: "pip-cluster-test-cluster-test-node-subnet-natgw",
+										Name: "pip-cluster-test-node-natgw-1",
 									},
 								},
 							},
@@ -549,7 +549,7 @@ func TestSubnetDefaults(t *testing.T) {
 										Name: "cluster-test-node-natgw-1",
 									},
 									NatGatewayIP: PublicIPSpec{
-										Name: "pip-cluster-test-my-node-subnet-natgw",
+										Name: "pip-cluster-test-node-natgw-1",
 									},
 								},
 							},

--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -128,11 +128,6 @@ func GenerateFrontendIPConfigName(lbName string) string {
 	return fmt.Sprintf("%s-%s", lbName, "frontEnd")
 }
 
-// GenerateNatGatewayIPName generates a NAT gateway IP name.
-func GenerateNatGatewayIPName(clusterName, subnetName string) string {
-	return fmt.Sprintf("pip-%s-%s-natgw", clusterName, subnetName)
-}
-
 // GenerateNodeOutboundIPName generates a public IP name, based on the cluster name.
 func GenerateNodeOutboundIPName(clusterName string) string {
 	return fmt.Sprintf("pip-%s-node-outbound", clusterName)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: The default name for nat gateway IP is currently "pip-" + cluster name + subnet name. Since the default subnet name already contains cluster name, this can lead to very long and repetitive IP names, such as this one observed in tests:

```
 Resource name pip-k8s-upgrade-and-conformance-ol1nwl-k8s-upgrade-and-conformance-ol1nwl-node-subnet-natgw is invalid. The name can be up to 80 characters long
 ```

This PR changes the default name to reuse the natgw name instead so the public IP name is consistent with the nat gateway it belongs too, and isn't so repetitive and long when cluster name is on the longer side.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3421 

**Special notes for your reviewer**:

This should be backwards compatible since it's changing the default value but not touching existing clusters.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change default nat gateway IP name to generate shorter names
```
