### PR TITLE
Fix custom backendPool not being used

### DIFF
--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -63,7 +63,7 @@ type NetworkDescriber interface {
 	ControlPlaneRouteTable() infrav1.RouteTable
 	APIServerLB() *infrav1.LoadBalancerSpec
 	APIServerLBName() string
-	APIServerLBPoolName(string) string
+	APIServerLBPoolName() string
 	IsAPIServerPrivate() bool
 	GetPrivateDNSZoneName() string
 	OutboundLBName(string) string

--- a/azure/mock_azure/azure_mock.go
+++ b/azure/mock_azure/azure_mock.go
@@ -349,17 +349,17 @@ func (mr *MockNetworkDescriberMockRecorder) APIServerLBName() *gomock.Call {
 }
 
 // APIServerLBPoolName mocks base method.
-func (m *MockNetworkDescriber) APIServerLBPoolName(arg0 string) string {
+func (m *MockNetworkDescriber) APIServerLBPoolName() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIServerLBPoolName", arg0)
+	ret := m.ctrl.Call(m, "APIServerLBPoolName")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // APIServerLBPoolName indicates an expected call of APIServerLBPoolName.
-func (mr *MockNetworkDescriberMockRecorder) APIServerLBPoolName(arg0 interface{}) *gomock.Call {
+func (mr *MockNetworkDescriberMockRecorder) APIServerLBPoolName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLBPoolName", reflect.TypeOf((*MockNetworkDescriber)(nil).APIServerLBPoolName), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLBPoolName", reflect.TypeOf((*MockNetworkDescriber)(nil).APIServerLBPoolName))
 }
 
 // ControlPlaneRouteTable mocks base method.
@@ -966,17 +966,17 @@ func (mr *MockClusterScoperMockRecorder) APIServerLBName() *gomock.Call {
 }
 
 // APIServerLBPoolName mocks base method.
-func (m *MockClusterScoper) APIServerLBPoolName(arg0 string) string {
+func (m *MockClusterScoper) APIServerLBPoolName() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIServerLBPoolName", arg0)
+	ret := m.ctrl.Call(m, "APIServerLBPoolName")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // APIServerLBPoolName indicates an expected call of APIServerLBPoolName.
-func (mr *MockClusterScoperMockRecorder) APIServerLBPoolName(arg0 interface{}) *gomock.Call {
+func (mr *MockClusterScoperMockRecorder) APIServerLBPoolName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLBPoolName", reflect.TypeOf((*MockClusterScoper)(nil).APIServerLBPoolName), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLBPoolName", reflect.TypeOf((*MockClusterScoper)(nil).APIServerLBPoolName))
 }
 
 // AdditionalTags mocks base method.

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -711,33 +711,37 @@ func (s *ClusterScope) GetPrivateDNSZoneName() string {
 }
 
 // APIServerLBPoolName returns the API Server LB backend pool name.
-func (s *ClusterScope) APIServerLBPoolName(loadBalancerName string) string {
-	return azure.GenerateBackendAddressPoolName(loadBalancerName)
+func (s *ClusterScope) APIServerLBPoolName() string {
+	return s.APIServerLB().BackendPool.Name
+}
+
+// OutboundLB returns the outbound LB.
+func (s *ClusterScope) outboundLB(role string) *infrav1.LoadBalancerSpec {
+	if role == infrav1.Node {
+		return s.NodeOutboundLB()
+	}
+	if s.IsAPIServerPrivate() {
+		return s.ControlPlaneOutboundLB()
+	}
+	return s.APIServerLB()
 }
 
 // OutboundLBName returns the name of the outbound LB.
 func (s *ClusterScope) OutboundLBName(role string) string {
-	if role == infrav1.Node {
-		if s.NodeOutboundLB() == nil {
-			return ""
-		}
-		return s.NodeOutboundLB().Name
+	lb := s.outboundLB(role)
+	if lb == nil {
+		return ""
 	}
-	if s.IsAPIServerPrivate() {
-		if s.ControlPlaneOutboundLB() == nil {
-			return ""
-		}
-		return s.ControlPlaneOutboundLB().Name
-	}
-	return s.APIServerLBName()
+	return lb.Name
 }
 
 // OutboundPoolName returns the outbound LB backend pool name.
-func (s *ClusterScope) OutboundPoolName(loadBalancerName string) string {
-	if loadBalancerName == "" {
+func (s *ClusterScope) OutboundPoolName(role string) string {
+	lb := s.outboundLB(role)
+	if lb == nil {
 		return ""
 	}
-	return azure.GenerateOutboundBackendAddressPoolName(loadBalancerName)
+	return lb.BackendPool.Name
 }
 
 // ResourceGroup returns the cluster resource group.

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -1968,6 +1968,11 @@ func TestAPIServerLBPoolName(t *testing.T) {
 					},
 				},
 				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: infrav1.LoadBalancerSpec{
+							Name: tc.lbName,
+						},
+					},
 					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						SubscriptionID: "123",
 					},
@@ -1985,8 +1990,9 @@ func TestAPIServerLBPoolName(t *testing.T) {
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
 			})
+			clusterScope.AzureCluster.SetBackendPoolNameDefault()
 			g.Expect(err).NotTo(HaveOccurred())
-			got := clusterScope.APIServerLBPoolName(tc.lbName)
+			got := clusterScope.APIServerLBPoolName()
 			g.Expect(tc.expectLBpoolName).Should(Equal(got))
 		})
 	}
