### PR TITLE
test integration with CAPI cluster-autoscaler

### DIFF
--- a/azure/services/agentpools/agentpools.go
+++ b/azure/services/agentpools/agentpools.go
@@ -46,6 +46,7 @@ type AgentPoolScope interface {
 	RemoveCAPIMachinePoolAnnotation(key string)
 	SetSubnetName()
 	IsPreviewEnabled() bool
+	ReconcileReplicas(ctx context.Context, vmssReplicas int) error
 }
 
 // New creates a new service.
@@ -70,8 +71,6 @@ func postCreateOrUpdateResourceHook(ctx context.Context, scope AgentPoolScope, o
 	if ptr.Deref(agentPool.Status.EnableAutoScaling, false) {
 		scope.SetCAPIMachinePoolAnnotation(clusterv1.ReplicasManagedByAnnotation, "true")
 		scope.SetCAPIMachinePoolReplicas(agentPool.Status.Count)
-	} else { // Otherwise, remove the annotation.
-		scope.RemoveCAPIMachinePoolAnnotation(clusterv1.ReplicasManagedByAnnotation)
 	}
 	return nil
 }

--- a/azure/services/agentpools/agentpools_test.go
+++ b/azure/services/agentpools/agentpools_test.go
@@ -45,8 +45,6 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		scope := mock_agentpools.NewMockAgentPoolScope(mockCtrl)
 
