### PR TITLE
Fix e2e config gob conversion to string

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -22,6 +22,7 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/gob"
 	"flag"
 	"os"
@@ -78,12 +79,13 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	var configBuf bytes.Buffer
 	enc := gob.NewEncoder(&configBuf)
 	Expect(enc.Encode(e2eConfig)).To(Succeed())
+	configStr := base64.StdEncoding.EncodeToString(configBuf.Bytes())
 
 	return []byte(
 		strings.Join([]string{
 			artifactFolder,
 			clusterctlConfigPath,
-			configBuf.String(),
+			configStr,
 			bootstrapClusterProxy.GetKubeconfigPath(),
 		}, ","),
 	)
@@ -97,7 +99,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	clusterctlConfigPath = parts[1]
 
 	// Decode the e2e config
-	buf := bytes.NewBuffer([]byte(parts[2]))
+	configBytes, err := base64.StdEncoding.DecodeString(parts[2])
+	Expect(err).NotTo(HaveOccurred())
+	buf := bytes.NewBuffer(configBytes)
 	dec := gob.NewDecoder(buf)
 	Expect(dec.Decode(&e2eConfig)).To(Succeed())
 


### PR DESCRIPTION
 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This change fixes the e2e tests failing in the `SynchronizedBeforeSuite` function, because of the `string()` conversion of the gob encoded e2e config file.

When converting the e2e config gob encoded [bytes to a UTF-8 string](https://cs.opensource.google/go/go/+/refs/tags/go1.20.5:src/bytes/buffer.go;l=65), one of those bytes could represent a `,` (comma) in UTF-8, which leads to the next function accepting the UTF-8 representation of the gob encoded e2e config to fail. This is due to the next function accepting a specific number of comma separated strings as arguments.

In order to keep the existing implementation as-is, i.e. pass comma separated strings to the next function, we need to ensure that the string representation of the gob encoded e2e config does not include any commas.

Using base64 encoding for the gob encoded e2e config resolves this issue, as there is no comma in [base64](https://datatracker.ietf.org/doc/html/rfc4648#section-4).

> PS. I bumped into this issue while trying to run `./scripts/ci-e2e.sh` from my workstation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