@@ -2125,6 +2131,7 @@ func TestOutboundLBName(t *testing.T) {
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
 			})
+			clusterScope.AzureCluster.SetBackendPoolNameDefault()
 			g.Expect(err).NotTo(HaveOccurred())
 			got := clusterScope.OutboundLBName(tc.role)
 			g.Expect(tc.expected).Should(Equal(got))
@@ -2253,6 +2260,7 @@ func TestBackendPoolName(t *testing.T) {
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
 			})
+			clusterScope.AzureCluster.SetBackendPoolNameDefault()
 			g.Expect(err).NotTo(HaveOccurred())
 			got := clusterScope.LBSpecs()
 			g.Expect(len(got)).To(Equal(3))
@@ -2325,7 +2333,15 @@ func TestOutboundPoolName(t *testing.T) {
 				},
 			}
 
+			if tc.loadBalancerName != "" {
+				azureCluster.Spec.NetworkSpec.NodeOutboundLB = &infrav1.LoadBalancerSpec{
+					Name: tc.loadBalancerName,
+				}
+			}
+
 			initObjects := []runtime.Object{cluster, azureCluster}
+			azureCluster.Default()
+
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
@@ -2336,8 +2352,9 @@ func TestOutboundPoolName(t *testing.T) {
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
 			})
+			clusterScope.AzureCluster.SetBackendPoolNameDefault()
 			g.Expect(err).NotTo(HaveOccurred())
