### PR TITLE
Machine pool machine scope from ampm

### DIFF
--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -116,7 +116,7 @@ func NewMachinePoolScope(params MachinePoolScopeParams) (*MachinePoolScope, erro
 	}, nil
 }
 
-// GetClient returns the client associated with the MachinePoolMachineScope
+// GetClient returns the client associated with the MachinePoolMachineScope.
 func (m *MachinePoolScope) GetClient() client.Client {
 	return m.client
 }

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -116,6 +116,11 @@ func NewMachinePoolScope(params MachinePoolScopeParams) (*MachinePoolScope, erro
 	}, nil
 }
 
+// GetClient returns the client associated with the MachinePoolMachineScope
+func (m *MachinePoolScope) GetClient() client.Client {
+	return m.client
+}
+
 // ScaleSetSpec returns the scale set spec.
 func (m *MachinePoolScope) ScaleSetSpec() azure.ScaleSetSpec {
 	return azure.ScaleSetSpec{

--- a/exp/controllers/azuremachinepool_reconciler.go
+++ b/exp/controllers/azuremachinepool_reconciler.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/roleassignments"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/scalesets"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
@@ -86,4 +87,18 @@ func (s *azureMachinePoolService) Delete(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (s *azureMachinePoolService) MachinePoolMachineScopeFromAmpm(ampm *infrav1exp.AzureMachinePoolMachine) *scope.MachinePoolMachineScope {
+	myscope, err := scope.NewMachinePoolMachineScope(scope.MachinePoolMachineScopeParams{
+		Client:                  s.scope.GetClient(),
+		MachinePool:             s.scope.MachinePool,
+		AzureMachinePool:        s.scope.AzureMachinePool,
+		AzureMachinePoolMachine: ampm,
+		ClusterScope:            s.scope.ClusterScoper,
+	})
+	if err != nil {
+		return nil
+	}
+	return myscope
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR allows for us to quickly construct an MachinePoolMachineScope from our AzureMachinePool reconciler by just passing in an AzureMachinePoolMachine. This is important because functionality has already been written for cordoning and draining the node associated with this scope and getting the node associated with this scope, both of which we don't want to arbitrarily have to rewrite.

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
