### PR TITLE
Update virtualmachineimages service to SDK v2

### DIFF
--- a/azure/defaults_test.go
+++ b/azure/defaults_test.go
@@ -24,10 +24,96 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
+
+func TestARMClientOptions(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name          string
+		cloudName     string
+		expectedCloud cloud.Configuration
+		expectError   bool
+	}{
+		{
+			name:          "should return default client options if cloudName is empty",
+			cloudName:     "",
+			expectedCloud: cloud.Configuration{},
+		},
+		{
+			name:          "should return Azure public cloud client options",
+			cloudName:     PublicCloudName,
+			expectedCloud: cloud.AzurePublic,
+		},
+		{
+			name:          "should return Azure China cloud client options",
+			cloudName:     ChinaCloudName,
+			expectedCloud: cloud.AzureChina,
+		},
+		{
+			name:          "should return Azure government cloud client options",
+			cloudName:     USGovernmentCloudName,
+			expectedCloud: cloud.AzureGovernment,
+		},
+		{
+			name:        "should return error if cloudName is unrecognized",
+			cloudName:   "AzureUnrecognizedCloud",
+			expectError: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, err := ARMClientOptions(tc.cloudName)
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(opts.Cloud).To(Equal(tc.expectedCloud))
+			g.Expect(opts.Retry.MaxRetries).To(BeNumerically("==", -1))
+			g.Expect(opts.PerCallPolicies).To(HaveLen(2))
+		})
+	}
+}
+
+func TestPerCallPolicies(t *testing.T) {
+	g := NewWithT(t)
+
+	corrID := "test-1234abcd-5678efgh"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g.Expect(r.Header.Get("User-Agent")).To(ContainSubstring("cluster-api-provider-azure/"))
+		g.Expect(r.Header.Get(string(tele.CorrIDKeyVal))).To(Equal(corrID))
+		fmt.Fprintf(w, "Hello, %s", r.Proto)
+	}))
+	defer server.Close()
+
+	opts, err := ARMClientOptions("")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(opts.PerCallPolicies).To(HaveLen(2))
+	ctx := context.WithValue(context.Background(), tele.CorrIDKeyVal, tele.CorrID(corrID))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, server.URL)
+	g.Expect(err).NotTo(HaveOccurred())
+	pipeline := defaultTestPipeline(opts.PerCallPolicies)
+	resp, err := pipeline.Do(req)
+	g.Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+	g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+}
+
+func defaultTestPipeline(policies []policy.Policy) runtime.Pipeline {
+	return runtime.NewPipeline(
+		"testmodule",
+		"v0.1.0",
+		runtime.PipelineOptions{},
+		&policy.ClientOptions{PerCallPolicies: policies},
+	)
+}
 
 func TestAutoRestClientAppendUserAgent(t *testing.T) {
 	g := NewWithT(t)

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -697,7 +697,10 @@ func (m *MachineScope) GetVMImage(ctx context.Context) (*infrav1.Image, error) {
 		return m.AzureMachine.Spec.Image, nil
 	}
 
-	svc := virtualmachineimages.New(m)
+	svc, err := virtualmachineimages.New(m)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create virtualmachineimages service")
+	}
 
 	if m.AzureMachine.Spec.OSDisk.OSType == azure.WindowsOS {
 		runtime := m.AzureMachine.Annotations["runtime"]

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -1377,9 +1377,9 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 
 	clusterMock := mock_azure.NewMockClusterScoper(mockCtrl)
 	clusterMock.EXPECT().Authorizer().AnyTimes()
-	clusterMock.EXPECT().BaseURI().AnyTimes()
 	clusterMock.EXPECT().Location().AnyTimes()
 	clusterMock.EXPECT().SubscriptionID().AnyTimes()
+	clusterMock.EXPECT().CloudEnvironment().AnyTimes()
 	svc := virtualmachineimages.Service{Client: mock_virtualmachineimages.NewMockClient(mockCtrl)}
 
 	tests := []struct {

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -626,12 +626,16 @@ func (m *MachinePoolScope) GetVMImage(ctx context.Context) (*infrav1.Image, erro
 		return m.AzureMachinePool.Spec.Template.Image, nil
 	}
 
-	svc := virtualmachineimages.New(m)
-
 	var (
 		err          error
 		defaultImage *infrav1.Image
 	)
+
+	svc, err := virtualmachineimages.New(m)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create virtualmachineimages service")
+	}
+
 	if m.AzureMachinePool.Spec.Template.OSDisk.OSType == azure.WindowsOS {
 		runtime := m.AzureMachinePool.Annotations["runtime"]
 		windowsServerVersion := m.AzureMachinePool.Annotations["windowsServerVersion"]

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -326,9 +326,9 @@ func TestMachinePoolScope_GetVMImage(t *testing.T) {
 
 	clusterMock := mock_azure.NewMockClusterScoper(mockCtrl)
 	clusterMock.EXPECT().Authorizer().AnyTimes()
-	clusterMock.EXPECT().BaseURI().AnyTimes()
 	clusterMock.EXPECT().Location().AnyTimes()
 	clusterMock.EXPECT().SubscriptionID().AnyTimes()
+	clusterMock.EXPECT().CloudEnvironment().AnyTimes()
 	cases := []struct {
 		Name   string
 		Setup  func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool)

--- a/azure/services/virtualmachineimages/cache.go
+++ b/azure/services/virtualmachineimages/cache.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/cache/ttllru"
@@ -39,7 +39,7 @@ type Key struct {
 // Cache stores VM image list resources.
 type Cache struct {
 	client Client
-	data   map[Key]compute.ListVirtualMachineImageResource
+	data   map[Key]armcompute.VirtualMachineImagesClientListResponse
 }
 
 // Cacher allows getting items from and adding them to a cache.
@@ -55,10 +55,14 @@ var (
 )
 
 // newCache instantiates a cache.
-func newCache(auth azure.Authorizer) *Cache {
-	return &Cache{
-		client: NewClient(auth),
+func newCache(auth azure.Authorizer) (*Cache, error) {
+	client, err := NewClient(auth)
+	if err != nil {
+		return nil, err
 	}
+	return &Cache{
+		client: client,
+	}, nil
 }
 
 // GetCache either creates a new VM images cache or returns the existing one.
@@ -77,7 +81,10 @@ func GetCache(auth azure.Authorizer) (*Cache, error) {
 		return c.(*Cache), nil
 	}
 
-	c = newCache(auth)
+	c, err = newCache(auth)
+	if err != nil {
+		return nil, err
+	}
 	_ = clientCache.Add(key, c)
 	return c.(*Cache), nil
 }
@@ -98,12 +105,12 @@ func (c *Cache) refresh(ctx context.Context, key Key) error {
 }
 
 // Get returns a VM image list resource in a location given a publisher, offer, and sku.
-func (c *Cache) Get(ctx context.Context, location, publisher, offer, sku string) (compute.ListVirtualMachineImageResource, error) {
+func (c *Cache) Get(ctx context.Context, location, publisher, offer, sku string) (armcompute.VirtualMachineImagesClientListResponse, error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "virtualmachineimages.Cache.Get")
 	defer done()
 
 	if c.data == nil {
-		c.data = make(map[Key]compute.ListVirtualMachineImageResource)
+		c.data = make(map[Key]armcompute.VirtualMachineImagesClientListResponse)
 	}
 
 	key := Key{
@@ -116,7 +123,7 @@ func (c *Cache) Get(ctx context.Context, location, publisher, offer, sku string)
 	if _, ok := c.data[key]; !ok {
 		log.V(4).Info("VM images cache miss", "location", key.location, "publisher", key.publisher, "offer", key.offer, "sku", key.sku)
 		if err := c.refresh(ctx, key); err != nil {
-			return compute.ListVirtualMachineImageResource{}, err
+			return armcompute.VirtualMachineImagesClientListResponse{}, err
 		}
 	} else {
 		log.V(4).Info("VM images cache hit", "location", key.location, "publisher", key.publisher, "offer", key.offer, "sku", key.sku)

--- a/azure/services/virtualmachineimages/cache_test.go
+++ b/azure/services/virtualmachineimages/cache_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -34,13 +34,13 @@ func TestCacheGet(t *testing.T) {
 		publisher     string
 		offer         string
 		sku           string
-		have          compute.ListVirtualMachineImageResource
+		have          armcompute.VirtualMachineImagesClientListResponse
 		expectedError error
 	}{
 		"should find": {
 			location: "test", publisher: "foo", offer: "bar", sku: "baz",
-			have: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			have: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("foo")},
 				},
 			},
@@ -48,8 +48,8 @@ func TestCacheGet(t *testing.T) {
 		},
 		"should not find": {
 			location: "test", publisher: "foo", offer: "bar", sku: "baz",
-			have: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{},
+			have: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{},
 			},
 			expectedError: errors.New("failed to refresh VM images cache"),
 		},

--- a/azure/services/virtualmachineimages/client.go
+++ b/azure/services/virtualmachineimages/client.go
@@ -19,45 +19,56 @@ package virtualmachineimages
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
-	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
+	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
 // Client is an interface for listing VM images.
 type Client interface {
-	List(ctx context.Context, location, publisher, offer, sku string) (compute.ListVirtualMachineImageResource, error)
+	List(ctx context.Context, location, publisher, offer, sku string) (armcompute.VirtualMachineImagesClientListResponse, error)
 }
 
 // AzureClient contains the Azure go-sdk Client.
 type AzureClient struct {
-	images compute.VirtualMachineImagesClient
+	images armcompute.VirtualMachineImagesClient
 }
 
 var _ Client = (*AzureClient)(nil)
 
-// NewClient creates a new VM images client from auth info.
-func NewClient(auth azure.Authorizer) *AzureClient {
-	return &AzureClient{
-		images: newVirtualMachineImagesClient(auth.SubscriptionID(), auth.BaseURI(), auth.Authorizer()),
+// NewClient creates an AzureClient from an Authorizer.
+func NewClient(auth azure.Authorizer) (*AzureClient, error) {
+	c, err := newVirtualMachineImagesClient(auth.SubscriptionID(), auth.CloudEnvironment())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create VM images client")
 	}
+	return &AzureClient{c}, nil
 }
 
-// newVirtualMachineImagesClient creates a new VM images client from subscription ID, base URI and authorizer.
-func newVirtualMachineImagesClient(subscriptionID, baseURI string, authorizer autorest.Authorizer) compute.VirtualMachineImagesClient {
-	c := compute.NewVirtualMachineImagesClientWithBaseURI(baseURI, subscriptionID)
-	azure.SetAutoRestClientDefaults(&c.Client, authorizer)
-	return c
+// newVirtualMachineImagesClient creates a new VM images client from subscription ID and base URI.
+func newVirtualMachineImagesClient(subscriptionID, azureEnvironment string) (armcompute.VirtualMachineImagesClient, error) {
+	credential, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return armcompute.VirtualMachineImagesClient{}, errors.Wrap(err, "failed to create default Azure credential")
+	}
+	opts, err := azure.ARMClientOptions(azureEnvironment)
+	if err != nil {
+		return armcompute.VirtualMachineImagesClient{}, errors.Wrap(err, "failed to create ARM client options")
+	}
+	computeClientFactory, err := armcompute.NewClientFactory(subscriptionID, credential, opts)
+	if err != nil {
+		return armcompute.VirtualMachineImagesClient{}, errors.Wrap(err, "failed to create ARM compute client factory")
+	}
+	return *computeClientFactory.NewVirtualMachineImagesClient(), nil
 }
 
-// List returns a VM image list resource.
-func (ac *AzureClient) List(ctx context.Context, location, publisher, offer, sku string) (compute.ListVirtualMachineImageResource, error) {
+// List returns a VM image list response.
+func (ac *AzureClient) List(ctx context.Context, location, publisher, offer, sku string) (armcompute.VirtualMachineImagesClientListResponse, error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachineimages.AzureClient.List")
 	defer done()
 
-	// See https://docs.microsoft.com/en-us/odata/concepts/queryoptions-overview for how to use these query options.
-	expand, orderby := "", ""
-	var top *int32
-	return ac.images.List(ctx, location, publisher, offer, sku, expand, top, orderby)
+	opts := &armcompute.VirtualMachineImagesClientListOptions{}
+	return ac.images.List(ctx, location, publisher, offer, sku, opts)
 }

--- a/azure/services/virtualmachineimages/images.go
+++ b/azure/services/virtualmachineimages/images.go
@@ -35,12 +35,16 @@ type Service struct {
 	azure.Authorizer
 }
 
-// New creates a new VM Images service.
-func New(auth azure.Authorizer) *Service {
-	return &Service{
-		Client:     NewClient(auth),
-		Authorizer: auth,
+// New creates a VM Images service.
+func New(auth azure.Authorizer) (*Service, error) {
+	client, err := NewClient(auth)
+	if err != nil {
+		return nil, err
 	}
+	return &Service{
+		Client:     client,
+		Authorizer: auth,
+	}, nil
 }
 
 // GetDefaultUbuntuImage returns the default image spec for Ubuntu.
@@ -142,20 +146,20 @@ func (s *Service) getSKUAndVersion(ctx context.Context, location, publisher, off
 		return "", "", errors.Wrap(err, "failed to get image cache")
 	}
 
-	listVMImagesResource, err := imageCache.Get(ctx, location, publisher, offer, sku)
+	listImagesResponse, err := imageCache.Get(ctx, location, publisher, offer, sku)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "unable to list VM images for publisher \"%s\" offer \"%s\" sku \"%s\"", publisher, offer, sku)
 	}
 
-	vmImages := listVMImagesResource.Value
-	if vmImages == nil || len(*vmImages) == 0 {
+	vmImages := listImagesResponse.VirtualMachineImageResourceArray
+	if len(vmImages) == 0 {
 		return "", "", errors.Errorf("no VM images found for publisher \"%s\" offer \"%s\" sku \"%s\"", publisher, offer, sku)
 	}
 
 	// Sort the VM image names descending, so more recent dates sort first.
 	// (The date is encoded into the end of the name, for example "124.0.20220512").
 	names := []string{}
-	for _, vmImage := range *vmImages {
+	for _, vmImage := range vmImages {
 		names = append(names, *vmImage.Name)
 	}
 	sort.Sort(sort.Reverse(sort.StringSlice(names)))

--- a/azure/services/virtualmachineimages/images_test.go
+++ b/azure/services/virtualmachineimages/images_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
@@ -35,7 +35,7 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 		k8sVersion      string
 		expectedSKU     string
 		expectedVersion string
-		versions        compute.ListVirtualMachineImageResource
+		versions        armcompute.VirtualMachineImagesClientListResponse
 	}{
 		{
 			k8sVersion:      "v1.15.6",
@@ -86,8 +86,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.21.13",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "121.13.20220613",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("121.13.20220526")},
 					{Name: pointer.String("121.13.20220613")},
 					{Name: pointer.String("121.13.20220524")},
@@ -108,8 +108,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.22.10",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "122.10.20220613",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("122.10.20220524")},
 					{Name: pointer.String("122.10.20220613")},
 				},
@@ -119,8 +119,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.22.16",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "122.16.20221117",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("122.16.20221117")},
 				},
 			},
@@ -134,8 +134,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.23.7",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "123.7.20231231",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("123.7.20221124")},
 					{Name: pointer.String("123.7.20220524")},
 					{Name: pointer.String("123.7.20231231")},
@@ -147,8 +147,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.24.0",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "124.0.20220512",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("124.0.20220512")},
 				},
 			},
@@ -157,8 +157,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.23.12",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "123.12.20220921",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("123.12.20220921")},
 				},
 			},
@@ -167,8 +167,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.23.13",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "123.13.20221014",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("123.13.20221014")},
 				},
 			},
@@ -177,8 +177,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.24.6",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "124.6.20220921",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("124.6.20220921")},
 				},
 			},
