### PR TITLE
Prioritize workload ID creds for SDKv2 services

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -20,9 +20,11 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/go-autorest/autorest"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	"sigs.k8s.io/cluster-api-provider-azure/version"
@@ -381,6 +383,54 @@ type userAgentPolicy struct{}
 func (p userAgentPolicy) Do(req *policy.Request) (*http.Response, error) {
 	req.Raw().Header.Set("User-Agent", req.Raw().UserAgent()+" "+UserAgent())
 	return req.Next()
+}
+
+// NewDefaultCredential creates a new credential that uses the following methods, in order of precedence:
+// 1. Workload Identity
+// 2. Managed Identity
+// 3. Environment variables
+// 4. Azure CLI.
+func NewDefaultCredential(clientOptions *azcore.ClientOptions) (*azidentity.ChainedTokenCredential, error) {
+	sources := []azcore.TokenCredential{}
+
+	if clientOptions == nil {
+		clientOptions = &azcore.ClientOptions{}
+	}
+
+	workloadIDOpts := azidentity.WorkloadIdentityCredentialOptions{ClientOptions: *clientOptions}
+	workloadIDCred, err := azidentity.NewWorkloadIdentityCredential(&workloadIDOpts)
+	if err != nil {
+		// TODO: log error
+	} else {
+		sources = append(sources, workloadIDCred)
+	}
+
+	managedIDOpts := azidentity.ManagedIdentityCredentialOptions{ClientOptions: *clientOptions}
+	managedIDCred, err := azidentity.NewManagedIdentityCredential(&managedIDOpts)
+	if err != nil {
+		// TODO: log error
+	} else {
+		sources = append(sources, managedIDCred)
+	}
+
+	environmentOpts := azidentity.EnvironmentCredentialOptions{ClientOptions: *clientOptions}
+	environmentCred, err := azidentity.NewEnvironmentCredential(&environmentOpts)
+	if err != nil {
+		// TODO: log error
+	} else {
+		sources = append(sources, environmentCred)
+	}
+
+	azureCLIOpts := azidentity.AzureCLICredentialOptions{}
+	azureCLICred, err := azidentity.NewAzureCLICredential(&azureCLIOpts)
+	if err != nil {
+		// TODO: log error
+	} else {
+		sources = append(sources, azureCLICred)
+	}
+
+	chainedCredOptions := azidentity.ChainedTokenCredentialOptions{}
+	return azidentity.NewChainedTokenCredential(sources, &chainedCredOptions)
 }
 
 // SetAutoRestClientDefaults set authorizer and user agent for autorest client.

--- a/azure/services/virtualmachineimages/client.go
+++ b/azure/services/virtualmachineimages/client.go
@@ -19,7 +19,6 @@ package virtualmachineimages
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -49,7 +48,7 @@ func NewClient(auth azure.Authorizer) (*AzureClient, error) {
 
 // newVirtualMachineImagesClient creates a new VM images client from subscription ID and base URI.
 func newVirtualMachineImagesClient(subscriptionID, azureEnvironment string) (armcompute.VirtualMachineImagesClient, error) {
-	credential, err := azidentity.NewDefaultAzureCredential(nil)
+	credential, err := azure.NewDefaultCredential(nil)
 	if err != nil {
 		return armcompute.VirtualMachineImagesClient{}, errors.Wrap(err, "failed to create default Azure credential")
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Replaces the SDKv2 `DefaultAzureCredential` with a `ChainedTokenCredential` that prefers workload ID and managed ID to environment (or `az` CLI) auth.

**Which issue(s) this PR fixes**:

Fixes #3569

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
