### PR TITLE
fix Cluster to AzureManagedControlPlane mapper

### DIFF
--- a/controllers/azuremanagedcontrolplane_controller_test.go
+++ b/controllers/azuremanagedcontrolplane_controller_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controllers
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestClusterToAzureManagedControlPlane(t *testing.T) {
+	tests := []struct {
+		name            string
+		controlPlaneRef *corev1.ObjectReference
+		expected        []ctrl.Request
+	}{
+		{
+			name:            "nil",
+			controlPlaneRef: nil,
+			expected:        nil,
+		},
+		{
+			name: "bad kind",
+			controlPlaneRef: &corev1.ObjectReference{
+				Kind: "NotAzureManagedControlPlane",
+			},
+			expected: nil,
+		},
+		{
+			name: "ok",
+			controlPlaneRef: &corev1.ObjectReference{
+				Kind:      "AzureManagedControlPlane",
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			expected: []ctrl.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Name:      "name",
+						Namespace: "namespace",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			actual := (&AzureManagedControlPlaneReconciler{}).ClusterToAzureManagedControlPlane(&clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					ControlPlaneRef: test.controlPlaneRef,
+				},
+			})
+			if test.expected == nil {
+				g.Expect(actual).To(BeNil())
+			} else {
+				g.Expect(actual).To(Equal(test.expected))
+			}
+		})
+	}
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR fixes the mapper used for the `Cluster` watcher set up by the AzureManagedControlPlaneController. I had been observing Cluster unpause events not cause the AzureManagedControlPlane to re-reconcile.

The issue was that using `ClusterToInfrastructureMapFunc` maps a Cluster to _Infrastructure_ (i.e. the Cluster's `spec.infrastructureRef`) whereas AzureManagedControlPlane is a _ControlPlane_ (referred to by the Cluster's `spec.controlPlaneRef`). This was causing all Cluster events intended to re-reconcile AzureManagedControlPlane resources to be ignored.

This change copies a modified version of the mapper from CAPI used for KubeadmControlPlane resources: https://github.com/kubernetes-sigs/cluster-api/blob/00dbf7b9f6322d7ebd06ae2efa703b23354dd37d/controlplane/kubeadm/internal/controllers/controller.go#L530

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
