### PR TITLE
Corrected a language error in the documentation

### DIFF
--- a/docs/book/src/developers/development.md
+++ b/docs/book/src/developers/development.md
@@ -101,7 +101,7 @@ Change some code!
 
 ### Modules and dependencies
 
-This repositories uses [Go Modules](https://github.com/golang/go/wiki/Modules) to track and vendor dependencies.
+This repository uses [Go Modules](https://github.com/golang/go/wiki/Modules) to track and vendor dependencies.
 
 To pin a new dependency:
 


### PR DESCRIPTION
What type of PR is this?
```/kind documentation```

What this PR does / why we need it?
I was going through the CAPZ documentation. There existed a tiny language error. I've corrected it. Hope it helps

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
