### PR TITLE
Fix retrying in Helm e2e helper func

### DIFF
--- a/test/e2e/helm.go
+++ b/test/e2e/helm.go
@@ -68,11 +68,11 @@ func InstallHelmChart(ctx context.Context, clusterProxy framework.ClusterProxy, 
 	}
 
 	// Install the chart and retry if needed
-	Eventually(func(g Gomega) {
+	Eventually(func() error {
 		cmd := exec.Command(helm, args...)
 		Logf("Helm command: %s", cmd.String())
 		output, err := cmd.CombinedOutput()
 		Logf("Helm install output: %s", string(output))
-		Expect(err).NotTo(HaveOccurred())
+		return err
 	}, helmInstallTimeout, retryableOperationSleepBetweenRetries).Should(Succeed())
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Fixes a logic error in the refactoring of the `InstallHelmChart` helper function so it retries as intended if the command returns an error.

**Which issue(s) this PR fixes**:

Fixes #3787

**Special notes for your reviewer**:

I created a demo Ginkgo test suite to reproduce this and isolate the problem, then ported the now-obvious fix back to CAPZ. I did a before-and-after test locally with `./scripts/ci-e2e.sh` and verified that we aren't currently retrying but that this change fixes that.

I guess the good news is that even without retry, the new implementation has only rarely failed. 😄 

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
