### PR TITLE
Allow skipping Linux profile on managed clusters

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_default.go
+++ b/api/v1beta1/azuremanagedcontrolplane_default.go
@@ -34,13 +34,13 @@ const (
 
 // setDefaultSSHPublicKey sets the default SSHPublicKey for an AzureManagedControlPlane.
 func (m *AzureManagedControlPlane) setDefaultSSHPublicKey() error {
-	if sshKeyData := m.Spec.SSHPublicKey; sshKeyData == "" {
+	if sshKey := m.Spec.SSHPublicKey; sshKey != nil && *sshKey == "" {
 		_, publicRsaKey, err := utilSSH.GenerateSSHKey()
 		if err != nil {
 			return err
 		}
 
-		m.Spec.SSHPublicKey = base64.StdEncoding.EncodeToString(ssh.MarshalAuthorizedKey(publicRsaKey))
+		m.Spec.SSHPublicKey = pointer.String(base64.StdEncoding.EncodeToString(ssh.MarshalAuthorizedKey(publicRsaKey)))
 	}
 
 	return nil

--- a/api/v1beta1/azuremanagedcontrolplane_default_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_default_test.go
@@ -36,11 +36,11 @@ func TestAzureManagedControlPlane_SetDefaultSSHPublicKey(t *testing.T) {
 
 	err := publicKeyExistTest.m.setDefaultSSHPublicKey()
 	g.Expect(err).To(BeNil())
-	g.Expect(publicKeyExistTest.m.Spec.SSHPublicKey).To(Equal(existingPublicKey))
+	g.Expect(*publicKeyExistTest.m.Spec.SSHPublicKey).To(Equal(existingPublicKey))
 
 	err = publicKeyNotExistTest.m.setDefaultSSHPublicKey()
 	g.Expect(err).To(BeNil())
-	g.Expect(publicKeyNotExistTest.m.Spec.SSHPublicKey).NotTo(BeEmpty())
+	g.Expect(*publicKeyNotExistTest.m.Spec.SSHPublicKey).NotTo(BeEmpty())
 }
 
 func createAzureManagedControlPlaneWithSSHPublicKey(sshPublicKey string) *AzureManagedControlPlane {
@@ -50,7 +50,7 @@ func createAzureManagedControlPlaneWithSSHPublicKey(sshPublicKey string) *AzureM
 func hardcodedAzureManagedControlPlaneWithSSHKey(sshPublicKey string) *AzureManagedControlPlane {
 	return &AzureManagedControlPlane{
 		Spec: AzureManagedControlPlaneSpec{
-			SSHPublicKey: sshPublicKey,
+			SSHPublicKey: &sshPublicKey,
 		},
 	}
 }

--- a/api/v1beta1/azuremanagedcontrolplane_types.go
+++ b/api/v1beta1/azuremanagedcontrolplane_types.go
@@ -124,8 +124,10 @@ type AzureManagedControlPlaneSpec struct {
 	OutboundType *ManagedControlPlaneOutboundType `json:"outboundType,omitempty"`
 
 	// SSHPublicKey is a string literal containing an ssh public key base64 encoded.
+	// Use empty string to autogenerate new key. Use null value to not set key.
 	// Immutable.
-	SSHPublicKey string `json:"sshPublicKey"`
+	// +optional
+	SSHPublicKey *string `json:"sshPublicKey,omitempty"`
 
 	// DNSServiceIP is an IP address assigned to the Kubernetes DNS service.
 	// It must be within the Kubernetes service address range specified in serviceCidr.

--- a/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -307,9 +307,8 @@ func (m *AzureManagedControlPlane) validateVersion(_ client.Client) error {
 
 // validateSSHKey validates an SSHKey.
 func (m *AzureManagedControlPlane) validateSSHKey(_ client.Client) error {
-	if m.Spec.SSHPublicKey != "" {
-		sshKey := m.Spec.SSHPublicKey
-		if errs := ValidateSSHKey(sshKey, field.NewPath("sshKey")); len(errs) > 0 {
+	if sshKey := m.Spec.SSHPublicKey; sshKey != nil && *sshKey != "" {
+		if errs := ValidateSSHKey(*sshKey, field.NewPath("sshKey")); len(errs) > 0 {
 			return kerrors.NewAggregate(errs.ToAggregate().Errors())
 		}
 	}

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1175,6 +1175,11 @@ func (in *AzureManagedControlPlaneSpec) DeepCopyInto(out *AzureManagedControlPla
 		*out = new(ManagedControlPlaneOutboundType)
 		**out = **in
 	}
+	if in.SSHPublicKey != nil {
+		in, out := &in.SSHPublicKey, &out.SSHPublicKey
+		*out = new(string)
+		**out = **in
+	}
 	if in.DNSServiceIP != nil {
 		in, out := &in.DNSServiceIP, &out.DNSServiceIP
 		*out = new(string)

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -465,7 +465,6 @@ func (s *ManagedControlPlaneScope) ManagedClusterSpec() azure.ResourceSpecGetter
 		Tags:              s.ControlPlane.Spec.AdditionalTags,
 		Headers:           maps.FilterByKeyPrefix(s.ManagedClusterAnnotations(), infrav1.CustomHeaderPrefix),
 		Version:           strings.TrimPrefix(s.ControlPlane.Spec.Version, "v"),
-		SSHPublicKey:      s.ControlPlane.Spec.SSHPublicKey,
 		DNSServiceIP:      s.ControlPlane.Spec.DNSServiceIP,
 		VnetSubnetID: azure.SubnetID(
 			s.ControlPlane.Spec.SubscriptionID,
@@ -479,6 +478,9 @@ func (s *ManagedControlPlaneScope) ManagedClusterSpec() azure.ResourceSpecGetter
 		KubeletUserAssignedIdentity: s.ControlPlane.Spec.KubeletUserAssignedIdentity,
 	}
 
+	if s.ControlPlane.Spec.SSHPublicKey != nil {
+		managedClusterSpec.SSHPublicKey = *s.ControlPlane.Spec.SSHPublicKey
+	}
 	if s.ControlPlane.Spec.NetworkPlugin != nil {
 		managedClusterSpec.NetworkPlugin = *s.ControlPlane.Spec.NetworkPlugin
 	}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -391,7 +391,8 @@ spec:
                 type: object
               sshPublicKey:
                 description: SSHPublicKey is a string literal containing an ssh public
-                  key base64 encoded. Immutable.
+                  key base64 encoded. Use empty string to autogenerate new key. Use
+                  null value to not set key. Immutable.
                 type: string
               subscriptionID:
                 description: SubscriptionID is the GUID of the Azure subscription
@@ -532,7 +533,6 @@ spec:
             required:
             - location
             - resourceGroupName
-            - sshPublicKey
             - version
             type: object
           status:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
In order to be able to not set `LinuxProfile` in AKS I have changed `AzureManagedControlPlane` `SSHPublicKey` to be optional. If it is null then new key will not be autogenerated and `LinuxProfile` will not be set, if it is set to empty string then new key will be generated just like it was done until now.

See Slack thread: https://kubernetes.slack.com/archives/CEX9HENG7/p1687961825757119

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
- [ ] cherry-pick candidate

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
Allow skipping Linux profile on managed clusters
```
