### PR TITLE
Enable ASO

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -184,6 +184,7 @@ def observability():
 
     k8s_resource(workload = "capz-controller-manager", labels = ["cluster-api"])
     k8s_resource(workload = "capz-nmi", labels = ["cluster-api"])
+    k8s_resource(workload = "azureserviceoperator-controller-manager", labels = ["cluster-api"])
 
 # Build CAPZ and add feature gates
 def capz():

--- a/azure/services/asogroups/groups.go
+++ b/azure/services/asogroups/groups.go
@@ -59,7 +59,7 @@ func (s *Service) Name() string {
 
 // Reconcile idempotently creates or updates a resource group.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.Service.Reconcile")
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "asogroups.Service.Reconcile")
 	defer done()
 
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
@@ -77,7 +77,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes the resource group if it is managed by capz.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.Service.Delete")
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "asogroups.Service.Delete")
 	defer done()
 
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)

--- a/config/aso/credentials.yaml
+++ b/config/aso/credentials.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aso-controller-settings
 type: Opaque
 data:
-  AZURE_SUBSCRIPTION_ID: ${AZURE_SUBSCRIPTION_ID_B64:=""}
-  AZURE_TENANT_ID: ${AZURE_TENANT_ID_B64:=""}
-  AZURE_CLIENT_ID: ${AZURE_CLIENT_ID_B64:=""}
-  AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET_B64:=""}
+  # Per-resource Secrets will be created based on a Cluster's AzureClusterIdentity.
+  AZURE_SUBSCRIPTION_ID: ""
+  AZURE_TENANT_ID: ""
+  AZURE_CLIENT_ID: ""

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,2 +1,5 @@
 resources:
   - ../capz
