### PR TITLE
Refactor and add missing test coverage for validateclustertemplatespec

### DIFF
--- a/api/v1beta1/azureclustertemplate_validation.go
+++ b/api/v1beta1/azureclustertemplate_validation.go
@@ -55,6 +55,18 @@ func (c *AzureClusterTemplate) validateClusterTemplateSpec() field.ErrorList {
 		field.NewPath("spec").Child("template").Child("spec").Child("networkSpec").Child("apiServerLB"),
 	)...)
 
+	allErrs = append(allErrs, c.validateNetworkSpec()...)
+
+	allErrs = append(allErrs, c.validateControlPlaneOutboundLB()...)
+
+	allErrs = append(allErrs, c.validatePrivateDNSZoneName()...)
+
+	return allErrs
+}
+
+func (c *AzureClusterTemplate) validateNetworkSpec() field.ErrorList {
+	var allErrs field.ErrorList
+
 	var needOutboundLB bool
 	networkSpec := c.Spec.Template.Spec.NetworkSpec
 	for _, subnet := range networkSpec.Subnets {
@@ -66,10 +78,6 @@ func (c *AzureClusterTemplate) validateClusterTemplateSpec() field.ErrorList {
 	if needOutboundLB {
 		allErrs = append(allErrs, c.validateNodeOutboundLB()...)
 	}
-
-	allErrs = append(allErrs, c.validateControlPlaneOutboundLB()...)
-
-	allErrs = append(allErrs, c.validatePrivateDNSZoneName()...)
 
 	return allErrs
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds test for https://app.codecov.io/github/kubernetes-sigs/cluster-api-provider-azure/blob/main/api/v1beta1/azureclustertemplate_validation.go#L58 and move code block https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/api/v1beta1/azureclustertemplate_validation.go#L58-L68  to its helper function

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3371

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