@@ -187,8 +187,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.24.7",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "124.7.20221014",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("124.7.20221014")},
 				},
 			},
@@ -197,8 +197,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.25.2",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "125.2.20220921",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("125.2.20220921")},
 				},
 			},
@@ -207,8 +207,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.25.3",
 			expectedSKU:     "ubuntu-2204-gen1",
 			expectedVersion: "125.3.20221014",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("125.3.20221014")},
 				},
 			},
@@ -226,12 +226,12 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			mockAuth := mock_azure.NewMockAuthorizer(mockCtrl)
 			mockAuth.EXPECT().HashKey().Return(t.Name()).AnyTimes()
 			mockAuth.EXPECT().Authorizer().AnyTimes()
-			mockAuth.EXPECT().BaseURI().AnyTimes()
 			mockAuth.EXPECT().SubscriptionID().AnyTimes()
+			mockAuth.EXPECT().CloudEnvironment().AnyTimes()
 			mockClient := mock_virtualmachineimages.NewMockClient(mockCtrl)
 			svc := Service{Client: mockClient, Authorizer: mockAuth}
 
-			if test.versions.Value != nil {
+			if test.versions.VirtualMachineImageResourceArray != nil {
 				mockClient.EXPECT().
 					List(gomock.Any(), location, azure.DefaultImagePublisherID, azure.DefaultImageOfferID, gomock.Any()).
 					Return(test.versions, nil)
@@ -349,7 +349,7 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 		expectedSKU     string
 		expectedVersion string
 		expectedError   bool
-		versions        compute.ListVirtualMachineImageResource
+		versions        armcompute.VirtualMachineImagesClientListResponse
 	}{
 		{
 			k8sVersion:      "v1.14.9",
@@ -432,8 +432,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "121.13.20300524",
 			expectedError:   false,
 			osAndVersion:    "windows-2022",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("121.13.20220524")},
 					{Name: pointer.String("124.0.20220512")},
 					{Name: pointer.String("121.13.20220524")},
@@ -482,8 +482,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "123.12.20220921",
 			expectedError:   false,
 			osAndVersion:    "ubuntu-2004",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("123.12.20220921")},
 				},
 			},
