### PR TITLE
Revert "Update virtualmachineimages service to SDK v2"

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -20,9 +20,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/go-autorest/autorest"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	"sigs.k8s.io/cluster-api-provider-azure/version"
@@ -35,10 +32,6 @@ const (
 	DefaultAKSUserName = "azureuser"
 	// PublicCloudName is the name of the Azure public cloud.
 	PublicCloudName = "AzurePublicCloud"
-	// ChinaCloudName is the name of the Azure China cloud.
-	ChinaCloudName = "AzureChinaCloud"
-	// USGovernmentCloudName is the name of the Azure US Government cloud.
-	USGovernmentCloudName = "AzureUSGovernmentCloud"
 )
 
 const (
@@ -334,53 +327,6 @@ func GetBootstrappingVMExtension(osType string, cloud string, vmName string) *Ex
 // UserAgent specifies a string to append to the agent identifier.
 func UserAgent() string {
 	return fmt.Sprintf("cluster-api-provider-azure/%s", version.Get().String())
-}
-
-// ARMClientOptions returns default ARM client options for CAPZ SDK v2 requests.
-func ARMClientOptions(azureEnvironment string) (*arm.ClientOptions, error) {
-	opts := &arm.ClientOptions{}
-
-	switch azureEnvironment {
-	case PublicCloudName:
-		opts.Cloud = cloud.AzurePublic
-	case ChinaCloudName:
-		opts.Cloud = cloud.AzureChina
-	case USGovernmentCloudName:
-		opts.Cloud = cloud.AzureGovernment
-	case "":
-		// No cloud name provided, so leave at defaults.
-	default:
-		return nil, fmt.Errorf("invalid cloud name %q", azureEnvironment)
-	}
-	opts.PerCallPolicies = []policy.Policy{
-		correlationIDPolicy{},
-		userAgentPolicy{},
-	}
-	opts.Retry.MaxRetries = -1 // Less than zero means one try and no retries.
-
-	return opts, nil
-}
-
-// correlationIDPolicy adds the "x-ms-correlation-request-id" header to requests.
-// It implements the policy.Policy interface.
-type correlationIDPolicy struct{}
-
-// Do adds the "x-ms-correlation-request-id" header if a request has a correlation ID in its context.
-func (p correlationIDPolicy) Do(req *policy.Request) (*http.Response, error) {
-	if corrID, ok := tele.CorrIDFromCtx(req.Raw().Context()); ok {
-		req.Raw().Header.Set(string(tele.CorrIDKeyVal), string(corrID))
-	}
-	return req.Next()
-}
-
-// userAgentPolicy extends the "User-Agent" header on requests.
-// It implements the policy.Policy interface.
-type userAgentPolicy struct{}
-
-// Do extends the "User-Agent" header of a request by appending CAPZ's user agent.
-func (p userAgentPolicy) Do(req *policy.Request) (*http.Response, error) {
-	req.Raw().Header.Set("User-Agent", req.Raw().UserAgent()+" "+UserAgent())
-	return req.Next()
 }
 
 // SetAutoRestClientDefaults set authorizer and user agent for autorest client.

--- a/azure/defaults_test.go
+++ b/azure/defaults_test.go
@@ -24,96 +24,10 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
-
-func TestARMClientOptions(t *testing.T) {
-	g := NewWithT(t)
-
-	tests := []struct {
-		name          string
-		cloudName     string
-		expectedCloud cloud.Configuration
-		expectError   bool
-	}{
-		{
-			name:          "should return default client options if cloudName is empty",
-			cloudName:     "",
-			expectedCloud: cloud.Configuration{},
-		},
-		{
-			name:          "should return Azure public cloud client options",
-			cloudName:     PublicCloudName,
-			expectedCloud: cloud.AzurePublic,
-		},
-		{
-			name:          "should return Azure China cloud client options",
-			cloudName:     ChinaCloudName,
-			expectedCloud: cloud.AzureChina,
-		},
-		{
-			name:          "should return Azure government cloud client options",
-			cloudName:     USGovernmentCloudName,
-			expectedCloud: cloud.AzureGovernment,
-		},
-		{
-			name:        "should return error if cloudName is unrecognized",
-			cloudName:   "AzureUnrecognizedCloud",
-			expectError: true,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			opts, err := ARMClientOptions(tc.cloudName)
-			if tc.expectError {
-				g.Expect(err).To(HaveOccurred())
-				return
-			}
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(opts.Cloud).To(Equal(tc.expectedCloud))
-			g.Expect(opts.Retry.MaxRetries).To(BeNumerically("==", -1))
-			g.Expect(opts.PerCallPolicies).To(HaveLen(2))
-		})
-	}
-}
-
-func TestPerCallPolicies(t *testing.T) {
-	g := NewWithT(t)
-
-	corrID := "test-1234abcd-5678efgh"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		g.Expect(r.Header.Get("User-Agent")).To(ContainSubstring("cluster-api-provider-azure/"))
-		g.Expect(r.Header.Get(string(tele.CorrIDKeyVal))).To(Equal(corrID))
-		fmt.Fprintf(w, "Hello, %s", r.Proto)
-	}))
-	defer server.Close()
-
-	opts, err := ARMClientOptions("")
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(opts.PerCallPolicies).To(HaveLen(2))
-	ctx := context.WithValue(context.Background(), tele.CorrIDKeyVal, tele.CorrID(corrID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, server.URL)
-	g.Expect(err).NotTo(HaveOccurred())
-	pipeline := defaultTestPipeline(opts.PerCallPolicies)
-	resp, err := pipeline.Do(req)
-	g.Expect(err).NotTo(HaveOccurred())
-	defer resp.Body.Close()
-	g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-}
-
-func defaultTestPipeline(policies []policy.Policy) runtime.Pipeline {
-	return runtime.NewPipeline(
-		"testmodule",
-		"v0.1.0",
-		runtime.PipelineOptions{},
-		&policy.ClientOptions{PerCallPolicies: policies},
-	)
-}
 
 func TestAutoRestClientAppendUserAgent(t *testing.T) {
 	g := NewWithT(t)

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -697,10 +697,7 @@ func (m *MachineScope) GetVMImage(ctx context.Context) (*infrav1.Image, error) {
 		return m.AzureMachine.Spec.Image, nil
 	}
 
-	svc, err := virtualmachineimages.New(m)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create virtualmachineimages service")
-	}
+	svc := virtualmachineimages.New(m)
 
 	if m.AzureMachine.Spec.OSDisk.OSType == azure.WindowsOS {
 		runtime := m.AzureMachine.Annotations["runtime"]

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -1377,9 +1377,9 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 
 	clusterMock := mock_azure.NewMockClusterScoper(mockCtrl)
 	clusterMock.EXPECT().Authorizer().AnyTimes()
+	clusterMock.EXPECT().BaseURI().AnyTimes()
 	clusterMock.EXPECT().Location().AnyTimes()
 	clusterMock.EXPECT().SubscriptionID().AnyTimes()
-	clusterMock.EXPECT().CloudEnvironment().AnyTimes()
 	svc := virtualmachineimages.Service{Client: mock_virtualmachineimages.NewMockClient(mockCtrl)}
 
 	tests := []struct {

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -626,16 +626,12 @@ func (m *MachinePoolScope) GetVMImage(ctx context.Context) (*infrav1.Image, erro
 		return m.AzureMachinePool.Spec.Template.Image, nil
 	}
 
+	svc := virtualmachineimages.New(m)
+
 	var (
 		err          error
 		defaultImage *infrav1.Image
 	)
-
-	svc, err := virtualmachineimages.New(m)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create virtualmachineimages service")
-	}
-
 	if m.AzureMachinePool.Spec.Template.OSDisk.OSType == azure.WindowsOS {
 		runtime := m.AzureMachinePool.Annotations["runtime"]
 		windowsServerVersion := m.AzureMachinePool.Annotations["windowsServerVersion"]

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -326,9 +326,9 @@ func TestMachinePoolScope_GetVMImage(t *testing.T) {
 
 	clusterMock := mock_azure.NewMockClusterScoper(mockCtrl)
 	clusterMock.EXPECT().Authorizer().AnyTimes()
+	clusterMock.EXPECT().BaseURI().AnyTimes()
 	clusterMock.EXPECT().Location().AnyTimes()
 	clusterMock.EXPECT().SubscriptionID().AnyTimes()
-	clusterMock.EXPECT().CloudEnvironment().AnyTimes()
 	cases := []struct {
 		Name   string
 		Setup  func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool)

--- a/azure/services/virtualmachineimages/cache_test.go
+++ b/azure/services/virtualmachineimages/cache_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -34,13 +34,13 @@ func TestCacheGet(t *testing.T) {
 		publisher     string
 		offer         string
 		sku           string
-		have          armcompute.VirtualMachineImagesClientListResponse
+		have          compute.ListVirtualMachineImageResource
 		expectedError error
 	}{
 		"should find": {
 			location: "test", publisher: "foo", offer: "bar", sku: "baz",
-			have: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			have: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("foo")},
 				},
 			},
@@ -48,8 +48,8 @@ func TestCacheGet(t *testing.T) {
 		},
 		"should not find": {
 			location: "test", publisher: "foo", offer: "bar", sku: "baz",
-			have: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{},
+			have: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{},
 			},
 			expectedError: errors.New("failed to refresh VM images cache"),
 		},

--- a/azure/services/virtualmachineimages/images_test.go
+++ b/azure/services/virtualmachineimages/images_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
@@ -35,7 +35,7 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 		k8sVersion      string
 		expectedSKU     string
 		expectedVersion string
-		versions        armcompute.VirtualMachineImagesClientListResponse
+		versions        compute.ListVirtualMachineImageResource
 	}{
 		{
 			k8sVersion:      "v1.15.6",
@@ -86,8 +86,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.21.13",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "121.13.20220613",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("121.13.20220526")},
 					{Name: pointer.String("121.13.20220613")},
 					{Name: pointer.String("121.13.20220524")},
@@ -108,8 +108,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.22.10",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "122.10.20220613",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("122.10.20220524")},
 					{Name: pointer.String("122.10.20220613")},
 				},
@@ -119,8 +119,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.22.16",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "122.16.20221117",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("122.16.20221117")},
 				},
 			},
