### PR TITLE
Revert "Temporarily disable useHostProcessContainers"

### DIFF
--- a/test/e2e/cloud-provider-azure.go
+++ b/test/e2e/cloud-provider-azure.go
@@ -87,7 +87,7 @@ func InstallAzureDiskCSIDriverHelmChart(ctx context.Context, input clusterctl.Ap
 	}
 	// TODO: make this always true once HostProcessContainers are on for all supported k8s versions.
 	if hasWindows {
-		options.Values = append(options.Values, "windows.useHostProcessContainers=false")
+		options.Values = append(options.Values, "windows.useHostProcessContainers=true")
 	}
 	clusterProxy := input.ClusterProxy.GetWorkloadCluster(ctx, input.ConfigCluster.Namespace, input.ConfigCluster.ClusterName)
 	InstallHelmChart(ctx, clusterProxy, kubesystem, azureDiskCSIDriverHelmRepoURL, azureDiskCSIDriverChartName, azureDiskCSIDriverHelmReleaseName, options, "")


### PR DESCRIPTION
/kind failing-test

Reverts kubernetes-sigs/cluster-api-provider-azure#3636

This PR sets `useHostProcessContainers=true` and reverting the temporary fix for azure csi driver for Windows nodes. Once a working csi driver image is published, this PR will be ready for merge.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```