-			got := clusterScope.OutboundPoolName(tc.loadBalancerName)
+			got := clusterScope.OutboundPoolName(infrav1.Node)
 			g.Expect(tc.expectOutboundPoolName).Should(Equal(got))
 		})
 	}

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -277,13 +277,13 @@ func (m *MachineScope) BuildNICSpec(nicName string, infrav1NetworkInterface infr
 
 		if m.Role() == infrav1.ControlPlane {
 			spec.PublicLBName = m.OutboundLBName(m.Role())
-			spec.PublicLBAddressPoolName = m.OutboundPoolName(m.OutboundLBName(m.Role()))
+			spec.PublicLBAddressPoolName = m.OutboundPoolName(m.Role())
 			if m.IsAPIServerPrivate() {
 				spec.InternalLBName = m.APIServerLBName()
-				spec.InternalLBAddressPoolName = m.APIServerLBPoolName(m.APIServerLBName())
+				spec.InternalLBAddressPoolName = m.APIServerLBPoolName()
 			} else {
 				spec.PublicLBNATRuleName = m.Name()
-				spec.PublicLBAddressPoolName = m.APIServerLBPoolName(m.APIServerLBName())
+				spec.PublicLBAddressPoolName = m.APIServerLBPoolName()
 			}
 		}
 
@@ -293,12 +293,7 @@ func (m *MachineScope) BuildNICSpec(nicName string, infrav1NetworkInterface infr
 		// If the NAT gateway is not enabled and node has no public IP, then the NIC needs to reference the LB to get outbound traffic.
 		if m.Role() == infrav1.Node && !m.Subnet().IsNatGatewayEnabled() && !m.AzureMachine.Spec.AllocatePublicIP {
 			spec.PublicLBName = m.OutboundLBName(m.Role())
-			spec.PublicLBAddressPoolName = m.OutboundPoolName(m.OutboundLBName(m.Role()))
-		}
-		// If the NAT gateway is not enabled and node has no public IP, then the NIC needs to reference the LB to get outbound traffic.
-		if m.Role() == infrav1.Node && !m.Subnet().IsNatGatewayEnabled() && !m.AzureMachine.Spec.AllocatePublicIP {
-			spec.PublicLBName = m.OutboundLBName(m.Role())
-			spec.PublicLBAddressPoolName = m.OutboundPoolName(m.OutboundLBName(m.Role()))
+			spec.PublicLBAddressPoolName = m.OutboundPoolName(m.Role())
 		}
 	}
 

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -1715,6 +1715,9 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 								},
 								NodeOutboundLB: &infrav1.LoadBalancerSpec{
 									Name: "outbound-lb",
+									BackendPool: infrav1.BackendPool{
+										Name: "outbound-lb-outboundBackendPool",
+									},
 								},
 							},
 						},
@@ -1819,6 +1822,9 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 								},
 								NodeOutboundLB: &infrav1.LoadBalancerSpec{
 									Name: "outbound-lb",
+									BackendPool: infrav1.BackendPool{
+										Name: "outbound-lb-outboundBackendPool",
+									},
 								},
 							},
 						},
@@ -2147,6 +2153,9 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 									LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 										Type: infrav1.Internal,
 									},
+									BackendPool: infrav1.BackendPool{
+										Name: "api-lb-backendPool",
+									},
 								},
 								NodeOutboundLB: &infrav1.LoadBalancerSpec{
 									Name: "outbound-lb",
@@ -2254,6 +2263,9 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 								},
 								APIServerLB: infrav1.LoadBalancerSpec{
 									Name: "api-lb",
+									BackendPool: infrav1.BackendPool{
+										Name: "api-lb-backendPool",
+									},
 								},
 								NodeOutboundLB: &infrav1.LoadBalancerSpec{
 									Name: "outbound-lb",
@@ -2361,6 +2373,9 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 								},
 								APIServerLB: infrav1.LoadBalancerSpec{
 									Name: "api-lb",
+									BackendPool: infrav1.BackendPool{
+										Name: "api-lb-backendPool",
+									},
 								},
 								NodeOutboundLB: &infrav1.LoadBalancerSpec{
 									Name: "outbound-lb",
@@ -2472,6 +2487,9 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 								},
 								NodeOutboundLB: &infrav1.LoadBalancerSpec{
 									Name: "outbound-lb",
+									BackendPool: infrav1.BackendPool{
+										Name: "outbound-lb-outboundBackendPool",
+									},
 								},
 							},
 						},
