### PR TITLE
add BYO ASO resource

### DIFF
--- a/api/v1beta1/consts.go
+++ b/api/v1beta1/consts.go
@@ -159,3 +159,10 @@ const (
 	// WindowsOS is Windows OS value for OSDisk.OSType.
 	WindowsOS = "Windows"
 )
+
+const (
+	// OwnedByClusterLabelKey communicates CAPZ's ownership of an ASO resource
+	// independently of its ownership of the underlying Azure resource. The
+	// value for the label is the CAPI Cluster Name.
+	OwnedByClusterLabelKey = NameAzureProviderPrefix + string(ResourceLifecycleOwned)
+)

--- a/azure/services/aso/aso_test.go
+++ b/azure/services/aso/aso_test.go
@@ -30,12 +30,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
 	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+const clusterName = "cluster"
 
 type ErroringGetClient struct {
 	client.Client
@@ -74,7 +77,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		c := fakeclient.NewClientBuilder().
 			WithScheme(sch).
 			Build()
-		s := New(c)
+		s := New(c, clusterName)
 
 		mockCtrl := gomock.NewController(t)
 		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
@@ -90,6 +93,9 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
 				Namespace: "namespace",
+				Labels: map[string]string{
+					infrav1.OwnedByClusterLabelKey: clusterName,
+				},
 			},
 			Status: asoresourcesv1.ResourceGroup_STATUS{},
 		})).To(Succeed())
@@ -108,7 +114,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		c := fakeclient.NewClientBuilder().
 			WithScheme(sch).
 			Build()
-		s := New(c)
+		s := New(c, clusterName)
 
 		mockCtrl := gomock.NewController(t)
 		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
@@ -137,6 +143,12 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		g.Expect(c.Get(ctx, types.NamespacedName{Name: "name", Namespace: "namespace"}, created)).To(Succeed())
 		g.Expect(created.Name).To(Equal("name"))
 		g.Expect(created.Namespace).To(Equal("namespace"))
+		g.Expect(created.Labels).To(Equal(map[string]string{
+			infrav1.OwnedByClusterLabelKey: clusterName,
+		}))
+		g.Expect(created.Annotations).To(Equal(map[string]string{
+			ReconcilePolicyAnnotation: ReconcilePolicyManage,
+		}))
 		g.Expect(created.Spec).To(Equal(asoresourcesv1.ResourceGroup_Spec{
 			Location: pointer.String("location"),
 		}))
@@ -150,7 +162,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		c := fakeclient.NewClientBuilder().
 			WithScheme(sch).
 			Build()
-		s := New(c)
+		s := New(c, clusterName)
 
 		mockCtrl := gomock.NewController(t)
 		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
@@ -166,6 +178,9 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
 				Namespace: "namespace",
