### PR TITLE
allow setting the NatGateway name if it's empty when update AzureCluster

### DIFF
--- a/api/v1beta1/azurecluster_webhook.go
+++ b/api/v1beta1/azurecluster_webhook.go
@@ -168,7 +168,7 @@ func (c *AzureCluster) validateSubnetUpdate(old *AzureCluster) field.ErrorList {
 						c.Spec.NetworkSpec.Subnets[i].RouteTable.Name, "field is immutable"),
 				)
 			}
-			if subnet.NatGateway.Name != oldSubnet.NatGateway.Name {
+			if (subnet.NatGateway.Name != oldSubnet.NatGateway.Name) && (oldSubnet.NatGateway.Name != "") {
 				allErrs = append(allErrs,
 					field.Invalid(field.NewPath("spec", "networkSpec", "subnets").Index(oldSubnetIndex[subnet.Name]).Child("NatGateway").Child("Name"),
 						c.Spec.NetworkSpec.Subnets[i].NatGateway.Name, "field is immutable"),

--- a/api/v1beta1/azurecluster_webhook_test.go
+++ b/api/v1beta1/azurecluster_webhook_test.go
@@ -318,6 +318,30 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "natGateway name is immutable",
+			oldCluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Subnets[0].NatGateway.Name = "cluster-test-node-natgw-0"
+				return cluster
+			}(),
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Subnets[0].NatGateway.Name = "cluster-test-node-natgw-1"
+				return cluster
+			}(),
+			wantErr: true,
+		},
+		{
+			name:       "natGateway name can be empty before AzureCluster is updated",
+			oldCluster: createValidCluster(),
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Subnets[0].NatGateway.Name = "cluster-test-node-natgw"
+				return cluster
+			}(),
+			wantErr: false,
+		},
 	}
 	for _, tc := range tests {
 		tc := tc


### PR DESCRIPTION

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Now, we [default use the NAT gateway for the node outbound connection if cluster is not using IPv6](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3365). So we should allow setting the NatGateway name if it's empty when update AzureCluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Our AzureCluster webhook is validated if the old gateway name is same with the new gateway name when update:
```
			if (subnet.NatGateway.Name != oldSubnet.NatGateway.Name) {
				allErrs = append(allErrs,
					field.Invalid(field.NewPath("spec", "networkSpec", "subnets").Index(oldSubnetIndex[subnet.Name]).Child("NatGateway").Child("Name"),
						c.Spec.NetworkSpec.Subnets[i].NatGateway.Name, "field is immutable"),
				)
			}
```
If they are different, then below error will happen:
```
E0509 15:24:33.726961       1 controller.go:329] "Reconciler error" err="error reconciling the Cluster topology: failed to create patch helper for AzureCluster/wl-antrea-1-5f692: server side apply dry-run failed for modified object: admission webhook \"validation.azurecluster.infrastructure.cluster.x-k8s.io\" denied the request: AzureCluster.infrastructure.cluster.x-k8s.io \"wl-antrea-1-5f692\" is invalid: spec.networkSpec.subnets[1].NatGateway.Name: Invalid value: \"wl-antrea-1-5f692-node-natgw-1\": field is immutable" controller="topology/cluster" controllerGroup="cluster.x-k8s.io" controllerKind="Cluster" Cluster="default/wl-antrea-1" namespace="default" name="wl-antrea-1" reconcileID=59bb6d5c-88c6-44b6-a90d-a32817f9d700
E0509 15:24:33.735506       1 controller.go:329] "Reconciler error" err="error reconciling the Cluster topology: failed to create patch helper for AzureCluster/tkg-upgrade-10900mgmt-azure-tpmd7: server side apply dry-run failed for modified object: admission webhook \"validation.azurecluster.infrastructure.cluster.x-k8s.io\" denied the request: AzureCluster.infrastructure.cluster.x-k8s.io \"tkg-upgrade-10900mgmt-azure-tpmd7\" is invalid: spec.networkSpec.subnets[1].NatGateway.Name: Invalid value: \"tkg-upgrade-10900mgmt-azure-tpmd7-node-natgw-1\": field is immutable" controller="topology/cluster" controllerGroup="cluster.x-k8s.io" controllerKind="Cluster" Cluster="tkg-system/tkg-upgrade-10900mgmt-azure" namespace="tkg-system" name="tkg-upgrade-10900mgmt-azure" reconcileID=cea35543-a8d9-494b-8498-fb3dc831844d
```
This error is expected if a NatGateway has created before upgrade. 
But the current situation is the NatGateway name is empty, then we will [generate a new one default](https://github.com/xiujuanx/cluster-api-provider-azure/blob/e60f052c7a6d96cd28e130aacbf194327412b228/api/v1beta1/azurecluster_default.go#L131-L133). This makes the old NatGateway name is different with the new one, so webhook complains error. This is not expected. We should allow setting the NatGateway name if it's empty when update AzureCluster

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
