### PR TITLE
Increase AKS reconcile timeout

### DIFF
--- a/azure/services/managedclusters/managedclusters.go
+++ b/azure/services/managedclusters/managedclusters.go
@@ -71,7 +71,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "managedclusters.Service.Reconcile")
 	defer done()
 
-	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
+	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAKSServiceReconcileTimeout)
 	defer cancel()
 
 	managedClusterSpec := s.Scope.ManagedClusterSpec()

--- a/util/reconciler/defaults.go
+++ b/util/reconciler/defaults.go
@@ -27,6 +27,8 @@ const (
 	DefaultMappingTimeout = 60 * time.Second
 	// DefaultAzureServiceReconcileTimeout is the default timeout for an Azure service reconcile.
 	DefaultAzureServiceReconcileTimeout = 12 * time.Second
+	// DefaultAKSServiceReconcileTimeout is the default timeout for an AKS service reconcile.
+	DefaultAKSServiceReconcileTimeout = 30 * time.Second
 	// DefaultAzureCallTimeout is the default timeout for an Azure request after which an Azure operation is considered long running.
 	DefaultAzureCallTimeout = 2 * time.Second
 	// DefaultReconcilerRequeue is the default value for the reconcile retry.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR increases the AKS reconcile timeout to fix an issue where AKS upgrade tests are extremely flaky. We pinned the issue down to being related to the AKS PUT request taking too long (13-20 seconds), which is above our 12 second reconcile timeout.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Increase AKS reconcile timeout
```
