### PR TITLE
add pause handling for AzureManagedControlPlane

### DIFF
--- a/controllers/azuremanagedcontrolplane_controller_test.go
+++ b/controllers/azuremanagedcontrolplane_controller_test.go
@@ -16,13 +16,22 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/internal/test"
+	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestClusterToAzureManagedControlPlane(t *testing.T) {
@@ -76,4 +85,69 @@ func TestClusterToAzureManagedControlPlane(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAzureManagedControlPlaneReconcilePaused(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := context.Background()
+
+	sb := runtime.NewSchemeBuilder(
+		clusterv1.AddToScheme,
+		infrav1.AddToScheme,
+	)
+	s := runtime.NewScheme()
+	g.Expect(sb.AddToScheme(s)).To(Succeed())
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		Build()
+
+	recorder := record.NewFakeRecorder(1)
+
+	reconciler := &AzureManagedControlPlaneReconciler{
+		Client:           c,
+		Recorder:         recorder,
+		ReconcileTimeout: reconciler.DefaultLoopTimeout,
+		WatchFilterValue: "",
+	}
+	name := test.RandomName("paused", 10)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: clusterv1.ClusterSpec{
+			Paused: true,
+		},
+	}
+	g.Expect(c.Create(ctx, cluster)).To(Succeed())
+
+	instance := &infrav1.AzureManagedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "Cluster",
+					APIVersion: clusterv1.GroupVersion.String(),
+					Name:       cluster.Name,
+				},
+			},
+		},
+		Spec: infrav1.AzureManagedControlPlaneSpec{
+			SubscriptionID: "something",
+		},
+	}
+	g.Expect(c.Create(ctx, instance)).To(Succeed())
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKey{
+			Namespace: instance.Namespace,
+			Name:      instance.Name,
+		},
+	})
+
+	g.Expect(err).To(BeNil())
+	g.Expect(result.RequeueAfter).To(BeZero())
 }

--- a/controllers/azuremanagedcontrolplane_reconciler.go
+++ b/controllers/azuremanagedcontrolplane_reconciler.go
@@ -77,6 +77,24 @@ func (r *azureManagedControlPlaneService) Reconcile(ctx context.Context) error {
 	return nil
 }
 
+// Pause pauses all components making up the cluster.
+func (r *azureManagedControlPlaneService) Pause(ctx context.Context) error {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureManagedControlPlaneService.Pause")
+	defer done()
+
+	for _, service := range r.services {
+		pauser, ok := service.(azure.Pauser)
+		if !ok {
+			continue
+		}
+		if err := pauser.Pause(ctx); err != nil {
+			return errors.Wrapf(err, "failed to pause AzureManagedControlPlane service %s", service.Name())
+		}
+	}
+
+	return nil
+}
+
 // Delete reconciles all the services in a predetermined order.
 func (r *azureManagedControlPlaneService) Delete(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureManagedControlPlaneService.Delete")

--- a/controllers/azuremanagedcontrolplane_reconciler_test.go
+++ b/controllers/azuremanagedcontrolplane_reconciler_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"go.uber.org/mock/gomock"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
+	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
+)
+
+func TestAzureManagedControlPlaneServicePause(t *testing.T) {
+	type pausingServiceReconciler struct {
+		*mock_azure.MockServiceReconciler
+		*mock_azure.MockPauser
+	}
+
+	cases := map[string]struct {
+		expectedError string
+		expect        func(one pausingServiceReconciler, two pausingServiceReconciler, three pausingServiceReconciler)
+	}{
+		"all services are paused in order": {
+			expectedError: "",
+			expect: func(one pausingServiceReconciler, two pausingServiceReconciler, three pausingServiceReconciler) {
+				gomock.InOrder(
+					one.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(nil),
+					two.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(nil),
+					three.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(nil))
+			},
+		},
+		"service pause fails": {
+			expectedError: "failed to pause AzureManagedControlPlane service two: some error happened",
+			expect: func(one pausingServiceReconciler, two pausingServiceReconciler, _ pausingServiceReconciler) {
+				gomock.InOrder(
+					one.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(nil),
+					two.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(errors.New("some error happened")),
+					two.MockServiceReconciler.EXPECT().Name().Return("two"))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			newPausingServiceReconciler := func() pausingServiceReconciler {
+				return pausingServiceReconciler{
+					mock_azure.NewMockServiceReconciler(mockCtrl),
+					mock_azure.NewMockPauser(mockCtrl),
+				}
+			}
+			svcOneMock := newPausingServiceReconciler()
+			svcTwoMock := newPausingServiceReconciler()
+			svcThreeMock := newPausingServiceReconciler()
+
+			tc.expect(svcOneMock, svcTwoMock, svcThreeMock)
+
+			s := &azureManagedControlPlaneService{
+				services: []azure.ServiceReconciler{
+					svcOneMock,
+					svcTwoMock,
+					svcThreeMock,
+				},
+			}
+
+			err := s.Pause(context.TODO())
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR adds the capability for the AzureManagedControlPlane controller to react when resources are paused using the same pattern as #3735. See that PR for more context.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3525

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
