### PR TITLE
fix tilt live reload for capz-controller-manager

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -118,7 +118,8 @@ RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com
 
 tilt_dockerfile_header = """
 FROM gcr.io/distroless/base:debug as tilt
-WORKDIR /
+WORKDIR /tilt
+RUN ["/busybox/chmod", "0777", "."]
 COPY --from=tilt-helper /process.txt .
 COPY --from=tilt-helper /start.sh .
 COPY --from=tilt-helper /restart.sh .
@@ -219,7 +220,7 @@ def capz():
         tilt_dockerfile_header,
     ])
 
-    entrypoint = ["sh", "/start.sh", "/manager"]
+    entrypoint = ["sh", "/tilt/start.sh", "/tilt/manager"]
     extra_args = settings.get("extra_args")
     if extra_args:
         entrypoint.extend(extra_args)
@@ -234,8 +235,8 @@ def capz():
         entrypoint = entrypoint,
         only = "manager",
         live_update = [
-            sync(".tiltbuild/manager", "/manager"),
-            run("sh /restart.sh"),
+            sync(".tiltbuild/manager", "/tilt/manager"),
+            run("sh /tilt/restart.sh"),
         ],
         ignore = ["templates"],
     )


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR fixes an issue where Tilt was failing to perform live updates of capz-controller-manager due to insufficient permissions on the parent directory of the `manager` binary. This change moves the Tilt-specific files in the CAPZ container into a new `/tilt` directory with world-writeable permissions so the non-root user running the container newly specified in #3399 is able to delete the old `manager` binary.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3497

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate (#3399 was not cherry picked so release branches are not affected)

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
