### PR TITLE
make ASO adopt previously managed resources

### DIFF
--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -137,4 +137,7 @@ type ASOResourceSpecGetter interface {
 	// Parameters returns a modified object if it points to a non-nil resource.
 	// Otherwise it returns a new value or nil if no updates are needed.
 	Parameters(ctx context.Context, object genruntime.MetaObject) (genruntime.MetaObject, error)
+	// WasManaged returns whether or not the given resource was managed by a
+	// non-ASO-backed CAPZ and should be considered eligible for adoption.
+	WasManaged(genruntime.MetaObject) bool
 }

--- a/azure/mock_azure/azure_mock.go
+++ b/azure/mock_azure/azure_mock.go
@@ -1925,3 +1925,17 @@ func (mr *MockASOResourceSpecGetterMockRecorder) ResourceRef() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceRef", reflect.TypeOf((*MockASOResourceSpecGetter)(nil).ResourceRef))
 }
+
+// WasManaged mocks base method.
+func (m *MockASOResourceSpecGetter) WasManaged(arg0 genruntime.MetaObject) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WasManaged", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WasManaged indicates an expected call of WasManaged.
+func (mr *MockASOResourceSpecGetterMockRecorder) WasManaged(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WasManaged", reflect.TypeOf((*MockASOResourceSpecGetter)(nil).WasManaged), arg0)
+}

--- a/azure/services/aso/aso.go
+++ b/azure/services/aso/aso.go
@@ -163,6 +163,8 @@ func (s *Service) CreateOrUpdateResource(ctx context.Context, spec azure.ASOReso
 		// Azure and the ASO resource will be adopted by changing this
 		// annotation to "manage".
 		annotations[ReconcilePolicyAnnotation] = ReconcilePolicySkip
+	} else {
+		adopt = adopt || spec.WasManaged(existing)
 	}
 	if adopt {
 		annotations[ReconcilePolicyAnnotation] = ReconcilePolicyManage

--- a/azure/services/asogroups/spec.go
+++ b/azure/services/asogroups/spec.go
@@ -68,3 +68,12 @@ func (s *GroupSpec) Parameters(ctx context.Context, object genruntime.MetaObject
 		},
 	}, nil
 }
+
+// WasManaged implements azure.ASOResourceSpecGetter.
+func (s *GroupSpec) WasManaged(object genruntime.MetaObject) bool {
+	group, ok := object.(*asoresourcesv1.ResourceGroup)
+	if !ok {
+		return false
+	}
+	return infrav1.Tags(group.Status.Tags).HasOwned(s.ClusterName)
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

The goal of this PR is to smooth the transition from non-ASO-backed CAPZ to ASO-backed CAPZ by automatically adopting pre-existing Azure resources that are identified to have been managed by a previous version of CAPZ.

Depending on the resource type, the indicator that it was managed by a previous version of CAPZ will either be the `sigs.k8s.io_cluster-api-provider-azure_cluster_*` tag on the resource in Azure or a static `true` for resources not eligible for BYO currently, like managedclusters:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/8e1c9aead5a0c7aa7da343331c82c00364a9b9fd/azure/services/managedclusters/managedclusters.go#L125-L128

More context in the proposal: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/8e1c9aead5a0c7aa7da343331c82c00364a9b9fd/docs/proposals/20230123-azure-service-operator.md#upgrade-strategy

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3521

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

This branch includes this change and the necessary plumbing to make this functional if you'd like to test this yourself: https://github.com/kubernetes-sigs/cluster-api-provider-azure/compare/main...nojnhuh:cluster-api-provider-azure:aso-wired


- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