-		scope.EXPECT().RemoveCAPIMachinePoolAnnotation(clusterv1.ReplicasManagedByAnnotation)
-
 		managedCluster := &asocontainerservicev1.ManagedClustersAgentPool{
 			Status: asocontainerservicev1.ManagedClusters_AgentPool_STATUS{
 				EnableAutoScaling: ptr.To(false),

--- a/azure/services/agentpools/mock_agentpools/agentpools_mock.go
+++ b/azure/services/agentpools/mock_agentpools/agentpools_mock.go
@@ -26,6 +26,7 @@ limitations under the License.
 package mock_agentpools
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -224,6 +225,20 @@ func (m *MockAgentPoolScope) NodeResourceGroup() string {
 func (mr *MockAgentPoolScopeMockRecorder) NodeResourceGroup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeResourceGroup", reflect.TypeOf((*MockAgentPoolScope)(nil).NodeResourceGroup))
+}
+
+// ReconcileReplicas mocks base method.
+func (m *MockAgentPoolScope) ReconcileReplicas(ctx context.Context, vmssReplicas int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileReplicas", ctx, vmssReplicas)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReconcileReplicas indicates an expected call of ReconcileReplicas.
+func (mr *MockAgentPoolScopeMockRecorder) ReconcileReplicas(ctx, vmssReplicas any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileReplicas", reflect.TypeOf((*MockAgentPoolScope)(nil).ReconcileReplicas), ctx, vmssReplicas)
 }
 
 // RemoveCAPIMachinePoolAnnotation mocks base method.

--- a/controllers/azuremanagedmachinepool_controller_test.go
+++ b/controllers/azuremanagedmachinepool_controller_test.go
@@ -69,6 +69,7 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 				agentpools.SetSubnetName()
 				agentpools.AgentPoolSpec().Return(&fakeAgentPoolSpec)
 				agentpools.NodeResourceGroup().Return("fake-rg")
+				agentpools.ReconcileReplicas(gomock2.AContext(), 1)
 				agentpools.SetAgentPoolProviderIDList(providerIDs)
 				agentpools.SetAgentPoolReplicas(int32(len(providerIDs))).Return()
 				agentpools.SetAgentPoolReady(true).Return()

--- a/controllers/azuremanagedmachinepool_reconciler.go
+++ b/controllers/azuremanagedmachinepool_reconciler.go
@@ -164,6 +164,9 @@ func (s *azureManagedMachinePoolService) Reconcile(ctx context.Context) error {
 		providerIDs[i] = providerID
 	}
 
+	if err := s.scope.ReconcileReplicas(ctx, len(instances)); err != nil {
+		return errors.Wrap(err, "unable to reconcile VMSS replicas")
+	}
 	s.scope.SetAgentPoolProviderIDList(providerIDs)
 	s.scope.SetAgentPoolReplicas(int32(len(providerIDs)))
 	s.scope.SetAgentPoolReady(true)

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,13 @@ require (
 )
 
 require (
+	github.com/chai2010/gettext-go v1.0.2 // indirect
+	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+)
+
+require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.7.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kubernetesconfiguration/armkubernetesconfiguration v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chai2010/gettext-go v1.0.2 h1:1Lwwip6Q2QGsAdl/ZKPCwTe9fe0CjlUbqj5bFNSjIRk=
+github.com/chai2010/gettext-go v1.0.2/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -186,6 +188,8 @@ github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lSh
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
+github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
+github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
@@ -352,6 +356,8 @@ github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa1
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
+github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
@@ -408,6 +414,7 @@ github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -61,6 +61,14 @@ capz::util::should_build_ccm() {
     echo "false"
 }
 
+capz::util::should_build_cluster_autoscaler() {
+    # TEST_CLUSTER_AUTOSCALER is an environment variable set by a prow job to indicate that the cluster-autoscaler runtime should be built and tested.
+    if [[ -n "${TEST_CLUSTER_AUTOSCALER:-}" ]]; then
+        echo "true" && return
+    fi
+    echo "false"
+}
+
 # all test regions must support AvailabilityZones
 capz::util::get_random_region() {
     local REGIONS=("canadacentral" "eastus" "eastus2" "northeurope" "uksouth" "westeurope" "westus2" "westus3")

--- a/scripts/ci-build-cluster-autoscaler.sh
+++ b/scripts/ci-build-cluster-autoscaler.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${REPO_ROOT}" || exit 1
+
+# shellcheck source=hack/ensure-go.sh
+source "${REPO_ROOT}/hack/ensure-go.sh"
+# shellcheck source=hack/parse-prow-creds.sh
+source "${REPO_ROOT}/hack/parse-prow-creds.sh"
+
+: "${REGISTRY:?Environment variable empty or not defined.}"
+
+# cluster-autoscaler image
+export CLUSTER_AUTOSCALER_IMAGE_NAME=cluster-autoscaler-amd64
+
+setup() {
+    CLUSTER_AUTOSCALER_ROOT="${CLUSTER_AUTOSCALER_ROOT:-""}"
+    if [[ -z "${CLUSTER_AUTOSCALER_ROOT}" ]]; then
+        CLUSTER_AUTOSCALER_ROOT="$(go env GOPATH)/src/k8s.io/autoscaler/cluster-autoscaler"
+        export CLUSTER_AUTOSCALER_ROOT
+    fi
+
+    # the azure-cloud-provider repo expects IMAGE_REGISTRY.
+    export IMAGE_REGISTRY=${REGISTRY}
+    pushd "${CLUSTER_AUTOSCALER_ROOT}" && TAG=$(git rev-parse --short=7 HEAD) &&
+      export TAG && popd
+    export CLUSTER_AUTOSCALER_IMAGE="${REGISTRY}/${CLUSTER_AUTOSCALER_IMAGE_NAME}:${TAG}"
+    # We use CLUSTER_AUTOSCALER_IMAGE_REPO to pass to the helm install command
+    export CLUSTER_AUTOSCALER_IMAGE_REPO="${REGISTRY}/${CLUSTER_AUTOSCALER_IMAGE_NAME}"
+    # We use CLUSTER_AUTOSCALER_IMAGE_TAG to pass to the helm install command
+    export CLUSTER_AUTOSCALER_IMAGE_TAG="${TAG}"
+    echo "Image registry is ${REGISTRY}"
+    echo "Image Tag is ${TAG}"
+    echo "Image reference is ${CLUSTER_AUTOSCALER_IMAGE}"
+}
+
+main() {
+    if [[ "$(can_reuse_artifacts)" =~ "false" ]]; then
+        echo "Building Linux amd64 cluster-autoscaler"
+        export GOFLAGS=-mod=mod
+        make -C "${CLUSTER_AUTOSCALER_ROOT}" build
+        make -C "${CLUSTER_AUTOSCALER_ROOT}" make-image
+        docker push "${CLUSTER_AUTOSCALER_IMAGE}"
+    fi
+}
+
+# can_reuse_artifacts returns true if there exists CCM artifacts built from a PR that we can reuse
+can_reuse_artifacts() {
+    if ! docker pull "${CLUSTER_AUTOSCALER_IMAGE}"; then
+        echo "false" && return
+    fi
+    echo "true"
+}
+
+capz::ci-build-cluster-autoscaler::cleanup() {
+    echo "cluster-autoscaler cleanup"
+    if [[ -d "${CLUSTER_AUTOSCALER_ROOT:-}" ]]; then
+        make -C "${CLUSTER_AUTOSCALER_ROOT}" clean || true
+    fi
+}
+
+trap capz::ci-build-cluster-autoscaler::cleanup EXIT
+
+setup
+main

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -42,7 +42,7 @@ source "${REPO_ROOT}/hack/util.sh"
 capz::util::ensure_azure_envs
 
 export LOCAL_ONLY=${LOCAL_ONLY:-"true"}
-export USE_LOCAL_KIND_REGISTRY=${USE_LOCAL_KIND_REGISTRY:-${LOCAL_ONLY}} 
+export USE_LOCAL_KIND_REGISTRY=${USE_LOCAL_KIND_REGISTRY:-${LOCAL_ONLY}}
 export BUILD_MANAGER_IMAGE=${BUILD_MANAGER_IMAGE:-"true"}
 
 if [[ "${USE_LOCAL_KIND_REGISTRY}" == "false" ]]; then
@@ -64,7 +64,12 @@ if [[ "$(capz::util::should_build_ccm)" == "true" ]]; then
   echo "Will use the ${IMAGE_REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG_CNM} cloud-node-manager image for external cloud-provider-azure cluster"
 fi
 
-export GINKGO_NODES=10
+if [[ "$(capz::util::should_build_cluster_autoscaler)" == "true" ]]; then
+  # shellcheck source=scripts/ci-build-cluster-autoscaler.sh
+  source "${REPO_ROOT}/scripts/ci-build-cluster-autoscaler.sh"
+fi
+
+export GINKGO_NODES=${GINKGO_NODES:-10}
 
 export AZURE_LOCATION="${AZURE_LOCATION:-$(capz::util::get_random_region)}"
 export AZURE_LOCATION_GPU="${AZURE_LOCATION_GPU:-$(capz::util::get_random_region_gpu)}"

--- a/templates/test/ci/cluster-template-prow-aks-cluster-autoscaler.yaml
+++ b/templates/test/ci/cluster-template-prow-aks-cluster-autoscaler.yaml
@@ -1,0 +1,139 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks:
+      - 192.168.0.0/16
+  controlPlaneRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureManagedControlPlane
+    name: ${CLUSTER_NAME}
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureManagedCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedControlPlane
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
+    creationTimestamp: ${TIMESTAMP}
+    jobName: ${JOB_NAME}
+  addonProfiles:
+  - enabled: true
+    name: azurepolicy
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureClusterIdentity
+    name: ${CLUSTER_IDENTITY_NAME}
+  location: ${AZURE_LOCATION}
+  oidcIssuerProfile:
+    enabled: true
+  resourceGroupName: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
+  sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+  subscriptionID: ${AZURE_SUBSCRIPTION_ID}
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: ${CLUSTER_NAME}-pool0
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT:=2}
+  template:
+    metadata: {}
+    spec:
+      bootstrap:
+        dataSecretName: ""
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureManagedMachinePool
+        name: ${CLUSTER_NAME}-pool0
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedMachinePool
+metadata:
+  name: ${CLUSTER_NAME}-pool0
+  namespace: default
+spec:
+  availabilityZones:
+  - "1"
+  - "2"
+  enableNodePublicIP: false
+  enableUltraSSD: true
+  maxPods: 30
+  mode: System
+  name: pool0
+  osDiskSizeGB: 30
+  osDiskType: Managed
+  sku: ${AZURE_AKS_NODE_MACHINE_TYPE:=Standard_D2s_v3}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  annotations:
+    cluster.x-k8s.io/replicas-managed-by: cluster-autoscaler
+  name: ${CLUSTER_NAME}-pool1
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT:=2}
+  template:
+    metadata: {}
+    spec:
+      bootstrap:
+        dataSecretName: ""
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureManagedMachinePool
+        name: ${CLUSTER_NAME}-pool1
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedMachinePool
+metadata:
+  name: ${CLUSTER_NAME}-pool1
+  namespace: default
+spec:
+  enableNodePublicIP: false
+  mode: User
+  name: pool1
+  osDiskSizeGB: 40
+  osDiskType: Ephemeral
+  scaleSetPriority: Regular
+  sku: ${AZURE_AKS_NODE_MACHINE_TYPE:=Standard_D2s_v3}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureClusterIdentity
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  name: ${CLUSTER_IDENTITY_NAME}
+  namespace: default
+spec:
+  allowedNamespaces: {}
+  clientID: ${AZURE_CLIENT_ID}
+  clientSecret:
+    name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
+    namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
+  tenantID: ${AZURE_TENANT_ID}
+  type: ServicePrincipal

--- a/templates/test/ci/cluster-template-prow-cluster-autoscaler-capi.yaml
+++ b/templates/test/ci/cluster-template-prow-cluster-autoscaler-capi.yaml
@@ -1,0 +1,321 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL:=azure}
+    cni: calico
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
+    creationTimestamp: ${TIMESTAMP}
+    jobName: ${JOB_NAME}
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureClusterIdentity
+    name: ${CLUSTER_IDENTITY_NAME}
+  location: ${AZURE_LOCATION}
+  networkSpec:
+    subnets:
+    - name: control-plane-subnet
+      role: control-plane
+    - name: node-subnet
+      role: node
+    vnet:
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
+  subscriptionID: ${AZURE_SUBSCRIPTION_ID}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
+          cloud-provider: external
+        timeoutForControlPlane: 20m
+      controllerManager:
+        extraArgs:
+          allocate-node-cidrs: "false"
+          cloud-provider: external
+          cluster-name: ${CLUSTER_NAME}
+          v: "4"
+      etcd:
+        local:
+          dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
+    diskSetup:
+      filesystems:
+      - device: /dev/disk/azure/scsi1/lun0
+        extraOpts:
+        - -E
+        - lazy_itable_init=1,lazy_journal_init=1
+        filesystem: ext4
+        label: etcd_disk
+      - device: ephemeral0.1
+        filesystem: ext4
+        label: ephemeral0
+        replaceFS: ntfs
+      partitions:
+      - device: /dev/disk/azure/scsi1/lun0
+        layout: true
+        overwrite: false
+        tableType: gpt
+    files:
+    - contentFrom:
+        secret:
+          key: control-plane-azure.json
+          name: ${CLUSTER_NAME}-control-plane-azure-json
+      owner: root:root
+      path: /etc/kubernetes/azure.json
+      permissions: "0644"
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+        name: '{{ ds.meta_data["local_hostname"] }}'
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+        name: '{{ ds.meta_data["local_hostname"] }}'
+    mounts:
+    - - LABEL=etcd_disk
+      - /var/lib/etcddisk
+    postKubeadmCommands: []
+    preKubeadmCommands: []
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: AzureMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      dataDisks:
+      - diskSizeGB: 256
+        lun: 0
+        nameSuffix: etcddisk
+      osDisk:
+        diskSizeGB: 128
+        osType: Linux
+      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  annotations:
+    capacity.cluster-autoscaler.kubernetes.io/cpu: "2"
+    capacity.cluster-autoscaler.kubernetes.io/ephemeral-disk: 128Gi
+    capacity.cluster-autoscaler.kubernetes.io/memory: 4Gi
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "5"
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "1"
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT:=2}
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-md-0
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureMachineTemplate
+        name: ${CLUSTER_NAME}-md-0
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      osDisk:
+        diskSizeGB: 128
+        osType: Linux
+      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      vmSize: ${AZURE_NODE_MACHINE_TYPE}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      files:
+      - contentFrom:
+          secret:
+            key: worker-node-azure.json
+            name: ${CLUSTER_NAME}-md-0-azure-json
+        owner: root:root
+        path: /etc/kubernetes/azure.json
+        permissions: "0644"
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
+          name: '{{ ds.meta_data["local_hostname"] }}'
+      preKubeadmCommands: []
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureClusterIdentity
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  name: ${CLUSTER_IDENTITY_NAME}
+  namespace: default
+spec:
+  allowedNamespaces: {}
+  clientID: ${AZURE_CLIENT_ID}
+  clientSecret:
+    name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
+    namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
+  tenantID: ${AZURE_TENANT_ID}
+  type: ServicePrincipal
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}
+      registry: mcr.microsoft.com/oss
+    # Image and registry configuration for the tigera/operator pod.
+    tigeraOperator:
+      image: tigera/operator
+      registry: mcr.microsoft.com/oss
+    calicoctl:
+      image: mcr.microsoft.com/oss/calico/ctl
+  version: ${CALICO_VERSION}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: azuredisk-csi-driver-chart
+  namespace: default
+spec:
+  chartName: azuredisk-csi-driver
+  clusterSelector:
+    matchLabels:
+      azuredisk-csi: "true"
+  namespace: kube-system
+  releaseName: azuredisk-csi-driver-oot
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
+  valuesTemplate: |-
+    controller:
+      replicas: 1
+      runOnControlPlane: true
+    windows:
+      useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure-oot
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure-oot
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      cloudConfig: ${CLOUD_CONFIG:-"/etc/kubernetes/azure.json"}
+      cloudConfigSecretName: ${CONFIG_SECRET_NAME:-""}
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: "${CCM_IMAGE_NAME:-""}"
+      imageRepository: "${IMAGE_REGISTRY:-""}"
+      imageTag: "${IMAGE_TAG_CCM:-""}"
+      logVerbosity: ${CCM_LOG_VERBOSITY:-4}
+      replicas: ${CCM_COUNT:-1}
+      enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+    cloudNodeManager:
+      imageName: "${CNM_IMAGE_NAME:-""}"
+      imageRepository: "${IMAGE_REGISTRY:-""}"
+      imageTag: "${IMAGE_TAG_CNM:-""}"