+				Labels: map[string]string{
+					infrav1.OwnedByClusterLabelKey: clusterName,
+				},
 			},
 			Status: asoresourcesv1.ResourceGroup_STATUS{
 				Conditions: []conditions.Condition{
@@ -195,7 +210,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		c := fakeclient.NewClientBuilder().
 			WithScheme(sch).
 			Build()
-		s := New(c)
+		s := New(c, clusterName)
 
 		mockCtrl := gomock.NewController(t)
 		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
@@ -211,6 +226,9 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
 				Namespace: "namespace",
+				Labels: map[string]string{
+					infrav1.OwnedByClusterLabelKey: clusterName,
+				},
 			},
 			Status: asoresourcesv1.ResourceGroup_STATUS{
 				Conditions: []conditions.Condition{
@@ -237,7 +255,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		c := fakeclient.NewClientBuilder().
 			WithScheme(sch).
 			Build()
-		s := New(c)
+		s := New(c, clusterName)
 
 		mockCtrl := gomock.NewController(t)
 		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
@@ -253,6 +271,9 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
 				Namespace: "namespace",
+				Labels: map[string]string{
+					infrav1.OwnedByClusterLabelKey: clusterName,
+				},
 			},
 			Status: asoresourcesv1.ResourceGroup_STATUS{
 				Conditions: []conditions.Condition{
@@ -282,7 +303,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		c := fakeclient.NewClientBuilder().
 			WithScheme(sch).
 			Build()
-		s := New(ErroringGetClient{Client: c, err: errors.New("an error")})
+		s := New(ErroringGetClient{Client: c, err: errors.New("an error")}, clusterName)
 
 		mockCtrl := gomock.NewController(t)
 		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
@@ -308,7 +329,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		c := fakeclient.NewClientBuilder().
 			WithScheme(sch).
 			Build()
-		s := New(c)
+		s := New(c, clusterName)
 
 		mockCtrl := gomock.NewController(t)
 		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
@@ -329,6 +350,9 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
 				Namespace: "namespace",
+				Labels: map[string]string{
+					infrav1.OwnedByClusterLabelKey: clusterName,
+				},
 			},
 			Status: asoresourcesv1.ResourceGroup_STATUS{
 				Conditions: []conditions.Condition{
@@ -353,7 +377,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		c := fakeclient.NewClientBuilder().
 			WithScheme(sch).
 			Build()
-		s := New(c)
+		s := New(c, clusterName)
 
 		mockCtrl := gomock.NewController(t)
 		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
@@ -364,6 +388,50 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			},
 		})
 		specMock.EXPECT().Parameters(gomockinternal.AContext(), gomock.Not(gomock.Nil())).Return(nil, errors.New("parameters error"))
+
+		ctx := context.Background()
+		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+				Labels: map[string]string{
+					infrav1.OwnedByClusterLabelKey: clusterName,
+				},
+			},
+			Status: asoresourcesv1.ResourceGroup_STATUS{
+				Conditions: []conditions.Condition{
+					{
+						Type:   conditions.ConditionTypeReady,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		})).To(Succeed())
+
+		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
+		g.Expect(result).To(BeNil())
+		g.Expect(err).NotTo(BeNil())
+		g.Expect(err.Error()).To(ContainSubstring("parameters error"))
+	})
+
+	t.Run("skip update for unmanaged resource", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		sch := runtime.NewScheme()
+		g.Expect(asoresourcesv1.AddToScheme(sch)).To(Succeed())
+		c := fakeclient.NewClientBuilder().
+			WithScheme(sch).
+			Build()
+		s := New(c, clusterName)
+
+		mockCtrl := gomock.NewController(t)
+		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
+		specMock.EXPECT().ResourceRef().Return(&asoresourcesv1.ResourceGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+		})
 
 		ctx := context.Background()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
@@ -382,9 +450,8 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})).To(Succeed())
 
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
-		g.Expect(result).To(BeNil())
-		g.Expect(err).NotTo(BeNil())
-		g.Expect(err.Error()).To(ContainSubstring("parameters error"))
+		g.Expect(result).NotTo(BeNil())
+		g.Expect(err).To(BeNil())
 	})
 
 	t.Run("resource up to date", func(t *testing.T) {
@@ -395,7 +462,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		c := fakeclient.NewClientBuilder().
 			WithScheme(sch).
 			Build()
-		s := New(c)
+		s := New(c, clusterName)
 
 		mockCtrl := gomock.NewController(t)
 		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
@@ -414,6 +481,12 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
 				Namespace: "namespace",
+				Labels: map[string]string{
+					infrav1.OwnedByClusterLabelKey: clusterName,
+				},
+				Annotations: map[string]string{
+					ReconcilePolicyAnnotation: ReconcilePolicyManage,
+				},
 			},
 			Spec: asoresourcesv1.ResourceGroup_Spec{
 				Location: pointer.String("location"),
@@ -434,7 +507,6 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		g.Expect(result.GetName()).To(Equal("name"))
 		g.Expect(result.GetNamespace()).To(Equal("namespace"))
-		g.Expect(result.GetLabels()).To(BeEmpty()) // label only added on create
 		g.Expect(result.(*asoresourcesv1.ResourceGroup).Spec.Location).To(Equal(pointer.String("location")))
 	})
 
