### PR TITLE
Add ARM64 support for CAPZ Bootstrapping Extension

### DIFF
--- a/azure/defaults_test.go
+++ b/azure/defaults_test.go
@@ -117,3 +117,70 @@ func TestMSCorrelationIDSendDecorator(t *testing.T) {
 		receivedReq.Header.Get(string(tele.CorrIDKeyVal)),
 	).To(Equal(string(corrID)))
 }
+
+func TestGetBootstrappingVMExtension(t *testing.T) {
+	testCases := []struct {
+		name            string
+		osType          string
+		cloud           string
+		vmName          string
+		cpuArchitecture string
+		expectedVersion string
+		expectNil       bool
+	}{
+		{
+			name:            "Linux OS, Public Cloud, x64 CPU Architecture",
+			osType:          LinuxOS,
+			cloud:           PublicCloudName,
+			vmName:          "test-vm",
+			cpuArchitecture: "x64",
+			expectedVersion: "1.0",
+		},
+		{
+			name:            "Linux OS, Public Cloud, arm64 CPU Architecture",
+			osType:          LinuxOS,
+			cloud:           PublicCloudName,
+			vmName:          "test-vm",
+			cpuArchitecture: "arm64",
+			expectedVersion: "1.1.1",
+		},
+		{
+			name:            "Windows OS, Public Cloud",
+			osType:          WindowsOS,
+			cloud:           PublicCloudName,
+			vmName:          "test-vm",
+			cpuArchitecture: "x64",
+			expectedVersion: "1.0",
+		},
+		{
+			name:            "Invalid OS Type",
+			osType:          "invalid",
+			cloud:           PublicCloudName,
+			vmName:          "test-vm",
+			cpuArchitecture: "x64",
+			expectedVersion: "1.0",
+			expectNil:       true,
+		},
+		{
+			name:            "Invalid Cloud",
+			osType:          LinuxOS,
+			cloud:           "invalid",
+			vmName:          "test-vm",
+			cpuArchitecture: "x64",
+			expectedVersion: "1.0",
+			expectNil:       true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			actualExtension := GetBootstrappingVMExtension(tc.osType, tc.cloud, tc.vmName, tc.cpuArchitecture)
+			if tc.expectNil {
+				g.Expect(actualExtension).To(BeNil())
+			} else {
+				g.Expect(actualExtension.Version).To(Equal(tc.expectedVersion))
+			}
+		})
+	}
+}

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -375,7 +375,8 @@ func (m *MachineScope) VMExtensionSpecs() []azure.ResourceSpecGetter {
 		})
 	}
 
-	bootstrapExtensionSpec := azure.GetBootstrappingVMExtension(m.AzureMachine.Spec.OSDisk.OSType, m.CloudEnvironment(), m.Name())
+	cpuArchitectureType, _ := m.cache.VMSKU.GetCapability(resourceskus.CPUArchitectureType)
+	bootstrapExtensionSpec := azure.GetBootstrappingVMExtension(m.AzureMachine.Spec.OSDisk.OSType, m.CloudEnvironment(), m.Name(), cpuArchitectureType)
 
 	if bootstrapExtensionSpec != nil {
 		extensionSpecs = append(extensionSpecs, &vmextensions.VMExtensionSpec{

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -573,6 +573,9 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachineCache{
+					VMSKU: resourceskus.SKU{},
+				},
 			},
 			want: []azure.ResourceSpecGetter{
 				&vmextensions.VMExtensionSpec{
@@ -621,6 +624,9 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachineCache{
+					VMSKU: resourceskus.SKU{},
+				},
 			},
 			want: []azure.ResourceSpecGetter{},
 		},
@@ -654,6 +660,9 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 							},
 						},
 					},
+				},
+				cache: &MachineCache{
+					VMSKU: resourceskus.SKU{},
 				},
 			},
 			want: []azure.ResourceSpecGetter{
@@ -703,6 +712,9 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachineCache{
+					VMSKU: resourceskus.SKU{},
+				},
 			},
 			want: []azure.ResourceSpecGetter{},
 		},
@@ -737,6 +749,9 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachineCache{
+					VMSKU: resourceskus.SKU{},
+				},
 			},
 			want: []azure.ResourceSpecGetter{},
 		},
@@ -770,6 +785,9 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 							},
 						},
 					},
+				},
+				cache: &MachineCache{
+					VMSKU: resourceskus.SKU{},
 				},
 			},
 			want: []azure.ResourceSpecGetter{},
@@ -817,6 +835,9 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 							},
 						},
 					},
+				},
+				cache: &MachineCache{
+					VMSKU: resourceskus.SKU{},
 				},
 			},
 			want: []azure.ResourceSpecGetter{

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -34,6 +34,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/roleassignments"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/scalesets"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
@@ -886,6 +887,9 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachinePoolCache{
+					VMSKU: resourceskus.SKU{},
+				},
 			},
 			want: []azure.ResourceSpecGetter{
 				&scalesets.VMSSExtensionSpec{
@@ -932,6 +936,9 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachinePoolCache{
+					VMSKU: resourceskus.SKU{},
+				},
 			},
 			want: []azure.ResourceSpecGetter{},
 		},
@@ -965,6 +972,9 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 							ResourceGroup: "my-rg",
 						},
 					},
+				},
+				cache: &MachinePoolCache{
+					VMSKU: resourceskus.SKU{},
 				},
 			},
 			want: []azure.ResourceSpecGetter{
@@ -1013,6 +1023,9 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachinePoolCache{
+					VMSKU: resourceskus.SKU{},
+				},
 			},
 			want: []azure.ResourceSpecGetter{},
 		},
@@ -1046,6 +1059,9 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 						},
 					},
 				},
+				cache: &MachinePoolCache{
+					VMSKU: resourceskus.SKU{},
+				},
 			},
 			want: []azure.ResourceSpecGetter{},
 		},
@@ -1078,6 +1094,9 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 							ResourceGroup: "my-rg",
 						},
 					},
+				},
+				cache: &MachinePoolCache{
+					VMSKU: resourceskus.SKU{},
 				},
 			},
 			want: []azure.ResourceSpecGetter{},
@@ -1127,6 +1146,9 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 							},
 						},
 					},
+				},
+				cache: &MachinePoolCache{
+					VMSKU: resourceskus.SKU{},
 				},
 			},
 			want: []azure.ResourceSpecGetter{

--- a/azure/services/resourceskus/sku.go
+++ b/azure/services/resourceskus/sku.go
@@ -72,6 +72,8 @@ const (
 	TrustedLaunchDisabled = "TrustedLaunchDisabled"
 	// ConfidentialComputingType identifies the capability for confidentical computing.
 	ConfidentialComputingType = "ConfidentialComputingType"
+	// CPUArchitectureType identifies the capability for cpu architecture.
+	CPUArchitectureType = "CpuArchitectureType"
 )
 
 // HasCapability return true for a capability which can be either


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR adds ARM64 support for the CAPZ Bootstrapping Extension. We have published a new extension version `v1.1.1` with support for ARM64 VMs while `x64` VMs will continue to use extension version `v1.0`. This is due to a known issue with Ubuntu 20.04 not supporting the updated extension.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3423

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add ARM64 support for CAPZ Bootstrapping Extension
```