--- a/templates/test/ci/cluster-template-prow-cluster-autoscaler-external.yaml
+++ b/templates/test/ci/cluster-template-prow-cluster-autoscaler-external.yaml
@@ -1,0 +1,393 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL:=azure}
+    cni: calico
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
+    creationTimestamp: ${TIMESTAMP}
+    jobName: ${JOB_NAME}
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureClusterIdentity
+    name: ${CLUSTER_IDENTITY_NAME}
+  location: ${AZURE_LOCATION}
+  networkSpec:
+    subnets:
+    - name: control-plane-subnet
+      role: control-plane
+    - name: node-subnet
+      role: node
+    vnet:
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
+  subscriptionID: ${AZURE_SUBSCRIPTION_ID}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
+          cloud-provider: external
+        timeoutForControlPlane: 20m
+      controllerManager:
+        extraArgs:
+          allocate-node-cidrs: "false"
+          cloud-provider: external
+          cluster-name: ${CLUSTER_NAME}
+          v: "4"
+      etcd:
+        local:
+          dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
+    diskSetup:
+      filesystems:
+      - device: /dev/disk/azure/scsi1/lun0
+        extraOpts:
+        - -E
+        - lazy_itable_init=1,lazy_journal_init=1
+        filesystem: ext4
+        label: etcd_disk
+      - device: ephemeral0.1
+        filesystem: ext4
+        label: ephemeral0
+        replaceFS: ntfs
+      partitions:
+      - device: /dev/disk/azure/scsi1/lun0
+        layout: true
+        overwrite: false
+        tableType: gpt
+    files:
+    - contentFrom:
+        secret:
+          key: control-plane-azure.json
+          name: ${CLUSTER_NAME}-control-plane-azure-json
+      owner: root:root
+      path: /etc/kubernetes/azure.json
+      permissions: "0644"
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+        name: '{{ ds.meta_data["local_hostname"] }}'
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+        name: '{{ ds.meta_data["local_hostname"] }}'
+    mounts:
+    - - LABEL=etcd_disk
+      - /var/lib/etcddisk
+    postKubeadmCommands: []
+    preKubeadmCommands: []
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: AzureMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      dataDisks:
+      - diskSizeGB: 256
+        lun: 0
+        nameSuffix: etcddisk
+      osDisk:
+        diskSizeGB: 128
+        osType: Linux
+      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: ${CLUSTER_NAME}-mp-0
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT:=2}
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfig
+          name: ${CLUSTER_NAME}-mp-0
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureMachinePool
+        name: ${CLUSTER_NAME}-mp-0
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachinePool
+metadata:
+  name: ${CLUSTER_NAME}-mp-0
+  namespace: default
+spec:
+  location: ${AZURE_LOCATION}
+  strategy:
+    rollingUpdate:
+      deletePolicy: Oldest
+      maxSurge: 25%
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    osDisk:
+      diskSizeGB: 30
+      managedDisk:
+        storageAccountType: Premium_LRS
+      osType: Linux
+    sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+    vmExtensions:
+    - name: CustomScript
+      protectedSettings:
+        commandToExecute: |
+          #!/bin/sh
+          echo "This script is a no-op used for extension testing purposes ..."
+          touch test_file
+      publisher: Microsoft.Azure.Extensions
+      version: "2.1"
+    vmSize: ${AZURE_NODE_MACHINE_TYPE}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfig
+metadata:
+  name: ${CLUSTER_NAME}-mp-0
+  namespace: default
+spec:
+  files:
+  - contentFrom:
+      secret:
+        key: worker-node-azure.json
+        name: ${CLUSTER_NAME}-mp-0-azure-json
+    owner: root:root
+    path: /etc/kubernetes/azure.json
+    permissions: "0644"
+  joinConfiguration:
+    nodeRegistration:
+      kubeletExtraArgs:
+        cloud-provider: external
+      name: '{{ ds.meta_data["local_hostname"] }}'
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureClusterIdentity
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  name: ${CLUSTER_IDENTITY_NAME}
+  namespace: default
+spec:
+  allowedNamespaces: {}
+  clientID: ${AZURE_CLIENT_ID}
+  clientSecret:
+    name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
+    namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
+  tenantID: ${AZURE_TENANT_ID}
+  type: ServicePrincipal
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}
+      registry: mcr.microsoft.com/oss
+    # Image and registry configuration for the tigera/operator pod.
+    tigeraOperator:
+      image: tigera/operator
+      registry: mcr.microsoft.com/oss
+    calicoctl:
+      image: mcr.microsoft.com/oss/calico/ctl
+  version: ${CALICO_VERSION}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: azuredisk-csi-driver-chart
+  namespace: default
+spec:
+  chartName: azuredisk-csi-driver
+  clusterSelector:
+    matchLabels:
+      azuredisk-csi: "true"
+  namespace: kube-system
+  releaseName: azuredisk-csi-driver-oot
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
+  valuesTemplate: |-
+    controller:
+      replicas: 1
+      runOnControlPlane: true
+    windows:
+      useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure-oot
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure-oot
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      cloudConfig: ${CLOUD_CONFIG:-"/etc/kubernetes/azure.json"}
+      cloudConfigSecretName: ${CONFIG_SECRET_NAME:-""}
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: "${CCM_IMAGE_NAME:-""}"
+      imageRepository: "${IMAGE_REGISTRY:-""}"
+      imageTag: "${IMAGE_TAG_CCM:-""}"
+      logVerbosity: ${CCM_LOG_VERBOSITY:-4}
+      replicas: ${CCM_COUNT:-1}
+      enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+    cloudNodeManager:
+      imageName: "${CNM_IMAGE_NAME:-""}"
+      imageRepository: "${IMAGE_REGISTRY:-""}"
+      imageTag: "${IMAGE_TAG_CNM:-""}"
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  annotations:
+    cluster.x-k8s.io/replicas-managed-by: cluster-autoscaler
+  name: ${CLUSTER_NAME}-mp-1
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT:=1}
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfig
+          name: ${CLUSTER_NAME}-mp-1
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureMachinePool
+        name: ${CLUSTER_NAME}-mp-1
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachinePool
+metadata:
+  name: ${CLUSTER_NAME}-mp-1
+  namespace: default
+spec:
+  location: ${AZURE_LOCATION}
+  strategy:
+    rollingUpdate:
+      deletePolicy: Oldest
+      maxSurge: 25%
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    osDisk:
+      diskSizeGB: 30
+      managedDisk:
+        storageAccountType: Premium_LRS
+      osType: Linux
+    sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+    vmSize: ${AZURE_NODE_MACHINE_TYPE}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfig
+metadata:
+  name: ${CLUSTER_NAME}-mp-1
+  namespace: default
+spec:
+  files:
+  - contentFrom:
+      secret:
+        key: worker-node-azure.json
+        name: ${CLUSTER_NAME}-mp-1-azure-json
+    owner: root:root
+    path: /etc/kubernetes/azure.json
+    permissions: "0644"
+  joinConfiguration:
+    nodeRegistration:
+      kubeletExtraArgs:
+        cloud-provider: external
+      name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/patches/cluster-autoscaler-capi-annotations.yaml
+++ b/templates/test/ci/patches/cluster-autoscaler-capi-annotations.yaml
@@ -1,0 +1,8 @@
+- op: add
+  path: /metadata/annotations
+  value:
+    "cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size": "1"
+    "cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size": "5"
+    "capacity.cluster-autoscaler.kubernetes.io/memory": "4Gi"
+    "capacity.cluster-autoscaler.kubernetes.io/cpu": "2"
+    "capacity.cluster-autoscaler.kubernetes.io/ephemeral-disk": "128Gi"

--- a/templates/test/ci/patches/cluster-autoscaler-external-annotations.yaml
+++ b/templates/test/ci/patches/cluster-autoscaler-external-annotations.yaml
@@ -1,0 +1,4 @@
+- op: add
+  path: /metadata/annotations
+  value:
+    "cluster.x-k8s.io/replicas-managed-by": "cluster-autoscaler"

--- a/templates/test/ci/prow-aks-cluster-autoscaler/kustomization.yaml
+++ b/templates/test/ci/prow-aks-cluster-autoscaler/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ../../../flavors/aks
+patches:
+- target:
+    group: cluster.x-k8s.io
+    version: v1beta1
+    kind: MachinePool
+    name: ".*-pool1"
+  path: ../patches/cluster-autoscaler-external-annotations.yaml
+patchesStrategicMerge:
+  - ../patches/tags-aks.yaml
+  - patches/aks-pool0.yaml
+  - patches/aks-pool1.yaml
+  - patches/addons.yaml

--- a/templates/test/ci/prow-aks-cluster-autoscaler/patches/addons.yaml
+++ b/templates/test/ci/prow-aks-cluster-autoscaler/patches/addons.yaml
@@ -1,0 +1,9 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedControlPlane
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  addonProfiles:
+  - enabled: true
+    name: azurepolicy