@@ -134,8 +134,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.23.7",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "123.7.20231231",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("123.7.20221124")},
 					{Name: pointer.String("123.7.20220524")},
 					{Name: pointer.String("123.7.20231231")},
@@ -147,8 +147,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.24.0",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "124.0.20220512",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("124.0.20220512")},
 				},
 			},
@@ -157,8 +157,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.23.12",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "123.12.20220921",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("123.12.20220921")},
 				},
 			},
@@ -167,8 +167,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.23.13",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "123.13.20221014",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("123.13.20221014")},
 				},
 			},
@@ -177,8 +177,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.24.6",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "124.6.20220921",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("124.6.20220921")},
 				},
 			},
@@ -187,8 +187,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.24.7",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "124.7.20221014",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("124.7.20221014")},
 				},
 			},
@@ -197,8 +197,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.25.2",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "125.2.20220921",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("125.2.20220921")},
 				},
 			},
@@ -207,8 +207,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.25.3",
 			expectedSKU:     "ubuntu-2204-gen1",
 			expectedVersion: "125.3.20221014",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("125.3.20221014")},
 				},
 			},
@@ -226,12 +226,12 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			mockAuth := mock_azure.NewMockAuthorizer(mockCtrl)
 			mockAuth.EXPECT().HashKey().Return(t.Name()).AnyTimes()
 			mockAuth.EXPECT().Authorizer().AnyTimes()
