### PR TITLE
Don't default NAT Gateway for existing node subnet

### DIFF
--- a/api/v1beta1/azurecluster_default.go
+++ b/api/v1beta1/azurecluster_default.go
@@ -125,9 +125,10 @@ func (c *AzureCluster) setSubnetDefaults() {
 			subnet.RouteTable.Name = generateNodeRouteTableName(c.ObjectMeta.Name)
 		}
 
-		if !subnet.IsIPv6Enabled() {
-			// NAT gateway supports the use of IPv4 public IP addresses for outbound connectivity.
-			// So default use the NAT gateway for outbound traffic in IPv4 cluster instead of loadbalancer.
+		// NAT gateway only supports the use of IPv4 public IP addresses for outbound connectivity.
+		// So default use the NAT gateway for outbound traffic in IPv4 cluster instead of loadbalancer.
+		// We assume that if the ID is set, the subnet already exists so we shouldn't add a NAT gateway.
+		if !subnet.IsIPv6Enabled() && subnet.ID == "" {
 			if subnet.NatGateway.Name == "" {
 				subnet.NatGateway.Name = withIndex(generateNatGatewayName(c.ObjectMeta.Name), nodeSubnetCounter)
 			}

--- a/api/v1beta1/azurecluster_default_test.go
+++ b/api/v1beta1/azurecluster_default_test.go
@@ -724,6 +724,73 @@ func TestSubnetDefaults(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "don't default NAT Gateway if subnet already exists",
+			cluster: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-test",
+				},
+				Spec: AzureClusterSpec{
+					NetworkSpec: NetworkSpec{
+						Subnets: Subnets{
+							{
+								SubnetClassSpec: SubnetClassSpec{
+									Role: SubnetControlPlane,
+									Name: "cluster-test-controlplane-subnet",
+								},
+								ID: "my-subnet-id",
+							},
+							{
+								SubnetClassSpec: SubnetClassSpec{
+									Role: SubnetNode,
+									Name: "cluster-test-node-subnet",
+								},
+								ID: "my-subnet-id-2",
+							},
+						},
+					},
+				},
+			},
+			output: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-test",
+				},
+				Spec: AzureClusterSpec{
+					NetworkSpec: NetworkSpec{
+						Subnets: Subnets{
+							{
+								SubnetClassSpec: SubnetClassSpec{
+									Role:       SubnetControlPlane,
+									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
+									Name:       "cluster-test-controlplane-subnet",
+								},
+								ID:            "my-subnet-id",
+								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
+								RouteTable:    RouteTable{},
+							},
+							{
+								SubnetClassSpec: SubnetClassSpec{
+									Role:       SubnetNode,
+									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
+									Name:       "cluster-test-node-subnet",
+								},
+								ID:            "my-subnet-id-2",
+								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
+								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
+								NatGateway: NatGateway{
+									NatGatewayClassSpec: NatGatewayClassSpec{
+										Name: "",
+									},
+									NatGatewayIP: PublicIPSpec{
+										Name: "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: If a cluster is not using NAT gateways for the nodes after upgrading CAPZ to v1.9.2 or v1.9.3 new VMs no longer have egress to the Internet and never join the cluster.

This PR:

1. Changes the defaulting to not update existing subnets
This is a bit of a hack because it relies on the ID field to determine that the defaulting is happening on an existing subnet vs a new subnet. Ideally, NAT Gateway would be a pointer so we could differentiate between disable NAT Gateway and new cluster, and we could have simply switch the default from empty string to default name, but that is not the case :(

2. We update existing subnets to "attach" the NAT Gateway if it gets added by the user later, so users can migrate to NAT Gateways for outbound connection (since it's the recommended way to do outbound connection in Azure).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3664 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't default NAT Gateway for existing node subnet
```
