### PR TITLE
Use && to run clean-release-git after test-e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -669,7 +669,7 @@ test-e2e-run: generate-e2e-templates install-tools ## Run e2e tests.
     	-e2e.artifacts-folder="$(ARTIFACTS)" \
     	-e2e.config="$(E2E_CONF_FILE_ENVSUBST)" \
     	-e2e.skip-log-collection="$(SKIP_LOG_COLLECTION)" \
-    	-e2e.skip-resource-cleanup=$(SKIP_CLEANUP) -e2e.use-existing-cluster=$(SKIP_CREATE_MGMT_CLUSTER) $(E2E_ARGS) ; \
+    	-e2e.skip-resource-cleanup=$(SKIP_CLEANUP) -e2e.use-existing-cluster=$(SKIP_CREATE_MGMT_CLUSTER) $(E2E_ARGS)
 	$(MAKE) clean-release-git
 
 .PHONY: test-e2e


### PR DESCRIPTION
/kind failing-test

Fixes an issue caused by #3562 where the exit code from the ginkgo command is overwritten by running clean-release-git, causing failed E2E tests to show up as passed.

Fixes #3635

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```