### PR TITLE
use default backend pool name in capz controller if empty

### DIFF
--- a/api/v1beta1/azurecluster_default.go
+++ b/api/v1beta1/azurecluster_default.go
@@ -204,10 +204,7 @@ func (c *AzureCluster) setAPIServerLBDefaults() {
 			}
 		}
 	}
-
-	if lb.BackendPool.Name == "" {
-		lb.BackendPool.Name = generateBackendAddressPoolName(lb.Name)
-	}
+	c.SetAPIServerLBBackendPoolNameDefault()
 }
 
 // SetNodeOutboundLBDefaults sets the default values for the NodeOutboundLB.
@@ -247,10 +244,7 @@ func (c *AzureCluster) SetNodeOutboundLBDefaults() {
 	}
 
 	c.setOutboundLBFrontendIPs(lb, generateNodeOutboundIPName)
-
-	if lb.BackendPool.Name == "" {
-		lb.BackendPool.Name = generateOutboundBackendAddressPoolName(lb.Name)
-	}
+	c.SetNodeOutboundLBBackendPoolNameDefault()
 }
 
 // SetControlPlaneOutboundLBDefaults sets the default values for the control plane's outbound LB.
@@ -269,9 +263,37 @@ func (c *AzureCluster) SetControlPlaneOutboundLBDefaults() {
 		lb.FrontendIPsCount = pointer.Int32(1)
 	}
 	c.setOutboundLBFrontendIPs(lb, generateControlPlaneOutboundIPName)
+	c.SetControlPlaneOutboundLBBackendPoolNameDefault()
+}
 
-	if lb.BackendPool.Name == "" {
-		lb.BackendPool.Name = generateOutboundBackendAddressPoolName(generateControlPlaneOutboundLBName(c.ObjectMeta.Name))
+// SetBackendPoolNameDefault defaults the backend pool name of the LBs.
+func (c *AzureCluster) SetBackendPoolNameDefault() {
+	c.SetAPIServerLBBackendPoolNameDefault()
+	c.SetNodeOutboundLBBackendPoolNameDefault()
+	c.SetControlPlaneOutboundLBBackendPoolNameDefault()
+}
+
+// SetAPIServerLBBackendPoolNameDefault defaults the name of the backend pool for apiserver LB.
+func (c *AzureCluster) SetAPIServerLBBackendPoolNameDefault() {
+	apiServerLB := &c.Spec.NetworkSpec.APIServerLB
+	if apiServerLB.BackendPool.Name == "" {
+		apiServerLB.BackendPool.Name = generateBackendAddressPoolName(apiServerLB.Name)
+	}
+}
+
+// SetNodeOutboundLBBackendPoolNameDefault defaults the name of the backend pool for node outbound LB.
+func (c *AzureCluster) SetNodeOutboundLBBackendPoolNameDefault() {
+	nodeOutboundLB := c.Spec.NetworkSpec.NodeOutboundLB
+	if nodeOutboundLB != nil && nodeOutboundLB.BackendPool.Name == "" {
+		nodeOutboundLB.BackendPool.Name = generateOutboundBackendAddressPoolName(nodeOutboundLB.Name)
+	}
+}
+
+// SetControlPlaneOutboundLBBackendPoolNameDefault defaults the name of the backend pool for control plane outbound LB.
+func (c *AzureCluster) SetControlPlaneOutboundLBBackendPoolNameDefault() {
+	controlPlaneOutboundLB := c.Spec.NetworkSpec.ControlPlaneOutboundLB
+	if controlPlaneOutboundLB != nil && controlPlaneOutboundLB.BackendPool.Name == "" {
+		controlPlaneOutboundLB.BackendPool.Name = generateOutboundBackendAddressPoolName(generateControlPlaneOutboundLBName(c.ObjectMeta.Name))
 	}
 }
 

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -85,6 +85,7 @@ func (s *azureClusterService) Reconcile(ctx context.Context) error {
 		return errors.Wrap(err, "failed to get availability zones")
 	}
 
+	s.scope.AzureCluster.SetBackendPoolNameDefault()
 	s.scope.SetDNSName()
 	s.scope.SetControlPlaneSecurityRules()
 


### PR DESCRIPTION
fixes #3252 

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
/kind bug
-->

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use default backend pool name in capz controller.
```
