### PR TITLE
[release-1.9] add machine pool wait to default e2e parameters

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -327,6 +327,7 @@ func createApplyClusterTemplateInput(specName string, changes ...func(*clusterct
 		WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
 		WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
 		WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+		WaitForMachinePools:          e2eConfig.GetIntervals(specName, "wait-machine-pool-nodes"),
 	}
 	for _, change := range changes {
 		change(&input)


### PR DESCRIPTION
This is a manual cherry-pick of #3761.

/assign @nojnhuh 

```release-note
NONE
```