@@ -494,8 +494,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "123.13.20220524",
 			expectedError:   false,
 			osAndVersion:    "ubuntu-2204",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("123.13.20220524")},
 				},
 			},
@@ -504,8 +504,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			k8sVersion:    "v1.23.13",
 			expectedError: true,
 			osAndVersion:  "ubuntu-2004",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{},
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{},
 			},
 		},
 		{
@@ -514,8 +514,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "124.0.20220512",
 			expectedError:   false,
 			osAndVersion:    "ubuntu-2004",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("124.0.20220512")},
 				},
 			},
@@ -526,8 +526,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "124.0.20220606",
 			expectedError:   false,
 			osAndVersion:    "windows-2022-containerd",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("124.0.20220606")},
 				},
 			},
@@ -536,8 +536,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			k8sVersion:    "v1.24.1",
 			expectedError: true,
 			osAndVersion:  "windows-2022-containerd",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("124.0.20220606")},
 				},
 			},
@@ -548,8 +548,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "125.4.20221011",
 			expectedError:   false,
 			osAndVersion:    "ubuntu-2204",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: pointer.String("125.4.20221011")},
 				},
 			},
@@ -567,8 +567,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			mockAuth := mock_azure.NewMockAuthorizer(mockCtrl)
 			mockAuth.EXPECT().HashKey().Return(t.Name()).AnyTimes()
 			mockAuth.EXPECT().Authorizer().AnyTimes()
