### PR TITLE
Allow azure:// prefix when parsing resource IDs

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -19,7 +19,9 @@ package azure
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/go-autorest/autorest"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	"sigs.k8s.io/cluster-api-provider-azure/version"
@@ -360,4 +362,9 @@ func msCorrelationIDSendDecorator(snd autorest.Sender) autorest.Sender {
 		}
 		return snd.Do(r)
 	})
+}
+
+// ParseResourceID parses a string to an *arm.ResourceID, first removing any "azure://" prefix.
+func ParseResourceID(id string) (*arm.ResourceID, error) {
+	return arm.ParseResourceID(strings.TrimPrefix(id, ProviderIDPrefix))
 }

--- a/azure/defaults_test.go
+++ b/azure/defaults_test.go
@@ -117,3 +117,55 @@ func TestMSCorrelationIDSendDecorator(t *testing.T) {
 		receivedReq.Header.Get(string(tele.CorrIDKeyVal)),
 	).To(Equal(string(corrID)))
 }
+
+func TestParseResourceID(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name         string
+		id           string
+		expectedName string
+		errExpected  bool
+	}{
+		{
+			name:         "invalid",
+			id:           "invalid",
+			expectedName: "",
+			errExpected:  true,
+		},
+		{
+			name:         "invalid: must start with slash",
+			id:           "subscriptions/123/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm",
+			expectedName: "",
+			errExpected:  true,
+		},
+		{
+			name:         "invalid: must start with subscriptions or providers",
+			id:           "/prescriptions/123/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm",
+			expectedName: "",
+			errExpected:  true,
+		},
+		{
+			name:         "valid",
+			id:           "/subscriptions/123/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm",
+			expectedName: "vm",
+		},
+		{
+			name:         "valid with provider prefix",
+			id:           "azure:///subscriptions/123/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm",
+			expectedName: "vm",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resourceID, err := ParseResourceID(tt.id)
+			if tt.errExpected {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resourceID.Name).To(Equal(tt.expectedName))
+			}
+		})
+	}
+}

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -378,7 +377,7 @@ func (m *MachinePoolScope) createMachine(ctx context.Context, machine azure.VMSS
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "scope.MachinePoolScope.createMachine")
 	defer done()
 
-	parsed, err := arm.ParseResourceID(machine.ID)
+	parsed, err := azure.ParseResourceID(machine.ID)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to parse resource id %q", machine.ID))
 	}

--- a/azure/services/identities/client.go
+++ b/azure/services/identities/client.go
@@ -19,7 +19,6 @@ package identities
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/services/msi/mgmt/2018-11-30/msi"
 	"github.com/Azure/go-autorest/autorest"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -63,7 +62,7 @@ func (ac *AzureClient) GetClientID(ctx context.Context, providerID string) (stri
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "identities.GetClientID")
 	defer done()
 
-	parsed, err := arm.ParseResourceID(providerID)
+	parsed, err := azure.ParseResourceID(providerID)
 	if err != nil {
 		return "", err
 	}

--- a/azure/services/natgateways/spec.go
+++ b/azure/services/natgateways/spec.go
@@ -19,7 +19,6 @@ package natgateways
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/pkg/errors"
 	"k8s.io/utils/pointer"
@@ -97,7 +96,7 @@ func hasPublicIP(natGateway network.NatGateway, publicIPName string) bool {
 	}
 
 	for _, publicIP := range *natGateway.PublicIPAddresses {
-		resource, err := arm.ParseResourceID(*publicIP.ID)
+		resource, err := azure.ParseResourceID(*publicIP.ID)
 		if err != nil {
 			continue
 		}

--- a/azure/services/scalesetvms/scalesetvms.go
+++ b/azure/services/scalesetvms/scalesetvms.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -147,7 +146,7 @@ func (s *Service) deleteVMSSFlexVM(ctx context.Context, resourceID string) error
 		}
 	}()
 
-	parsed, err := arm.ParseResourceID(resourceID)
+	parsed, err := azure.ParseResourceID(resourceID)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to parse resource id %q", resourceID))
 	}

--- a/azure/services/virtualmachines/client.go
+++ b/azure/services/virtualmachines/client.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
@@ -90,7 +89,7 @@ func (ac *AzureClient) GetByID(ctx context.Context, resourceID string) (compute.
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "virtualmachines.AzureClient.GetByID")
 	defer done()
 
-	parsed, err := arm.ParseResourceID(resourceID)
+	parsed, err := azure.ParseResourceID(resourceID)
 	if err != nil {
 		return compute.VirtualMachine{}, errors.Wrap(err, fmt.Sprintf("failed parsing the VM resource id %q", resourceID))
 	}