@@ -446,7 +518,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		c := fakeclient.NewClientBuilder().
 			WithScheme(sch).
 			Build()
-		s := New(ErroringPatchClient{Client: c, err: errors.New("an error")})
+		s := New(ErroringPatchClient{Client: c, err: errors.New("an error")}, clusterName)
 
 		mockCtrl := gomock.NewController(t)
 		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
@@ -467,6 +539,9 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
 				Namespace: "namespace",
+				Labels: map[string]string{
+					infrav1.OwnedByClusterLabelKey: clusterName,
+				},
 			},
 			Status: asoresourcesv1.ResourceGroup_STATUS{
 				Conditions: []conditions.Condition{
@@ -495,7 +570,7 @@ func TestDeleteResource(t *testing.T) {
 		c := fakeclient.NewClientBuilder().
 			WithScheme(sch).
 			Build()
-		s := New(c)
+		s := New(c, clusterName)
 
 		mockCtrl := gomock.NewController(t)
 		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
@@ -504,7 +579,7 @@ func TestDeleteResource(t *testing.T) {
 				Name:      "name",
 				Namespace: "namespace",
 			},
-		})
+		}).AnyTimes()
 
 		ctx := context.Background()
 		err := s.DeleteResource(ctx, specMock, "service")
@@ -519,7 +594,7 @@ func TestDeleteResource(t *testing.T) {
 		c := fakeclient.NewClientBuilder().
 			WithScheme(sch).
 			Build()
-		s := New(c)
+		s := New(c, clusterName)
 
 		mockCtrl := gomock.NewController(t)
 		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
@@ -528,13 +603,16 @@ func TestDeleteResource(t *testing.T) {
 				Name:      "name",
 				Namespace: "namespace",
 			},
-		})
+		}).AnyTimes()
 
 		ctx := context.Background()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
 				Namespace: "namespace",
+				Labels: map[string]string{
+					infrav1.OwnedByClusterLabelKey: clusterName,
+				},
 			},
 		})).To(Succeed())
 
@@ -546,7 +624,7 @@ func TestDeleteResource(t *testing.T) {
 		g.Expect(recerr.IsTransient()).To(BeTrue())
 	})
 
-	t.Run("error deleting", func(t *testing.T) {
+	t.Run("skip delete for unmanaged resource", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		sch := runtime.NewScheme()
@@ -554,7 +632,7 @@ func TestDeleteResource(t *testing.T) {
 		c := fakeclient.NewClientBuilder().
 			WithScheme(sch).
 			Build()
-		s := New(ErroringDeleteClient{Client: c, err: errors.New("an error")})
+		s := New(c, clusterName)
 
 		mockCtrl := gomock.NewController(t)
 		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
@@ -563,13 +641,78 @@ func TestDeleteResource(t *testing.T) {
 				Name:      "name",
 				Namespace: "namespace",
 			},
-		})
+		}).AnyTimes()
 
 		ctx := context.Background()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
 				Namespace: "namespace",
+			},
+		})).To(Succeed())
+
+		err := s.DeleteResource(ctx, specMock, "service")
+		g.Expect(err).To(BeNil())
+	})
+
+	t.Run("error checking if resource is managed", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		sch := runtime.NewScheme()
+		g.Expect(asoresourcesv1.AddToScheme(sch)).To(Succeed())
+		c := fakeclient.NewClientBuilder().
+			WithScheme(sch).
+			Build()
+		s := New(ErroringGetClient{Client: c, err: errors.New("a get error")}, clusterName)
+
+		mockCtrl := gomock.NewController(t)
+		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
+		specMock.EXPECT().ResourceRef().Return(&asoresourcesv1.ResourceGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+		}).AnyTimes()
+
+		ctx := context.Background()
+		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+		})).To(Succeed())
+
+		err := s.DeleteResource(ctx, specMock, "service")
+		g.Expect(err).To(MatchError(ContainSubstring("a get error")))
+	})
+
+	t.Run("error deleting", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		sch := runtime.NewScheme()
+		g.Expect(asoresourcesv1.AddToScheme(sch)).To(Succeed())
+		c := fakeclient.NewClientBuilder().
+			WithScheme(sch).
+			Build()
+		s := New(ErroringDeleteClient{Client: c, err: errors.New("an error")}, clusterName)
+
+		mockCtrl := gomock.NewController(t)
+		specMock := mock_azure.NewMockASOResourceSpecGetter(mockCtrl)
+		specMock.EXPECT().ResourceRef().Return(&asoresourcesv1.ResourceGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+		}).AnyTimes()
+
+		ctx := context.Background()
+		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+				Labels: map[string]string{
+					infrav1.OwnedByClusterLabelKey: clusterName,
+				},
 			},
 		})).To(Succeed())
 

