### PR TITLE
[release-1.10] update project maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -17,3 +17,4 @@ emeritus_approvers:
   - nader-ziada
   - ncdc
   - shysank
+  - devigned

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -17,14 +17,13 @@ aliases:
     - vincepri
   cluster-api-azure-maintainers:
     - CecileRobertMichon
-    - devigned
     - jackfrancis
     - mboersma
+    - nojnhuh
+    - sonasingh46
   cluster-api-azure-reviewers:
     - Jont828
     - jsturtevant
     - marosset
     - nawazkh
-    - nojnhuh
-    - sonasingh46
     - willie-yao


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates project maintainers in the `release-1.10` branch to match `main`, so new maintainers can approve cherry-picks and newly emeritus maintainers are not assigned cherry-pick PRs.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