--- a/templates/test/ci/prow-aks-cluster-autoscaler/patches/aks-pool0.yaml
+++ b/templates/test/ci/prow-aks-cluster-autoscaler/patches/aks-pool0.yaml
@@ -1,0 +1,13 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedMachinePool
+metadata:
+  name: "${CLUSTER_NAME}-pool0"
+spec:
+  maxPods: 30
+  osDiskType: "Managed"
+  osDiskSizeGB: 30
+  enableNodePublicIP: false
+  enableUltraSSD: true
+  availabilityZones: ["1", "2"]
+  name: pool0
+  sku: "${AZURE_AKS_NODE_MACHINE_TYPE:=Standard_D2s_v3}"

--- a/templates/test/ci/prow-aks-cluster-autoscaler/patches/aks-pool1.yaml
+++ b/templates/test/ci/prow-aks-cluster-autoscaler/patches/aks-pool1.yaml
@@ -1,0 +1,11 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedMachinePool
+metadata:
+  name: "${CLUSTER_NAME}-pool1"
+spec:
+  osDiskType: "Ephemeral"
+  osDiskSizeGB: 40
+  enableNodePublicIP: false
+  scaleSetPriority: Regular
+  name: pool1
+  sku: "${AZURE_AKS_NODE_MACHINE_TYPE:=Standard_D2s_v3}"

--- a/templates/test/ci/prow-cluster-autoscaler-capi/kustomization.yaml
+++ b/templates/test/ci/prow-cluster-autoscaler-capi/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ../../../flavors/base
+  - ../../../flavors/default/machine-deployment.yaml
+  - ../../../azure-cluster-identity
+  - ../../../addons/cluster-api-helm/calico.yaml
+  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
+patchesStrategicMerge:
+  - ../patches/tags.yaml
+  - ../patches/controller-manager.yaml
+  - ../../../azure-cluster-identity/azurecluster-identity-ref.yaml
+  - ../patches/cluster-label-calico.yaml
+  - ../patches/cluster-label-cloud-provider-azure.yaml
+patches:
+- target:
+    group: cluster.x-k8s.io
+    version: v1beta1
+    kind: MachineDeployment
+    name: ".*-md-0"
+  path: ../patches/cluster-autoscaler-capi-annotations.yaml

--- a/templates/test/ci/prow-cluster-autoscaler-external/kustomization.yaml
+++ b/templates/test/ci/prow-cluster-autoscaler-external/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ../../../flavors/machinepool
+  - ../../../addons/cluster-api-helm/calico.yaml
+  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
+  - machine-pool-autoscale.yaml
+patches:
+- target:
+    group: cluster.x-k8s.io
+    version: v1beta1
+    kind: MachinePool
+    name: ".*-mp-1"
+  path: ../patches/cluster-autoscaler-external-annotations.yaml
+patchesStrategicMerge:
+  - ../patches/azuremachinepool-vmextension.yaml
+  - ../patches/tags.yaml
+  - ../patches/controller-manager.yaml
+  - ../patches/cluster-label-calico.yaml
+  - ../patches/cluster-label-cloud-provider-azure.yaml

--- a/templates/test/ci/prow-cluster-autoscaler-external/machine-pool-autoscale.yaml
+++ b/templates/test/ci/prow-cluster-autoscaler-external/machine-pool-autoscale.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: "${CLUSTER_NAME}-mp-1"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT:=1}
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-mp-1"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfig
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-mp-1"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureMachinePool
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachinePool
+metadata:
+  name: "${CLUSTER_NAME}-mp-1"
+spec:
+  location: ${AZURE_LOCATION}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 1
+      deletePolicy: Oldest
+  template:
+    vmSize: ${AZURE_NODE_MACHINE_TYPE}
+    osDisk:
+      osType: "Linux"
+      diskSizeGB: 30
+      managedDisk:
+        storageAccountType: "Premium_LRS"
+    sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfig
+metadata:
+  name: "${CLUSTER_NAME}-mp-1"
+spec:
+  joinConfiguration:
+    nodeRegistration:
+      name: '{{ ds.meta_data["local_hostname"] }}'
+      kubeletExtraArgs:
+        cloud-provider: external
+  files:
+  - contentFrom:
+      secret:
+        name: ${CLUSTER_NAME}-mp-1-azure-json
+        key: worker-node-azure.json
+    owner: root:root
+    path: /etc/kubernetes/azure.json
+    permissions: "0644"

