### PR TITLE
Fix tilt error creating process.txt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -112,12 +112,14 @@ FROM golang:1.19 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \
-    chmod +x /start.sh && chmod +x /restart.sh
+    chmod +x /start.sh && chmod +x /restart.sh && \
+    touch /process.txt && chmod 0777 /process.txt `# pre-create PID file to allow even non-root users to run the image`
 """
 
 tilt_dockerfile_header = """
 FROM gcr.io/distroless/base:debug as tilt
 WORKDIR /
+COPY --from=tilt-helper /process.txt .
 COPY --from=tilt-helper /start.sh .
 COPY --from=tilt-helper /restart.sh .
 COPY manager .


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Recently a change to the `gcr.io/distroless/base:debug` container seems to have created this persistent error in the capz-controller when run with `Tilt`:

```
/start.sh: line 34: can't create process.txt: Permission denied
```

This applies a workaround used in CAPI (from kubernetes-sigs/cluster-api#7162) that seems to work in my local testing.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

This is `Tilt` so it's not covered by any automated tests. Please test it locally if you can.

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
