### PR TITLE
add ASO pause logic

### DIFF
--- a/azure/services/asogroups/groups.go
+++ b/azure/services/asogroups/groups.go
@@ -99,6 +99,17 @@ func (s *Service) IsManaged(ctx context.Context) (bool, error) {
 	return aso.IsManaged(ctx, s.Scope.GetClient(), s.Scope.ASOGroupSpec(), s.Scope.ClusterName())
 }
 
+var _ azure.Pauser = (*Service)(nil)
+
+// Pause implements azure.Pauser.
+func (s *Service) Pause(ctx context.Context) error {
+	groupSpec := s.Scope.ASOGroupSpec()
+	if groupSpec == nil {
+		return nil
+	}
+	return aso.PauseResource(ctx, s.Scope.GetClient(), groupSpec, s.Scope.ClusterName(), ServiceName)
+}
+
 // ShouldDeleteIndividualResources returns false if the resource group is
 // managed and reconciled by ASO, meaning that we can rely on a single resource
 // group delete operation as opposed to deleting every individual resource.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR implements logic to pause ASO resources using the plumbing set up by #3735.

Specifically, the `serviceoperator.azure.com/reconcile-policy` annotation on ASO resources will be set to `skip` and the previous value will also be stored in a CAPZ-specific `sigs.k8s.io/cluster-api-provider-azure-pre-pause-reconcile-policy` annotation. Then when a Cluster is unpaused and reconciliation resumes normally, the `pre-pause-reconcile-policy` annotation will be used to restore the value as it was before the Cluster was paused. The reconcile policy cannot unconditionally be changed back to `manage` because ASO representations of BYO Azure resources (like ones created in the portal or CLI) will already be annotated with the `skip` reconcile policy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3525

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
