### PR TITLE
[release-1.8] update golang to v1.20

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '^1.19'
+        go-version: '^1.20'
     - run: "PATH=/usr/local/go/bin:$PATH make test-cover"
     - uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.19'
+          go-version: '^1.20'
       - name: generate release artifacts
         run: |
           make release

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -127,11 +127,11 @@ linters-settings:
         arguments:
           - disableStutteringCheck
   staticcheck:
-    go: "1.19"
+    go: "1.20"
   stylecheck:
-    go: "1.19"
+    go: "1.20"
   unused:
-    go: "1.19"
+    go: "1.20"
 
 issues:
   exclude-rules:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 ARG ARCH
 
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -364,7 +364,7 @@ delete-workload-cluster: $(KUBECTL) ## Deletes the example workload Kubernetes c
 .PHONY: docker-pull-prerequisites
 docker-pull-prerequisites: ## Pull prerequisites for building controller-manager.
 	docker pull docker/dockerfile:1.4
-	docker pull docker.io/library/golang:1.19
+	docker pull docker.io/library/golang:1.20
 	docker pull gcr.io/distroless/static:latest
 
 .PHONY: docker-build
@@ -610,7 +610,7 @@ release-binary: $(RELEASE_DIR) ## Compile and build release binaries.
 		-e GOARCH=$(GOARCH) \
 		-v "$$(pwd):/workspace" \
 		-w /workspace \
-		golang:1.19 \
+		golang:1.20 \
 		go build -a -ldflags '$(LDFLAGS) -extldflags "-static"' \
 		-o $(RELEASE_DIR)/$(notdir $(RELEASE_BINARY))-$(GOOS)-$(GOARCH) $(RELEASE_BINARY)
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -108,7 +108,7 @@ def validate_auth():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.19 as tilt-helper
+FROM golang:1.20 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy.go
+++ b/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy.go
@@ -290,8 +290,9 @@ func orderByOldest(machines []infrav1exp.AzureMachinePoolMachine) []infrav1exp.A
 }
 
 func orderRandom(machines []infrav1exp.AzureMachinePoolMachine) []infrav1exp.AzureMachinePoolMachine {
-	rand.Seed(time.Now().UnixNano())
-	rand.Shuffle(len(machines), func(i, j int) { machines[i], machines[j] = machines[j], machines[i] })
+	//nolint:gosec // We don't need a cryptographically appropriate random number here
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r.Shuffle(len(machines), func(i, j int) { machines[i], machines[j] = machines[j], machines[i] })
 	return machines
 }
 

--- a/docs/book/src/developers/development.md
+++ b/docs/book/src/developers/development.md
@@ -46,7 +46,7 @@
 ### Base requirements
 
 1. Install [go][go]
-   - Get the latest patch version for go v1.19.
+   - Get the latest patch version for go v1.20.
 2. Install [jq][jq]
    - `brew install jq` on macOS.
    - `sudo apt install jq` on Windows + WSL2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-azure
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Azure/aad-pod-identity v1.8.14

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -31,7 +31,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.19.0
+  minimum_go_version=go1.20.0
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-azure/hack/tools
 
-go 1.19
+go 1.20
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1


### PR DESCRIPTION
This is a manual cherry-pick of #3478

/assign CecileRobertMichon

```release-note
use golang v1.20 to build and test CAPZ
```