--- a/azure/services/asogroups/mock_asogroups/groups_mock.go
+++ b/azure/services/asogroups/mock_asogroups/groups_mock.go
@@ -67,6 +67,20 @@ func (mr *MockGroupScopeMockRecorder) ASOGroupSpec() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ASOGroupSpec", reflect.TypeOf((*MockGroupScope)(nil).ASOGroupSpec))
 }
 
+// ClusterName mocks base method.
+func (m *MockGroupScope) ClusterName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClusterName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ClusterName indicates an expected call of ClusterName.
+func (mr *MockGroupScopeMockRecorder) ClusterName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterName", reflect.TypeOf((*MockGroupScope)(nil).ClusterName))
+}
+
 // DeleteLongRunningOperationState mocks base method.
 func (m *MockGroupScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()

--- a/util/maps/maps.go
+++ b/util/maps/maps.go
@@ -33,3 +33,18 @@ func FilterByKeyPrefix(input map[string]string, prefix string) map[string]string
 	}
 	return result
 }
+
+// Merge merges the two maps and returns the result. For overlapping keys,
+// values from overrides take precedence.
+func Merge[K comparable, V any](base map[K]V, overrides map[K]V) map[K]V {
+	m := make(map[K]V)
+
+	for k, v := range base {
+		m[k] = v
+	}
+	for k, v := range overrides {
+		m[k] = v
+	}
+
+	return m
+}

--- a/util/maps/maps_test.go
+++ b/util/maps/maps_test.go
@@ -80,3 +80,44 @@ func TestFilterByKeyPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestMerge(t *testing.T) {
+	tests := []struct {
+		name      string
+		base      map[string]string
+		overrides map[string]string
+		expected  map[string]string
+	}{
+		{
+			name:      "nil base",
+			base:      nil,
+			overrides: map[string]string{"key": "value"},
+			expected:  map[string]string{"key": "value"},
+		},
+		{
+			name:      "nil overrides",
+			base:      map[string]string{"key": "value"},
+			overrides: nil,
+			expected:  map[string]string{"key": "value"},
+		},
+		{
+			name:      "overrides takes precedence",
+			base:      map[string]string{"key": "base"},
+			overrides: map[string]string{"key": "overrides"},
+			expected:  map[string]string{"key": "overrides"},
+		},
+		{
+			name:      "non-overlapping keys are all preserved",
+			base:      map[string]string{"base": "value"},
+			overrides: map[string]string{"overrides": "value"},
+			expected:  map[string]string{"base": "value", "overrides": "value"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			g.Expect(Merge(test.base, test.overrides)).To(gomega.Equal(test.expected))
+		})
+	}
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR makes it possible for users to bring-their-own ASO resources and have them participate in a CAPZ cluster. BYO ASO resources can be referred to by CAPZ objects but will not be modified or deleted by CAPZ, like how BYO Azure resources are handled currently.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3521

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

These changes are currently non-functional, but this branch includes all of the requisite changes to make this operable: https://github.com/kubernetes-sigs/cluster-api-provider-azure/compare/main...nojnhuh:cluster-api-provider-azure:aso-wired

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
