### PR TITLE
(feat): add workload identity in capz

### DIFF
--- a/api/v1beta1/azureclusteridentity_webhook_test.go
+++ b/api/v1beta1/azureclusteridentity_webhook_test.go
@@ -93,3 +93,84 @@ func TestAzureClusterIdentity_ValidateCreate(t *testing.T) {
 		})
 	}
 }
+
+func TestAzureClusterIdentity_ValidateUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name               string
+		oldClusterIdentity *AzureClusterIdentity
+		clusterIdentity    *AzureClusterIdentity
+		wantErr            bool
+	}{
+		{
+			name: "azureclusteridentity with no change",
+			clusterIdentity: &AzureClusterIdentity{
+				Spec: AzureClusterIdentitySpec{
+					Type:     ServicePrincipal,
+					ClientID: fakeClientID,
+					TenantID: fakeTenantID,
+				},
+			},
+			oldClusterIdentity: &AzureClusterIdentity{
+				Spec: AzureClusterIdentitySpec{
+					Type:     ServicePrincipal,
+					ClientID: fakeClientID,
+					TenantID: fakeTenantID,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "azureclusteridentity with a change in type",
+			clusterIdentity: &AzureClusterIdentity{
+				Spec: AzureClusterIdentitySpec{
+					Type:       ServicePrincipal,
+					ClientID:   fakeClientID,
+					TenantID:   fakeTenantID,
+					ResourceID: fakeResourceID,
+				},
+			},
+			oldClusterIdentity: &AzureClusterIdentity{
+				Spec: AzureClusterIdentitySpec{
+					Type:       WorkloadIdentity,
+					ClientID:   fakeClientID,
+					TenantID:   fakeTenantID,
+					ResourceID: fakeResourceID,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "azureclusteridentity with a change in client ID",
+			clusterIdentity: &AzureClusterIdentity{
+				Spec: AzureClusterIdentitySpec{
+					Type:       ServicePrincipal,
+					ClientID:   fakeClientID,
+					TenantID:   fakeTenantID,
+					ResourceID: fakeResourceID,
+				},
+			},
+			oldClusterIdentity: &AzureClusterIdentity{
+				Spec: AzureClusterIdentitySpec{
+					Type:       WorkloadIdentity,
+					ClientID:   "diff-fake-Client-ID",
+					TenantID:   fakeTenantID,
+					ResourceID: fakeResourceID,
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.clusterIdentity.ValidateUpdate(tc.oldClusterIdentity)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -557,7 +557,7 @@ const (
 )
 
 // IdentityType represents different types of identities.
-// +kubebuilder:validation:Enum=ServicePrincipal;UserAssignedMSI;ManualServicePrincipal;ServicePrincipalCertificate
+// +kubebuilder:validation:Enum=ServicePrincipal;UserAssignedMSI;ManualServicePrincipal;ServicePrincipalCertificate;WorkloadIdentity
 type IdentityType string
 
 const (
@@ -572,6 +572,9 @@ const (
 
 	// ServicePrincipalCertificate represents a service principal using a certificate as secret.
 	ServicePrincipalCertificate IdentityType = "ServicePrincipalCertificate"
+
+	// WorkloadIdentity represents a WorkloadIdentity.
+	WorkloadIdentity IdentityType = "WorkloadIdentity"
 )
 
 // OSDisk defines the operating system disk for a VM.

--- a/azure/scope/identity.go
+++ b/azure/scope/identity.go
@@ -142,6 +142,16 @@ func (p *AzureCredentialsProvider) GetAuthorizer(ctx context.Context, resourceMa
 	var authErr error
 	var cred azcore.TokenCredential
 	switch p.Identity.Spec.Type {
+	case infrav1.WorkloadIdentity:
+		azwiCredOptions, err := NewWorkloadIdentityCredentialOptions().
+			WithTenantID(p.Identity.Spec.TenantID).
+			WithClientID(p.Identity.Spec.ClientID).
+			WithDefaults()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to setup azwi options for identity %s", p.Identity.Name)
+		}
+		cred, authErr = NewWorkloadIdentityCredential(azwiCredOptions)
+
 	case infrav1.ServicePrincipal, infrav1.ServicePrincipalCertificate, infrav1.UserAssignedMSI:
 		if err := createAzureIdentityWithBindings(ctx, p.Identity, resourceManagerEndpoint, activeDirectoryEndpoint, clusterMeta, p.Client); err != nil {
 			return nil, err

--- a/azure/scope/workload_identity.go
+++ b/azure/scope/workload_identity.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"context"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/pkg/errors"
+)
+
+/*
+
+For workload identity to work we need the following.
+
+|-----------------------------------------------------------------------------------|
+|AZURE_AUTHORITY_HOST       | The Azure Active Directory (AAD) endpoint.            |
+|AZURE_CLIENT_ID            | The client ID of the Azure AD                         |
+|                           | application or user-assigned managed identity.        |
+|AZURE_TENANT_ID            | The tenant ID of the Azure subscription.              |
+|AZURE_FEDERATED_TOKEN_FILE | The path of the projected service account token file. |
+|-----------------------------------------------------------------------------------|
+
+With the current implementation, AZURE_CLIENT_ID and AZURE_TENANT_ID are read via AzureClusterIdentity
+object and fallback to reading from env variables if not found on AzureClusterIdentity.
+
+AZURE_FEDERATED_TOKEN_FILE is the path of the projected service account token which is by default
+"/var/run/secrets/azure/tokens/azure-identity-token".
+The path can be overridden by setting "AZURE_FEDERATED_TOKEN_FILE" env variable.
+
+*/
+
+const (
+	// azureFederatedTokenFileEnvKey is the env key for AZURE_FEDERATED_TOKEN_FILE.
+	azureFederatedTokenFileEnvKey = "AZURE_FEDERATED_TOKEN_FILE"
+	// azureClientIDEnvKey is the env key for AZURE_CLIENT_ID.
+	azureClientIDEnvKey = "AZURE_CLIENT_ID"
+	// azureTenantIDEnvKey is the env key for AZURE_TENANT_ID.
+	azureTenantIDEnvKey = "AZURE_TENANT_ID"
+	// azureTokenFilePath is the path of the projected token.
+	azureTokenFilePath = "/var/run/secrets/azure/tokens/azure-identity-token" // #nosec G101
+	// azureFederatedTokenFileRefreshTime is the time interval after which it should be read again.
+	azureFederatedTokenFileRefreshTime = 5 * time.Minute
+)
+
+type workloadIdentityCredential struct {
+	assertion string
+	file      string
+	cred      *azidentity.ClientAssertionCredential
+	lastRead  time.Time
+}
+
+// WorkloadIdentityCredentialOptions contains the configurable options for azwi.
+type WorkloadIdentityCredentialOptions struct {
+	azcore.ClientOptions
+	ClientID      string
+	TenantID      string
+	TokenFilePath string
+}
+
+// NewWorkloadIdentityCredentialOptions returns an empty instance of WorkloadIdentityCredentialOptions.
+func NewWorkloadIdentityCredentialOptions() *WorkloadIdentityCredentialOptions {
+	return &WorkloadIdentityCredentialOptions{}
+}
+
+// WithClientID sets client ID to WorkloadIdentityCredentialOptions.
+func (w *WorkloadIdentityCredentialOptions) WithClientID(clientID string) *WorkloadIdentityCredentialOptions {
+	w.ClientID = strings.TrimSpace(clientID)
+	return w
+}
+
+// WithTenantID sets tenant ID to WorkloadIdentityCredentialOptions.
+func (w *WorkloadIdentityCredentialOptions) WithTenantID(tenantID string) *WorkloadIdentityCredentialOptions {
+	w.TenantID = strings.TrimSpace(tenantID)
+	return w
+}
+
+// getProjectedTokenPath return projected token file path from the env variable.
+func getProjectedTokenPath() string {
+	tokenPath := strings.TrimSpace(os.Getenv(azureFederatedTokenFileEnvKey))
+	if tokenPath == "" {
+		return azureTokenFilePath
+	}
+	return tokenPath
+}
+
+// WithDefaults sets token file path. It also sets the client tenant ID from injected env in
+// case empty values are passed.
+func (w *WorkloadIdentityCredentialOptions) WithDefaults() (*WorkloadIdentityCredentialOptions, error) {
+	w.TokenFilePath = getProjectedTokenPath()
+
+	// Fallback to using client ID from env variable if not set.
+	if w.ClientID == "" {
+		w.ClientID = strings.TrimSpace(os.Getenv(azureClientIDEnvKey))
+		if w.ClientID == "" {
+			return nil, errors.New("empty client ID")
+		}
+	}
+
+	// Fallback to using tenant ID from env variable.
+	if w.TenantID == "" {
+		w.TenantID = strings.TrimSpace(os.Getenv(azureTenantIDEnvKey))
+		if w.TenantID == "" {
+			return nil, errors.New("empty tenant ID")
+		}
+	}
+	return w, nil
+}
+
+// NewWorkloadIdentityCredential returns a workload identity credential.
+func NewWorkloadIdentityCredential(options *WorkloadIdentityCredentialOptions) (azcore.TokenCredential, error) {
+	w := &workloadIdentityCredential{file: options.TokenFilePath}
+	cred, err := azidentity.NewClientAssertionCredential(options.TenantID, options.ClientID, w.getAssertion, &azidentity.ClientAssertionCredentialOptions{ClientOptions: options.ClientOptions})
+	if err != nil {
+		return nil, err
+	}
+	w.cred = cred
+	return w, nil
+}
+
+// GetToken returns the token for azwi.
+func (w *workloadIdentityCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return w.cred.GetToken(ctx, opts)
+}
+
+func (w *workloadIdentityCredential) getAssertion(context.Context) (string, error) {
+	if now := time.Now(); w.lastRead.Add(azureFederatedTokenFileRefreshTime).Before(now) {
+		content, err := os.ReadFile(w.file)
+		if err != nil {
+			return "", err
+		}
+		w.assertion = string(content)
+		w.lastRead = now
+	}
+	return w.assertion, nil
+}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml
@@ -150,6 +150,7 @@ spec:
                 - UserAssignedMSI
                 - ManualServicePrincipal
                 - ServicePrincipalCertificate
+                - WorkloadIdentity
                 type: string
             required:
             - clientID

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: system
   labels:
     control-plane: capz-controller-manager
+    #ToDo: (@sonasingh46): Remove this label as part of aad pod identity deprecation
     aadpodidbinding: capz-controller-aadpodidentity-selector
+
 spec:
   selector:
     matchLabels:
@@ -16,6 +18,7 @@ spec:
       labels:
         control-plane: capz-controller-manager
         aadpodidbinding: capz-controller-aadpodidentity-selector
+        azure.workload.identity/use: "true"
       annotations:
         kubectl.kubernetes.io/default-container: manager
     spec:
@@ -28,6 +31,10 @@ spec:
           image: controller:latest
           imagePullPolicy: Always
           name: manager
+          volumeMounts:
+            - mountPath: /var/run/secrets/azure/tokens
+              name: azure-identity-token
+              readOnly: true
           ports:
             - containerPort: 9440
               name: healthz
@@ -75,3 +82,12 @@ spec:
           key: node-role.kubernetes.io/master
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: azure-identity-token
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              audience: api://AzureADTokenExchange
+              expirationSeconds: 3600
+              path: azure-identity-token

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
   name: manager
   namespace: system

--- a/scripts/kind-with-registry.sh
+++ b/scripts/kind-with-registry.sh
@@ -21,6 +21,7 @@ set -o pipefail
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 KUBECTL="${REPO_ROOT}/hack/tools/bin/kubectl"
 KIND="${REPO_ROOT}/hack/tools/bin/kind"
+AZWI_ENABLED=${AZWI:-}
 make --directory="${REPO_ROOT}" "${KUBECTL##*/}" "${KIND##*/}"
 
 # Export desired cluster name; default is "capz"
@@ -41,6 +42,56 @@ if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true
     registry:2
 fi
 
+# To use workload identity, service account signing key pairs base64 encoded should be exposed via the
+# env variables. The function creates the key pair files after reading it from the env variables.
+function checkAZWIENVPreReqsAndCreateFiles() {
+  if [[ -z "${SERVICE_ACCOUNT_SIGNING_PUB}" ]]; then
+    echo "'SERVICE_ACCOUNT_SIGNING_PUB' is not set."
+    exit 1
+  fi
+
+  if [[ -z "${SERVICE_ACCOUNT_SIGNING_KEY}" ]]; then
+    echo "'SERVICE_ACCOUNT_SIGNING_KEY' is not set."
+    exit 1
+  fi
+  mkdir -p "$HOME"/azwi/creds
+  echo "${SERVICE_ACCOUNT_SIGNING_PUB}" > "$HOME"/azwi/creds/sa.pub
+  echo  "${SERVICE_ACCOUNT_SIGNING_KEY}" > "$HOME"/azwi/creds/sa.key
+  SERVICE_ACCOUNT_ISSUER="${SERVICE_ACCOUNT_ISSUER:-https://oidcissuercapzci.blob.core.windows.net/oidc-capzci/}"
+}
+
+# This function create a kind cluster for Workload identity which requires key pairs path
+# to be mounted on the kind cluster and hence extra mount flags are required.
+function createKindForAZWI() {
+  echo "creating azwi kind"
+  cat <<EOF | "${KIND}" create cluster --name "${KIND_CLUSTER_NAME}" --config=-
+  kind: Cluster
+  apiVersion: kind.x-k8s.io/v1alpha4
+  nodes:
+  - role: control-plane
+    extraMounts:
+      - hostPath: $HOME/azwi/creds/sa.pub
+        containerPath: /etc/kubernetes/pki/sa.pub
+      - hostPath: $HOME/azwi/creds/sa.key
+        containerPath: /etc/kubernetes/pki/sa.key
+    kubeadmConfigPatches:
+    - |
+      kind: ClusterConfiguration
+      apiServer:
+        extraArgs:
+          service-account-issuer: ${SERVICE_ACCOUNT_ISSUER}
+          service-account-key-file: /etc/kubernetes/pki/sa.pub
+          service-account-signing-key-file: /etc/kubernetes/pki/sa.key
+      controllerManager:
+        extraArgs:
+          service-account-private-key-file: /etc/kubernetes/pki/sa.key
+  containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry]
+       config_path = "/etc/containerd/certs.d"
+EOF
+}
+
 # 2. Create kind cluster with containerd registry config dir enabled
 # TODO: kind will eventually enable this by default and this patch will
 # be unnecessary.
@@ -49,7 +100,14 @@ fi
 # https://github.com/kubernetes-sigs/kind/issues/2875
 # https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
 # See: https://github.com/containerd/containerd/blob/main/docs/hosts.md
-cat <<EOF | ${KIND} create cluster --name "${KIND_CLUSTER_NAME}" --config=-
+if [ "$AZWI_ENABLED" == 'true' ]
+ then
+   echo "azwi is enabled..."
+   checkAZWIENVPreReqsAndCreateFiles
+   createKindForAZWI
+else
+  echo "azwi is not enabled..."
+ cat <<EOF | ${KIND} create cluster --name "${KIND_CLUSTER_NAME}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
@@ -57,6 +115,7 @@ containerdConfigPatches:
   [plugins."io.containerd.grpc.v1.cri".registry]
     config_path = "/etc/containerd/certs.d"
 EOF
+fi
 
 # 3. Add the registry config to the nodes
 #

--- a/templates/test/ci/cluster-template-prow-workload-identity.yaml
+++ b/templates/test/ci/cluster-template-prow-workload-identity.yaml
@@ -1,0 +1,220 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
+    creationTimestamp: ${TIMESTAMP}
+    jobName: ${JOB_NAME}
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureClusterIdentity
+    name: ${CLUSTER_IDENTITY_NAME}
+  location: ${AZURE_LOCATION}
+  networkSpec:
+    subnets:
+    - name: control-plane-subnet
+      role: control-plane
+    - name: node-subnet
+      role: node
+    vnet:
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
+  subscriptionID: ${AZURE_SUBSCRIPTION_ID}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
+          cloud-provider: external
+          feature-gates: MixedProtocolLBService=true
+        timeoutForControlPlane: 20m
+      controllerManager:
+        extraArgs:
+          allocate-node-cidrs: "false"
+          cloud-provider: external
+          cluster-name: ${CLUSTER_NAME}
+          v: "4"
+      etcd:
+        local:
+          dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
+    diskSetup:
+      filesystems:
+      - device: /dev/disk/azure/scsi1/lun0
+        extraOpts:
+        - -E
+        - lazy_itable_init=1,lazy_journal_init=1
+        filesystem: ext4
+        label: etcd_disk
+      - device: ephemeral0.1
+        filesystem: ext4
+        label: ephemeral0
+        replaceFS: ntfs
+      partitions:
+      - device: /dev/disk/azure/scsi1/lun0
+        layout: true
+        overwrite: false
+        tableType: gpt
+    files:
+    - contentFrom:
+        secret:
+          key: control-plane-azure.json
+          name: ${CLUSTER_NAME}-control-plane-azure-json
+      owner: root:root
+      path: /etc/kubernetes/azure.json
+      permissions: "0644"
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          azure-container-registry-config: /etc/kubernetes/azure.json
+          cloud-provider: external
+        name: '{{ ds.meta_data["local_hostname"] }}'
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          azure-container-registry-config: /etc/kubernetes/azure.json
+          cloud-provider: external
+        name: '{{ ds.meta_data["local_hostname"] }}'
+    mounts:
+    - - LABEL=etcd_disk
+      - /var/lib/etcddisk
+    postKubeadmCommands: []
+    preKubeadmCommands: []
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: AzureMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      dataDisks:
+      - diskSizeGB: 256
+        lun: 0
+        nameSuffix: etcddisk
+      identity: UserAssigned
+      osDisk:
+        diskSizeGB: 128
+        osType: Linux
+      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      userAssignedIdentities:
+      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
+      vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-md-0
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureMachineTemplate
+        name: ${CLUSTER_NAME}-md-0
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      identity: UserAssigned
+      osDisk:
+        diskSizeGB: 128
+        osType: Linux
+      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      userAssignedIdentities:
+      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
+      vmSize: ${AZURE_NODE_MACHINE_TYPE}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      files:
+      - contentFrom:
+          secret:
+            key: worker-node-azure.json
+            name: ${CLUSTER_NAME}-md-0-azure-json
+        owner: root:root
+        path: /etc/kubernetes/azure.json
+        permissions: "0644"
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            azure-container-registry-config: /etc/kubernetes/azure.json
+            cloud-provider: external
+          name: '{{ ds.meta_data["local_hostname"] }}'
+      preKubeadmCommands: []
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureClusterIdentity
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  name: ${CLUSTER_IDENTITY_NAME}
+  namespace: default
+spec:
+  allowedNamespaces: {}
+  clientID: ${AZURE_CLIENT_ID}
+  clientSecret:
+    name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
+    namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
+  tenantID: ${AZURE_TENANT_ID}
+  type: WorkloadIdentity

--- a/templates/test/ci/patches/azureclusteridentity-azwi.yaml
+++ b/templates/test/ci/patches/azureclusteridentity-azwi.yaml
@@ -1,0 +1,11 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureClusterIdentity
+metadata:
+  name: "${CLUSTER_IDENTITY_NAME}"
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+spec:
+  type: WorkloadIdentity
+  allowedNamespaces: {}
+  tenantID: "${AZURE_TENANT_ID}"
+  clientID: "${AZURE_CLIENT_ID}"

--- a/templates/test/ci/prow-workload-identity/kustomization.yaml
+++ b/templates/test/ci/prow-workload-identity/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ../../../flavors/default
+patchesStrategicMerge:
+  - ../patches/azureclusteridentity-azwi.yaml
+  - ../patches/tags.yaml
+  - ../patches/controller-manager.yaml
+  - ../patches/apiserver.yaml
+  - ../patches/uami-md-0.yaml
+  - ../patches/uami-control-plane.yaml

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -994,4 +994,55 @@ var _ = Describe("Workload cluster creation", func() {
 			By("PASSED!")
 		})
 	})
+
+	// Workload identity test
+	Context("Creating a cluster that uses workload identity [OPTIONAL]", func() {
+		It("with a 1 control plane nodes and 2 worker nodes", func() {
+			By("using workload-identity")
+			clusterName = getClusterName(clusterNamePrefix, "azwi")
+			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(
+				specName,
+				withFlavor("workload-identity"),
+				withNamespace(namespace.Name),
+				withClusterName(clusterName),
+				withControlPlaneMachineCount(1),
+				withWorkerMachineCount(2),
+				withControlPlaneWaiters(clusterctl.ControlPlaneWaiters{
+					WaitForControlPlaneInitialized: EnsureControlPlaneInitialized,
+				}),
+				withPostMachinesProvisioned(func() {
+					EnsureDaemonsets(ctx, func() DaemonsetsSpecInput {
+						return DaemonsetsSpecInput{
+							BootstrapClusterProxy: bootstrapClusterProxy,
+							Namespace:             namespace,
+							ClusterName:           clusterName,
+						}
+					})
+				}),
+			), result)
+
+			By("Verifying expected VM extensions are present on the node", func() {
+				AzureVMExtensionsSpec(ctx, func() AzureVMExtensionsSpecInput {
+					return AzureVMExtensionsSpecInput{
+						BootstrapClusterProxy: bootstrapClusterProxy,
+						Namespace:             namespace,
+						ClusterName:           clusterName,
+					}
+				})
+			})
+
+			By("Creating an accessible load balancer", func() {
+				AzureLBSpec(ctx, func() AzureLBSpecInput {
+					return AzureLBSpecInput{
+						BootstrapClusterProxy: bootstrapClusterProxy,
+						Namespace:             namespace,
+						ClusterName:           clusterName,
+						SkipCleanup:           skipCleanup,
+					}
+				})
+			})
+
+			By("Workload identity test PASSED!")
+		})
+	})
 })

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -122,6 +122,8 @@ providers:
         targetName: "cluster-template-intree-cloud-provider.yaml"
       - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml"
         targetName: "cluster-template-machine-pool-flex.yaml"
+      - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-workload-identity.yaml"
+        targetName: "cluster-template-workload-identity.yaml"
       - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-aks.yaml"
         targetName: "cluster-template-aks.yaml"
       - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-custom-vnet.yaml"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -168,11 +168,18 @@ func setupBootstrapCluster(config *clusterctl.E2EConfig, useExistingCluster bool
 
 		kubeconfigPath = clusterProvider.GetKubeconfigPath()
 		Expect(kubeconfigPath).To(BeAnExistingFile(), "Failed to get the kubeconfig file for the bootstrap cluster")
+	} else {
+		// @sonasingh46: Workaround for testing workload identity.
+		// Loading image for already created cluster
+		imagesInput := bootstrap.LoadImagesToKindClusterInput{
+			Name:   "capz-e2e",
+			Images: config.Images,
+		}
+		err := bootstrap.LoadImagesToKindCluster(context.TODO(), imagesInput)
+		Expect(err).To(BeNil(), "Failed to load images to the bootstrap cluster: %s", err)
 	}
-
 	clusterProxy := NewAzureClusterProxy("bootstrap", kubeconfigPath)
 	Expect(clusterProxy).NotTo(BeNil(), "Failed to get a bootstrap cluster proxy")
-
 	return clusterProvider, clusterProxy
 }
 


### PR DESCRIPTION
 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
This PR enables Workload Identity capability in capz.
<!--
Add one of the following kinds:
/kind feature
-->

**What this PR does / why we need it**:
Implementation of proposal https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2814
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3588 
Partly fixes #2205 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add support for workload identity in capz
```
