### PR TITLE
[WIP] e2e: Assert that AMPMs have a NodeRef before labeling

### DIFF
--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -205,6 +205,7 @@ func labelNodesWithMachinePoolName(ctx context.Context, workloadClient client.Cl
 	for _, ampm := range ampms {
 		n := &corev1.Node{}
 		Eventually(func(g Gomega) {
+			g.Expect(ampm.Status.NodeRef).NotTo(BeNil())
 			err := workloadClient.Get(ctx, client.ObjectKey{
 				Name:      ampm.Status.NodeRef.Name,
 				Namespace: ampm.Status.NodeRef.Namespace,


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Asserts that an `AzureMachinePoolMachine` has a valid `Status.NodeRef` before accessing it in the AMP drain test ("labeling the machine pool nodes with machine pool type and name").

**Which issue(s) this PR fixes**:

N/A, trying to address a panic I saw in e2e here:
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/3666/pull-cluster-api-provider-azure-e2e/1673385756317454336

**Special notes for your reviewer**:

- [x] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