+
+components:
+  - ../aso

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -261,3 +261,23 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - resources.azure.com
+  resources:
+  - resourcegroups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - resources.azure.com
+  resources:
+  - resourcegroups/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -111,6 +111,8 @@ func (acr *AzureClusterReconciler) SetupWithManager(ctx context.Context, mgr ctr
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=azuremachinetemplates;azuremachinetemplates/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=azureclusteridentities;azureclusteridentities/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;
+// +kubebuilder:rbac:groups=resources.azure.com,resources=resourcegroups,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=resources.azure.com,resources=resourcegroups/status,verbs=get;list;watch
 
 // Reconcile idempotently gets, creates, and updates a cluster.
 func (acr *AzureClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {

--- a/controllers/azuremanagedcontrolplane_controller.go
+++ b/controllers/azuremanagedcontrolplane_controller.go
@@ -111,6 +111,8 @@ func (amcpr *AzureManagedControlPlaneReconciler) SetupWithManager(ctx context.Co
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=azuremanagedcontrolplanes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=azuremanagedcontrolplanes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=resources.azure.com,resources=resourcegroups,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=resources.azure.com,resources=resourcegroups/status,verbs=get;list;watch
 
 // Reconcile idempotently gets, creates, and updates a managed control plane.
 func (amcpr *AzureManagedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {

--- a/controllers/azuremanagedcontrolplane_reconciler.go
+++ b/controllers/azuremanagedcontrolplane_reconciler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asogroups"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/groups"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/managedclusters"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/privateendpoints"
@@ -44,11 +45,15 @@ type azureManagedControlPlaneService struct {
 
 // newAzureManagedControlPlaneReconciler populates all the services based on input scope.
 func newAzureManagedControlPlaneReconciler(scope *scope.ManagedControlPlaneScope) *azureManagedControlPlaneService {
+	var groupsService azure.ServiceReconciler = asogroups.New(scope)
+	if scope.UseLegacyGroups {
+		groupsService = groups.New(scope)
+	}
 	return &azureManagedControlPlaneService{
 		kubeclient: scope.Client,
 		scope:      scope,
 		services: []azure.ServiceReconciler{
-			groups.New(scope),
+			groupsService,
 			virtualnetworks.New(scope),
 			subnets.New(scope),
 			managedclusters.New(scope),

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -37,6 +37,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asogroups"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/groups"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
@@ -606,11 +607,14 @@ func ShouldDeleteIndividualResources(ctx context.Context, clusterScope *scope.Cl
 	if clusterScope.Cluster.DeletionTimestamp.IsZero() {
 		return true
 	}
-	grpSvc := groups.New(clusterScope)
-	managed, err := grpSvc.IsManaged(ctx)
-	// Since this is a best effort attempt to speed up delete, we don't fail the delete if we can't get the RG status.
-	// Instead, take the long way and delete all resources one by one.
-	return err != nil || !managed
+	if clusterScope.UseLegacyGroups {
+		grpSvc := groups.New(clusterScope)
+		managed, err := grpSvc.IsManaged(ctx)
+		// Since this is a best effort attempt to speed up delete, we don't fail the delete if we can't get the RG status.
+		// Instead, take the long way and delete all resources one by one.
+		return err != nil || !managed
+	}
+	return asogroups.New(clusterScope).ShouldDeleteIndividualResources(ctx)
 }
 
 // GetClusterIdentityFromRef returns the AzureClusterIdentity referenced by the AzureCluster.

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -8,6 +8,7 @@
     - [AAD Integration](./topics/aad-integration.md)
     - [Addons](./topics/addons.md)
     - [API Server Endpoint](./topics/api-server-endpoint.md)
+    - [Azure Service Operator](./topics/aso.md)
     - [Cloud Provider Config](./topics/cloud-provider-config.md)
     - [Control Plane Outbound Load Balancer](./topics/control-plane-outbound-lb.md)
     - [Custom Images](./topics/custom-images.md)

--- a/docs/book/src/topics/aso.md
+++ b/docs/book/src/topics/aso.md
@@ -1,0 +1,55 @@
+# Azure Service Operator
+
+## Overview
+
+CAPZ interfaces with Azure to create and manage some types of resources using [Azure Service Operator
+(ASO)](https://azure.github.io/azure-service-operator/).
+
+More context around the decision for CAPZ to pivot towards using ASO can be found in the
+[proposal](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/proposals/20230123-azure-service-operator.md).
+
+## The biggest changes
+
+For most users, the introduction of ASO is expected to be fully transparent and backwards compatible. Changes
+that may affect specific use-cases are described below.
+
+### Installation
+
+Beginning with CAPZ v1.11.0, ASO's control plane will be installed automatically by `clusterctl` in the
+`capz-system` namespace alongside CAPZ's control plane components. When ASO is already installed on a cluster,
+installing ASO again with CAPZ is expected to fail and `clusterctl` cannot install CAPZ without ASO. The
+suggested workaround for users facing this issue is to uninstall the existing ASO control plane (but **keep**
+the ASO CRDs) and then to install CAPZ.
+
+### Bring-your-own (BYO) resource
+
+CAPZ had already allowed users to pre-create some resources like resource groups and virtual networks and
+reference those resources in CAPZ resources. CAPZ will then use those existing resources without creating new
+ones and assume the user is responsible for managing them, so will not actively reconcile changes to or delete
+those resources.
+
+This use case is still supported with ASO installed. The main difference is that an ASO resource will be
+created for CAPZ's own bookkeeping, but configured not to be actively reconciled by ASO. When the Cluster API
+Cluster owning the resource is deleted, the ASO resource will also be deleted from the management cluster but
+the resource will not be deleted in Azure.
+
+Additionally, BYO resources may include ASO resources managed by the user. CAPZ will not modify or delete such
+resources. Note that `clusterctl move` will not move user-managed ASO resources.
+
+## Using ASO for non-CAPZ resources
+
+CAPZ's installation of ASO can be used directly to manage Azure resources outside the domain of
+Cluster API.
+
+### Installing more CRDs
+
+CAPZ's installation of ASO configures only the ASO CRDs that are required by CAPZ. To make more resource types
+available, install their corresponding CRDs. ASO publishes a manifest containing all CRDs for each
+[release](https://github.com/Azure/azure-service-operator/releases). Extract only the ones you need using tool
+like [`yq`](https://mikefarah.gitbook.io/yq/), then make the following modifications to each CRD to account
+for CAPZ installing ASO in the `capz-system` namespace:
+
+- Change `metadata.annotations."cert-manager.io/inject-ca-from"` to `capz-system/azureserviceoperator-serving-cert`
+- Change `spec.conversion.webhook.clientConfig.service.namespace` to `capz-system`
+
+More details about how ASO manages CRDs can be found [here](https://azure.github.io/azure-service-operator/guide/crd-management/).

--- a/docs/book/src/topics/aso.md
+++ b/docs/book/src/topics/aso.md
@@ -8,10 +8,10 @@ CAPZ interfaces with Azure to create and manage some types of resources using [A
 More context around the decision for CAPZ to pivot towards using ASO can be found in the
 [proposal](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/proposals/20230123-azure-service-operator.md).
 
-## The biggest changes
+## Primary changes
 
 For most users, the introduction of ASO is expected to be fully transparent and backwards compatible. Changes
-that may affect specific use-cases are described below.
+that may affect specific use cases are described below.
 
 ### Installation
 

--- a/hack/observability/prometheus/resources/prometheus.yaml
+++ b/hack/observability/prometheus/resources/prometheus.yaml
@@ -51,8 +51,12 @@ metadata:
 spec:
   serviceAccountName: prometheus
   serviceMonitorSelector:
-    matchLabels:
-      control-plane: capz-controller-manager
+    matchExpressions:
+      - key: control-plane
+        operator: In
+        values:
+          - capz-controller-manager
+          - azureserviceoperator-controller-manager
   resources:
     requests:
       memory: 400Mi
@@ -90,3 +94,18 @@ spec:
   selector:
     matchLabels:
       control-plane: capz-controller-manager
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: azureserviceoperator-controller-manager
+  name: azureserviceoperator-controller-manager-metrics-monitor
+spec:
+  endpoints:
+    - path: /metrics
+      port: metrics
+      scheme: http
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 
 	// +kubebuilder:scaffold:imports
 	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
+	asoresourcesv1 "github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,6 +73,7 @@ func init() {
 	_ = clusterv1.AddToScheme(scheme)
 	_ = expv1.AddToScheme(scheme)
 	_ = kubeadmv1.AddToScheme(scheme)
+	_ = asoresourcesv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 
 	// Add aadpodidentity v1 to the scheme.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR enables all of the currently-merged ASO functionality which was previously inaccessible to users. Specifically, this change will install ASO alongside CAPZ and use it to manage resource groups.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3527, fixes #3523, fixes #3532

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

This PR is a work-in-progress opened early to start getting test signal and accumulate changes from other contributors as necessary. Reviews are welcome but I plan to rebase/force-push this branch frequently before removing the [WIP] status.

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Azure Service Operator is now installed alongside CAPZ and manages resource groups
```
