### PR TITLE
Add release 1.9 to metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -41,3 +41,6 @@ releaseSeries:
   - major: 1
     minor: 8
     contract: v1beta1
+  - major: 1
+    minor: 9
+    contract: v1beta1


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Preps for the v1.9.0 release by adding the 1.9 series to `metadata.yaml`, as specified in the [releasing docs](https://capz.sigs.k8s.io/developers/releasing.html#update-metadatayaml-skip-for-patch-releases).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