-			mockAuth.EXPECT().BaseURI().AnyTimes()
 			mockAuth.EXPECT().SubscriptionID().AnyTimes()
+			mockAuth.EXPECT().CloudEnvironment().AnyTimes()
 			mockClient := mock_virtualmachineimages.NewMockClient(mockCtrl)
 			svc := Service{Client: mockClient, Authorizer: mockAuth}
 
@@ -576,7 +576,7 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			if strings.HasPrefix(test.osAndVersion, "windows") {
 				offer = azure.DefaultWindowsImageOfferID
 			}
-			if test.versions.Value != nil {
+			if test.versions.VirtualMachineImageResourceArray != nil {
 				mockClient.EXPECT().
 					List(gomock.Any(), location, azure.DefaultImagePublisherID, offer, gomock.Any()).
 					Return(test.versions, nil)

--- a/azure/services/virtualmachineimages/mock_virtualmachineimages/client_mock.go
+++ b/azure/services/virtualmachineimages/mock_virtualmachineimages/client_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -52,10 +52,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // List mocks base method.
-func (m *MockClient) List(ctx context.Context, location, publisher, offer, sku string) (compute.ListVirtualMachineImageResource, error) {
+func (m *MockClient) List(ctx context.Context, location, publisher, offer, sku string) (armcompute.VirtualMachineImagesClientListResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, location, publisher, offer, sku)
-	ret0, _ := ret[0].(compute.ListVirtualMachineImageResource)
+	ret0, _ := ret[0].(armcompute.VirtualMachineImagesClientListResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4 v4.2.1
 	github.com/Azure/go-autorest/autorest v0.11.29
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.12
 	github.com/Azure/go-autorest/tracing v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,11 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0 h1:vcYCAze6p19qBW7MhZybI
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0/go.mod h1:OQeznEEkTZ9OrhHJoDD8ZDq51FHgXjqtP9z6bEwBq9U=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4 v4.2.1 h1:UPeCRD+XY7QlaGQte2EVI2iOcWvUYA2XY8w5T/8v0NQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4 v4.2.1/go.mod h1:oGV6NlB0cvi1ZbYRR2UN44QHxWFyGk+iylgD0qaMXjA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNLjCUeKhgnAJWAKhEUQM+RJQo2H1fuGSw1Ky1E=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.0.0 h1:nBy98uKOIfun5z6wx6jwWLrULcM0+cjBalBFZlEZ7CA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0 h1:ECsQtyERDVz3NP3kvDOTLvbQhqWp/x9EsGKtb4ogUr8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the `virtualmachineimages` service to azure-sdk-for-go v2.

**Which issue(s) this PR fixes**:

Fixes #3473

**Special notes for your reviewer**:

This service doesn't use the `async` framework and is thus simpler to convert. It's really only a `List` API and is not covered by ASO.

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
