### PR TITLE
persist AKS kubelet user-assigned identity in spec

### DIFF
--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -625,6 +625,11 @@ func (s *ManagedControlPlaneScope) SetKubeConfigData(kubeConfigData []byte) {
 	s.kubeConfigData = kubeConfigData
 }
 
+// SetKubeletIdentity sets the ID of the user-assigned identity for kubelet if not already set.
+func (s *ManagedControlPlaneScope) SetKubeletIdentity(id string) {
+	s.ControlPlane.Spec.KubeletUserAssignedIdentity = id
+}
+
 // SetLongRunningOperationState will set the future on the AzureManagedControlPlane status to allow the resource to continue
 // in the next reconciliation.
 func (s *ManagedControlPlaneScope) SetLongRunningOperationState(future *infrav1.Future) {

--- a/azure/services/managedclusters/managedclusters.go
+++ b/azure/services/managedclusters/managedclusters.go
@@ -33,12 +33,15 @@ import (
 
 const serviceName = "managedcluster"
 
+const kubeletIdentityKey = "kubeletidentity"
+
 // ManagedClusterScope defines the scope interface for a managed cluster.
 type ManagedClusterScope interface {
 	azure.Authorizer
 	azure.AsyncStatusUpdater
 	ManagedClusterSpec() azure.ResourceSpecGetter
 	SetControlPlaneEndpoint(clusterv1.APIEndpoint)
+	SetKubeletIdentity(string)
 	MakeEmptyKubeConfigSecret() corev1.Secret
 	GetKubeConfigData() []byte
 	SetKubeConfigData([]byte)
@@ -99,6 +102,12 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			return errors.Wrap(err, "failed to get credentials for managed cluster")
 		}
 		s.Scope.SetKubeConfigData(kubeConfigData)
+
+		// This field gets populated by AKS when not set by the user. Persist AKS's value so for future diffs,
+		// the "before" reflects the correct value.
+		if id := managedCluster.ManagedClusterProperties.IdentityProfile[kubeletIdentityKey]; id != nil && id.ResourceID != nil {
+			s.Scope.SetKubeletIdentity(*id.ResourceID)
+		}
 	}
 	s.Scope.UpdatePutStatus(infrav1.ManagedClusterRunningCondition, serviceName, resultErr)
 	return resultErr

--- a/azure/services/managedclusters/managedclusters_test.go
+++ b/azure/services/managedclusters/managedclusters_test.go
@@ -65,6 +65,11 @@ func TestReconcile(t *testing.T) {
 					ManagedClusterProperties: &containerservice.ManagedClusterProperties{
 						Fqdn:              pointer.String("my-managedcluster-fqdn"),
 						ProvisioningState: pointer.String("Succeeded"),
+						IdentityProfile: map[string]*containerservice.UserAssignedIdentity{
+							kubeletIdentityKey: {
+								ResourceID: pointer.String("kubelet-id"),
+							},
+						},
 					},
 				}, nil)
 				s.SetControlPlaneEndpoint(clusterv1.APIEndpoint{
@@ -73,6 +78,7 @@ func TestReconcile(t *testing.T) {
 				})
 				m.GetCredentials(gomockinternal.AContext(), "my-rg", "my-managedcluster").Return([]byte("credentials"), nil)
 				s.SetKubeConfigData([]byte("credentials"))
+				s.SetKubeletIdentity("kubelet-id")
 				s.UpdatePutStatus(infrav1.ManagedClusterRunningCondition, serviceName, nil)
 			},
 		},

--- a/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
+++ b/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
@@ -230,6 +230,18 @@ func (mr *MockManagedClusterScopeMockRecorder) SetKubeConfigData(arg0 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKubeConfigData", reflect.TypeOf((*MockManagedClusterScope)(nil).SetKubeConfigData), arg0)
 }
 
+// SetKubeletIdentity mocks base method.
+func (m *MockManagedClusterScope) SetKubeletIdentity(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetKubeletIdentity", arg0)
+}
+
+// SetKubeletIdentity indicates an expected call of SetKubeletIdentity.
+func (mr *MockManagedClusterScopeMockRecorder) SetKubeletIdentity(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKubeletIdentity", reflect.TypeOf((*MockManagedClusterScope)(nil).SetKubeletIdentity), arg0)
+}
+
 // SetLongRunningOperationState mocks base method.
 func (m *MockManagedClusterScope) SetLongRunningOperationState(arg0 *v1beta1.Future) {
 	m.ctrl.T.Helper()

--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -397,7 +397,7 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existing interface{
 
 	if s.KubeletUserAssignedIdentity != "" {
 		managedCluster.ManagedClusterProperties.IdentityProfile = map[string]*containerservice.UserAssignedIdentity{
-			"kubeletidentity": {
+			kubeletIdentityKey: {
 				ResourceID: pointer.String(s.KubeletUserAssignedIdentity),
 			},
 		}
@@ -590,16 +590,16 @@ func computeDiffOfNormalizedClusters(managedCluster containerservice.ManagedClus
 
 	if managedCluster.IdentityProfile != nil {
 		propertiesNormalized.IdentityProfile = map[string]*containerservice.UserAssignedIdentity{
-			"kubeletidentity": {
-				ResourceID: managedCluster.IdentityProfile["kubeletidentity"].ResourceID,
+			kubeletIdentityKey: {
+				ResourceID: managedCluster.IdentityProfile[kubeletIdentityKey].ResourceID,
 			},
 		}
 	}
 
 	if existingMC.IdentityProfile != nil {
 		existingMCPropertiesNormalized.IdentityProfile = map[string]*containerservice.UserAssignedIdentity{
-			"kubeletidentity": {
-				ResourceID: existingMC.IdentityProfile["kubeletidentity"].ResourceID,
+			kubeletIdentityKey: {
+				ResourceID: existingMC.IdentityProfile[kubeletIdentityKey].ResourceID,
 			},
 		}
 	}

--- a/azure/services/managedclusters/spec_test.go
+++ b/azure/services/managedclusters/spec_test.go
@@ -143,7 +143,7 @@ func TestParameters(t *testing.T) {
 				g.Expect(result.(containerservice.ManagedCluster).KubernetesVersion).To(Equal(pointer.String("v1.22.99")))
 				g.Expect(result.(containerservice.ManagedCluster).Identity.Type).To(Equal(containerservice.ResourceIdentityType("UserAssigned")))
 				g.Expect(result.(containerservice.ManagedCluster).Identity.UserAssignedIdentities).To(Equal(map[string]*containerservice.ManagedClusterIdentityUserAssignedIdentitiesValue{"/resource/ID": {}}))
-				g.Expect(result.(containerservice.ManagedCluster).IdentityProfile).To(Equal(map[string]*containerservice.UserAssignedIdentity{"kubeletidentity": {ResourceID: pointer.String("/resource/ID")}}))
+				g.Expect(result.(containerservice.ManagedCluster).IdentityProfile).To(Equal(map[string]*containerservice.UserAssignedIdentity{kubeletIdentityKey: {ResourceID: pointer.String("/resource/ID")}}))
 			},
 		},
 		{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug


<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR will persist the defaulted resource ID of a kubelet user-assigned identity to the new `spec.kubeletUserAssignedIdentity` field on AzureManagedControlPlane to fix a bug that caused constant reconciliation. Before, CAPZ was seeing the "desired" value as empty and the "actual" value as the default from AKS. Now, the "desired" value in the case where it gets defaulted will equal the "actual" value in AKS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
^ This feature has not yet landed in a published release.