### PR TITLE
Fix Ginkgov2 deprecation warnings

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/blang/semver"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -294,10 +295,10 @@ func EnsureControlPlaneInitialized(ctx context.Context, input clusterctl.ApplyCl
 // CheckTestBeforeCleanup checks to see if the current running Ginkgo test failed, and prints
 // a status message regarding cleanup.
 func CheckTestBeforeCleanup() {
-	if CurrentGinkgoTestDescription().Failed {
+	if CurrentSpecReport().State.Is(types.SpecStateFailureStates) {
 		Logf("FAILED!")
 	}
-	Logf("Cleaning up after \"%s\" spec", CurrentGinkgoTestDescription().FullTestText)
+	Logf("Cleaning up after \"%s\" spec", CurrentSpecReport().FullText())
 }
 
 func discoveryAndWaitForControlPlaneInitialized(ctx context.Context, input clusterctl.ApplyClusterTemplateAndWaitInput, result *clusterctl.ApplyClusterTemplateAndWaitResult) *kubeadmv1.KubeadmControlPlane {

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -425,7 +425,7 @@ func getAvailabilityZonesForRegion(location string, size string) ([]string, erro
 //	INFO: "With 1 worker node" started at Tue, 22 Sep 2020 13:19:08 PDT on Ginkgo node 2 of 3
 //	INFO: "With 1 worker node" ran for 18m34s on Ginkgo node 2 of 3
 func logCheckpoint(specTimes map[string]time.Time) {
-	text := CurrentGinkgoTestDescription().TestText
+	text := CurrentSpecReport().LeafNodeText
 	start, started := specTimes[text]
 	suiteConfig, reporterConfig := GinkgoConfiguration()
 	if !started {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Replaces three calls to the obsolete `CurrentGinkgoTestDescription()` to silence deprecation warnings.

**Which issue(s) this PR fixes**:

Fixes #2903

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
