### PR TITLE
add machine pool wait to default e2e parameters

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -328,6 +328,7 @@ func createApplyClusterTemplateInput(specName string, changes ...func(*clusterct
 		WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
 		WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
 		WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+		WaitForMachinePools:          e2eConfig.GetIntervals(specName, "wait-machine-pool-nodes"),
 		CNIManifestPath:              "",
 	}
 	for _, change := range changes {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR attempts to fix this particular variety of recent (~2 days ago) flakes in the ipv6 e2e presubmit:
```
{Timed out after 1.005s.
Timed out waiting for 1 ready replicas for MachinePool capz-e2e-pjalan/capz-e2e-pjalan-ipv6-mp-0
Expected
    <int>: 0
to equal
    <int>: 1 failed [FAILED] Timed out after 1.005s.
Timed out waiting for 1 ready replicas for MachinePool capz-e2e-pjalan/capz-e2e-pjalan-ipv6-mp-0
Expected
    <int>: 0
to equal
    <int>: 1
In [It] at: /home/prow/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.4.4/framework/machinepool_helpers.go:92 @ 07/25/23 21:33:43.83
}
```
> From https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/3735/pull-cluster-api-provider-azure-e2e/1683947289200037888

My current theory is that the `Timed out after 1.005s` is suggesting that we aren't setting any timeout to wait for ready machine pool replicas. I think the reason this ever passes is because if the machine pool replicas are already ready by the time the check runs the first time, the timeout/retry mechanism never needs to engage.

This PR adds `WaitForMachinePools` to the default `clusterctl.ApplyClusterTemplateAndWaitInput{}` used for most of the e2e tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate (I haven't seen this error come up on any release branch, but seems like a sensible change to backport anyway.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
