### PR TITLE
fix bug preventing AKS autoscaling from being disabled

### DIFF
--- a/azure/scope/managedmachinepool.go
+++ b/azure/scope/managedmachinepool.go
@@ -209,7 +209,7 @@ func buildAgentPoolSpec(managedControlPlane *infrav1.AzureManagedControlPlane,
 	}
 
 	if managedMachinePool.Spec.Scaling != nil {
-		agentPoolSpec.EnableAutoScaling = pointer.Bool(true)
+		agentPoolSpec.EnableAutoScaling = true
 		agentPoolSpec.MaxCount = managedMachinePool.Spec.Scaling.MaxSize
 		agentPoolSpec.MinCount = managedMachinePool.Spec.Scaling.MinSize
 	}

--- a/azure/scope/managedmachinepool_test.go
+++ b/azure/scope/managedmachinepool_test.go
@@ -108,7 +108,7 @@ func TestManagedMachinePoolScope_Autoscaling(t *testing.T) {
 				Mode:              "User",
 				Cluster:           "cluster1",
 				Replicas:          1,
-				EnableAutoScaling: pointer.Bool(true),
+				EnableAutoScaling: true,
 				MinCount:          pointer.Int32(2),
 				MaxCount:          pointer.Int32(10),
 				VnetSubnetID:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups//providers/Microsoft.Network/virtualNetworks//subnets/",

--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -101,7 +101,7 @@ type AgentPoolSpec struct {
 	NodeTaints []string `json:"nodeTaints,omitempty"`
 
 	// EnableAutoScaling - Whether to enable auto-scaler
-	EnableAutoScaling *bool `json:"enableAutoScaling,omitempty"`
+	EnableAutoScaling bool `json:"enableAutoScaling,omitempty"`
 
 	// AvailabilityZones represents the Availability zones for nodes in the AgentPool.
 	AvailabilityZones []string
@@ -211,7 +211,7 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (p
 				Count:               &s.Replicas,
 				OrchestratorVersion: s.Version,
 				Mode:                containerservice.AgentPoolMode(s.Mode),
-				EnableAutoScaling:   s.EnableAutoScaling,
+				EnableAutoScaling:   pointer.Bool(s.EnableAutoScaling),
 				MinCount:            s.MinCount,
 				MaxCount:            s.MaxCount,
 				NodeLabels:          s.NodeLabels,
@@ -247,7 +247,7 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (p
 		// When autoscaling is set, the count of the nodes differ based on the autoscaler and should not depend on the
 		// count present in MachinePool or AzureManagedMachinePool, hence we should not make an update API call based
 		// on difference in count.
-		if pointer.BoolDeref(s.EnableAutoScaling, false) {
+		if s.EnableAutoScaling {
 			normalizedProfile.Count = existingProfile.Count
 		}
 
@@ -357,7 +357,7 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (p
 		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
 			AvailabilityZones:    availabilityZones,
 			Count:                &s.Replicas,
-			EnableAutoScaling:    s.EnableAutoScaling,
+			EnableAutoScaling:    pointer.Bool(s.EnableAutoScaling),
 			EnableUltraSSD:       s.EnableUltraSSD,
 			KubeletConfig:        kubeletConfig,
 			KubeletDiskType:      containerservice.KubeletDiskType(pointer.StringDeref((*string)(s.KubeletDiskType), "")),

--- a/azure/services/agentpools/spec_test.go
+++ b/azure/services/agentpools/spec_test.go
@@ -38,7 +38,7 @@ func fakeAgentPool(changes ...func(*AgentPoolSpec)) AgentPoolSpec {
 		ResourceGroup:     "fake-rg",
 		Cluster:           "fake-cluster",
 		AvailabilityZones: []string{"fake-zone"},
-		EnableAutoScaling: pointer.Bool(true),
+		EnableAutoScaling: true,
 		EnableUltraSSD:    pointer.Bool(true),
 		KubeletDiskType:   (*infrav1.KubeletDiskType)(pointer.String("fake-kubelet-disk-type")),
 		MaxCount:          pointer.Int32(5),
@@ -73,7 +73,7 @@ func withReplicas(replicas int32) func(*AgentPoolSpec) {
 
 func withAutoscaling(enabled bool) func(*AgentPoolSpec) {
 	return func(pool *AgentPoolSpec) {
-		pool.EnableAutoScaling = pointer.Bool(enabled)
+		pool.EnableAutoScaling = enabled
 	}
 }
 

--- a/azure/services/managedclusters/spec_test.go
+++ b/azure/services/managedclusters/spec_test.go
@@ -348,6 +348,7 @@ func getSampleManagedCluster() containerservice.ManagedCluster {
 					Tags: map[string]*string{
 						"test-tag": pointer.String("test-value"),
 					},
+					EnableAutoScaling: pointer.Bool(false),
 				},
 				{
 					Name:                pointer.String("test-agentpool-1"),
@@ -363,6 +364,7 @@ func getSampleManagedCluster() containerservice.ManagedCluster {
 					Tags: map[string]*string{
 						"test-tag": pointer.String("test-value"),
 					},
+					EnableAutoScaling: pointer.Bool(false),
 				},
 			},
 			LinuxProfile: &containerservice.LinuxProfile{

--- a/controllers/azuremanagedmachinepool_controller_test.go
+++ b/controllers/azuremanagedmachinepool_controller_test.go
@@ -263,7 +263,7 @@ func fakeAgentPool(changes ...func(*agentpools.AgentPoolSpec)) agentpools.AgentP
 		ResourceGroup:     "fake-rg",
 		Cluster:           "fake-cluster",
 		AvailabilityZones: []string{"fake-zone"},
-		EnableAutoScaling: pointer.Bool(true),
+		EnableAutoScaling: true,
 		EnableUltraSSD:    pointer.Bool(true),
 		KubeletDiskType:   (*infrav1.KubeletDiskType)(pointer.String("fake-kubelet-disk-type")),
 		MaxCount:          pointer.Int32(5),


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR addresses the recent failures in the AKS autoscale e2e test which fails to disable autoscaling for an AKS node pool. Currently for a node pool, CAPZ sets its `ManagedClusterAgentPoolProfileProperties.EnableAutoScaling` to `nil` when an AzureManagedMachinePool's `spec.scaling` is `nil`. Since AKS interprets `nil` as "do not change" then autoscaling was never being disabled.

The functional change this PR makes is to always send a non-nil `true` or `false` to the AKS API. Part of that change involves changing the type of the CAPZ-internal `AgentPoolSpec.EnableAutoScaling` field from `*bool` to `bool` since it makes less sense to let `nil` be a possible value for that particular type anymore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3763

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate (This seems like an AKS change, so unrelated to the main branch of CAPZ)

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
