### PR TITLE
Don't reuse IMAGE_TAG var in multiple test scripts

### DIFF
--- a/scripts/ci-build-azure-ccm.sh
+++ b/scripts/ci-build-azure-ccm.sh
@@ -66,7 +66,7 @@ setup() {
 
 main() {
     if [[ "$(can_reuse_artifacts)" =~ "false" ]]; then
-        echo "Build Linux Azure amd64 cloud controller manager"
+        echo "Building Linux Azure amd64 cloud controller manager"
         make -C "${AZURE_CLOUD_PROVIDER_ROOT}" build-ccm-image-amd64 push-ccm-image-amd64
         echo "Building Linux amd64 and Windows ${WINDOWS_IMAGE_VERSION} amd64 cloud node managers"
         make -C "${AZURE_CLOUD_PROVIDER_ROOT}" build-node-image-linux-amd64 push-node-image-linux-amd64 push-node-image-windows-"${WINDOWS_IMAGE_VERSION}"-amd64 manifest-node-manager-image-windows-"${WINDOWS_IMAGE_VERSION}"-amd64
@@ -82,8 +82,7 @@ can_reuse_artifacts() {
         fi
     done
 
-    FULL_VERSION=$(docker manifest inspect mcr.microsoft.com/windows/nanoserver:${WINDOWS_IMAGE_VERSION} | jq -r '.manifests[0].platform["os.version"]')
-    if ! docker manifest inspect "${REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG_CNM}" | grep -q "\"os.version\": \"${FULL_VERSION}\""; then
+    if ! docker manifest inspect "${REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG_CNM}" | grep -q "\"os.version\": \"${WINDOWS_IMAGE_VERSION}\""; then
         echo "false" && return
     fi
 

--- a/scripts/ci-build-azure-ccm.sh
+++ b/scripts/ci-build-azure-ccm.sh
@@ -36,8 +36,6 @@ export CCM_IMAGE_NAME=azure-cloud-controller-manager
 export CNM_IMAGE_NAME=azure-cloud-node-manager
 # cloud node manager windows image version
 export WINDOWS_IMAGE_VERSION=1809
-declare -a IMAGES=("${CCM_IMAGE_NAME}" "${CNM_IMAGE_NAME}")
-
 
 setup() {
     AZURE_CLOUD_PROVIDER_ROOT="${AZURE_CLOUD_PROVIDER_ROOT:-""}"
@@ -48,11 +46,12 @@ setup() {
 
     # the azure-cloud-provider repo expects IMAGE_REGISTRY.
     export IMAGE_REGISTRY=${REGISTRY}
-    pushd "${AZURE_CLOUD_PROVIDER_ROOT}" && IMAGE_TAG=$(git rev-parse --short=7 HEAD) &&
-      IMAGE_TAG_CCM="${IMAGE_TAG_CCM:-${IMAGE_TAG}}" && IMAGE_TAG_CNM="${IMAGE_TAG_CNM:-${IMAGE_TAG}}" &&
-      export IMAGE_TAG && export IMAGE_TAG_CCM && export IMAGE_TAG_CNM && popd
+    pushd "${AZURE_CLOUD_PROVIDER_ROOT}" && TAG=$(git rev-parse --short=7 HEAD) &&
+      IMAGE_TAG_CCM="${IMAGE_TAG_CCM:-${TAG}}" && IMAGE_TAG_CNM="${IMAGE_TAG_CNM:-${TAG}}" &&
+      export IMAGE_TAG_CCM && export IMAGE_TAG_CNM && popd
     echo "Image registry is ${REGISTRY}"
-    echo "Image Tag is ${IMAGE_TAG}"
+    echo "Image Tag CCM is ${IMAGE_TAG_CCM}"
+    echo "Image Tag CNM is ${IMAGE_TAG_CNM}"
 
     if [[ -n "${WINDOWS_SERVER_VERSION:-}" ]]; then
         if [[ "${WINDOWS_SERVER_VERSION}" == "windows-2019" ]]; then
@@ -70,20 +69,21 @@ main() {
         echo "Build Linux Azure amd64 cloud controller manager"
         make -C "${AZURE_CLOUD_PROVIDER_ROOT}" build-ccm-image-amd64 push-ccm-image-amd64
         echo "Building Linux amd64 and Windows ${WINDOWS_IMAGE_VERSION} amd64 cloud node managers"
-            make -C "${AZURE_CLOUD_PROVIDER_ROOT}" build-node-image-linux-amd64 push-node-image-linux-amd64 push-node-image-windows-"${WINDOWS_IMAGE_VERSION}"-amd64 manifest-node-manager-image-windows-"${WINDOWS_IMAGE_VERSION}"-amd64
+        make -C "${AZURE_CLOUD_PROVIDER_ROOT}" build-node-image-linux-amd64 push-node-image-linux-amd64 push-node-image-windows-"${WINDOWS_IMAGE_VERSION}"-amd64 manifest-node-manager-image-windows-"${WINDOWS_IMAGE_VERSION}"-amd64
     fi
 }
 
 # can_reuse_artifacts returns true if there exists CCM artifacts built from a PR that we can reuse
 can_reuse_artifacts() {
-    for IMAGE_NAME in "${IMAGES[@]}"; do
-        if ! docker pull "${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"; then
+    declare -a IMAGES=("${CCM_IMAGE_NAME}:${IMAGE_TAG_CCM}" "${CNM_IMAGE_NAME}:${IMAGE_TAG_CNM}")
+    for IMAGE in "${IMAGES[@]}"; do
+        if ! docker pull "${REGISTRY}/${IMAGE}"; then
             echo "false" && return
         fi
     done
 
     FULL_VERSION=$(docker manifest inspect mcr.microsoft.com/windows/nanoserver:${WINDOWS_IMAGE_VERSION} | jq -r '.manifests[0].platform["os.version"]')
-    if ! docker manifest inspect "${REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG}" | grep -q "\"os.version\": \"${FULL_VERSION}\""; then
+    if ! docker manifest inspect "${REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG_CNM}" | grep -q "\"os.version\": \"${FULL_VERSION}\""; then
         echo "false" && return
     fi
 

--- a/scripts/ci-build-kubernetes.sh
+++ b/scripts/ci-build-kubernetes.sh
@@ -74,7 +74,7 @@ setup() {
     # Docker tags cannot contain '+'
     # ref: https://github.com/kubernetes/kubernetes/blob/5491484aa91fd09a01a68042e7674bc24d42687a/build/lib/release.sh#L345-L346
     export IMAGE_TAG="${KUBE_GIT_VERSION/+/_}"
-    echo "using IMAGE_TAG=${IMAGE_TAG}"
+    echo "using K8s IMAGE_TAG=${IMAGE_TAG}"
 }
 
 main() {

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -59,8 +59,8 @@ else
   if [[ "$(capz::util::should_build_ccm)" == "true" ]]; then
     # shellcheck source=scripts/ci-build-azure-ccm.sh
     source "${REPO_ROOT}/scripts/ci-build-azure-ccm.sh"
-    echo "Will use the ${IMAGE_REGISTRY}/${CCM_IMAGE_NAME}:${IMAGE_TAG} cloud-controller-manager image for external cloud-provider-cluster"
-    echo "Will use the ${IMAGE_REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG} cloud-node-manager image for external cloud-provider-azure cluster"
+    echo "Will use the ${IMAGE_REGISTRY}/${CCM_IMAGE_NAME}:${IMAGE_TAG_CCM} cloud-controller-manager image for external cloud-provider-cluster"
+    echo "Will use the ${IMAGE_REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG_CNM} cloud-node-manager image for external cloud-provider-azure cluster"
   fi
 fi
 

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -60,8 +60,8 @@ fi
 if [[ "$(capz::util::should_build_ccm)" == "true" ]]; then
   # shellcheck source=scripts/ci-build-azure-ccm.sh
   source "${REPO_ROOT}/scripts/ci-build-azure-ccm.sh"
-  echo "Will use the ${IMAGE_REGISTRY}/${CCM_IMAGE_NAME}:${IMAGE_TAG} cloud-controller-manager image for external cloud-provider-cluster"
-  echo "Will use the ${IMAGE_REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG} cloud-node-manager image for external cloud-provider-azure cluster"
+  echo "Will use the ${IMAGE_REGISTRY}/${CCM_IMAGE_NAME}:${IMAGE_TAG_CCM} cloud-controller-manager image for external cloud-provider-cluster"
+  echo "Will use the ${IMAGE_REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG_CNM} cloud-node-manager image for external cloud-provider-azure cluster"
 fi
 
 export GINKGO_NODES=10

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -55,15 +55,15 @@ setup() {
     if [[ "$(capz::util::should_build_ccm)" == "true" ]]; then
         # shellcheck source=scripts/ci-build-azure-ccm.sh
         source "${REPO_ROOT}/scripts/ci-build-azure-ccm.sh"
-        echo "Will use the ${IMAGE_REGISTRY}/${CCM_IMAGE_NAME}:${IMAGE_TAG} cloud-controller-manager image for external cloud-provider-cluster"
-        echo "Will use the ${IMAGE_REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG} cloud-node-manager image for external cloud-provider-azure cluster"
+        echo "Will use the ${IMAGE_REGISTRY}/${CCM_IMAGE_NAME}:${IMAGE_TAG_CCM} cloud-controller-manager image for external cloud-provider-cluster"
+        echo "Will use the ${IMAGE_REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG_CNM} cloud-node-manager image for external cloud-provider-azure cluster"
 
         export CCM_IMG_ARGS=(--set cloudControllerManager.imageRepository="${IMAGE_REGISTRY}"
         --set cloudNodeManager.imageRepository="${IMAGE_REGISTRY}"
         --set cloudControllerManager.imageName="${CCM_IMAGE_NAME}"
         --set cloudNodeManager.imageName="${CNM_IMAGE_NAME}"
-        --set-string cloudControllerManager.imageTag="${IMAGE_TAG}"
-        --set-string cloudNodeManager.imageTag="${IMAGE_TAG}")
+        --set-string cloudControllerManager.imageTag="${IMAGE_TAG_CCM}"
+        --set-string cloudNodeManager.imageTag="${IMAGE_TAG_CNM}")
     fi
 
     if [[ "$(capz::util::should_build_kubernetes)" == "true" ]]; then


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Fix an issue where the ci-build-azure-ccm.sh CI script overwrites the `IMAGE_TAG` variable set by the ci-build-kubernetes.sh CI script. This causes issues when using out of tree cloud-provider with custom k8s. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
