### PR TITLE
Run local verifying targets too before git commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,38 @@ repos:
   rev: v2.17.2
   hooks:
   - id: pylint
+- repo: local
+  hooks:
+  - id: make-verify-boilerplate
+    name: Run make verify-boilerplate
+    description: Runs `make verify-boilerplate` to check for boilerplate headers.
+    entry: make verify-boilerplate
+    language: system
+- repo: local
+  hooks:
+  - id: make-verify-modules
+    name: Run make verify-modules
+    description: Runs `make verify-modules` to verify go.sum go.mod are the latest.
+    entry: make verify-modules
+    language: system
+- repo: local
+  hooks:
+  - id: make-verify-shellcheck
+    name: Run make verify-shellcheck
+    description: Runs `make verify-shellcheck` to verify shell files are passing lint.
+    entry: make verify-shellcheck
+    language: system
+- repo: local
+  hooks:
+  - id: make-verify-tiltfile
+    name: Run make verify-tiltfile
+    description: Runs `make verify-tiltfile` to verify Tiltfile format.
+    entry: make verify-tiltfile
+    language: system
+- repo: local
+  hooks:
+  - id: make-codespell
+    name: Run make verify-codespell
+    description: Runs `make verify-codespell` to verify codespell format.
+    entry: make verify-codespell
+    language: system

--- a/docs/book/src/developers/development.md
+++ b/docs/book/src/developers/development.md
@@ -70,9 +70,10 @@
    - `sudo apt install make` on Linux.
 9. Install [timeout][timeout]
    - `brew install coreutils` on macOS.
-9. Install [pre-commit framework](https://pre-commit.com/#installation)
+10. Install [pre-commit framework](https://pre-commit.com/#installation)
    - `brew install pre-commit` Or `pip install pre-commit`. Installs pre-commit globally.
    - run `pre-commit install` at the root of the project to install pre-commit hooks to read `.pre-commit-config.yaml`
+   - *Note*: use `git commit --no-verify` to skip running pre-commit workflow as and when needed.
 
 When developing on Windows, it is suggested to set up the project on Windows + WSL2 and the file should be checked out on as wsl file system for better results.
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- This PR update `pre-commit-config.yaml` to run local Makefile targets as part of pre-commit workflow. 
  - verify-boilerplate
  - verify-modules
  - verify-shellcheck
  - verify-tiltfile
  - verify-codespell

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

Merge above PR before merging current PRs https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3706 and https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3630 before merging this PR.


- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Developer UX: Expand on the pre-commit workflow.
```
