### PR TITLE
[WIP] E2E: enforce timeout when creating SSH client connection

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -482,10 +482,22 @@ func getProxiedSSHClient(controlPlaneEndpoint, hostname, port string) (*ssh.Clie
 		return nil, errors.Wrapf(err, "dialing from control plane to target node at %s", hostname)
 	}
 
-	// Establish an authenticated SSH conn over the client -> control plane -> target transport
-	conn, chans, reqs, err := ssh.NewClientConn(c, hostname, config)
-	if err != nil {
-		return nil, errors.Wrap(err, "getting a new SSH client connection")
+	var conn ssh.Conn
+	var chans <-chan ssh.NewChannel
+	var reqs <-chan *ssh.Request
+	var newClientConnErr error
+	Eventually(func(g Gomega) error {
+		for {
+			time.Sleep(1 * time.Hour)
+		}
+		/*// Establish an authenticated SSH conn over the client -> control plane -> target transport
+		conn, chans, reqs, newClientConnErr = ssh.NewClientConn(c, hostname, config)
+		g.Expect(newClientConnErr).To(BeNil())*/
+
+	}, 1*time.Minute, 3*time.Second).Should(Succeed())
+	if newClientConnErr != nil {
+		c.Close()
+		return nil, newClientConnErr
 	}
 	client := ssh.NewClient(conn, chans, reqs)
 	return client, nil


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

Let's see what happens when we short-circuit during log collection ssh client connection foo...

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
