### PR TITLE
Add missing variable export to AKS docs

### DIFF
--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -50,6 +50,7 @@ export the following variables in your current shell.
 export AZURE_SUBSCRIPTION_ID="$(cat sp.json | jq -r .subscriptionId | tr -d '\n')"
 export AZURE_CLIENT_SECRET="$(cat sp.json | jq -r .clientSecret | tr -d '\n')"
 export AZURE_CLIENT_ID="$(cat sp.json | jq -r .clientId | tr -d '\n')"
+export AZURE_TENANT_ID="$(cat sp.json | jq -r .tenantId | tr -d '\n')"
 export AZURE_NODE_MACHINE_TYPE="Standard_D2s_v3"
 export AZURE_CLUSTER_IDENTITY_SECRET_NAME="cluster-identity-secret"
 export AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE="default"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
`AZURE_TENANT_ID` is required by `clusterctl generate cluster...` but not mentioned in docs.

**Which issue(s) this PR fixes** 

**Special notes for your reviewer**:
- [ ] cherry-pick candidate

**TODOs**:
- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
NONE
```
