### PR TITLE
Revert "E2E: don’t stop/start kubelet before kubeadm runs"

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -152,6 +152,7 @@ spec:
               $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
             done
           fi
+          systemctl restart kubelet
         fi
         echo "* checking binary versions"
         echo "ctr version: " $(ctr version)
@@ -337,6 +338,7 @@ spec:
                 $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
               done
             fi
+            systemctl restart kubelet
           fi
           echo "* checking binary versions"
           echo "ctr version: " $(ctr version)

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -150,6 +150,7 @@ spec:
               $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
             done
           fi
+          systemctl restart kubelet
         fi
         echo "* checking binary versions"
         echo "ctr version: " $(ctr version)
@@ -331,6 +332,7 @@ spec:
             $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
           done
         fi
+        systemctl restart kubelet
       fi
       echo "* checking binary versions"
       echo "ctr version: " $(ctr version)

--- a/templates/test/ci/patches/control-plane-kubeadm-boostrap-ci-version.yaml
+++ b/templates/test/ci/patches/control-plane-kubeadm-boostrap-ci-version.yaml
@@ -54,6 +54,7 @@
             $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
           done
         fi
+        systemctl restart kubelet
       fi
       echo "* checking binary versions"
       echo "ctr version: " $(ctr version)

--- a/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap.yaml
+++ b/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap.yaml
@@ -54,6 +54,7 @@
             $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
           done
         fi
+        systemctl restart kubelet
       fi
       echo "* checking binary versions"
       echo "ctr version: " $(ctr version)

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -63,6 +63,7 @@ spec:
               $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
             done
           fi
+          systemctl restart kubelet
         fi
         echo "* checking binary versions"
         echo "ctr version: " $(ctr version)

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -111,11 +111,13 @@ spec:
         set -o pipefail
         set -o errexit
 
+        systemctl stop kubelet
         declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
         for BINARY in "$${BINARIES[@]}"; do
           echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
           curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
         done
+        systemctl restart kubelet
 
         # prepull images from gcr.io/k8s-staging-ci-images and retag it to
         # registry.k8s.io so kubeadm can fetch correct images no matter what
@@ -288,11 +290,13 @@ spec:
       set -o pipefail
       set -o errexit
 
+      systemctl stop kubelet
       declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
       for BINARY in "$${BINARIES[@]}"; do
         echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
         curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
       done
+      systemctl restart kubelet
 
       echo "kubeadm version: $(kubeadm version -o=short)"
       echo "kubectl version: $(kubectl version --client=true --short=true)"

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -120,11 +120,13 @@ spec:
         set -o pipefail
         set -o errexit
 
+        systemctl stop kubelet
         declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
         for BINARY in "$${BINARIES[@]}"; do
           echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
           curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
         done
+        systemctl restart kubelet
 
         # prepull images from gcr.io/k8s-staging-ci-images and retag it to
         # registry.k8s.io so kubeadm can fetch correct images no matter what
@@ -295,11 +297,13 @@ spec:
           set -o pipefail
           set -o errexit
 
+          systemctl stop kubelet
           declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
           for BINARY in "$${BINARIES[@]}"; do
             echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
             curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
           done
+          systemctl restart kubelet
 
           echo "kubeadm version: $(kubeadm version -o=short)"
           echo "kubectl version: $(kubectl version --client=true --short=true)"

--- a/templates/test/dev/custom-builds-machine-pool/patches/custom-builds.yaml
+++ b/templates/test/dev/custom-builds-machine-pool/patches/custom-builds.yaml
@@ -16,11 +16,13 @@ spec:
       set -o pipefail
       set -o errexit
 
+      systemctl stop kubelet
       declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
       for BINARY in "$${BINARIES[@]}"; do
         echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
         curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
       done
+      systemctl restart kubelet
 
       echo "kubeadm version: $(kubeadm version -o=short)"
       echo "kubectl version: $(kubectl version --client=true --short=true)"

--- a/templates/test/dev/custom-builds/patches/kubeadm-bootstrap.yaml
+++ b/templates/test/dev/custom-builds/patches/kubeadm-bootstrap.yaml
@@ -8,11 +8,13 @@
       set -o pipefail
       set -o errexit
 
+      systemctl stop kubelet
       declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
       for BINARY in "$${BINARIES[@]}"; do
         echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
         curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
       done
+      systemctl restart kubelet
 
       echo "kubeadm version: $(kubeadm version -o=short)"
       echo "kubectl version: $(kubectl version --client=true --short=true)"

--- a/templates/test/dev/custom-builds/patches/kubeadm-controlplane-bootstrap.yaml
+++ b/templates/test/dev/custom-builds/patches/kubeadm-controlplane-bootstrap.yaml
@@ -8,11 +8,13 @@
         set -o pipefail
         set -o errexit
 
+        systemctl stop kubelet
         declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
         for BINARY in "$${BINARIES[@]}"; do
           echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
           curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
         done
+        systemctl restart kubelet
 
         # prepull images from gcr.io/k8s-staging-ci-images and retag it to
         # registry.k8s.io so kubeadm can fetch correct images no matter what

--- a/templates/test/dev/patches/control-plane-custom-builds.yaml
+++ b/templates/test/dev/patches/control-plane-custom-builds.yaml
@@ -24,11 +24,13 @@ spec:
         set -o pipefail
         set -o errexit
 
+        systemctl stop kubelet
         declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
         for BINARY in "$${BINARIES[@]}"; do
           echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
           curl --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${JOB_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
         done
+        systemctl restart kubelet
 
         # prepull images from gcr.io/k8s-staging-ci-images and retag it to
         # registry.k8s.io so kubeadm can fetch correct images no matter what


### PR DESCRIPTION
This reverts commit e42b27de4d9ba7eba4f47b67886783b86c12b9e6.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: While testing #3456, I ran into the following error multiple times in cloud-init:

```
[  108.621480] cloud-init[2124]: [2023-04-13 16:03:40] * installing package: kubelet v1.27.0
[  108.621997] cloud-init[2124]: [2023-04-13 16:03:40]   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
[  108.622530] cloud-init[2124]: [2023-04-13 16:03:40]                                  Dload  Upload   Total   Spent    Left  Speed
[  108.624458] cloud-init[2124]: [2023-04-13 16:03:40] 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to create the file /usr/bin/kubelet: Text file busy
```

This is on the control-plane node. This caused the control plane node to come up with a different k8s version than the worker nodes (as kubelet didn't get replaced). This PR reverts https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3127 as it was an optimization but is causing undesirable side effects.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
