### PR TITLE
Build Windows k8s artifacts if TEST_WINDOWS or WINDOWS is set

### DIFF
--- a/scripts/ci-build-kubernetes.sh
+++ b/scripts/ci-build-kubernetes.sh
@@ -61,6 +61,9 @@ setup() {
     export KUBE_GIT_VERSION
     echo "using KUBE_GIT_VERSION=${KUBE_GIT_VERSION}"
 
+    # allow both TEST_WINDOWS and WINDOWS for backwards compatibility.
+    export TEST_WINDOWS="${TEST_WINDOWS:-${WINDOWS:-}}"
+
     # get the latest ci version for a particular release so that kubeadm is
     # able to pull existing images before being replaced by custom images
     major="$(echo "${KUBE_GIT_VERSION}" | ${GREP_BINARY} -Po "(?<=v)[0-9]+")"
@@ -113,7 +116,7 @@ main() {
             az storage blob upload --overwrite --container-name "${JOB_NAME}" --file "${KUBE_ROOT}/_output/dockerized/bin/linux/amd64/${BINARY}" --name "${KUBE_GIT_VERSION}/bin/linux/amd64/${BINARY}"
         done
 
-        if [[ "${WINDOWS:-}" == "true" ]]; then
+        if [[ "${TEST_WINDOWS:-}" == "true" ]]; then
             echo "Building Kubernetes Windows binaries"
 
             for BINARY in "${WINDOWS_BINARIES[@]}"; do
@@ -141,7 +144,7 @@ can_reuse_artifacts() {
         fi
     done
 
-    if [[ "${WINDOWS:-}" == "true" ]]; then
+    if [[ "${TEST_WINDOWS:-}" == "true" ]]; then
         for BINARY in "${WINDOWS_BINARIES[@]}"; do
             if [[ "$(az storage blob exists --container-name "${JOB_NAME}" --name "${KUBE_GIT_VERSION}/bin/windows/amd64/${BINARY}.exe" --query exists)" == "false" ]]; then
                 echo "false" && return


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: `ci-entrypoint.sh` uses `TEST_WINDOWS` to determine Windows nodes should be built, while `ci-conformance.sh` uses `WINDOWS`. As test-infra jobs use both in different places, the quickest fix for now is to allow both. Eventually, we may want to consider converging to one or the other and refactoring all jobs for consistency.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
