### PR TITLE
renaming cleanup function in ci-build-azure-ccm.sh and ci-build-kubernetes.sh

### DIFF
--- a/hack/verify-starlark.sh
+++ b/hack/verify-starlark.sh
@@ -39,7 +39,7 @@ TMP_DIR=$(mktemp -d)
 OUT="${TMP_DIR}/out.log"
 
 # cleanup on exit
-cleanup() {
+capz::verify-starlark::cleanup() {
   ret=0
   if [[ -s "${OUT}" ]]; then
     echo "Found errors:"
@@ -52,7 +52,7 @@ cleanup() {
   rm -rf "${TMP_DIR}"
   exit ${ret}
 }
-trap cleanup EXIT
+trap capz::verify-starlark::cleanup EXIT
 
 BUILDIFIER="${SCRIPT_DIR}/tools/bin/buildifier/${VERSION}/buildifier"
 

--- a/scripts/ci-build-azure-ccm.sh
+++ b/scripts/ci-build-azure-ccm.sh
@@ -90,13 +90,14 @@ can_reuse_artifacts() {
     echo "true"
 }
 
-cleanup() {
+capz::ci-build-azure-ccm::cleanup() {
+    echo "cloud-provider-azure cleanup"
     if [[ -d "${AZURE_CLOUD_PROVIDER_ROOT:-}" ]]; then
         make -C "${AZURE_CLOUD_PROVIDER_ROOT}" clean || true
     fi
 }
 
-trap cleanup EXIT
+trap capz::ci-build-azure-ccm::cleanup EXIT
 
 setup
 main

--- a/scripts/ci-build-kubernetes.sh
+++ b/scripts/ci-build-kubernetes.sh
@@ -155,13 +155,13 @@ can_reuse_artifacts() {
     echo "true"
 }
 
-cleanup() {
+capz::ci-build-kubernetes::cleanup() {
     if [[ -d "${KUBE_ROOT:-}" ]]; then
         make -C "${KUBE_ROOT}" clean || true
     fi
 }
 
-trap cleanup EXIT
+trap capz::ci-build-kubernetes::cleanup EXIT
 
 setup
 main

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -78,11 +78,11 @@ export WINDOWS="${WINDOWS:-false}"
 # Generate SSH key.
 capz::util::generate_ssh_key
 
-cleanup() {
+capz::ci-conformance::cleanup() {
     "${REPO_ROOT}/hack/log/redact.sh" || true
 }
 
-trap cleanup EXIT
+trap capz::ci-conformance::cleanup EXIT
 
 if [[ "${WINDOWS}" == "true" ]]; then
   make test-windows-upstream

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -75,11 +75,11 @@ export KIND_EXPERIMENTAL_DOCKER_NETWORK="bridge"
 
 capz::util::generate_ssh_key
 
-cleanup() {
+capz::ci-e2e::cleanup() {
     "${REPO_ROOT}/hack/log/redact.sh" || true
 }
 
-trap cleanup EXIT
+trap capz::ci-e2e::cleanup EXIT
 # Image is configured as `${CONTROLLER_IMG}-${ARCH}:${TAG}` where `CONTROLLER_IMG` is defaulted to `${REGISTRY}/${IMAGE_NAME}`.
 if [[ "${BUILD_MANAGER_IMAGE}" == "false" ]]; then
   # Load an existing image, skip docker-build and docker-push.

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -301,7 +301,7 @@ copy_secret() {
     rm azure_json
 }
 
-on_exit() {
+capz::ci-entrypoint::on_exit() {
     if [[ -n ${KUBECONFIG:-} ]]; then
         "${KUBECTL}" get nodes -o wide || echo "Unable to get nodes"
         "${KUBECTL}" get pods -A -o wide || echo "Unable to get pods"
@@ -321,7 +321,7 @@ on_exit() {
 # setup all required variables and images
 setup
 
-trap on_exit EXIT
+trap capz::ci-entrypoint::on_exit EXIT
 export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
 
 # create cluster


### PR DESCRIPTION

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR renames the cleanup function in `ci-build-azure-ccm.sh` and `ci-build-kubernetes.sh` so we can call them in other scripts like `run-capz-e2e.sh`

Without renaming these functions and calling them explicitly we in the cleanup method of other scripts we cannot ensure that the cleanup happens due to how **trap** works when calling nested scripts.

See https://github.com/kubernetes-sigs/windows-testing/pull/382 for more details

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