+			mockAuth.EXPECT().BaseURI().AnyTimes()
 			mockAuth.EXPECT().SubscriptionID().AnyTimes()
-			mockAuth.EXPECT().CloudEnvironment().AnyTimes()
 			mockClient := mock_virtualmachineimages.NewMockClient(mockCtrl)
 			svc := Service{Client: mockClient, Authorizer: mockAuth}
 
-			if test.versions.VirtualMachineImageResourceArray != nil {
+			if test.versions.Value != nil {
 				mockClient.EXPECT().
 					List(gomock.Any(), location, azure.DefaultImagePublisherID, azure.DefaultImageOfferID, gomock.Any()).
 					Return(test.versions, nil)
@@ -349,7 +349,7 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 		expectedSKU     string
 		expectedVersion string
 		expectedError   bool
-		versions        armcompute.VirtualMachineImagesClientListResponse
+		versions        compute.ListVirtualMachineImageResource
 	}{
 		{
 			k8sVersion:      "v1.14.9",
@@ -432,8 +432,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "121.13.20300524",
 			expectedError:   false,
 			osAndVersion:    "windows-2022",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("121.13.20220524")},
 					{Name: pointer.String("124.0.20220512")},
 					{Name: pointer.String("121.13.20220524")},
@@ -482,8 +482,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "123.12.20220921",
 			expectedError:   false,
 			osAndVersion:    "ubuntu-2004",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("123.12.20220921")},
 				},
 			},
@@ -494,8 +494,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "123.13.20220524",
 			expectedError:   false,
 			osAndVersion:    "ubuntu-2204",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("123.13.20220524")},
 				},
 			},
@@ -504,8 +504,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			k8sVersion:    "v1.23.13",
 			expectedError: true,
 			osAndVersion:  "ubuntu-2004",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{},
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{},
 			},
 		},
 		{
@@ -514,8 +514,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "124.0.20220512",
 			expectedError:   false,
 			osAndVersion:    "ubuntu-2004",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("124.0.20220512")},
 				},
 			},
@@ -526,8 +526,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "124.0.20220606",
 			expectedError:   false,
 			osAndVersion:    "windows-2022-containerd",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("124.0.20220606")},
 				},
 			},
@@ -536,8 +536,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			k8sVersion:    "v1.24.1",
 			expectedError: true,
 			osAndVersion:  "windows-2022-containerd",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("124.0.20220606")},
 				},
 			},
