### PR TITLE
adding conditional blocks around Add/Remove Finalizer

### DIFF
--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -204,10 +204,11 @@ func (acr *AzureClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 	azureCluster := clusterScope.AzureCluster
 
 	// If the AzureCluster doesn't have our finalizer, add it.
-	controllerutil.AddFinalizer(azureCluster, infrav1.ClusterFinalizer)
-	// Register the finalizer immediately to avoid orphaning Azure resources on delete
-	if err := clusterScope.PatchObject(ctx); err != nil {
-		return reconcile.Result{}, err
+	if controllerutil.AddFinalizer(azureCluster, infrav1.ClusterFinalizer) {
+		// Register the finalizer immediately to avoid orphaning Azure resources on delete
+		if err := clusterScope.PatchObject(ctx); err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	acs, err := acr.createAzureClusterService(clusterScope)

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -248,10 +248,11 @@ func (amr *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineS
 	}
 
 	// If the AzureMachine doesn't have our finalizer, add it.
-	controllerutil.AddFinalizer(machineScope.AzureMachine, infrav1.MachineFinalizer)
-	// Register the finalizer immediately to avoid orphaning Azure resources on delete
-	if err := machineScope.PatchObject(ctx); err != nil {
-		return reconcile.Result{}, err
+	if controllerutil.AddFinalizer(machineScope.AzureMachine, infrav1.MachineFinalizer) {
+		// Register the finalizer immediately to avoid orphaning Azure resources on delete
+		if err := machineScope.PatchObject(ctx); err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	// Make sure the Cluster Infrastructure is ready.

--- a/controllers/azuremanagedcontrolplane_controller.go
+++ b/controllers/azuremanagedcontrolplane_controller.go
@@ -223,14 +223,14 @@ func (amcpr *AzureManagedControlPlaneReconciler) reconcileNormal(ctx context.Con
 
 	log.Info("Reconciling AzureManagedControlPlane")
 
-	// Remove deprecated Cluster finalizer if it exists.
-	controllerutil.RemoveFinalizer(scope.ControlPlane, infrav1.ClusterFinalizer)
-	// If the AzureManagedControlPlane doesn't have our finalizer, add it.
-	controllerutil.AddFinalizer(scope.ControlPlane, infrav1.ManagedClusterFinalizer)
-	// Register the finalizer immediately to avoid orphaning Azure resources on delete
-	if err := scope.PatchObject(ctx); err != nil {
-		amcpr.Recorder.Eventf(scope.ControlPlane, corev1.EventTypeWarning, "AzureManagedControlPlane unavailable", "failed to patch resource: %s", err)
-		return reconcile.Result{}, err
+	// Remove deprecated Cluster finalizer if it exists, if the AzureManagedControlPlane doesn't have our finalizer, add it.
+	if controllerutil.RemoveFinalizer(scope.ControlPlane, infrav1.ClusterFinalizer) ||
+		controllerutil.AddFinalizer(scope.ControlPlane, infrav1.ManagedClusterFinalizer) {
+		// Register the finalizer immediately to avoid orphaning Azure resources on delete
+		if err := scope.PatchObject(ctx); err != nil {
+			amcpr.Recorder.Eventf(scope.ControlPlane, corev1.EventTypeWarning, "AzureManagedControlPlane unavailable", "failed to patch resource: %s", err)
+			return reconcile.Result{}, err
+		}
 	}
 
 	if err := newAzureManagedControlPlaneReconciler(scope).Reconcile(ctx); err != nil {

--- a/controllers/azuremanagedmachinepool_controller.go
+++ b/controllers/azuremanagedmachinepool_controller.go
@@ -244,10 +244,11 @@ func (ammpr *AzureManagedMachinePoolReconciler) reconcileNormal(ctx context.Cont
 	log.Info("Reconciling AzureManagedMachinePool")
 
 	// If the AzureManagedMachinePool doesn't have our finalizer, add it.
-	controllerutil.AddFinalizer(scope.InfraMachinePool, infrav1.ClusterFinalizer)
-	// Register the finalizer immediately to avoid orphaning Azure resources on delete
-	if err := scope.PatchObject(ctx); err != nil {
-		return reconcile.Result{}, err
+	if controllerutil.AddFinalizer(scope.InfraMachinePool, infrav1.ClusterFinalizer) {
+		// Register the finalizer immediately to avoid orphaning Azure resources on delete
+		if err := scope.PatchObject(ctx); err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	svc, err := ammpr.createAzureManagedMachinePoolService(scope)

--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -275,10 +275,11 @@ func (ampr *AzureMachinePoolReconciler) reconcileNormal(ctx context.Context, mac
 	}
 
 	// If the AzureMachine doesn't have our finalizer, add it.
-	controllerutil.AddFinalizer(machinePoolScope.AzureMachinePool, expv1.MachinePoolFinalizer)
-	// Register the finalizer immediately to avoid orphaning Azure resources on delete
-	if err := machinePoolScope.PatchObject(ctx); err != nil {
-		return reconcile.Result{}, err
+	if controllerutil.AddFinalizer(machinePoolScope.AzureMachinePool, expv1.MachinePoolFinalizer) {
+		// Register the finalizer immediately to avoid orphaning Azure resources on delete
+		if err := machinePoolScope.PatchObject(ctx); err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	if !clusterScope.Cluster.Status.InfrastructureReady {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
AddFinalizer/RemoveFinalizer returns a bool if there was actually a modification to the runtime object. This PR will add conditionals around their calls and if there were no modifications to the object to skip the Patch call. I believe how patch works is it will diff the before/after of the path and return nil if they're the same, but this eliminates the extra computation as we already know when we are adding/removing the finalizers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The main point is to avoid the patch calls in the reconcile loops, I avoided new object creation and anything that looked like reconcile delete. My biggest logic concern is in `EnsureClusterIdentity` so please confirm you feel the code accomplishes the same task with the early return. I made a similar PR to CAPA which was well received and is now in the code base: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4095

**Release Note**
```release-note
Conditional blocks added to Add/Remove Finalizers to avoid unnecessary Patch calls
```
