### PR TITLE
Fix managed clusters and agent pools diffs

### DIFF
--- a/azure/services/agentpools/spec_test.go
+++ b/azure/services/agentpools/spec_test.go
@@ -261,6 +261,27 @@ func TestParameters(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "difference in system node labels shouldn't trigger update",
+			spec: fakeAgentPool(
+				func(pool *AgentPoolSpec) {
+					pool.NodeLabels = map[string]*string{
+						"fake-label": pointer.String("fake-value"),
+					}
+				},
+			),
+			existing: sdkFakeAgentPool(
+				func(pool *containerservice.AgentPool) {
+					pool.NodeLabels = map[string]*string{
+						"fake-label":                            pointer.String("fake-value"),
+						"kubernetes.azure.com/scalesetpriority": pointer.String("spot"),
+					}
+				},
+				sdkWithProvisioningState("Succeeded"),
+			),
+			expected:      nil,
+			expectedError: nil,
+		},
+		{
 			name: "parameters with an existing agent pool and update needed on node taints",
 			spec: fakeAgentPool(),
 			existing: sdkFakeAgentPool(

--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -382,10 +382,13 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existing interface{
 
 	if s.APIServerAccessProfile != nil {
 		managedCluster.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
-			AuthorizedIPRanges:             &s.APIServerAccessProfile.AuthorizedIPRanges,
 			EnablePrivateCluster:           s.APIServerAccessProfile.EnablePrivateCluster,
 			PrivateDNSZone:                 s.APIServerAccessProfile.PrivateDNSZone,
 			EnablePrivateClusterPublicFQDN: s.APIServerAccessProfile.EnablePrivateClusterPublicFQDN,
+		}
+
+		if len(s.APIServerAccessProfile.AuthorizedIPRanges) > 0 {
+			managedCluster.APIServerAccessProfile.AuthorizedIPRanges = &s.APIServerAccessProfile.AuthorizedIPRanges
 		}
 	}
 

--- a/azure/services/managedclusters/spec_test.go
+++ b/azure/services/managedclusters/spec_test.go
@@ -154,6 +154,29 @@ func TestParameters(t *testing.T) {
 				g.Expect(result).To(BeNil())
 			},
 		},
+		{
+			name:     "no update needed if both clusters have no authorized IP ranges",
+			existing: getExistingClusterWithAPIServerAccessProfile(),
+			spec: &ManagedClusterSpec{
+				Name:          "test-managedcluster",
+				ResourceGroup: "test-rg",
+				Location:      "test-location",
+				Tags: map[string]string{
+					"test-tag": "test-value",
+				},
+				Version:         "v1.22.0",
+				LoadBalancerSKU: "Standard",
+				APIServerAccessProfile: &APIServerAccessProfile{
+					AuthorizedIPRanges: func() []string {
+						var arr []string
+						return arr
+					}(),
+				},
+			},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+		},
 	}
 	for _, tc := range testcases {
 		tc := tc
@@ -171,6 +194,14 @@ func TestParameters(t *testing.T) {
 			tc.expect(g, result)
 		})
 	}
+}
+
+func getExistingClusterWithAPIServerAccessProfile() containerservice.ManagedCluster {
+	mc := getExistingCluster()
+	mc.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
+		EnablePrivateCluster: pointer.Bool(false),
+	}
+	return mc
 }
 
 func getExistingCluster() containerservice.ManagedCluster {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
While trying to migrate AKS clusters that were created with Terraform to CAPZ I have noticed two issues that were blocking control plane and node pools from being successfully reconciled. In both cases it was a case of diff being not empty.

1. Control plane having following field in its spec:

```yaml
apiServerAccessProfile:
  enablePrivateCluster: false
```

Was always marked as changed because of following diff:

```diff
- 			AuthorizedIPRanges:   &nil,
+ 			AuthorizedIPRanges:   nil,
```

2. A couple of Azure node pools had `kubernetes.azure.com/scalesetpriority : spot` node label. CAPZ webhook does not allow setting labels with `kubernetes.azure.com/scalesetpriority` prefix. This caused node pools getting marked as changed.

 After applying changes from this pull request control plane and node pools are getting successfully reconciled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
7. If no release note is required, just write "NONE".
-->
```release-note
Fix managed clusters and agent pools diffs
```
