### PR TITLE
vendor and sanitize ASO CRDs

### DIFF
--- a/config/aso/crds.yaml
+++ b/config/aso/crds.yaml
@@ -1,0 +1,502 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: azureserviceoperator-system/azureserviceoperator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.9.2
+  labels:
+    serviceoperator.azure.com/version: v2.0.0
+  name: resourcegroups.resources.azure.com
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: azureserviceoperator-webhook-service
+          namespace: azureserviceoperator-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+        - v1
+  group: resources.azure.com
+  names:
+    kind: ResourceGroup
+    listKind: ResourceGroupList
+    plural: resourcegroups
+    singular: resourcegroup
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].severity
+          name: Severity
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+          name: Reason
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].message
+          name: Message
+          type: string
+      name: v1api20200601
+      schema:
+        openAPIV3Schema:
+          description: 'Generator information: - Generated from: /resources/resource-manager/Microsoft.Resources/stable/2020-06-01/resources.json - ARM URI: /subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}'
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                azureName:
+                  description: 'AzureName: The name of the resource in Azure. This is often the same as the name of the resource in Kubernetes but it doesn''t have to be.'
+                  maxLength: 90
+                  minLength: 1
+                  type: string
+                location:
+                  description: 'Location: The location of the resource group. It cannot be changed after the resource group has been created. It must be one of the supported Azure locations.'
+                  type: string
+                managedBy:
+                  description: 'ManagedBy: The ID of the resource that manages this resource group.'
+                  type: string
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: 'Tags: The tags attached to the resource group.'
+                  type: object
+              required:
+                - location
+              type: object
+            status:
+              description: Resource group information.
+              properties:
+                conditions:
+                  description: 'Conditions: The observed state of the resource'
+                  items:
+                    description: Condition defines an extension to status (an observation) of a resource
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human readable message indicating details about the transition. This field may be empty.
+                        type: string
+                      observedGeneration:
+                        description: ObservedGeneration is the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        type: integer
+                      reason:
+                        description: Reason for the condition's last transition. Reasons are upper CamelCase (PascalCase) with no spaces. A reason is always provided, this field will not be empty.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. For conditions which have positive polarity (Status == True is their normal/healthy state), this will be omitted when Status == True For conditions which have negative polarity (Status == False is their normal/healthy state), this will be omitted when Status == False. This is omitted in all cases when Status == Unknown
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, or Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                id:
+                  description: 'Id: The ID of the resource group.'
+                  type: string
+                location:
+                  description: 'Location: The location of the resource group. It cannot be changed after the resource group has been created. It must be one of the supported Azure locations.'
+                  type: string
+                managedBy:
+                  description: 'ManagedBy: The ID of the resource that manages this resource group.'
+                  type: string
+                name:
+                  description: 'Name: The name of the resource group.'
+                  type: string
+                properties:
+                  description: 'Properties: The resource group properties.'
+                  properties:
+                    provisioningState:
+                      description: 'ProvisioningState: The provisioning state.'
+                      type: string
+                  type: object
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: 'Tags: The tags attached to the resource group.'
+                  type: object
+                type:
+                  description: 'Type: The type of the resource group.'
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].severity
+          name: Severity
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+          name: Reason
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].message
+          name: Message
+          type: string
+      name: v1api20200601storage
+      schema:
+        openAPIV3Schema:
+          description: 'Storage version of v1api20200601.ResourceGroup Generator information: - Generated from: /resources/resource-manager/Microsoft.Resources/stable/2020-06-01/resources.json - ARM URI: /subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}'
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Storage version of v1api20200601.ResourceGroup_Spec
+              properties:
+                $propertyBag:
+                  additionalProperties:
+                    type: string
+                  description: PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage resources, allowing for full fidelity round trip conversions
+                  type: object
+                azureName:
+                  description: 'AzureName: The name of the resource in Azure. This is often the same as the name of the resource in Kubernetes but it doesn''t have to be.'
+                  maxLength: 90
+                  minLength: 1
+                  type: string
+                location:
+                  type: string
+                managedBy:
+                  type: string
+                originalVersion:
+                  type: string
+                tags:
+                  additionalProperties:
+                    type: string
+                  type: object
+              type: object
+            status:
+              description: Storage version of v1api20200601.ResourceGroup_STATUS Resource group information.
+              properties:
+                $propertyBag:
+                  additionalProperties:
+                    type: string
+                  description: PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage resources, allowing for full fidelity round trip conversions
+                  type: object
+                conditions:
+                  items:
+                    description: Condition defines an extension to status (an observation) of a resource
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human readable message indicating details about the transition. This field may be empty.
+                        type: string
+                      observedGeneration:
+                        description: ObservedGeneration is the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        type: integer
+                      reason:
+                        description: Reason for the condition's last transition. Reasons are upper CamelCase (PascalCase) with no spaces. A reason is always provided, this field will not be empty.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. For conditions which have positive polarity (Status == True is their normal/healthy state), this will be omitted when Status == True For conditions which have negative polarity (Status == False is their normal/healthy state), this will be omitted when Status == False. This is omitted in all cases when Status == Unknown
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, or Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                id:
+                  type: string
+                location:
+                  type: string
+                managedBy:
+                  type: string
+                name:
+                  type: string
+                properties:
+                  description: Storage version of v1api20200601.ResourceGroupProperties_STATUS The resource group properties.
+                  properties:
+                    $propertyBag:
+                      additionalProperties:
+                        type: string
+                      description: PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage resources, allowing for full fidelity round trip conversions
+                      type: object
+                    provisioningState:
+                      type: string
+                  type: object
+                tags:
+                  additionalProperties:
+                    type: string
+                  type: object
+                type:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].severity
+          name: Severity
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+          name: Reason
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].message
+          name: Message
+          type: string
+      name: v1beta20200601
+      schema:
+        openAPIV3Schema:
+          description: Deprecated version of ResourceGroup. Use v1api20200601.ResourceGroup instead
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                azureName:
+                  description: 'AzureName: The name of the resource in Azure. This is often the same as the name of the resource in Kubernetes but it doesn''t have to be.'
+                  maxLength: 90
+                  minLength: 1
+                  type: string
+                location:
+                  type: string
+                managedBy:
+                  type: string
+                tags:
+                  additionalProperties:
+                    type: string
+                  type: object
+              required:
+                - location
+              type: object
+            status:
+              description: Deprecated version of ResourceGroup_STATUS. Use v1api20200601.ResourceGroup_STATUS instead
+              properties:
+                conditions:
+                  description: 'Conditions: The observed state of the resource'
+                  items:
+                    description: Condition defines an extension to status (an observation) of a resource
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human readable message indicating details about the transition. This field may be empty.
+                        type: string
+                      observedGeneration:
+                        description: ObservedGeneration is the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        type: integer
+                      reason:
+                        description: Reason for the condition's last transition. Reasons are upper CamelCase (PascalCase) with no spaces. A reason is always provided, this field will not be empty.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. For conditions which have positive polarity (Status == True is their normal/healthy state), this will be omitted when Status == True For conditions which have negative polarity (Status == False is their normal/healthy state), this will be omitted when Status == False. This is omitted in all cases when Status == Unknown
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, or Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                id:
+                  type: string
+                location:
+                  type: string
+                managedBy:
+                  type: string
+                name:
+                  type: string
+                properties:
+                  description: Deprecated version of ResourceGroupProperties_STATUS. Use v1api20200601.ResourceGroupProperties_STATUS instead
+                  properties:
+                    provisioningState:
+                      type: string
+                  type: object
+                tags:
+                  additionalProperties:
+                    type: string
+                  type: object
+                type:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].severity
+          name: Severity
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+          name: Reason
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].message
+          name: Message
+          type: string
+      name: v1beta20200601storage
+      schema:
+        openAPIV3Schema:
+          description: Storage version of v1beta20200601.ResourceGroup Deprecated version of ResourceGroup. Use v1api20200601.ResourceGroup instead
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Storage version of v1beta20200601.ResourceGroup_Spec
+              properties:
+                $propertyBag:
+                  additionalProperties:
+                    type: string
+                  description: PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage resources, allowing for full fidelity round trip conversions
+                  type: object
+                azureName:
+                  description: 'AzureName: The name of the resource in Azure. This is often the same as the name of the resource in Kubernetes but it doesn''t have to be.'
+                  maxLength: 90
+                  minLength: 1
+                  type: string
+                location:
+                  type: string
+                managedBy:
+                  type: string
+                originalVersion:
+                  type: string
+                tags:
+                  additionalProperties:
+                    type: string
+                  type: object
+              type: object
+            status:
+              description: Storage version of v1beta20200601.ResourceGroup_STATUS Deprecated version of ResourceGroup_STATUS. Use v1api20200601.ResourceGroup_STATUS instead
+              properties:
+                $propertyBag:
+                  additionalProperties:
+                    type: string
+                  description: PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage resources, allowing for full fidelity round trip conversions
+                  type: object
+                conditions:
+                  items:
+                    description: Condition defines an extension to status (an observation) of a resource
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human readable message indicating details about the transition. This field may be empty.
+                        type: string
+                      observedGeneration:
+                        description: ObservedGeneration is the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        type: integer
+                      reason:
+                        description: Reason for the condition's last transition. Reasons are upper CamelCase (PascalCase) with no spaces. A reason is always provided, this field will not be empty.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. For conditions which have positive polarity (Status == True is their normal/healthy state), this will be omitted when Status == True For conditions which have negative polarity (Status == False is their normal/healthy state), this will be omitted when Status == False. This is omitted in all cases when Status == Unknown
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, or Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                id:
+                  type: string
+                location:
+                  type: string
+                managedBy:
+                  type: string
+                name:
+                  type: string
+                properties:
+                  description: Storage version of v1beta20200601.ResourceGroupProperties_STATUS Deprecated version of ResourceGroupProperties_STATUS. Use v1api20200601.ResourceGroupProperties_STATUS instead
+                  properties:
+                    $propertyBag:
+                      additionalProperties:
+                        type: string
+                      description: PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage resources, allowing for full fidelity round trip conversions
+                      type: object
+                    provisioningState:
+                      type: string
+                  type: object
+                tags:
+                  additionalProperties:
+                    type: string
+                  type: object
+                type:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}

--- a/config/aso/kustomization.yaml
+++ b/config/aso/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Component
 namespace: capz-system
 resources:
 - https://github.com/Azure/azure-service-operator/releases/download/v2.0.0/azureserviceoperator_v2.0.0.yaml
-- https://github.com/Azure/azure-service-operator/releases/download/v2.0.0/azureserviceoperator_customresourcedefinitions_v2.0.0.yaml
+- crds.yaml
 - credentials.yaml
 
 patches:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
When testing installing ASO v2.1.0, I noticed the ASO controller manager getting stuck in CrashLoopBackoff because it was unexpectedly trying to update some CRDs and failing because CAPZ does not grant ASO permissions to do so. This was due to a few places where `envsubst` replaced `$$` with `$`. This change vendors the ASO CRDs to sanitize them by replacing `$$` with `$$$$` so after `envsubst`, the  intended`$$` remains.

ASO was also facing issues with high kube-apiserver memory usage when all its CRDs are installed, so this change also includes a filter to only install the ASO CRDs required by CAPZ: https://github.com/Azure/azure-service-operator/issues/2920.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