--- a/test/e2e/azure_csidriver.go
+++ b/test/e2e/azure_csidriver.go
@@ -94,7 +94,7 @@ func AzureDiskCSISpec(ctx context.Context, inputGetter func() AzureDiskCSISpecIn
 
 	By("creating a deployment that uses pvc")
 	deploymentName := "stateful" + util.RandomString(6)
-	statefulDeployment := deploymentBuilder.Create("nginx", deploymentName, corev1.NamespaceDefault).AddPVC(pvcName)
+	statefulDeployment := deploymentBuilder.Create("nginx", deploymentName, corev1.NamespaceDefault, int32(1)).AddPVC(pvcName)
 	deployment, err := statefulDeployment.Deploy(ctx, clientset)
 	Expect(err).NotTo(HaveOccurred())
 	waitForDeploymentAvailable(ctx, deployment, clientset, specName)

--- a/test/e2e/azure_lb.go
+++ b/test/e2e/azure_lb.go
@@ -77,7 +77,7 @@ func AzureLBSpec(ctx context.Context, inputGetter func() AzureLBSpecInput) {
 		deploymentName = "web-windows" + util.RandomString(6)
 	}
 
-	webDeployment := deploymentBuilder.Create("httpd", deploymentName, corev1.NamespaceDefault)
+	webDeployment := deploymentBuilder.Create("httpd", deploymentName, corev1.NamespaceDefault, int32(1))
 	webDeployment.AddContainerPort("http", "http", 80, corev1.ProtocolTCP)
 
 	if input.Windows {

--- a/test/e2e/azure_machinepools.go
+++ b/test/e2e/azure_machinepools.go
@@ -43,7 +43,7 @@ import (
 const (
 	AzureMachinePoolsSpecName = "azure-machinepools"
 	regexpFlexibleVM          = `^azure:\/\/\/subscriptions\/[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}\/resourceGroups\/.+\/providers\/Microsoft.Compute\/virtualMachines\/.+$`
-	regexpUniformInstance     = `^azure:\/\/\/subscriptions\/[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}\/resourceGroups\/.+\/providers\/Microsoft.Compute\/virtualMachineScaleSets\/.+\/virtualMachines\/\d+$`
+	regexpUniformInstance     = `^azure:\/\/\/subscriptions\/[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}\/resourceGroups\/(.+)\/providers\/Microsoft.Compute\/virtualMachineScaleSets\/(.+)\/virtualMachines\/\d+$`
 )
 
 // AzureMachinePoolsSpecInput is the input for AzureMachinePoolsSpec.

--- a/test/e2e/azure_net_pol.go
+++ b/test/e2e/azure_net_pol.go
@@ -96,7 +96,7 @@ func AzureNetPolSpec(ctx context.Context, inputGetter func() AzureNetPolSpecInpu
 	// Front end Prod
 	frontendProdDeploymentName := fmt.Sprintf("frontend-prod-%v", randInt)
 	Log("starting to create frontend-prod deployments")
-	frontEndProd := deploymentBuilder.Create("library/nginx:1.21.1", frontendProdDeploymentName, namespaceProd.GetName())
+	frontEndProd := deploymentBuilder.Create("library/nginx:1.21.1", frontendProdDeploymentName, namespaceProd.GetName(), int32(1))
 	frontEndProd.AddLabels(frontendLabels)
 	frontendProdDeployment, err := frontEndProd.Deploy(ctx, clientset)
 	Expect(err).NotTo(HaveOccurred())
@@ -104,7 +104,7 @@ func AzureNetPolSpec(ctx context.Context, inputGetter func() AzureNetPolSpecInpu
 	// Front end Dev
 	frontendDevDeploymentName := fmt.Sprintf("frontend-dev-%v", randInt+100000)
 	Log("starting to create frontend-dev deployments")
-	frontEndDev := deploymentBuilder.Create("library/nginx:1.21.1", frontendDevDeploymentName, namespaceDev.GetName())
+	frontEndDev := deploymentBuilder.Create("library/nginx:1.21.1", frontendDevDeploymentName, namespaceDev.GetName(), int32(1))
 	frontEndDev.AddLabels(frontendLabels)
 	frontendDevDeployment, err := frontEndDev.Deploy(ctx, clientset)
 	Expect(err).NotTo(HaveOccurred())
@@ -113,7 +113,7 @@ func AzureNetPolSpec(ctx context.Context, inputGetter func() AzureNetPolSpecInpu
 	backendDeploymentName := fmt.Sprintf("backend-%v", randInt+200000)
 	backendLabels := map[string]string{"app": "webapp", "role": "backend"}
 	Log("starting to create backend deployments")
-	backendDev := deploymentBuilder.Create("library/nginx:1.21.1", backendDeploymentName, namespaceDev.GetName())
+	backendDev := deploymentBuilder.Create("library/nginx:1.21.1", backendDeploymentName, namespaceDev.GetName(), int32(1))
 	backendDev.AddLabels(backendLabels)
 	backendDeployment, err := backendDev.Deploy(ctx, clientset)
 	Expect(err).NotTo(HaveOccurred())
@@ -122,7 +122,7 @@ func AzureNetPolSpec(ctx context.Context, inputGetter func() AzureNetPolSpecInpu
 	nwpolicyDeploymentName := fmt.Sprintf("network-policy-%v", randInt+300000)
 	nwpolicyLabels := map[string]string{"app": "webapp", "role": "any"}
 	Log("starting to create network-policy deployments")
-	nwpolicy := deploymentBuilder.Create("library/nginx:1.21.1", nwpolicyDeploymentName, namespaceDev.GetName())
+	nwpolicy := deploymentBuilder.Create("library/nginx:1.21.1", nwpolicyDeploymentName, namespaceDev.GetName(), int32(1))
 	nwpolicy.AddLabels(nwpolicyLabels)
 	nwpolicyDeployment, err := nwpolicy.Deploy(ctx, clientset)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/cluster_autoscaler.go
+++ b/test/e2e/cluster_autoscaler.go
@@ -1,0 +1,573 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	kubedrain "k8s.io/kubectl/pkg/drain"
+	"k8s.io/utils/ptr"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	deploymentBuilder "sigs.k8s.io/cluster-api-provider-azure/test/e2e/kubernetes/deployment"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	clusterAutoscalerHelmRepoURL                   = "https://kubernetes.github.io/autoscaler"
+	clusterAutoscalerChartName                     = "cluster-autoscaler"
+	clusterAutoscalerDeploymentLabelKey            = "app.kubernetes.io/name"
+	clusterAutoscalerCAPIDeploymentLabelVal        = "clusterapi-cluster-autoscaler"
+	clusterAutoscalerAzureDeploymentLabelVal       = "azure-cluster-autoscaler"
+	defaultKubeletMaxPods                    int32 = 110
+)
+
+// ClusterAutoscalerInstallInput is the input for InstallClusterAutoscaler.
+type ClusterAutoscalerInstallInput struct {
+	BootstrapClusterProxy framework.ClusterProxy
+	Namespace             *corev1.Namespace
+	ClusterName           string
+	E2EConfig             *clusterctl.E2EConfig
+}
+
+// InstallClusterAutoscaler implements a test that verifies cluster-autoscaler behaviors.
+func InstallClusterAutoscaler(ctx context.Context, inputGetter func() ClusterAutoscalerInstallInput) {
+	var (
+		specName = "clusterAutoscaler"
+		input    ClusterAutoscalerInstallInput
+	)
+
+	Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
+
+	input = inputGetter()
+	Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+	Expect(input.Namespace).ToNot(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
+	Expect(input.ClusterName).ToNot(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
+
+	mgmtClient := bootstrapClusterProxy.GetClient()
+	Expect(mgmtClient).NotTo(BeNil())
+	workloadClusterProxy := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
+	workloadClusterClient := workloadClusterProxy.GetClient()
+	Expect(workloadClusterClient).NotTo(BeNil())
+	Expect(workloadClusterProxy).NotTo(BeNil())
+	mdList := framework.GetMachineDeploymentsByCluster(ctx, framework.GetMachineDeploymentsByClusterInput{
+		Lister:      mgmtClient,
+		ClusterName: input.ClusterName,
+		Namespace:   input.Namespace.Name,
+	})
+	mpList := framework.GetMachinePoolsByCluster(ctx, framework.GetMachinePoolsByClusterInput{
+		Lister:      mgmtClient,
+		ClusterName: input.ClusterName,
+		Namespace:   input.Namespace.Name,
+	})
+	amcpList := &infrav1.AzureManagedControlPlaneList{}
+	Eventually(func() error {
+		return mgmtClient.List(ctx, amcpList, []client.ListOption{
+			client.InNamespace(input.Namespace.Name),
+			client.MatchingLabels{
+				clusterv1.ClusterNameLabel: input.ClusterName,
+			},
+		}...)
+	}, retryableOperationTimeout, retryableOperationSleepBetweenRetries).Should(Succeed(), "Failed to list MachinePools object for Cluster %s", klog.KRef(input.Namespace.Name, input.ClusterName))
+	var hasAKSAutoscalerCapability bool
+	if len(amcpList.Items) > 0 {
+		hasAKSAutoscalerCapability = true
+	}
+	var hasCAPIClusterAutoscalerConfig bool
+	for _, md := range mdList {
+		if _, ok := md.GetAnnotations()["cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"]; ok {
+			if _, ok := md.GetAnnotations()["cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"]; ok {
+				hasCAPIClusterAutoscalerConfig = true
+			}
+		}
+	}
+	var autoscalerEnabledMachinePool *expv1.MachinePool
+	for _, mp := range mpList {
+		if _, ok := mp.GetAnnotations()["cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"]; ok {
+			if _, ok := mp.GetAnnotations()["cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"]; ok {
+				hasCAPIClusterAutoscalerConfig = true
+			}
+		}
+	}
+	var options *HelmOptions
+	var targetCluster framework.ClusterProxy
+	if hasCAPIClusterAutoscalerConfig {
+		options = &HelmOptions{
+			Values: []string{
+				"extraArgs.balance-similar-node-groups=true",
+				"extraArgs.scale-down-unneeded-time=1m",
+				"cloudProvider=clusterapi",
+				fmt.Sprintf("autoDiscovery.clusterName=%s", input.ClusterName),
+				fmt.Sprintf("clusterAPIKubeconfigSecret=%s-kubeconfig", input.ClusterName),
+				"clusterAPIMode=kubeconfig-incluster",
+			},
+			StringValues: []string{
+				"extraArgs.scan-interval=1m",
+			},
+		}
+		targetCluster = bootstrapClusterProxy
+	}
+	var hasExternalAutoscalerConfig bool
+	var vmssName string
+	for _, mp := range mpList {
+		if _, ok := mp.GetAnnotations()["cluster.x-k8s.io/replicas-managed-by"]; ok {
+			hasExternalAutoscalerConfig = !hasAKSAutoscalerCapability
+			vmssName = mp.Spec.Template.Spec.InfrastructureRef.Name
+			autoscalerEnabledMachinePool = mp
+		}
+	}
+	if hasExternalAutoscalerConfig {
+		options = &HelmOptions{
+			Values: []string{
+				"cloudProvider=azure",
+				"azureVMType=vmss",
+				fmt.Sprintf("autoscalingGroups[0].name=%s", vmssName),
+				fmt.Sprintf("azureResourceGroup=%s", input.ClusterName),
+			},
+			StringValues: []string{
+				fmt.Sprintf("azureClientID=%s", input.E2EConfig.GetVariable(AzureClientID)),
+				fmt.Sprintf("azureClientSecret=%s", input.E2EConfig.GetVariable(AzureClientSecret)),
+				fmt.Sprintf("azureSubscriptionID=%s", input.E2EConfig.GetVariable(AzureSubscriptionID)),
+				fmt.Sprintf("azureTenantID=%s", input.E2EConfig.GetVariable(AzureTenantID)),
+				fmt.Sprintf("autoscalingGroups[0].minSize=%s", input.E2EConfig.GetVariable(ClusterAutoscalerExternalMinNodes)),
+				fmt.Sprintf("autoscalingGroups[0].maxSize=%s", input.E2EConfig.GetVariable(ClusterAutoscalerExternalMaxNodes)),
+				"extraArgs.scan-interval=1m",
+				"extraArgs.scale-down-unneeded-time=1m",
+			},
+		}
+		targetCluster = workloadClusterProxy
+	}
+	ammpList := &infrav1.AzureManagedMachinePoolList{}
+	if hasAKSAutoscalerCapability {
+		Expect(autoscalerEnabledMachinePool).NotTo(BeNil())
+		var aksVMSSName, aksVMSSResourceGroup string
+		Eventually(func() error {
+			return mgmtClient.List(ctx, ammpList, byClusterOptions(input.ClusterName, input.Namespace.Name)...)
+		}, retryableOperationTimeout, retryableOperationSleepBetweenRetries).Should(Succeed(), "Failed to list MachinePools object for Cluster %s", input.ClusterName)
+		r := regexp.MustCompile(regexpUniformInstance)
+		for _, ammp := range ammpList.Items {
+			if ammp.Spec.Mode == string(infrav1.NodePoolModeUser) && ammp.Name == autoscalerEnabledMachinePool.Name {
+				for _, providerID := range ammp.Spec.ProviderIDList {
+					matches := r.FindStringSubmatch(providerID)
+					Expect(matches).To(HaveLen(4))
+					aksVMSSResourceGroup = matches[2]
+					aksVMSSName = matches[3]
+				}
+				if aksVMSSName != "" {
+					break
+				}
+			}
+		}
+		options = &HelmOptions{
+			Values: []string{
+				"cloudProvider=azure",
+				"azureVMType=vmss",
+				fmt.Sprintf("autoscalingGroups[0].name=%s", aksVMSSName),
+				fmt.Sprintf("azureResourceGroup=%s", aksVMSSResourceGroup),
+			},
+			StringValues: []string{
+				fmt.Sprintf("azureClientID=%s", input.E2EConfig.GetVariable(AzureClientID)),
+				fmt.Sprintf("azureClientSecret=%s", input.E2EConfig.GetVariable(AzureClientSecret)),
+				fmt.Sprintf("azureSubscriptionID=%s", input.E2EConfig.GetVariable(AzureSubscriptionID)),
+				fmt.Sprintf("azureTenantID=%s", input.E2EConfig.GetVariable(AzureTenantID)),
+				fmt.Sprintf("autoscalingGroups[0].minSize=%s", input.E2EConfig.GetVariable(ClusterAutoscalerExternalMinNodes)),
+				fmt.Sprintf("autoscalingGroups[0].maxSize=%s", input.E2EConfig.GetVariable(ClusterAutoscalerExternalMaxNodes)),
+				fmt.Sprintf("azureScaleDownPolicy=%s", input.E2EConfig.GetVariable(ClusterAutoscalerExternalMaxNodes)),
+				"extraArgs.scan-interval=10s",
+				"extraArgs.scale-down-delay-after-add=1m",
+				"extraArgs.scale-down-delay-after-delete=10s",
+				"extraArgs.scale-down-delay-after-failure=3m",
+				"extraArgs.scale-down-unneeded-time=1m",
+				"extraArgs.scale-down-unready-time=20m",
+				"extraArgs.scale-down-utilization-threshold=0.5",
+				"extraArgs.max-graceful-termination-sec=600",
+				"extraArgs.balance-similar-node-groups=false",
+				"extraArgs.skip-nodes-with-local-storage=false",
+				"extraArgs.skip-nodes-with-system-pods=true",
+				"extraArgs.max-empty-bulk-delete=10",
+				"extraArgs.expander=random",
+				"extraArgs.new-pod-scale-up-delay=0s",
+				"extraArgs.max-total-unready-percentage=45",
+				"extraArgs.ok-total-unready-count=100",
+				"extraArgs.max-node-provision-time=15m",
+				"extraArgs.v=2",
+			},
+		}
+		targetCluster = workloadClusterProxy
+	}
+	imageRepo := input.E2EConfig.GetVariable(ClusterAutoscalerImageRepo)
+	if imageRepo != "" {
+		options.Values = append(options.Values, fmt.Sprintf("image.repository=%s", imageRepo))
+	}
+	imageTag := input.E2EConfig.GetVariable(ClusterAutoscalerImageTag)
+	if imageTag != "" {
+		options.Values = append(options.Values, fmt.Sprintf("image.tag=%s", imageTag))
+	}
+	InstallHelmChart(ctx, targetCluster, input.Namespace.Name, clusterAutoscalerHelmRepoURL, clusterAutoscalerChartName, input.ClusterName, options, "")
+	Eventually(func(g Gomega) bool {
+		var d = &appsv1.DeploymentList{}
+		var deploymentLabelVal string
+		if hasCAPIClusterAutoscalerConfig {
+			deploymentLabelVal = clusterAutoscalerCAPIDeploymentLabelVal
+		} else if hasExternalAutoscalerConfig || hasAKSAutoscalerCapability {
+			deploymentLabelVal = clusterAutoscalerAzureDeploymentLabelVal
+		}
+		Logf("Listing deployments in namespace %s with label %s=%s", input.Namespace.Name, clusterAutoscalerDeploymentLabelKey, deploymentLabelVal)
+		err := targetCluster.GetClient().List(ctx, d, client.InNamespace(input.Namespace.Name), client.MatchingLabels{clusterAutoscalerDeploymentLabelKey: deploymentLabelVal})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(d).NotTo(BeNil())
+		g.Expect(d.Items).To(HaveLen(1))
+		for _, c := range d.Items[0].Status.Conditions {
+			if c.Type == appsv1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue())
+}
+
+// AzureAutoscalerSpecInput is the input for AzureAutoscalerSpec.
+type AzureAutoscalerSpecInput struct {
+	BootstrapClusterProxy framework.ClusterProxy
+	Namespace             *corev1.Namespace
+	ClusterName           string
+	E2EConfig             *clusterctl.E2EConfig
+}
+
+// AzureAutoscalerSpec implements a test that verifies we can autoscale.
+func AzureAutoscalerSpec(ctx context.Context, inputGetter func() AzureAutoscalerSpecInput) {
+	var (
+		specName = "azure-autoscaler"
+		input    AzureAutoscalerSpecInput
+	)
+
+	Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
+
+	input = inputGetter()
+	Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+	Expect(input.Namespace).ToNot(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
+	Expect(input.ClusterName).ToNot(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
+
+	By("Creating a Kubernetes client to the workload cluster")
+	workloadClusterProxy := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
+	Expect(workloadClusterProxy).NotTo(BeNil())
+	mgmtClient := bootstrapClusterProxy.GetClient()
+	Expect(mgmtClient).NotTo(BeNil())
+	clientset := workloadClusterProxy.GetClientSet()
+	Expect(clientset).NotTo(BeNil())
+	workloadClusterClient := workloadClusterProxy.GetClient()
+	Expect(workloadClusterClient).NotTo(BeNil())
+
+	By("Calculating how many pod replicas we need to scale out to maximum")
+	mdList := framework.GetMachineDeploymentsByCluster(ctx, framework.GetMachineDeploymentsByClusterInput{
+		Lister:      mgmtClient,
+		ClusterName: input.ClusterName,
+		Namespace:   input.Namespace.Name,
+	})
+	mpList := framework.GetMachinePoolsByCluster(ctx, framework.GetMachinePoolsByClusterInput{
+		Lister:      mgmtClient,
+		ClusterName: input.ClusterName,
+		Namespace:   input.Namespace.Name,
+	})
+
+	clusterAutoscalerMaxNodes, hasNodeHeadroom, hasCapiClusterAutoscaler, hasExternalClusterAutoscaler := getAutoscalerContext(input, mdList, mpList)
+	if !hasNodeHeadroom {
+		By("Bypassing cluster-autoscaler scale out because our current node count is not less than our max-size configuration for any pools")
+		return
+	}
+	By(fmt.Sprintf("Will validate cluster autoscaler can scale out to %d nodes", clusterAutoscalerMaxNodes))
+
+	nodes := &corev1.NodeList{}
+	By("Verifying that no pods are scheduled to the autoscaler-enabled MachineDeployment nodes")
+	Eventually(func(g Gomega) {
+		mdList := framework.GetMachineDeploymentsByCluster(ctx, framework.GetMachineDeploymentsByClusterInput{
+			Lister:      mgmtClient,
+			ClusterName: input.ClusterName,
+			Namespace:   input.Namespace.Name,
+		})
+		for _, md := range mdList {
+			_, ok := md.GetAnnotations()["cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"]
+			if !ok {
+				continue
+			}
+			// get nodes that start with name
+			g.Expect(workloadClusterClient.List(ctx, nodes)).To(Succeed())
+			drainer := &kubedrain.Helper{
+				Client:              clientset,
+				Ctx:                 ctx,
+				Force:               true,
+				IgnoreAllDaemonSets: true,
+				DeleteEmptyDirData:  true,
+				GracePeriodSeconds:  -1,
+				// If a pod is not evicted in 20 seconds, retry the eviction next time the
+				// machine gets reconciled again (to allow other machines to be reconciled).
+				Timeout: 20 * time.Second,
+				ErrOut:  os.Stderr,
+				Out:     os.Stdout,
+			}
+			By(fmt.Sprintf("Cordoning and Draining all replicaset pods from MachineDeployment %s", md.Name))
+			for _, n := range nodes.Items {
+				cordonDrainNode := n
+				if strings.Contains(n.Name, md.Name) {
+					g.Expect(kubedrain.RunCordonOrUncordon(drainer, &cordonDrainNode, true)).To(Succeed())
+					g.Expect(kubedrain.RunNodeDrain(drainer, cordonDrainNode.Name)).To(Succeed())
+					uncordonDrainer := &kubedrain.Helper{
+						Client: clientset,
+						ErrOut: os.Stderr,
+						Out:    os.Stdout,
+						Ctx:    ctx,
+					}
+					g.Expect(kubedrain.RunCordonOrUncordon(uncordonDrainer, &cordonDrainNode, false)).To(Succeed())
+				}
+			}
+		}
+	}, e2eConfig.GetIntervals(specName, "node-drain/wait-machine-deleted")...).Should(Succeed())
+	By("Verifying that no pods are scheduled to the autoscaler-enabled MachinePool nodes")
+	Eventually(func(g Gomega) {
+		mpList := framework.GetMachinePoolsByCluster(ctx, framework.GetMachinePoolsByClusterInput{
+			Lister:      mgmtClient,
+			ClusterName: input.ClusterName,
+			Namespace:   input.Namespace.Name,
+		})
+		for _, mp := range mpList {
+			if _, ok := mp.GetAnnotations()["cluster.x-k8s.io/replicas-managed-by"]; !ok {
+				continue
+			}
+			// get nodes that start with name
+			Expect(workloadClusterClient.List(ctx, nodes)).To(Succeed())
+			drainer := &kubedrain.Helper{
+				Client:              clientset,
+				Ctx:                 ctx,
+				Force:               true,
+				IgnoreAllDaemonSets: true,
+				DeleteEmptyDirData:  true,
+				GracePeriodSeconds:  -1,
+				// If a pod is not evicted in 20 seconds, retry the eviction next time the
+				// machine gets reconciled again (to allow other machines to be reconciled).
+				Timeout: 20 * time.Second,
+				ErrOut:  os.Stderr,
+				Out:     os.Stdout,
+			}
+			By(fmt.Sprintf("Cordoning and Draining all replicaset pods from MachinePool %s", mp.Name))
+			for _, n := range nodes.Items {
+				cordonDrainNode := n
+				if strings.Contains(n.Name, mp.Name) {
+					g.Expect(kubedrain.RunCordonOrUncordon(drainer, &cordonDrainNode, true)).To(Succeed())
+					g.Expect(kubedrain.RunNodeDrain(drainer, cordonDrainNode.Name)).To(Succeed())
+					uncordonDrainer := &kubedrain.Helper{
+						Client: clientset,
+						ErrOut: os.Stderr,
+						Out:    os.Stdout,
+						Ctx:    ctx,
+					}
+					g.Expect(kubedrain.RunCordonOrUncordon(uncordonDrainer, &cordonDrainNode, false)).To(Succeed())
+				}
+			}
+		}
+	}, e2eConfig.GetIntervals(specName, "node-drain/wait-machine-deleted")...).Should(Succeed())
+
+	By("Verifying that all nodes have scaled in")
+	validateScaleIn(ctx, specName, input, mgmtClient, workloadClusterClient)
+
+	numReplicas := (int32(len(nodes.Items)) + clusterAutoscalerMaxNodes) * defaultKubeletMaxPods
+	By(fmt.Sprintf("creating an HTTP deployment with %d replicas", numReplicas))
+	deploymentName := "web" + util.RandomString(6)
+	webDeployment := deploymentBuilder.Create("httpd", deploymentName, corev1.NamespaceDefault, numReplicas)
+	webDeployment.AddContainerPort("http", "http", 80, corev1.ProtocolTCP)
+
+	deployment, err := webDeployment.Deploy(ctx, clientset)
+	Expect(err).NotTo(HaveOccurred())
+
+	if hasCapiClusterAutoscaler {
+		By("Verifying that all cluster-autoscaler-enabled MachineDeployments have scaled out")
+		Eventually(func(g Gomega) {
+			mdList := framework.GetMachineDeploymentsByCluster(ctx, framework.GetMachineDeploymentsByClusterInput{
+				Lister:      mgmtClient,
+				ClusterName: input.ClusterName,
+				Namespace:   input.Namespace.Name,
+			})
+			for _, md := range mdList {
+				val, ok := md.GetAnnotations()["cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"]
+				if !ok {
+					continue
+				}
+				maxSize, err := strconv.ParseInt(val, 10, 32)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(*md.Spec.Replicas).To(Equal(int32(maxSize)))
+				g.Expect(md.Status.Phase).To(Equal(string(clusterv1.MachineDeploymentPhaseRunning)))
+				nodes := &corev1.NodeList{}
+				g.Expect(workloadClusterClient.List(ctx, nodes)).To(Succeed())
+				numRunningNodes := 0
+				for _, n := range nodes.Items {
+					if strings.Contains(n.Name, md.Name) {
+						for _, condition := range n.Status.Conditions {
+							if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+								numRunningNodes++
+							}
+						}
+					}
+				}
+				g.Expect(numRunningNodes).To(Equal(int(maxSize)))
+			}
+		}, e2eConfig.GetIntervals(specName, "wait-autoscale-out")...).Should(Succeed())
+	}
+
+	if hasExternalClusterAutoscaler {
+		By("Verifying that cluster-autoscaler-enabled MachinePool has scaled out")
+		Eventually(func(g Gomega) {
+			mpList := framework.GetMachinePoolsByCluster(ctx, framework.GetMachinePoolsByClusterInput{
+				Lister:      mgmtClient,
+				ClusterName: input.ClusterName,
+				Namespace:   input.Namespace.Name,
+			})
+			var autoscalerEnabledMachinePool *expv1.MachinePool
+			for _, mp := range mpList {
+				if _, ok := mp.GetAnnotations()["cluster.x-k8s.io/replicas-managed-by"]; ok {
+					autoscalerEnabledMachinePool = mp
+				}
+			}
+			g.Expect(autoscalerEnabledMachinePool).ToNot(BeNil())
+			maxSize, err := strconv.ParseInt(input.E2EConfig.GetVariable(ClusterAutoscalerExternalMaxNodes), 10, 32)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(*autoscalerEnabledMachinePool.Spec.Replicas).To(Equal(int32(maxSize)))
+			g.Expect(autoscalerEnabledMachinePool.Status.ReadyReplicas).To(Equal(int32(maxSize)))
+			g.Expect(autoscalerEnabledMachinePool.Status.Phase).To(Equal(string(expv1.MachinePoolPhaseRunning)))
+			g.Expect(autoscalerEnabledMachinePool.Spec.ProviderIDList).To(HaveLen(int(maxSize)))
+			g.Expect(autoscalerEnabledMachinePool.Status.NodeRefs).To(HaveLen(int(maxSize)))
+			nodes := &corev1.NodeList{}
+			g.Expect(workloadClusterClient.List(ctx, nodes)).To(Succeed())
+			numNodes := 0
+			split := strings.Split(autoscalerEnabledMachinePool.Status.NodeRefs[0].Name, "-")
+			nodeNamePrefix := strings.Join(split[:len(split)-1], "-")
+			for _, n := range nodes.Items {
+				if strings.Contains(n.Name, nodeNamePrefix) {
+					numNodes++
+				}
+			}
+			g.Expect(numNodes).To(BeNumerically(">=", int(maxSize)))
+		}, e2eConfig.GetIntervals(specName, "wait-autoscale-out")...).Should(Succeed())
+	}
+
+	By("Reducing deployment replicas to zero")
+	Eventually(func(g Gomega) {
+		d, err := clientset.AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		d.Spec.Replicas = ptr.To[int32](0)
+		err = workloadClusterClient.Update(ctx, d)
+		g.Expect(err).NotTo(HaveOccurred())
+	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(Succeed())
+	By("Verifying that all nodes have scaled back in")
+	validateScaleIn(ctx, specName, input, mgmtClient, workloadClusterClient)
+}
+
+func validateScaleIn(ctx context.Context, specName string, input AzureAutoscalerSpecInput, mgmtClient, workloadClusterClient client.Client) {
+	Eventually(func(g Gomega) {
+		mdList := framework.GetMachineDeploymentsByCluster(ctx, framework.GetMachineDeploymentsByClusterInput{
+			Lister:      mgmtClient,
+			ClusterName: input.ClusterName,
+			Namespace:   input.Namespace.Name,
+		})
+		mpList := framework.GetMachinePoolsByCluster(ctx, framework.GetMachinePoolsByClusterInput{
+			Lister:      mgmtClient,
+			ClusterName: input.ClusterName,
+			Namespace:   input.Namespace.Name,
+		})
+		minSize, err := strconv.ParseInt(input.E2EConfig.GetVariable(ClusterAutoscalerExternalMinNodes), 10, 32)
+		g.Expect(err).NotTo(HaveOccurred())
+		for _, mp := range mpList {
+			if _, ok := mp.GetAnnotations()["cluster.x-k8s.io/replicas-managed-by"]; !ok {
+				continue
+			}
+			By(fmt.Sprintf("Waiting for MachinePool %s to scale down to %d or fewer replicas", mp.Name, minSize))
+			g.Expect(int64(*mp.Spec.Replicas) <= minSize).To(BeTrue())
+			nodes := &corev1.NodeList{}
+			g.Expect(workloadClusterClient.List(ctx, nodes)).To(Succeed())
+		}
+		for _, md := range mdList {
+			val, ok := md.GetAnnotations()["cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"]
+			if !ok {
+				continue
+			}
+			minSize, err := strconv.ParseInt(val, 10, 32)
+			g.Expect(err).NotTo(HaveOccurred())
+			By(fmt.Sprintf("Waiting for MachineDeployment %s to scale down to %d replicas", md.Name, minSize))
+			g.Expect(int64(*md.Spec.Replicas)).To(Equal(minSize))
+			nodes := &corev1.NodeList{}
+			g.Expect(workloadClusterClient.List(ctx, nodes)).To(Succeed())
+		}
+	}, e2eConfig.GetIntervals(specName, "wait-autoscale-in")...).Should(Succeed())
+}
+
+func getAutoscalerContext(input AzureAutoscalerSpecInput,
+	mdList []*clusterv1.MachineDeployment,
+	mpList []*expv1.MachinePool) (
+	clusterAutoscalerMaxNodes int32,
+	hasNodeHeadroom, hasCapiClusterAutoscaler, hasExternalClusterAutoscaler bool) {
+	for _, md := range mdList {
+		val, ok := md.GetAnnotations()["cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"]
+		if !ok {
+			continue
+		}
+		hasCapiClusterAutoscaler = true
+		maxSize, err := strconv.ParseInt(val, 10, 32)
+		Expect(err).NotTo(HaveOccurred())
+		if maxSize > int64(*md.Spec.Replicas) {
+			hasNodeHeadroom = true
+		}
+		clusterAutoscalerMaxNodes += int32(maxSize)
+	}
+	for _, mp := range mpList {
+		if _, ok := mp.GetAnnotations()["cluster.x-k8s.io/replicas-managed-by"]; ok {
+			hasExternalClusterAutoscaler = true
+			maxSize, err := strconv.ParseInt(input.E2EConfig.GetVariable(ClusterAutoscalerExternalMaxNodes), 10, 32)
+			Expect(err).NotTo(HaveOccurred())
+			if maxSize > int64(*mp.Spec.Replicas) {
+				hasNodeHeadroom = true
+			}
+			clusterAutoscalerMaxNodes += int32(maxSize)
+		}
+		if val, ok := mp.GetAnnotations()["cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"]; ok {
+			hasCapiClusterAutoscaler = true
+			maxSize, err := strconv.ParseInt(val, 10, 32)
+			Expect(err).NotTo(HaveOccurred())
+			if maxSize > int64(*mp.Spec.Replicas) {
+				hasNodeHeadroom = true
+			}
+			clusterAutoscalerMaxNodes += int32(maxSize)
+		}
+	}
+	return clusterAutoscalerMaxNodes, hasNodeHeadroom, hasCapiClusterAutoscaler, hasExternalClusterAutoscaler
+}

--- a/test/e2e/cluster_autoscaler.go
+++ b/test/e2e/cluster_autoscaler.go
@@ -133,6 +133,7 @@ func InstallClusterAutoscaler(ctx context.Context, inputGetter func() ClusterAut
 				fmt.Sprintf("autoDiscovery.clusterName=%s", input.ClusterName),
 				fmt.Sprintf("clusterAPIKubeconfigSecret=%s-kubeconfig", input.ClusterName),
 				"clusterAPIMode=kubeconfig-incluster",
+				"extraArgs.enable-provisioning-requests=true",
 			},
 			StringValues: []string{
 				"extraArgs.scan-interval=1m",
@@ -166,6 +167,7 @@ func InstallClusterAutoscaler(ctx context.Context, inputGetter func() ClusterAut
 				fmt.Sprintf("autoscalingGroups[0].maxSize=%s", input.E2EConfig.GetVariable(ClusterAutoscalerExternalMaxNodes)),
 				"extraArgs.scan-interval=1m",
 				"extraArgs.scale-down-unneeded-time=1m",
+				"extraArgs.enable-provisioning-requests=true",
 			},
 		}
 		targetCluster = workloadClusterProxy
@@ -223,6 +225,7 @@ func InstallClusterAutoscaler(ctx context.Context, inputGetter func() ClusterAut
 				"extraArgs.max-total-unready-percentage=45",
 				"extraArgs.ok-total-unready-count=100",
 				"extraArgs.max-node-provision-time=15m",
+				"extraArgs.enable-provisioning-requests=true",
 				"extraArgs.v=2",
 			},
 		}

--- a/test/e2e/cluster_autoscaler.go
+++ b/test/e2e/cluster_autoscaler.go
@@ -176,8 +176,14 @@ func InstallClusterAutoscaler(ctx context.Context, inputGetter func() ClusterAut
 	if hasAKSAutoscalerCapability {
 		Expect(autoscalerEnabledMachinePool).NotTo(BeNil())
 		var aksVMSSName, aksVMSSResourceGroup string
+		listOptions := []client.ListOption{
+			client.InNamespace(input.Namespace.Name),
+			client.MatchingLabels{
+				clusterv1.ClusterNameLabel: input.ClusterName,
+			},
+		}
 		Eventually(func() error {
-			return mgmtClient.List(ctx, ammpList, byClusterOptions(input.ClusterName, input.Namespace.Name)...)
+			return mgmtClient.List(ctx, ammpList, listOptions...)
 		}, retryableOperationTimeout, retryableOperationSleepBetweenRetries).Should(Succeed(), "Failed to list MachinePools object for Cluster %s", input.ClusterName)
 		r := regexp.MustCompile(regexpUniformInstance)
 		for _, ammp := range ammpList.Items {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -100,6 +100,11 @@ const (
 	OldAddonProviderUpgradeVersion    = "OLD_CAAPH_UPGRADE_VERSION"
 	LatestAddonProviderUpgradeVersion = "LATEST_CAAPH_UPGRADE_VERSION"
 	KubernetesVersionAPIUpgradeFrom   = "KUBERNETES_VERSION_API_UPGRADE_FROM"
+	ClusterAutoscalerImageRepo        = "CLUSTER_AUTOSCALER_IMAGE_REPO"
+	ClusterAutoscalerImageTag         = "CLUSTER_AUTOSCALER_IMAGE_TAG"
+	ClusterAutoscalerExternalMinNodes = "CLUSTER_AUTOSCALER_EXTERNAL_MIN_NODES"
+	ClusterAutoscalerExternalMaxNodes = "CLUSTER_AUTOSCALER_EXTERNAL_MAX_NODES"
+	ClusterAutoscalerScaleDownPolicy  = "CLUSTER_AUTOSCALER_SCALE_DOWN_POLICY"
 )
 
 func Byf(format string, a ...interface{}) {

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -163,6 +163,12 @@ providers:
         targetName: "cluster-template-azure-cni-v1.yaml"
       - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-spot.yaml"
         targetName: "cluster-template-spot.yaml"
+      - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-cluster-autoscaler-capi.yaml"
+        targetName: "cluster-template-cluster-autoscaler-capi.yaml"
+      - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-cluster-autoscaler-external.yaml"
+        targetName: "cluster-template-cluster-autoscaler-external.yaml"
+      - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-aks-cluster-autoscaler.yaml"
+        targetName: "cluster-template-aks-cluster-autoscaler.yaml"
       replacements:
       - old: "--v=0"
         new: "--v=2"
@@ -232,6 +238,11 @@ variables:
   LATEST_PROVIDER_UPGRADE_VERSION: "v1.15.1"
   OLD_CAAPH_UPGRADE_VERSION: "v0.1.0-alpha.10"
   LATEST_CAAPH_UPGRADE_VERSION: "v0.1.1-alpha.1"
+  CLUSTER_AUTOSCALER_IMAGE_REPO: "${CLUSTER_AUTOSCALER_IMAGE_REPO:-}"
+  CLUSTER_AUTOSCALER_IMAGE_TAG: "${CLUSTER_AUTOSCALER_IMAGE_TAG:-}"
+  CLUSTER_AUTOSCALER_EXTERNAL_MIN_NODES: "${CLUSTER_AUTOSCALER_EXTERNAL_MIN_NODES:-0}"
+  CLUSTER_AUTOSCALER_EXTERNAL_MAX_NODES: "${CLUSTER_AUTOSCALER_EXTERNAL_MAX_NODES:-5}"
+  CLUSTER_AUTOSCALER_SCALE_DOWN_POLICY: "${CLUSTER_AUTOSCALER_SCALE_DOWN_POLICY:-Delete}"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]
@@ -253,6 +264,8 @@ intervals:
   default/wait-service: ["15m", "10s"]
   default/wait-machine-pool-nodes: ["30m", "10s"]
   default/wait-nsg-update: ["20m", "10s"]
+  default/wait-autoscale-out: ["15m", "10s"]
+  default/wait-autoscale-in: ["30m", "1m"]
   csi-migration/wait-controlplane-upgrade: ["60m", "10s"]
   csi-migration/wait-worker-nodes: ["60m", "10s"]
   csi-migration/wait-control-plane: ["60m", "10s"]

--- a/test/e2e/helm.go
+++ b/test/e2e/helm.go
@@ -70,7 +70,6 @@ func InstallHelmChart(ctx context.Context, clusterProxy framework.ClusterProxy, 
 	// Install the chart and retry if needed
 	Eventually(func() error {
 		cmd := exec.Command(helm, args...)
-		Logf("Helm command: %s", cmd.String())
 		output, err := cmd.CombinedOutput()
 		Logf("Helm install output: %s", string(output))
 		return err

--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -54,7 +54,7 @@ type (
 )
 
 // Create will create a deployment for a given image with a name in a namespace
-func Create(image, name, namespace string) *Builder {
+func Create(image, name, namespace string, replicas int32) *Builder {
 	e2eDeployment := &Builder{
 		deployment: &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -63,7 +63,7 @@ func Create(image, name, namespace string) *Builder {
 				Labels:    map[string]string{},
 			},
 			Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](1),
+				Replicas: ptr.To[int32](replicas),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"app": name,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR adds test integration with the three different upstream cluster-autoscaler scenarios for Azure:

- "azure" provider running on Azure Kubernetes in VMSS config
- "azure" provider running on AKS in VMSS config
- "capi" provider running on CAPZ

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add cluster-autoscaler test scenarios
```