--- a/test/e2e/azure_edgezone.go
+++ b/test/e2e/azure_edgezone.go
@@ -21,9 +21,7 @@ package e2e
 
 import (
 	"context"
-	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	. "github.com/onsi/ginkgo/v2"
@@ -87,8 +85,7 @@ func AzureEdgeZoneClusterSpec(ctx context.Context, inputGetter func() AzureEdgeZ
 		vmClient.Authorizer = auth
 
 		// get the resource group name
-		resourceID := strings.TrimPrefix(*machineList.Items[0].Spec.ProviderID, azure.ProviderIDPrefix)
-		resource, err := arm.ParseResourceID(resourceID)
+		resource, err := azure.ParseResourceID(*machineList.Items[0].Spec.ProviderID)
 		Expect(err).NotTo(HaveOccurred())
 
 		vmListResults, err := vmClient.List(ctx, resource.ResourceGroupName, "")

--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/pkg/errors"
@@ -401,8 +400,7 @@ func collectVMBootLog(ctx context.Context, am *infrav1.AzureMachine, outputPath 
 		return errors.New("AzureMachine provider ID is nil")
 	}
 
-	resourceID := strings.TrimPrefix(*am.Spec.ProviderID, azure.ProviderIDPrefix)
-	resource, err := arm.ParseResourceID(resourceID)
+	resource, err := azure.ParseResourceID(*am.Spec.ProviderID)
 	if err != nil {
 		return errors.Wrap(err, "failed to parse resource id")
 	}
@@ -432,7 +430,7 @@ func collectVMSSBootLog(ctx context.Context, providerID string, outputPath strin
 	v := strings.Split(resourceID, "/")
 	instanceID := v[len(v)-1]
 	resourceID = strings.TrimSuffix(resourceID, "/virtualMachines/"+instanceID)
-	resource, err := arm.ParseResourceID(resourceID)
+	resource, err := azure.ParseResourceID(resourceID)
 	if err != nil {
 		return errors.Wrap(err, "failed to parse resource id")
 	}

--- a/test/e2e/azure_privatecluster.go
+++ b/test/e2e/azure_privatecluster.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/msi/mgmt/2018-11-30/msi"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
@@ -421,7 +420,7 @@ func SetupExistingVNet(ctx context.Context, vnetCidr string, cpSubnetCidrs, node
 }
 
 func getAPIVersion(resourceID string) (string, error) {
-	parsed, err := arm.ParseResourceID(resourceID)
+	parsed, err := azure.ParseResourceID(resourceID)
 	if err != nil {
 		return "", errors.Wrap(err, fmt.Sprintf("unable to parse resource ID %q", resourceID))
 	}
@@ -455,7 +454,7 @@ func getClientIDforMSI(resourceID string) string {
 	msiClient := msi.NewUserAssignedIdentitiesClient(subscriptionID)
 	msiClient.Authorizer = authorizer
 
-	parsed, err := arm.ParseResourceID(resourceID)
+	parsed, err := azure.ParseResourceID(resourceID)
 	Expect(err).NotTo(HaveOccurred())
 
 	id, err := msiClient.Get(context.TODO(), parsed.ResourceGroupName, parsed.Name)

--- a/test/e2e/azure_vmextensions.go
+++ b/test/e2e/azure_vmextensions.go
@@ -21,9 +21,7 @@ package e2e
 
 import (
 	"context"
-	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	. "github.com/onsi/ginkgo/v2"
@@ -98,8 +96,7 @@ func AzureVMExtensionsSpec(ctx context.Context, inputGetter func() AzureVMExtens
 		vmExtensionsClient.Authorizer = auth
 
 		// get the resource group name
-		resourceID := strings.TrimPrefix(*machineList.Items[0].Spec.ProviderID, azure.ProviderIDPrefix)
-		resource, err := arm.ParseResourceID(resourceID)
+		resource, err := azure.ParseResourceID(*machineList.Items[0].Spec.ProviderID)
 		Expect(err).NotTo(HaveOccurred())
 
 		vmListResults, err := vmClient.List(ctx, resource.ResourceGroupName, "")
@@ -146,8 +143,7 @@ func AzureVMExtensionsSpec(ctx context.Context, inputGetter func() AzureVMExtens
 		vmssExtensionsClient.Authorizer = auth
 
 		// get the resource group name
-		resourceID := strings.TrimPrefix(machinePoolList.Items[0].Spec.ProviderID, azure.ProviderIDPrefix)
-		resource, err := arm.ParseResourceID(resourceID)
+		resource, err := azure.ParseResourceID(machinePoolList.Items[0].Spec.ProviderID)
 		Expect(err).NotTo(HaveOccurred())
 
 		vmssListResults, err := vmssClient.List(ctx, resource.ResourceGroupName)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Handles user-assigned identity resource identifiers starting with an `azure://` prefix, which the new `ParseResourceID()` func doesn't tolerate.

**Which issue(s) this PR fixes**:

Fixes #3597

**Special notes for your reviewer**:

- [x] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Allow azure:// prefix when parsing resource IDs
```
