### PR TITLE
Bump Linux VM extension to v1.1

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -296,7 +296,7 @@ func GetBootstrappingVMExtension(osType string, cloud string, vmName string) *Ex
 			Name:      BootstrappingExtensionLinux,
 			VMName:    vmName,
 			Publisher: "Microsoft.Azure.ContainerUpstream",
-			Version:   "1.0",
+			Version:   "1.1",
 			ProtectedSettings: map[string]string{
 				"commandToExecute": LinuxBootstrapExtensionCommand,
 			},

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -580,7 +580,7 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 						Name:      "CAPZ.Linux.Bootstrapping",
 						VMName:    "machine-name",
 						Publisher: "Microsoft.Azure.ContainerUpstream",
-						Version:   "1.0",
+						Version:   "1.1",
 						ProtectedSettings: map[string]string{
 							"commandToExecute": azure.LinuxBootstrapExtensionCommand,
 						},
@@ -841,7 +841,7 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 						Name:      "CAPZ.Linux.Bootstrapping",
 						VMName:    "machine-name",
 						Publisher: "Microsoft.Azure.ContainerUpstream",
-						Version:   "1.0",
+						Version:   "1.1",
 						ProtectedSettings: map[string]string{
 							"commandToExecute": azure.LinuxBootstrapExtensionCommand,
 						},

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -893,7 +893,7 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 						Name:      "CAPZ.Linux.Bootstrapping",
 						VMName:    "machinepool-name",
 						Publisher: "Microsoft.Azure.ContainerUpstream",
-						Version:   "1.0",
+						Version:   "1.1",
 						ProtectedSettings: map[string]string{
 							"commandToExecute": azure.LinuxBootstrapExtensionCommand,
 						},
@@ -1150,7 +1150,7 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 						Name:      "CAPZ.Linux.Bootstrapping",
 						VMName:    "machinepool-name",
 						Publisher: "Microsoft.Azure.ContainerUpstream",
-						Version:   "1.0",
+						Version:   "1.1",
 						ProtectedSettings: map[string]string{
 							"commandToExecute": azure.LinuxBootstrapExtensionCommand,
 						},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR bumps the version for the Linux Bootstrap VM extension to a new version that supports ARM64. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3423 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add ARM64 support for VM extension
```
