### PR TITLE
[release-1.7] disable surging if externally managed autoscaler is used

### DIFF
--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -298,7 +298,7 @@ func (s *Service) patchVMSSIfNeeded(ctx context.Context, infraVMSS *azure.VMSS) 
 	if !isFlex {
 		updated = infraVMSS.HasEnoughLatestModelOrNotMixedModel()
 	}
-	if maxSurge > 0 && (hasModelChanges || !updated) {
+	if maxSurge > 0 && (hasModelChanges || !updated) && !s.Scope.HasReplicasExternallyManaged(ctx) {
 		// surge capacity with the intention of lowering during instance reconciliation
 		surge := spec.Capacity + int64(maxSurge)
 		log.V(4).Info("surging...", "surge", surge, "hasModelChanges", hasModelChanges, "updated", updated)

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -618,7 +618,7 @@ func TestReconcileVMSS(t *testing.T) {
 				m.GetResultIfDone(gomockinternal.AContext(), patchFuture).Return(compute.VirtualMachineScaleSet{}, azure.NewOperationNotDoneError(patchFuture))
 				m.Get(gomockinternal.AContext(), defaultResourceGroup, defaultVMSSName).Return(clone, nil)
 				m.ListInstances(gomockinternal.AContext(), defaultResourceGroup, defaultVMSSName).Return(instances, nil)
-				s.HasReplicasExternallyManaged(gomockinternal.AContext()).Return(false)
+				s.HasReplicasExternallyManaged(gomockinternal.AContext()).Times(2).Return(false)
 			},
 		},
 		{


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3440 due to issues occurring with the automated cherry-pick in https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3460.

```release-note
Disables surging if the machine pool used an externally managed autoscaler.
```