### PR TITLE
Updated wasm docs to include wasm workers server

### DIFF
--- a/docs/book/src/topics/multitenancy.md
+++ b/docs/book/src/topics/multitenancy.md
@@ -8,7 +8,7 @@ This is achieved using the [aad-pod-identity](https://azure.github.io/aad-pod-id
 
 ### Service Principal With Client Password
 
-Once a new SP Identity is created in Azure, the corresponding values should be used to create an `AzureClusterIdentity` resource:
+Once a new SP Identity is created in Azure, the corresponding values should be used to create an `AzureClusterIdentity` Kubernetes resource. Create an `azure-cluster-identity.yaml` file with the following contents:
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -24,6 +24,11 @@ spec:
   allowedNamespaces: 
     list:
     - <cluster-namespace>
+```
+
+Deploy this resource to your cluster:
+```bash
+kubectl apply -f azure-cluster-identity.yaml
 ```
 
 A Kubernetes Secret should also be created to store the client password:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind documentation

**What this PR does / why we need it**:
1. Updates documentation for WASM runtimes to include Wasm Workers Server
2. Added more explicit instructions for initial setup

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- Follows up on kubernetes-sigs/image-builder#1220

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [X] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updated wasm docs to include wasm workers server
```