@@ -2747,6 +2765,9 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 								},
 								NodeOutboundLB: &infrav1.LoadBalancerSpec{
 									Name: "outbound-lb",
+									BackendPool: infrav1.BackendPool{
+										Name: "outbound-lb-outboundBackendPool",
+									},
 								},
 							},
 						},

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -129,7 +129,7 @@ func (m *MachinePoolScope) ScaleSetSpec() azure.ScaleSetSpec {
 		VNetName:                     m.Vnet().Name,
 		VNetResourceGroup:            m.Vnet().ResourceGroup,
 		PublicLBName:                 m.OutboundLBName(infrav1.Node),
-		PublicLBAddressPoolName:      azure.GenerateOutboundBackendAddressPoolName(m.OutboundLBName(infrav1.Node)),
+		PublicLBAddressPoolName:      m.OutboundPoolName(infrav1.Node),
 		AcceleratedNetworking:        m.AzureMachinePool.Spec.Template.NetworkInterfaces[0].AcceleratedNetworking,
 		Identity:                     m.AzureMachinePool.Spec.Identity,
 		UserAssignedIdentities:       m.AzureMachinePool.Spec.UserAssignedIdentities,

--- a/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
+++ b/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
@@ -82,17 +82,17 @@ func (mr *MockBastionScopeMockRecorder) APIServerLBName() *gomock.Call {
 }
 
 // APIServerLBPoolName mocks base method.
-func (m *MockBastionScope) APIServerLBPoolName(arg0 string) string {
+func (m *MockBastionScope) APIServerLBPoolName() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIServerLBPoolName", arg0)
+	ret := m.ctrl.Call(m, "APIServerLBPoolName")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // APIServerLBPoolName indicates an expected call of APIServerLBPoolName.
-func (mr *MockBastionScopeMockRecorder) APIServerLBPoolName(arg0 interface{}) *gomock.Call {
+func (mr *MockBastionScopeMockRecorder) APIServerLBPoolName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLBPoolName", reflect.TypeOf((*MockBastionScope)(nil).APIServerLBPoolName), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLBPoolName", reflect.TypeOf((*MockBastionScope)(nil).APIServerLBPoolName))
 }
 
 // AdditionalTags mocks base method.

--- a/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
+++ b/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
@@ -82,17 +82,17 @@ func (mr *MockLBScopeMockRecorder) APIServerLBName() *gomock.Call {
 }
 
 // APIServerLBPoolName mocks base method.
-func (m *MockLBScope) APIServerLBPoolName(arg0 string) string {
+func (m *MockLBScope) APIServerLBPoolName() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIServerLBPoolName", arg0)
+	ret := m.ctrl.Call(m, "APIServerLBPoolName")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // APIServerLBPoolName indicates an expected call of APIServerLBPoolName.
-func (mr *MockLBScopeMockRecorder) APIServerLBPoolName(arg0 interface{}) *gomock.Call {
+func (mr *MockLBScopeMockRecorder) APIServerLBPoolName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLBPoolName", reflect.TypeOf((*MockLBScope)(nil).APIServerLBPoolName), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLBPoolName", reflect.TypeOf((*MockLBScope)(nil).APIServerLBPoolName))
 }
 
 // AdditionalTags mocks base method.

--- a/azure/services/natgateways/mock_natgateways/natgateways_mock.go
+++ b/azure/services/natgateways/mock_natgateways/natgateways_mock.go
@@ -82,17 +82,17 @@ func (mr *MockNatGatewayScopeMockRecorder) APIServerLBName() *gomock.Call {
 }
 
 // APIServerLBPoolName mocks base method.
-func (m *MockNatGatewayScope) APIServerLBPoolName(arg0 string) string {
+func (m *MockNatGatewayScope) APIServerLBPoolName() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIServerLBPoolName", arg0)
+	ret := m.ctrl.Call(m, "APIServerLBPoolName")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // APIServerLBPoolName indicates an expected call of APIServerLBPoolName.
-func (mr *MockNatGatewayScopeMockRecorder) APIServerLBPoolName(arg0 interface{}) *gomock.Call {
+func (mr *MockNatGatewayScopeMockRecorder) APIServerLBPoolName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLBPoolName", reflect.TypeOf((*MockNatGatewayScope)(nil).APIServerLBPoolName), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLBPoolName", reflect.TypeOf((*MockNatGatewayScope)(nil).APIServerLBPoolName))
 }
 
 // AdditionalTags mocks base method.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
In some places the default backendPool name was being used instead of using the specified value. This caused machine creation to fail when attempting to use loadBalancer with custom backendPool name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix default `backendPool` name being used when custom name is set.
```
