### PR TITLE
Use Ubuntu 22.04 as base OS image for k8s CI tests

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -206,7 +206,7 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -252,7 +252,7 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -204,7 +204,7 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -252,7 +252,7 @@ spec:
       marketplace:
         offer: capi
         publisher: cncf-upstream
-        sku: ubuntu-1804-gen1
+        sku: ubuntu-2204-gen1
         version: latest
     osDisk:
       diskSizeGB: 30

--- a/templates/test/ci/patches/control-plane-image-ci-version.yaml
+++ b/templates/test/ci/patches/control-plane-image-ci-version.yaml
@@ -11,5 +11,5 @@ spec:
         marketplace:
           publisher: cncf-upstream
           offer: capi
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest

--- a/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version.yaml
+++ b/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version.yaml
@@ -11,5 +11,5 @@ spec:
         marketplace:
           publisher: cncf-upstream
           offer: capi
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: "latest"

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -91,5 +91,5 @@ spec:
       marketplace:
         publisher: cncf-upstream
         offer: capi
-        sku: ubuntu-1804-gen1
+        sku: ubuntu-2204-gen1
         version: latest

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -195,7 +195,7 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -243,7 +243,7 @@ spec:
       marketplace:
         offer: capi
         publisher: cncf-upstream
-        sku: ubuntu-1804-gen1
+        sku: ubuntu-2204-gen1
         version: latest
     osDisk:
       diskSizeGB: 30

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -197,7 +197,7 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -243,7 +243,7 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/dev/custom-builds-machine-pool/patches/custom-builds.yaml
+++ b/templates/test/dev/custom-builds-machine-pool/patches/custom-builds.yaml
@@ -47,5 +47,5 @@ spec:
       marketplace:
         publisher: cncf-upstream
         offer: capi
-        sku: ubuntu-1804-gen1
+        sku: ubuntu-2204-gen1
         version: latest

--- a/templates/test/dev/custom-builds/patches/machine-deployment-pr-version.yaml
+++ b/templates/test/dev/custom-builds/patches/machine-deployment-pr-version.yaml
@@ -11,7 +11,7 @@ spec:
         marketplace:
           publisher: cncf-upstream
           offer: capi
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -27,7 +27,7 @@ spec:
         marketplace:
           publisher: cncf-upstream
           offer: capi
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/templates/test/dev/patches/control-plane-custom-builds.yaml
+++ b/templates/test/dev/patches/control-plane-custom-builds.yaml
@@ -87,5 +87,5 @@ spec:
         marketplace:
           publisher: cncf-upstream
           offer: capi
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Noticed we were still using the old Ubuntu 18.04 images for k8s CI and PR tests. This PR updates the templates to use the 22.04 images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
