### PR TITLE
Added test for setDefaultAutoScalerProfile

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_default_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_default_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
 )
 
 func TestAzureManagedControlPlane_SetDefaultSSHPublicKey(t *testing.T) {
@@ -52,4 +53,80 @@ func hardcodedAzureManagedControlPlaneWithSSHKey(sshPublicKey string) *AzureMana
 			SSHPublicKey: sshPublicKey,
 		},
 	}
+}
+
+func TestSetDefaultAutoScalerProfile(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		amcp *AzureManagedControlPlane
+	}
+
+	defaultAMP := &AzureManagedControlPlane{
+		Spec: AzureManagedControlPlaneSpec{
+			AutoScalerProfile: &AutoScalerProfile{
+				BalanceSimilarNodeGroups:      (*BalanceSimilarNodeGroups)(pointer.String(string(BalanceSimilarNodeGroupsFalse))),
+				Expander:                      (*Expander)(pointer.String(string(ExpanderRandom))),
+				MaxEmptyBulkDelete:            pointer.String("10"),
+				MaxGracefulTerminationSec:     pointer.String("600"),
+				MaxNodeProvisionTime:          pointer.String("15m"),
+				MaxTotalUnreadyPercentage:     pointer.String("45"),
+				NewPodScaleUpDelay:            pointer.String("0s"),
+				OkTotalUnreadyCount:           pointer.String("3"),
+				ScanInterval:                  pointer.String("10s"),
+				ScaleDownDelayAfterAdd:        pointer.String("10m"),
+				ScaleDownDelayAfterDelete:     pointer.String("10s"),
+				ScaleDownDelayAfterFailure:    pointer.String("3m"),
+				ScaleDownUnneededTime:         pointer.String("10m"),
+				ScaleDownUnreadyTime:          pointer.String("20m"),
+				ScaleDownUtilizationThreshold: pointer.String("0.5"),
+				SkipNodesWithLocalStorage:     (*SkipNodesWithLocalStorage)(pointer.String(string(SkipNodesWithLocalStorageFalse))),
+				SkipNodesWithSystemPods:       (*SkipNodesWithSystemPods)(pointer.String(string(SkipNodesWithSystemPodsTrue))),
+			},
+		},
+	}
+
+	allFieldsAreNilTest := test{amcp: &AzureManagedControlPlane{
+		Spec: AzureManagedControlPlaneSpec{
+			AutoScalerProfile: &AutoScalerProfile{},
+		},
+	}}
+
+	allFieldsAreNilTest.amcp.setDefaultAutoScalerProfile()
+
+	g.Expect(allFieldsAreNilTest.amcp.Spec.AutoScalerProfile).To(Equal(defaultAMP.Spec.AutoScalerProfile))
+
+	expectedNotNil := &AzureManagedControlPlane{
+		Spec: AzureManagedControlPlaneSpec{
+			AutoScalerProfile: &AutoScalerProfile{
+				BalanceSimilarNodeGroups:      (*BalanceSimilarNodeGroups)(pointer.String(string(BalanceSimilarNodeGroupsTrue))),
+				Expander:                      (*Expander)(pointer.String(string(ExpanderLeastWaste))),
+				MaxEmptyBulkDelete:            pointer.String("5"),
+				MaxGracefulTerminationSec:     pointer.String("300"),
+				MaxNodeProvisionTime:          pointer.String("10m"),
+				MaxTotalUnreadyPercentage:     pointer.String("30"),
+				NewPodScaleUpDelay:            pointer.String("30s"),
+				OkTotalUnreadyCount:           pointer.String("5"),
+				ScanInterval:                  pointer.String("20s"),
+				ScaleDownDelayAfterAdd:        pointer.String("5m"),
+				ScaleDownDelayAfterDelete:     pointer.String("1m"),
+				ScaleDownDelayAfterFailure:    pointer.String("2m"),
+				ScaleDownUnneededTime:         pointer.String("5m"),
+				ScaleDownUnreadyTime:          pointer.String("10m"),
+				ScaleDownUtilizationThreshold: pointer.String("0.4"),
+				SkipNodesWithLocalStorage:     (*SkipNodesWithLocalStorage)(pointer.String(string(SkipNodesWithLocalStorageTrue))),
+				SkipNodesWithSystemPods:       (*SkipNodesWithSystemPods)(pointer.String(string(SkipNodesWithSystemPodsFalse))),
+			},
+		},
+	}
+
+	allFieldsAreNotNilTest := test{amcp: &AzureManagedControlPlane{
+		Spec: AzureManagedControlPlaneSpec{
+			AutoScalerProfile: expectedNotNil.Spec.AutoScalerProfile,
+		},
+	}}
+
+	allFieldsAreNotNilTest.amcp.setDefaultAutoScalerProfile()
+
+	g.Expect(allFieldsAreNotNilTest.amcp.Spec.AutoScalerProfile).To(Equal(expectedNotNil.Spec.AutoScalerProfile))
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?** Added missing code coverage

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR impoves code coverage

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3431 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