@@ -548,8 +548,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "125.4.20221011",
 			expectedError:   false,
 			osAndVersion:    "ubuntu-2204",
-			versions: armcompute.VirtualMachineImagesClientListResponse{
-				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
+			versions: compute.ListVirtualMachineImageResource{
+				Value: &[]compute.VirtualMachineImageResource{
 					{Name: pointer.String("125.4.20221011")},
 				},
 			},
@@ -567,8 +567,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			mockAuth := mock_azure.NewMockAuthorizer(mockCtrl)
 			mockAuth.EXPECT().HashKey().Return(t.Name()).AnyTimes()
 			mockAuth.EXPECT().Authorizer().AnyTimes()
+			mockAuth.EXPECT().BaseURI().AnyTimes()
 			mockAuth.EXPECT().SubscriptionID().AnyTimes()
-			mockAuth.EXPECT().CloudEnvironment().AnyTimes()
 			mockClient := mock_virtualmachineimages.NewMockClient(mockCtrl)
 			svc := Service{Client: mockClient, Authorizer: mockAuth}
 
@@ -576,7 +576,7 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			if strings.HasPrefix(test.osAndVersion, "windows") {
 				offer = azure.DefaultWindowsImageOfferID
 			}
-			if test.versions.VirtualMachineImageResourceArray != nil {
+			if test.versions.Value != nil {
 				mockClient.EXPECT().
 					List(gomock.Any(), location, azure.DefaultImagePublisherID, offer, gomock.Any()).
 					Return(test.versions, nil)

--- a/azure/services/virtualmachineimages/mock_virtualmachineimages/client_mock.go
+++ b/azure/services/virtualmachineimages/mock_virtualmachineimages/client_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
+	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -52,10 +52,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // List mocks base method.
-func (m *MockClient) List(ctx context.Context, location, publisher, offer, sku string) (armcompute.VirtualMachineImagesClientListResponse, error) {
+func (m *MockClient) List(ctx context.Context, location, publisher, offer, sku string) (compute.ListVirtualMachineImageResource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, location, publisher, offer, sku)
-	ret0, _ := ret[0].(armcompute.VirtualMachineImagesClientListResponse)
+	ret0, _ := ret[0].(compute.ListVirtualMachineImageResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4 v4.2.1
 	github.com/Azure/azure-service-operator/v2 v2.0.0
 	github.com/Azure/go-autorest/autorest v0.11.29
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.12

--- a/go.sum
+++ b/go.sum
@@ -53,15 +53,10 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0/go.mod h1:OQeznEEkTZ9Orh
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appconfiguration/armappconfiguration v1.0.0 h1:5reBX+9pzc5xp9VrjSUoPrE8Wl/3y7wjfHzGjXzJbNk=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4 v4.2.1 h1:UPeCRD+XY7QlaGQte2EVI2iOcWvUYA2XY8w5T/8v0NQ=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4 v4.2.1/go.mod h1:oGV6NlB0cvi1ZbYRR2UN44QHxWFyGk+iylgD0qaMXjA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice v1.0.0 h1:figxyQZXzZQIcP3njhC68bYUiTw45J8/SsHaLW8Ax0M=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos v1.0.0 h1:Fv8iibGn1eSw0lt2V3cTsuokBEnOP+M//n8OiMcCgTM=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNLjCUeKhgnAJWAKhEUQM+RJQo2H1fuGSw1Ky1E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning v1.0.0 h1:KWvCVjnOTKCZAlqED5KPNoN9AfcK2BhUeveLdiwy33Q=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.0.0 h1:nBy98uKOIfun5z6wx6jwWLrULcM0+cjBalBFZlEZ7CA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis v1.0.0 h1:nmpTBgRg1HynngFYICRhceC7s5dmbKN9fJ/XQz/UQ2I=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0 h1:ECsQtyERDVz3NP3kvDOTLvbQhqWp/x9EsGKtb4ogUr8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.0.0 h1:TMEyRFKh1zaSPmoQh3kxK+xRAYVq8guCI/7SMO0F3KY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.0.0 h1:vsovXlTyKHZXnqzQyt7QMVkwpJBDkHchQL53qXaGBRY=
 github.com/Azure/azure-service-operator/v2 v2.0.0 h1:qse4mdpy+X5OXvXs6MRwrqzZJnBLM8AYKOTAIXshnKo=


### PR DESCRIPTION
This reverts commit 0200628a42c46160970b312a19d1edb07a2d2942.

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Reverts the changes in #3474 to unblock Workload ID progress while we fix #3569.

**Which issue(s) this PR fixes**:

Refs #3569

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
