### PR TITLE
Use k8s.io/utils/ptr for pointer helper funcs

### DIFF
--- a/api/v1beta1/azurecluster_default.go
+++ b/api/v1beta1/azurecluster_default.go
@@ -19,7 +19,7 @@ package v1beta1
 import (
 	"fmt"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -241,7 +241,7 @@ func (c *AzureCluster) SetNodeOutboundLBDefaults() {
 	}
 
 	if lb.FrontendIPsCount == nil {
-		lb.FrontendIPsCount = pointer.Int32(1)
+		lb.FrontendIPsCount = ptr.To[int32](1)
 	}
 
 	c.setOutboundLBFrontendIPs(lb, generateNodeOutboundIPName)
@@ -261,7 +261,7 @@ func (c *AzureCluster) SetControlPlaneOutboundLBDefaults() {
 		lb.Name = generateControlPlaneOutboundLBName(c.ObjectMeta.Name)
 	}
 	if lb.FrontendIPsCount == nil {
-		lb.FrontendIPsCount = pointer.Int32(1)
+		lb.FrontendIPsCount = ptr.To[int32](1)
 	}
 	c.setOutboundLBFrontendIPs(lb, generateControlPlaneOutboundIPName)
 	c.SetControlPlaneOutboundLBBackendPoolNameDefault()
@@ -356,7 +356,7 @@ func (lb *LoadBalancerClassSpec) setAPIServerLBDefaults() {
 		lb.SKU = SKUStandard
 	}
 	if lb.IdleTimeoutInMinutes == nil {
-		lb.IdleTimeoutInMinutes = pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes)
+		lb.IdleTimeoutInMinutes = ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes)
 	}
 }
 
@@ -372,7 +372,7 @@ func (lb *LoadBalancerClassSpec) setOutboundLBDefaults() {
 	lb.Type = Public
 	lb.SKU = SKUStandard
 	if lb.IdleTimeoutInMinutes == nil {
-		lb.IdleTimeoutInMinutes = pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes)
+		lb.IdleTimeoutInMinutes = ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes)
 	}
 }
 
@@ -391,7 +391,7 @@ func setControlPlaneOutboundLBDefaults(lb *LoadBalancerClassSpec, apiserverLBTyp
 	lb.SKU = SKUStandard
 
 	if lb.IdleTimeoutInMinutes == nil {
-		lb.IdleTimeoutInMinutes = pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes)
+		lb.IdleTimeoutInMinutes = ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes)
 	}
 }
 

--- a/api/v1beta1/azurecluster_default_test.go
+++ b/api/v1beta1/azurecluster_default_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestResourceGroupDefault(t *testing.T) {
@@ -139,7 +139,7 @@ func TestVnetDefaults(t *testing.T) {
 							},
 						},
 						NodeOutboundLB: &LoadBalancerSpec{
-							FrontendIPsCount: pointer.Int32(1),
+							FrontendIPsCount: ptr.To[int32](1),
 						},
 					},
 				},
@@ -656,10 +656,10 @@ func TestSubnetDefaults(t *testing.T) {
 												Description:      "allow port 50000",
 												Protocol:         "*",
 												Priority:         2202,
-												SourcePorts:      pointer.String("*"),
-												DestinationPorts: pointer.String("*"),
-												Source:           pointer.String("*"),
-												Destination:      pointer.String("*"),
+												SourcePorts:      ptr.To("*"),
+												DestinationPorts: ptr.To("*"),
+												Source:           ptr.To("*"),
+												Destination:      ptr.To("*"),
 											},
 										},
 									},
@@ -691,10 +691,10 @@ func TestSubnetDefaults(t *testing.T) {
 												Description:      "allow port 50000",
 												Protocol:         "*",
 												Priority:         2202,
-												SourcePorts:      pointer.String("*"),
-												DestinationPorts: pointer.String("*"),
-												Source:           pointer.String("*"),
-												Destination:      pointer.String("*"),
+												SourcePorts:      ptr.To("*"),
+												DestinationPorts: ptr.To("*"),
+												Source:           ptr.To("*"),
+												Destination:      ptr.To("*"),
 												Direction:        SecurityRuleDirectionInbound,
 											},
 										},
@@ -970,7 +970,7 @@ func TestAPIServerLBDefaults(t *testing.T) {
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								SKU:                  SKUStandard,
 								Type:                 Public,
-								IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 						},
 					},
@@ -1014,7 +1014,7 @@ func TestAPIServerLBDefaults(t *testing.T) {
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								SKU:                  SKUStandard,
 								Type:                 Internal,
-								IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 							Name: "cluster-test-internal-lb",
 						},
@@ -1062,7 +1062,7 @@ func TestAPIServerLBDefaults(t *testing.T) {
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								SKU:                  SKUStandard,
 								Type:                 Internal,
-								IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 							Name: "cluster-test-internal-lb",
 						},
@@ -1310,11 +1310,11 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							BackendPool: BackendPool{
 								Name: "cluster-test-outboundBackendPool",
 							},
-							FrontendIPsCount: pointer.Int32(1),
+							FrontendIPsCount: ptr.To[int32](1),
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								SKU:                  SKUStandard,
 								Type:                 Public,
-								IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 						},
 					},
@@ -1409,11 +1409,11 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							BackendPool: BackendPool{
 								Name: "cluster-test-outboundBackendPool",
 							},
-							FrontendIPsCount: pointer.Int32(1),
+							FrontendIPsCount: ptr.To[int32](1),
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								SKU:                  SKUStandard,
 								Type:                 Public,
-								IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 						},
 					},
@@ -1623,11 +1623,11 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							BackendPool: BackendPool{
 								Name: "cluster-test-outboundBackendPool",
 							},
-							FrontendIPsCount: pointer.Int32(1),
+							FrontendIPsCount: ptr.To[int32](1),
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								SKU:                  SKUStandard,
 								Type:                 Public,
-								IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 						},
 					},
@@ -1671,12 +1671,12 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 					NetworkSpec: NetworkSpec{
 						APIServerLB: LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
 						NodeOutboundLB: &LoadBalancerSpec{
-							FrontendIPsCount: pointer.Int32(2),
+							FrontendIPsCount: ptr.To[int32](2),
 							BackendPool: BackendPool{
 								Name: "custom-backend-pool",
 							},
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								IdleTimeoutInMinutes: pointer.Int32(15),
+								IdleTimeoutInMinutes: ptr.To[int32](15),
 							},
 						},
 					},
@@ -1711,11 +1711,11 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							BackendPool: BackendPool{
 								Name: "custom-backend-pool",
 							},
-							FrontendIPsCount: pointer.Int32(2), // we expect the original value to be respected here
+							FrontendIPsCount: ptr.To[int32](2), // we expect the original value to be respected here
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								SKU:                  SKUStandard,
 								Type:                 Public,
-								IdleTimeoutInMinutes: pointer.Int32(15), // we expect the original value to be respected here
+								IdleTimeoutInMinutes: ptr.To[int32](15), // we expect the original value to be respected here
 							},
 							Name: "cluster-test",
 						},
@@ -1805,11 +1805,11 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 							BackendPool: BackendPool{
 								Name: "user-defined-name-outboundBackendPool",
 							},
-							FrontendIPsCount: pointer.Int32(1),
+							FrontendIPsCount: ptr.To[int32](1),
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								SKU:                  SKUStandard,
 								Type:                 Public,
-								IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 						},
 						ControlPlaneOutboundLB: &LoadBalancerSpec{
@@ -1905,9 +1905,9 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 					NetworkSpec: NetworkSpec{
 						APIServerLB: LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Internal}},
 						ControlPlaneOutboundLB: &LoadBalancerSpec{
-							FrontendIPsCount: pointer.Int32(2),
+							FrontendIPsCount: ptr.To[int32](2),
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								IdleTimeoutInMinutes: pointer.Int32(15),
+								IdleTimeoutInMinutes: ptr.To[int32](15),
 							},
 						},
 					},
@@ -1943,11 +1943,11 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 									},
 								},
 							},
-							FrontendIPsCount: pointer.Int32(2),
+							FrontendIPsCount: ptr.To[int32](2),
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								SKU:                  SKUStandard,
 								Type:                 Public,
-								IdleTimeoutInMinutes: pointer.Int32(15),
+								IdleTimeoutInMinutes: ptr.To[int32](15),
 							},
 						},
 					},
@@ -1968,7 +1968,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 								Name: "custom-outbound-lb",
 							},
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								IdleTimeoutInMinutes: pointer.Int32(15),
+								IdleTimeoutInMinutes: ptr.To[int32](15),
 							},
 						},
 					},
@@ -1998,11 +1998,11 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 									},
 								},
 							},
-							FrontendIPsCount: pointer.Int32(1),
+							FrontendIPsCount: ptr.To[int32](1),
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								SKU:                  SKUStandard,
 								Type:                 Public,
-								IdleTimeoutInMinutes: pointer.Int32(15),
+								IdleTimeoutInMinutes: ptr.To[int32](15),
 							},
 						},
 					},

--- a/api/v1beta1/azurecluster_validation.go
+++ b/api/v1beta1/azurecluster_validation.go
@@ -26,7 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 )
 
@@ -364,7 +364,7 @@ func validateAPIServerLB(lb LoadBalancerSpec, old LoadBalancerSpec, cidrs []stri
 	}
 
 	// There should only be one IP config.
-	if len(lb.FrontendIPs) != 1 || pointer.Int32Deref(lb.FrontendIPsCount, 1) != 1 {
+	if len(lb.FrontendIPs) != 1 || ptr.Deref[int32](lb.FrontendIPsCount, 1) != 1 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("frontendIPConfigs"), lb.FrontendIPs,
 			"API Server Load balancer should have 1 Frontend IP"))
 	} else {
@@ -521,7 +521,7 @@ func validateClassSpecForAPIServerLB(lb LoadBalancerClassSpec, old *LoadBalancer
 	}
 
 	// IdletimeoutInMinutes should be immutable.
-	if old != nil && old.IdleTimeoutInMinutes != nil && !pointer.Int32Equal(old.IdleTimeoutInMinutes, lb.IdleTimeoutInMinutes) {
+	if old != nil && old.IdleTimeoutInMinutes != nil && !ptr.Equal(old.IdleTimeoutInMinutes, lb.IdleTimeoutInMinutes) {
 		allErrs = append(allErrs, field.Forbidden(apiServerLBPath.Child("idleTimeoutInMinutes"), "API Server load balancer idle timeout cannot be modified after AzureCluster creation."))
 	}
 
@@ -554,7 +554,7 @@ func validateClassSpecForNodeOutboundLB(lb *LoadBalancerClassSpec, old *LoadBala
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("type"), "Node outbound load balancer Type cannot be modified after AzureCluster creation."))
 	}
 
-	if old != nil && !pointer.Int32Equal(old.IdleTimeoutInMinutes, lb.IdleTimeoutInMinutes) {
+	if old != nil && !ptr.Equal(old.IdleTimeoutInMinutes, lb.IdleTimeoutInMinutes) {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("idleTimeoutInMinutes"), "Node outbound load balancer idle timeout cannot be modified after AzureCluster creation."))
 	}
 

--- a/api/v1beta1/azurecluster_validation_test.go
+++ b/api/v1beta1/azurecluster_validation_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestClusterNameValidation(t *testing.T) {
@@ -1075,7 +1075,7 @@ func TestValidateNodeOutboundLB(t *testing.T) {
 				}, {
 					Name: "some-frontend-ip-2",
 				}},
-				FrontendIPsCount: pointer.Int32(2),
+				FrontendIPsCount: ptr.To[int32](2),
 			},
 			old: &LoadBalancerSpec{
 				FrontendIPs: []FrontendIP{{
@@ -1088,7 +1088,7 @@ func TestValidateNodeOutboundLB(t *testing.T) {
 		{
 			name: "frontend ips count exceeds max value",
 			lb: &LoadBalancerSpec{
-				FrontendIPsCount: pointer.Int32(100),
+				FrontendIPsCount: ptr.To[int32](100),
 			},
 			wantErr: true,
 			expectedErr: field.Error{
@@ -1164,7 +1164,7 @@ func TestValidateControlPlaneNodeOutboundLB(t *testing.T) {
 		{
 			name: "frontend ips count exceeds max value",
 			lb: &LoadBalancerSpec{
-				FrontendIPsCount: pointer.Int32(100),
+				FrontendIPsCount: ptr.To[int32](100),
 			},
 			apiServerLB: LoadBalancerSpec{
 				LoadBalancerClassSpec: LoadBalancerClassSpec{
@@ -1357,7 +1357,7 @@ func createValidAPIServerLB() LoadBalancerSpec {
 
 func createValidNodeOutboundLB() *LoadBalancerSpec {
 	return &LoadBalancerSpec{
-		FrontendIPsCount: pointer.Int32(1),
+		FrontendIPsCount: ptr.To[int32](1),
 	}
 }
 

--- a/api/v1beta1/azureclustertemplate_default_test.go
+++ b/api/v1beta1/azureclustertemplate_default_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestVnetTemplateDefaults(t *testing.T) {
@@ -472,7 +472,7 @@ func TestAPIServerLBClassDefaults(t *testing.T) {
 								APIServerLB: LoadBalancerClassSpec{
 									SKU:                  SKUStandard,
 									Type:                 Public,
-									IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+									IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
 						},
@@ -509,7 +509,7 @@ func TestAPIServerLBClassDefaults(t *testing.T) {
 								APIServerLB: LoadBalancerClassSpec{
 									SKU:                  SKUStandard,
 									Type:                 Internal,
-									IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+									IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
 						},
@@ -648,7 +648,7 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 								NodeOutboundLB: &LoadBalancerClassSpec{
 									SKU:                  SKUStandard,
 									Type:                 Public,
-									IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+									IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
 						},
@@ -720,7 +720,7 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 								NodeOutboundLB: &LoadBalancerClassSpec{
 									SKU:                  SKUStandard,
 									Type:                 Public,
-									IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+									IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
 						},
@@ -794,7 +794,7 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 								NodeOutboundLB: &LoadBalancerClassSpec{
 									SKU:                  SKUStandard,
 									Type:                 Public,
-									IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+									IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
 						},
@@ -910,7 +910,7 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 							NetworkSpec: NetworkTemplateSpec{
 								APIServerLB: LoadBalancerClassSpec{Type: Internal},
 								NodeOutboundLB: &LoadBalancerClassSpec{
-									IdleTimeoutInMinutes: pointer.Int32(15),
+									IdleTimeoutInMinutes: ptr.To[int32](15),
 								},
 							},
 						},
@@ -927,7 +927,7 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 							NetworkSpec: NetworkTemplateSpec{
 								APIServerLB: LoadBalancerClassSpec{Type: Internal},
 								NodeOutboundLB: &LoadBalancerClassSpec{
-									IdleTimeoutInMinutes: pointer.Int32(15),
+									IdleTimeoutInMinutes: ptr.To[int32](15),
 									SKU:                  SKUStandard,
 									Type:                 Public,
 								},

--- a/api/v1beta1/azureclustertemplate_validation_test.go
+++ b/api/v1beta1/azureclustertemplate_validation_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestValdateVnetCIDRs(t *testing.T) {
@@ -446,7 +446,7 @@ func TestValidateAPIServerLBTemplate(t *testing.T) {
 								APIServerLB: LoadBalancerClassSpec{
 									SKU:                  SKUStandard,
 									Type:                 Public,
-									IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+									IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
 						},
@@ -468,7 +468,7 @@ func TestValidateAPIServerLBTemplate(t *testing.T) {
 								APIServerLB: LoadBalancerClassSpec{
 									SKU:                  SKU("wrong"),
 									Type:                 Public,
-									IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+									IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
 						},
@@ -490,7 +490,7 @@ func TestValidateAPIServerLBTemplate(t *testing.T) {
 								APIServerLB: LoadBalancerClassSpec{
 									SKU:                  SKUStandard,
 									Type:                 LBType("wrong"),
-									IdleTimeoutInMinutes: pointer.Int32(DefaultOutboundRuleIdleTimeoutInMinutes),
+									IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
 						},
@@ -580,7 +580,7 @@ func TestControlPlaneOutboundLBTemplate(t *testing.T) {
 									Type: Internal,
 								},
 								ControlPlaneOutboundLB: &LoadBalancerClassSpec{
-									IdleTimeoutInMinutes: pointer.Int32(2),
+									IdleTimeoutInMinutes: ptr.To[int32](2),
 								},
 							},
 						},
@@ -603,7 +603,7 @@ func TestControlPlaneOutboundLBTemplate(t *testing.T) {
 									Type: Internal,
 								},
 								ControlPlaneOutboundLB: &LoadBalancerClassSpec{
-									IdleTimeoutInMinutes: pointer.Int32(60),
+									IdleTimeoutInMinutes: ptr.To[int32](60),
 								},
 							},
 						},
@@ -710,7 +710,7 @@ func TestNodeOutboundLBTemplate(t *testing.T) {
 									Type: Public,
 								},
 								NodeOutboundLB: &LoadBalancerClassSpec{
-									IdleTimeoutInMinutes: pointer.Int32(2),
+									IdleTimeoutInMinutes: ptr.To[int32](2),
 								},
 							},
 						},
@@ -733,7 +733,7 @@ func TestNodeOutboundLBTemplate(t *testing.T) {
 									Type: Public,
 								},
 								NodeOutboundLB: &LoadBalancerClassSpec{
-									IdleTimeoutInMinutes: pointer.Int32(60),
+									IdleTimeoutInMinutes: ptr.To[int32](60),
 								},
 							},
 						},

--- a/api/v1beta1/azureimage_validation_test.go
+++ b/api/v1beta1/azureimage_validation_test.go
@@ -21,7 +21,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestImageOptional(t *testing.T) {
@@ -74,15 +74,15 @@ func TestComputeImageGalleryValid(t *testing.T) {
 		},
 		"AzureComputeGalleryImage - fully specified private image": {
 			expectedErrors: 0,
-			image:          createTestComputeImage(pointer.String("SUB1234"), pointer.String("RG1234")),
+			image:          createTestComputeImage(ptr.To("SUB1234"), ptr.To("RG1234")),
 		},
 		"AzureComputeGalleryImage - private image with missing subscription": {
 			expectedErrors: 1,
-			image:          createTestComputeImage(nil, pointer.String("RG1234")),
+			image:          createTestComputeImage(nil, ptr.To("RG1234")),
 		},
 		"AzureComputeGalleryImage - private image with missing resource group": {
 			expectedErrors: 1,
-			image:          createTestComputeImage(pointer.String("SUB1234"), nil),
+			image:          createTestComputeImage(ptr.To("SUB1234"), nil),
 		},
 	}
 

--- a/api/v1beta1/azuremachine_default_test.go
+++ b/api/v1beta1/azuremachine_default_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -142,13 +142,13 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 				{
 					NameSuffix:  "testdisk1",
 					DiskSizeGB:  30,
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: "ReadWrite",
 				},
 				{
 					NameSuffix:  "testdisk2",
 					DiskSizeGB:  30,
-					Lun:         pointer.Int32(1),
+					Lun:         ptr.To[int32](1),
 					CachingType: "ReadWrite",
 				},
 			},
@@ -159,13 +159,13 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 				{
 					NameSuffix:  "testdisk1",
 					DiskSizeGB:  30,
-					Lun:         pointer.Int32(5),
+					Lun:         ptr.To[int32](5),
 					CachingType: "ReadWrite",
 				},
 				{
 					NameSuffix:  "testdisk2",
 					DiskSizeGB:  30,
-					Lun:         pointer.Int32(3),
+					Lun:         ptr.To[int32](3),
 					CachingType: "ReadWrite",
 				},
 			},
@@ -173,13 +173,13 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 				{
 					NameSuffix:  "testdisk1",
 					DiskSizeGB:  30,
-					Lun:         pointer.Int32(5),
+					Lun:         ptr.To[int32](5),
 					CachingType: "ReadWrite",
 				},
 				{
 					NameSuffix:  "testdisk2",
 					DiskSizeGB:  30,
-					Lun:         pointer.Int32(3),
+					Lun:         ptr.To[int32](3),
 					CachingType: "ReadWrite",
 				},
 			},
@@ -190,7 +190,7 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 				{
 					NameSuffix:  "testdisk1",
 					DiskSizeGB:  30,
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: "ReadWrite",
 				},
 				{
@@ -201,7 +201,7 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 				{
 					NameSuffix:  "testdisk3",
 					DiskSizeGB:  30,
-					Lun:         pointer.Int32(1),
+					Lun:         ptr.To[int32](1),
 					CachingType: "ReadWrite",
 				},
 				{
@@ -214,25 +214,25 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 				{
 					NameSuffix:  "testdisk1",
 					DiskSizeGB:  30,
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: "ReadWrite",
 				},
 				{
 					NameSuffix:  "testdisk2",
 					DiskSizeGB:  30,
-					Lun:         pointer.Int32(2),
+					Lun:         ptr.To[int32](2),
 					CachingType: "ReadWrite",
 				},
 				{
 					NameSuffix:  "testdisk3",
 					DiskSizeGB:  30,
-					Lun:         pointer.Int32(1),
+					Lun:         ptr.To[int32](1),
 					CachingType: "ReadWrite",
 				},
 				{
 					NameSuffix:  "testdisk4",
 					DiskSizeGB:  30,
-					Lun:         pointer.Int32(3),
+					Lun:         ptr.To[int32](3),
 					CachingType: "ReadWrite",
 				},
 			},
@@ -243,12 +243,12 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 				{
 					NameSuffix: "testdisk1",
 					DiskSizeGB: 30,
-					Lun:        pointer.Int32(0),
+					Lun:        ptr.To[int32](0),
 				},
 				{
 					NameSuffix: "testdisk2",
 					DiskSizeGB: 30,
-					Lun:        pointer.Int32(2),
+					Lun:        ptr.To[int32](2),
 				},
 				{
 					NameSuffix: "testdisk3",
@@ -256,26 +256,26 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "UltraSSD_LRS",
 					},
-					Lun: pointer.Int32(3),
+					Lun: ptr.To[int32](3),
 				},
 			},
 			output: []DataDisk{
 				{
 					NameSuffix:  "testdisk1",
 					DiskSizeGB:  30,
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: "ReadWrite",
 				},
 				{
 					NameSuffix:  "testdisk2",
 					DiskSizeGB:  30,
-					Lun:         pointer.Int32(2),
+					Lun:         ptr.To[int32](2),
 					CachingType: "ReadWrite",
 				},
 				{
 					NameSuffix: "testdisk3",
 					DiskSizeGB: 30,
-					Lun:        pointer.Int32(3),
+					Lun:        ptr.To[int32](3),
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "UltraSSD_LRS",
 					},
@@ -353,7 +353,7 @@ func TestAzureMachineSpec_SetNetworkInterfacesDefaults(t *testing.T) {
 			machine: &AzureMachine{
 				Spec: AzureMachineSpec{
 					SubnetName:            "test-subnet",
-					AcceleratedNetworking: pointer.Bool(true),
+					AcceleratedNetworking: ptr.To(true),
 				},
 			},
 			want: &AzureMachine{
@@ -364,7 +364,7 @@ func TestAzureMachineSpec_SetNetworkInterfacesDefaults(t *testing.T) {
 						{
 							SubnetName:            "test-subnet",
 							PrivateIPConfigs:      1,
-							AcceleratedNetworking: pointer.Bool(true),
+							AcceleratedNetworking: ptr.To(true),
 						},
 					},
 				},

--- a/api/v1beta1/azuremachine_validation_test.go
+++ b/api/v1beta1/azuremachine_validation_test.go
@@ -28,7 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 	"golang.org/x/crypto/ssh"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestAzureMachine_ValidateSSHKey(t *testing.T) {
@@ -101,7 +101,7 @@ func TestAzureMachine_ValidateOSDisk(t *testing.T) {
 			name:    "valid ephemeral os disk spec",
 			wantErr: false,
 			osDisk: OSDisk{
-				DiskSizeGB:  pointer.Int32(30),
+				DiskSizeGB:  ptr.To[int32](30),
 				CachingType: "None",
 				OSType:      "blah",
 				DiffDiskSettings: &DiffDiskSettings{
@@ -116,7 +116,7 @@ func TestAzureMachine_ValidateOSDisk(t *testing.T) {
 			name:    "byoc encryption with ephemeral os disk spec",
 			wantErr: true,
 			osDisk: OSDisk{
-				DiskSizeGB:  pointer.Int32(30),
+				DiskSizeGB:  ptr.To[int32](30),
 				CachingType: "None",
 				OSType:      "blah",
 				DiffDiskSettings: &DiffDiskSettings{
@@ -152,42 +152,42 @@ func generateNegativeTestCases() []osDiskTestInput {
 	invalidDiskSpecs := []OSDisk{
 		{},
 		{
-			DiskSizeGB: pointer.Int32(0),
+			DiskSizeGB: ptr.To[int32](0),
 			OSType:     "blah",
 		},
 		{
-			DiskSizeGB: pointer.Int32(-10),
+			DiskSizeGB: ptr.To[int32](-10),
 			OSType:     "blah",
 		},
 		{
-			DiskSizeGB: pointer.Int32(2050),
+			DiskSizeGB: ptr.To[int32](2050),
 			OSType:     "blah",
 		},
 		{
-			DiskSizeGB: pointer.Int32(20),
+			DiskSizeGB: ptr.To[int32](20),
 			OSType:     "",
 		},
 		{
-			DiskSizeGB:  pointer.Int32(30),
+			DiskSizeGB:  ptr.To[int32](30),
 			OSType:      "blah",
 			ManagedDisk: &ManagedDiskParameters{},
 		},
 		{
-			DiskSizeGB: pointer.Int32(30),
+			DiskSizeGB: ptr.To[int32](30),
 			OSType:     "blah",
 			ManagedDisk: &ManagedDiskParameters{
 				StorageAccountType: "",
 			},
 		},
 		{
-			DiskSizeGB: pointer.Int32(30),
+			DiskSizeGB: ptr.To[int32](30),
 			OSType:     "blah",
 			ManagedDisk: &ManagedDiskParameters{
 				StorageAccountType: "invalid_type",
 			},
 		},
 		{
-			DiskSizeGB: pointer.Int32(30),
+			DiskSizeGB: ptr.To[int32](30),
 			OSType:     "blah",
 			ManagedDisk: &ManagedDiskParameters{
 				StorageAccountType: "Premium_LRS",
@@ -211,7 +211,7 @@ func generateNegativeTestCases() []osDiskTestInput {
 
 func generateValidOSDisk() OSDisk {
 	return OSDisk{
-		DiskSizeGB: pointer.Int32(30),
+		DiskSizeGB: ptr.To[int32](30),
 		OSType:     LinuxOS,
 		ManagedDisk: &ManagedDiskParameters{
 			StorageAccountType: "Premium_LRS",
@@ -250,13 +250,13 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 				{
 					NameSuffix:  "my_disk",
 					DiskSizeGB:  64,
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 				{
 					NameSuffix:  "my_other_disk",
 					DiskSizeGB:  64,
-					Lun:         pointer.Int32(1),
+					Lun:         ptr.To[int32](1),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 			},
@@ -268,13 +268,13 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 				{
 					NameSuffix:  "disk",
 					DiskSizeGB:  64,
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 				{
 					NameSuffix:  "disk",
 					DiskSizeGB:  64,
-					Lun:         pointer.Int32(1),
+					Lun:         ptr.To[int32](1),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 			},
@@ -286,13 +286,13 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 				{
 					NameSuffix:  "my_disk",
 					DiskSizeGB:  64,
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 				{
 					NameSuffix:  "my_other_disk",
 					DiskSizeGB:  64,
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 			},
@@ -304,7 +304,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 				{
 					NameSuffix:  "my_disk",
 					DiskSizeGB:  0,
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 			},
@@ -316,7 +316,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 				{
 					NameSuffix:  "",
 					DiskSizeGB:  0,
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 			},
@@ -328,7 +328,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 				{
 					NameSuffix:  "my_disk",
 					DiskSizeGB:  64,
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: "invalidCacheType",
 				},
 			},
@@ -340,7 +340,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 				{
 					NameSuffix:  "my_disk",
 					DiskSizeGB:  64,
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 			},
@@ -355,7 +355,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 					},
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 				{
@@ -364,7 +364,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
-					Lun:         pointer.Int32(1),
+					Lun:         ptr.To[int32](1),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 			},
@@ -379,7 +379,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "invalid storage account",
 					},
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 			},
@@ -394,7 +394,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: string(compute.StorageAccountTypesUltraSSDLRS),
 					},
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.CachingTypesNone),
 				},
 			},
@@ -409,7 +409,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: string(compute.StorageAccountTypesUltraSSDLRS),
 					},
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.CachingTypesReadWrite),
 				},
 			},
@@ -424,7 +424,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: string(compute.StorageAccountTypesUltraSSDLRS),
 					},
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.CachingTypesReadOnly),
 				},
 			},
@@ -676,7 +676,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 				{
 					NameSuffix: "my_disk",
 					DiskSizeGB: 64,
-					Lun:        pointer.Int32(0),
+					Lun:        ptr.To[int32](0),
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
@@ -685,7 +685,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 				{
 					NameSuffix: "my_other_disk",
 					DiskSizeGB: 64,
-					Lun:        pointer.Int32(1),
+					Lun:        ptr.To[int32](1),
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
@@ -696,7 +696,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 				{
 					NameSuffix: "my_disk",
 					DiskSizeGB: 64,
-					Lun:        pointer.Int32(0),
+					Lun:        ptr.To[int32](0),
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
@@ -705,7 +705,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 				{
 					NameSuffix: "my_other_disk",
 					DiskSizeGB: 64,
-					Lun:        pointer.Int32(1),
+					Lun:        ptr.To[int32](1),
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
@@ -723,7 +723,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 			},
@@ -734,7 +734,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 					},
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 			},
@@ -749,7 +749,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
-					Lun: pointer.Int32(0),
+					Lun: ptr.To[int32](0),
 				},
 			},
 			oldDisks: []DataDisk{
@@ -770,7 +770,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 			},
@@ -781,7 +781,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 					},
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 				{
@@ -790,7 +790,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 					},
-					Lun:         pointer.Int32(2),
+					Lun:         ptr.To[int32](2),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 			},
@@ -805,7 +805,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 				{
@@ -814,7 +814,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 					},
-					Lun:         pointer.Int32(2),
+					Lun:         ptr.To[int32](2),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 			},
@@ -825,7 +825,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
-					Lun:         pointer.Int32(0),
+					Lun:         ptr.To[int32](0),
 					CachingType: string(compute.PossibleCachingTypesValues()[0]),
 				},
 			},
@@ -858,7 +858,7 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 		{
 			name:                  "valid config with deprecated network fields",
 			subnetName:            "subnet1",
-			acceleratedNetworking: pointer.Bool(true),
+			acceleratedNetworking: ptr.To(true),
 			networkInterfaces:     nil,
 			wantErr:               false,
 		},
@@ -868,7 +868,7 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 			acceleratedNetworking: nil,
 			networkInterfaces: []NetworkInterface{{
 				SubnetName:            "subnet1",
-				AcceleratedNetworking: pointer.Bool(true),
+				AcceleratedNetworking: ptr.To(true),
 				PrivateIPConfigs:      1,
 			}},
 			wantErr: false,
@@ -880,12 +880,12 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 			networkInterfaces: []NetworkInterface{
 				{
 					SubnetName:            "subnet1",
-					AcceleratedNetworking: pointer.Bool(true),
+					AcceleratedNetworking: ptr.To(true),
 					PrivateIPConfigs:      1,
 				},
 				{
 					SubnetName:            "subnet2",
-					AcceleratedNetworking: pointer.Bool(true),
+					AcceleratedNetworking: ptr.To(true),
 					PrivateIPConfigs:      30,
 				},
 			},
@@ -905,10 +905,10 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 		{
 			name:                  "invalid config using both deprecated acceleratedNetworking and networkInterfaces",
 			subnetName:            "",
-			acceleratedNetworking: pointer.Bool(true),
+			acceleratedNetworking: ptr.To(true),
 			networkInterfaces: []NetworkInterface{{
 				SubnetName:            "subnet1",
-				AcceleratedNetworking: pointer.Bool(true),
+				AcceleratedNetworking: ptr.To(true),
 				PrivateIPConfigs:      1,
 			}},
 			wantErr: true,
@@ -919,7 +919,7 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 			acceleratedNetworking: nil,
 			networkInterfaces: []NetworkInterface{{
 				SubnetName:            "subnet1",
-				AcceleratedNetworking: pointer.Bool(true),
+				AcceleratedNetworking: ptr.To(true),
 				PrivateIPConfigs:      0,
 			}},
 			wantErr: true,
@@ -965,7 +965,7 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 				},
 			},
 			securityProfile: &SecurityProfile{
-				EncryptionAtHost: pointer.Bool(true),
+				EncryptionAtHost: ptr.To(true),
 			},
 			wantErr: false,
 		},
@@ -979,8 +979,8 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 			securityProfile: &SecurityProfile{
 				SecurityType: SecurityTypesConfidentialVM,
 				UefiSettings: &UefiSettings{
-					VTpmEnabled:       pointer.Bool(true),
-					SecureBootEnabled: pointer.Bool(false),
+					VTpmEnabled:       ptr.To(true),
+					SecureBootEnabled: ptr.To(false),
 				},
 			},
 			wantErr: false,
@@ -995,8 +995,8 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 			securityProfile: &SecurityProfile{
 				SecurityType: SecurityTypesConfidentialVM,
 				UefiSettings: &UefiSettings{
-					VTpmEnabled:       pointer.Bool(true),
-					SecureBootEnabled: pointer.Bool(true),
+					VTpmEnabled:       ptr.To(true),
+					SecureBootEnabled: ptr.To(true),
 				},
 			},
 			wantErr: false,
@@ -1009,10 +1009,10 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 				},
 			},
 			securityProfile: &SecurityProfile{
-				EncryptionAtHost: pointer.Bool(true),
+				EncryptionAtHost: ptr.To(true),
 				SecurityType:     SecurityTypesConfidentialVM,
 				UefiSettings: &UefiSettings{
-					VTpmEnabled: pointer.Bool(true),
+					VTpmEnabled: ptr.To(true),
 				},
 			},
 			wantErr: false,
@@ -1027,8 +1027,8 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 			securityProfile: &SecurityProfile{
 				SecurityType: SecurityTypesConfidentialVM,
 				UefiSettings: &UefiSettings{
-					SecureBootEnabled: pointer.Bool(true),
-					VTpmEnabled:       pointer.Bool(true),
+					SecureBootEnabled: ptr.To(true),
+					VTpmEnabled:       ptr.To(true),
 				},
 			},
 			wantErr: false,
@@ -1041,7 +1041,7 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 				},
 			},
 			securityProfile: &SecurityProfile{
-				EncryptionAtHost: pointer.Bool(true),
+				EncryptionAtHost: ptr.To(true),
 			},
 			wantErr: true,
 		},
@@ -1055,8 +1055,8 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 			securityProfile: &SecurityProfile{
 				SecurityType: SecurityTypesConfidentialVM,
 				UefiSettings: &UefiSettings{
-					VTpmEnabled:       pointer.Bool(false),
-					SecureBootEnabled: pointer.Bool(false),
+					VTpmEnabled:       ptr.To(false),
+					SecureBootEnabled: ptr.To(false),
 				},
 			},
 			wantErr: true,
@@ -1071,8 +1071,8 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 			securityProfile: &SecurityProfile{
 				SecurityType: SecurityTypesConfidentialVM,
 				UefiSettings: &UefiSettings{
-					VTpmEnabled:       pointer.Bool(true),
-					SecureBootEnabled: pointer.Bool(false),
+					VTpmEnabled:       ptr.To(true),
+					SecureBootEnabled: ptr.To(false),
 				},
 			},
 			wantErr: true,
@@ -1086,8 +1086,8 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 			},
 			securityProfile: &SecurityProfile{
 				UefiSettings: &UefiSettings{
-					VTpmEnabled:       pointer.Bool(true),
-					SecureBootEnabled: pointer.Bool(true),
+					VTpmEnabled:       ptr.To(true),
+					SecureBootEnabled: ptr.To(true),
 				},
 			},
 			wantErr: true,
@@ -1101,8 +1101,8 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 			},
 			securityProfile: &SecurityProfile{
 				UefiSettings: &UefiSettings{
-					VTpmEnabled:       pointer.Bool(true),
-					SecureBootEnabled: pointer.Bool(true),
+					VTpmEnabled:       ptr.To(true),
+					SecureBootEnabled: ptr.To(true),
 				},
 			},
 			wantErr: true,

--- a/api/v1beta1/azuremachine_webhook_test.go
+++ b/api/v1beta1/azuremachine_webhook_test.go
@@ -26,7 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -245,14 +245,14 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 			oldMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
 					Image: &Image{
-						ID: pointer.String("imageID-1"),
+						ID: ptr.To("imageID-1"),
 					},
 				},
 			},
 			newMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
 					Image: &Image{
-						ID: pointer.String("imageID-2"),
+						ID: ptr.To("imageID-2"),
 					},
 				},
 			},
@@ -263,14 +263,14 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 			oldMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
 					Image: &Image{
-						ID: pointer.String("imageID-1"),
+						ID: ptr.To("imageID-1"),
 					},
 				},
 			},
 			newMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
 					Image: &Image{
-						ID: pointer.String("imageID-1"),
+						ID: ptr.To("imageID-1"),
 					},
 				},
 			},
@@ -580,12 +580,12 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 			name: "invalidTest: azuremachine.spec.AcceleratedNetworking is immutable",
 			oldMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
-					AcceleratedNetworking: pointer.Bool(true),
+					AcceleratedNetworking: ptr.To(true),
 				},
 			},
 			newMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
-					AcceleratedNetworking: pointer.Bool(false),
+					AcceleratedNetworking: ptr.To(false),
 				},
 			},
 			wantErr: true,
@@ -594,12 +594,12 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 			name: "validTest: azuremachine.spec.AcceleratedNetworking is immutable",
 			oldMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
-					AcceleratedNetworking: pointer.Bool(true),
+					AcceleratedNetworking: ptr.To(true),
 				},
 			},
 			newMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
-					AcceleratedNetworking: pointer.Bool(true),
+					AcceleratedNetworking: ptr.To(true),
 				},
 			},
 			wantErr: false,
@@ -608,7 +608,7 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 			name: "validTest: azuremachine.spec.AcceleratedNetworking transition(from true) to nil is acceptable",
 			oldMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
-					AcceleratedNetworking: pointer.Bool(true),
+					AcceleratedNetworking: ptr.To(true),
 				},
 			},
 			newMachine: &AzureMachine{
@@ -622,7 +622,7 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 			name: "validTest: azuremachine.spec.AcceleratedNetworking transition(from false) to nil is acceptable",
 			oldMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
-					AcceleratedNetworking: pointer.Bool(false),
+					AcceleratedNetworking: ptr.To(false),
 				},
 			},
 			newMachine: &AzureMachine{
@@ -672,12 +672,12 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 			name: "invalidTest: azuremachine.spec.SecurityProfile is immutable",
 			oldMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
-					SecurityProfile: &SecurityProfile{EncryptionAtHost: pointer.Bool(true)},
+					SecurityProfile: &SecurityProfile{EncryptionAtHost: ptr.To(true)},
 				},
 			},
 			newMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
-					SecurityProfile: &SecurityProfile{EncryptionAtHost: pointer.Bool(false)},
+					SecurityProfile: &SecurityProfile{EncryptionAtHost: ptr.To(false)},
 				},
 			},
 			wantErr: true,
@@ -686,12 +686,12 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 			name: "validTest: azuremachine.spec.SecurityProfile is immutable",
 			oldMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
-					SecurityProfile: &SecurityProfile{EncryptionAtHost: pointer.Bool(true)},
+					SecurityProfile: &SecurityProfile{EncryptionAtHost: ptr.To(true)},
 				},
 			},
 			newMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
-					SecurityProfile: &SecurityProfile{EncryptionAtHost: pointer.Bool(true)},
+					SecurityProfile: &SecurityProfile{EncryptionAtHost: ptr.To(true)},
 				},
 			},
 			wantErr: false,
@@ -1036,7 +1036,7 @@ func createMachineWithConfidentialCompute(securityEncryptionType SecurityEncrypt
 	}
 
 	osDisk := OSDisk{
-		DiskSizeGB: pointer.Int32(30),
+		DiskSizeGB: ptr.To[int32](30),
 		OSType:     LinuxOS,
 		ManagedDisk: &ManagedDiskParameters{
 			StorageAccountType: "Premium_LRS",

--- a/api/v1beta1/azuremachinetemplate_webhook_test.go
+++ b/api/v1beta1/azuremachinetemplate_webhook_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -183,7 +183,7 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 			machineTemplate: createAzureMachineTemplateFromMachine(
 				createMachineWithNetworkConfig(
 					"",
-					pointer.Bool(true),
+					ptr.To(true),
 					[]NetworkInterface{
 						{SubnetName: "subnet1", PrivateIPConfigs: 1},
 						{SubnetName: "subnet2", PrivateIPConfigs: 1},
@@ -271,7 +271,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							FailureDomain: &failureDomain,
 							OSDisk: OSDisk{
 								OSType:     "type",
-								DiskSizeGB: pointer.Int32(11),
+								DiskSizeGB: ptr.To[int32](11),
 							},
 							DataDisks:    []DataDisk{},
 							SSHPublicKey: "",
@@ -287,7 +287,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							FailureDomain: &failureDomain,
 							OSDisk: OSDisk{
 								OSType:     "type",
-								DiskSizeGB: pointer.Int32(11),
+								DiskSizeGB: ptr.To[int32](11),
 							},
 							DataDisks:    []DataDisk{},
 							SSHPublicKey: "fake ssh key",
@@ -307,7 +307,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							FailureDomain: &failureDomain,
 							OSDisk: OSDisk{
 								OSType:     "type",
-								DiskSizeGB: pointer.Int32(11),
+								DiskSizeGB: ptr.To[int32](11),
 							},
 							DataDisks:    []DataDisk{},
 							SSHPublicKey: "fake ssh key",
@@ -326,7 +326,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							FailureDomain: &failureDomain,
 							OSDisk: OSDisk{
 								OSType:     "type",
-								DiskSizeGB: pointer.Int32(11),
+								DiskSizeGB: ptr.To[int32](11),
 							},
 							DataDisks:    []DataDisk{},
 							SSHPublicKey: "fake ssh key",
@@ -349,7 +349,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							FailureDomain: &failureDomain,
 							OSDisk: OSDisk{
 								OSType:      "type",
-								DiskSizeGB:  pointer.Int32(11),
+								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "",
 							},
 							DataDisks:    []DataDisk{},
@@ -369,7 +369,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							FailureDomain: &failureDomain,
 							OSDisk: OSDisk{
 								OSType:      "type",
-								DiskSizeGB:  pointer.Int32(11),
+								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
 							DataDisks:    []DataDisk{},
@@ -396,7 +396,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							FailureDomain: &failureDomain,
 							OSDisk: OSDisk{
 								OSType:      "type",
-								DiskSizeGB:  pointer.Int32(11),
+								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
 							DataDisks:    []DataDisk{},
@@ -416,7 +416,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							FailureDomain: &failureDomain,
 							OSDisk: OSDisk{
 								OSType:      "type",
-								DiskSizeGB:  pointer.Int32(11),
+								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
 							DataDisks:    []DataDisk{},
@@ -440,13 +440,13 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							FailureDomain: &failureDomain,
 							OSDisk: OSDisk{
 								OSType:      "type",
-								DiskSizeGB:  pointer.Int32(11),
+								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
 							DataDisks:             []DataDisk{},
 							SSHPublicKey:          "fake ssh key",
 							SubnetName:            "subnet1",
-							AcceleratedNetworking: pointer.Bool(true),
+							AcceleratedNetworking: ptr.To(true),
 						},
 					},
 				},
@@ -459,7 +459,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							FailureDomain: &failureDomain,
 							OSDisk: OSDisk{
 								OSType:      "type",
-								DiskSizeGB:  pointer.Int32(11),
+								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
 							DataDisks:             []DataDisk{},
@@ -469,7 +469,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							NetworkInterfaces: []NetworkInterface{
 								{
 									SubnetName:            "subnet1",
-									AcceleratedNetworking: pointer.Bool(true),
+									AcceleratedNetworking: ptr.To(true),
 									PrivateIPConfigs:      1,
 								},
 							},
@@ -489,13 +489,13 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							FailureDomain: &failureDomain,
 							OSDisk: OSDisk{
 								OSType:      "type",
-								DiskSizeGB:  pointer.Int32(11),
+								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
 							DataDisks:             []DataDisk{},
 							SSHPublicKey:          "fake ssh key",
 							SubnetName:            "",
-							AcceleratedNetworking: pointer.Bool(true),
+							AcceleratedNetworking: ptr.To(true),
 							NetworkInterfaces:     []NetworkInterface{},
 						},
 					},
@@ -509,7 +509,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							FailureDomain: &failureDomain,
 							OSDisk: OSDisk{
 								OSType:      "type",
-								DiskSizeGB:  pointer.Int32(11),
+								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
 							DataDisks:             []DataDisk{},
@@ -519,7 +519,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							NetworkInterfaces: []NetworkInterface{
 								{
 									SubnetName:            "",
-									AcceleratedNetworking: pointer.Bool(true),
+									AcceleratedNetworking: ptr.To(true),
 									PrivateIPConfigs:      1,
 								},
 							},
@@ -539,7 +539,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							FailureDomain: &failureDomain,
 							OSDisk: OSDisk{
 								OSType:      "type",
-								DiskSizeGB:  pointer.Int32(11),
+								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
 							DataDisks:    []DataDisk{},
@@ -547,7 +547,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							NetworkInterfaces: []NetworkInterface{
 								{
 									SubnetName:            "subnet1",
-									AcceleratedNetworking: pointer.Bool(true),
+									AcceleratedNetworking: ptr.To(true),
 									PrivateIPConfigs:      1,
 								},
 							},
@@ -563,7 +563,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							FailureDomain: &failureDomain,
 							OSDisk: OSDisk{
 								OSType:      "type",
-								DiskSizeGB:  pointer.Int32(11),
+								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
 							DataDisks:    []DataDisk{},
@@ -571,7 +571,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 							NetworkInterfaces: []NetworkInterface{
 								{
 									SubnetName:            "subnet2",
-									AcceleratedNetworking: pointer.Bool(true),
+									AcceleratedNetworking: ptr.To(true),
 									PrivateIPConfigs:      1,
 								},
 							},
@@ -587,7 +587,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 	for _, amt := range tests {
 		amt := amt
 		t.Run(amt.name, func(t *testing.T) {
-			ctx := admission.NewContextWithRequest(context.Background(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: pointer.Bool(true)}})
+			ctx := admission.NewContextWithRequest(context.Background(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(true)}})
 			err := amt.template.ValidateUpdate(ctx, amt.oldTemplate, amt.template)
 			if amt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -601,7 +601,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 		amt := amt
 		t.Run(amt.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := admission.NewContextWithRequest(context.Background(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: pointer.Bool(false)}})
+			ctx := admission.NewContextWithRequest(context.Background(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(false)}})
 			err := amt.template.ValidateUpdate(ctx, amt.oldTemplate, amt.template)
 			if amt.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/api/v1beta1/azuremanagedcontrolplane_default.go
+++ b/api/v1beta1/azuremanagedcontrolplane_default.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"golang.org/x/crypto/ssh"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	utilSSH "sigs.k8s.io/cluster-api-provider-azure/util/ssh"
 )
 
@@ -40,7 +40,7 @@ func (m *AzureManagedControlPlane) setDefaultSSHPublicKey() error {
 			return err
 		}
 
-		m.Spec.SSHPublicKey = pointer.String(base64.StdEncoding.EncodeToString(ssh.MarshalAuthorizedKey(publicRsaKey)))
+		m.Spec.SSHPublicKey = ptr.To(base64.StdEncoding.EncodeToString(ssh.MarshalAuthorizedKey(publicRsaKey)))
 	}
 
 	return nil
@@ -92,55 +92,55 @@ func (m *AzureManagedControlPlane) setDefaultAutoScalerProfile() {
 	// Default values are from https://learn.microsoft.com/en-us/azure/aks/cluster-autoscaler#using-the-autoscaler-profile
 	// If any values are set, they all need to be set.
 	if m.Spec.AutoScalerProfile.BalanceSimilarNodeGroups == nil {
-		m.Spec.AutoScalerProfile.BalanceSimilarNodeGroups = (*BalanceSimilarNodeGroups)(pointer.String(string(BalanceSimilarNodeGroupsFalse)))
+		m.Spec.AutoScalerProfile.BalanceSimilarNodeGroups = (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsFalse)))
 	}
 	if m.Spec.AutoScalerProfile.Expander == nil {
-		m.Spec.AutoScalerProfile.Expander = (*Expander)(pointer.String(string(ExpanderRandom)))
+		m.Spec.AutoScalerProfile.Expander = (*Expander)(ptr.To(string(ExpanderRandom)))
 	}
 	if m.Spec.AutoScalerProfile.MaxEmptyBulkDelete == nil {
-		m.Spec.AutoScalerProfile.MaxEmptyBulkDelete = pointer.String("10")
+		m.Spec.AutoScalerProfile.MaxEmptyBulkDelete = ptr.To("10")
 	}
 	if m.Spec.AutoScalerProfile.MaxGracefulTerminationSec == nil {
-		m.Spec.AutoScalerProfile.MaxGracefulTerminationSec = pointer.String("600")
+		m.Spec.AutoScalerProfile.MaxGracefulTerminationSec = ptr.To("600")
 	}
 	if m.Spec.AutoScalerProfile.MaxNodeProvisionTime == nil {
-		m.Spec.AutoScalerProfile.MaxNodeProvisionTime = pointer.String("15m")
+		m.Spec.AutoScalerProfile.MaxNodeProvisionTime = ptr.To("15m")
 	}
 	if m.Spec.AutoScalerProfile.MaxTotalUnreadyPercentage == nil {
-		m.Spec.AutoScalerProfile.MaxTotalUnreadyPercentage = pointer.String("45")
+		m.Spec.AutoScalerProfile.MaxTotalUnreadyPercentage = ptr.To("45")
 	}
 	if m.Spec.AutoScalerProfile.NewPodScaleUpDelay == nil {
-		m.Spec.AutoScalerProfile.NewPodScaleUpDelay = pointer.String("0s")
+		m.Spec.AutoScalerProfile.NewPodScaleUpDelay = ptr.To("0s")
 	}
 	if m.Spec.AutoScalerProfile.OkTotalUnreadyCount == nil {
-		m.Spec.AutoScalerProfile.OkTotalUnreadyCount = pointer.String("3")
+		m.Spec.AutoScalerProfile.OkTotalUnreadyCount = ptr.To("3")
 	}
 	if m.Spec.AutoScalerProfile.ScanInterval == nil {
-		m.Spec.AutoScalerProfile.ScanInterval = pointer.String("10s")
+		m.Spec.AutoScalerProfile.ScanInterval = ptr.To("10s")
 	}
 	if m.Spec.AutoScalerProfile.ScaleDownDelayAfterAdd == nil {
-		m.Spec.AutoScalerProfile.ScaleDownDelayAfterAdd = pointer.String("10m")
+		m.Spec.AutoScalerProfile.ScaleDownDelayAfterAdd = ptr.To("10m")
 	}
 	if m.Spec.AutoScalerProfile.ScaleDownDelayAfterDelete == nil {
 		// Default is the same as the ScanInterval so default to that same value if it isn't set
 		m.Spec.AutoScalerProfile.ScaleDownDelayAfterDelete = m.Spec.AutoScalerProfile.ScanInterval
 	}
 	if m.Spec.AutoScalerProfile.ScaleDownDelayAfterFailure == nil {
-		m.Spec.AutoScalerProfile.ScaleDownDelayAfterFailure = pointer.String("3m")
+		m.Spec.AutoScalerProfile.ScaleDownDelayAfterFailure = ptr.To("3m")
 	}
 	if m.Spec.AutoScalerProfile.ScaleDownUnneededTime == nil {
-		m.Spec.AutoScalerProfile.ScaleDownUnneededTime = pointer.String("10m")
+		m.Spec.AutoScalerProfile.ScaleDownUnneededTime = ptr.To("10m")
 	}
 	if m.Spec.AutoScalerProfile.ScaleDownUnreadyTime == nil {
-		m.Spec.AutoScalerProfile.ScaleDownUnreadyTime = pointer.String("20m")
+		m.Spec.AutoScalerProfile.ScaleDownUnreadyTime = ptr.To("20m")
 	}
 	if m.Spec.AutoScalerProfile.ScaleDownUtilizationThreshold == nil {
-		m.Spec.AutoScalerProfile.ScaleDownUtilizationThreshold = pointer.String("0.5")
+		m.Spec.AutoScalerProfile.ScaleDownUtilizationThreshold = ptr.To("0.5")
 	}
 	if m.Spec.AutoScalerProfile.SkipNodesWithLocalStorage == nil {
-		m.Spec.AutoScalerProfile.SkipNodesWithLocalStorage = (*SkipNodesWithLocalStorage)(pointer.String(string(SkipNodesWithLocalStorageFalse)))
+		m.Spec.AutoScalerProfile.SkipNodesWithLocalStorage = (*SkipNodesWithLocalStorage)(ptr.To(string(SkipNodesWithLocalStorageFalse)))
 	}
 	if m.Spec.AutoScalerProfile.SkipNodesWithSystemPods == nil {
-		m.Spec.AutoScalerProfile.SkipNodesWithSystemPods = (*SkipNodesWithSystemPods)(pointer.String(string(SkipNodesWithSystemPodsTrue)))
+		m.Spec.AutoScalerProfile.SkipNodesWithSystemPods = (*SkipNodesWithSystemPods)(ptr.To(string(SkipNodesWithSystemPodsTrue)))
 	}
 }

--- a/api/v1beta1/azuremanagedcontrolplane_default_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_default_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestAzureManagedControlPlane_SetDefaultSSHPublicKey(t *testing.T) {
@@ -65,23 +65,23 @@ func TestSetDefaultAutoScalerProfile(t *testing.T) {
 	defaultAMP := &AzureManagedControlPlane{
 		Spec: AzureManagedControlPlaneSpec{
 			AutoScalerProfile: &AutoScalerProfile{
-				BalanceSimilarNodeGroups:      (*BalanceSimilarNodeGroups)(pointer.String(string(BalanceSimilarNodeGroupsFalse))),
-				Expander:                      (*Expander)(pointer.String(string(ExpanderRandom))),
-				MaxEmptyBulkDelete:            pointer.String("10"),
-				MaxGracefulTerminationSec:     pointer.String("600"),
-				MaxNodeProvisionTime:          pointer.String("15m"),
-				MaxTotalUnreadyPercentage:     pointer.String("45"),
-				NewPodScaleUpDelay:            pointer.String("0s"),
-				OkTotalUnreadyCount:           pointer.String("3"),
-				ScanInterval:                  pointer.String("10s"),
-				ScaleDownDelayAfterAdd:        pointer.String("10m"),
-				ScaleDownDelayAfterDelete:     pointer.String("10s"),
-				ScaleDownDelayAfterFailure:    pointer.String("3m"),
-				ScaleDownUnneededTime:         pointer.String("10m"),
-				ScaleDownUnreadyTime:          pointer.String("20m"),
-				ScaleDownUtilizationThreshold: pointer.String("0.5"),
-				SkipNodesWithLocalStorage:     (*SkipNodesWithLocalStorage)(pointer.String(string(SkipNodesWithLocalStorageFalse))),
-				SkipNodesWithSystemPods:       (*SkipNodesWithSystemPods)(pointer.String(string(SkipNodesWithSystemPodsTrue))),
+				BalanceSimilarNodeGroups:      (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsFalse))),
+				Expander:                      (*Expander)(ptr.To(string(ExpanderRandom))),
+				MaxEmptyBulkDelete:            ptr.To("10"),
+				MaxGracefulTerminationSec:     ptr.To("600"),
+				MaxNodeProvisionTime:          ptr.To("15m"),
+				MaxTotalUnreadyPercentage:     ptr.To("45"),
+				NewPodScaleUpDelay:            ptr.To("0s"),
+				OkTotalUnreadyCount:           ptr.To("3"),
+				ScanInterval:                  ptr.To("10s"),
+				ScaleDownDelayAfterAdd:        ptr.To("10m"),
+				ScaleDownDelayAfterDelete:     ptr.To("10s"),
+				ScaleDownDelayAfterFailure:    ptr.To("3m"),
+				ScaleDownUnneededTime:         ptr.To("10m"),
+				ScaleDownUnreadyTime:          ptr.To("20m"),
+				ScaleDownUtilizationThreshold: ptr.To("0.5"),
+				SkipNodesWithLocalStorage:     (*SkipNodesWithLocalStorage)(ptr.To(string(SkipNodesWithLocalStorageFalse))),
+				SkipNodesWithSystemPods:       (*SkipNodesWithSystemPods)(ptr.To(string(SkipNodesWithSystemPodsTrue))),
 			},
 		},
 	}
@@ -99,23 +99,23 @@ func TestSetDefaultAutoScalerProfile(t *testing.T) {
 	expectedNotNil := &AzureManagedControlPlane{
 		Spec: AzureManagedControlPlaneSpec{
 			AutoScalerProfile: &AutoScalerProfile{
-				BalanceSimilarNodeGroups:      (*BalanceSimilarNodeGroups)(pointer.String(string(BalanceSimilarNodeGroupsTrue))),
-				Expander:                      (*Expander)(pointer.String(string(ExpanderLeastWaste))),
-				MaxEmptyBulkDelete:            pointer.String("5"),
-				MaxGracefulTerminationSec:     pointer.String("300"),
-				MaxNodeProvisionTime:          pointer.String("10m"),
-				MaxTotalUnreadyPercentage:     pointer.String("30"),
-				NewPodScaleUpDelay:            pointer.String("30s"),
-				OkTotalUnreadyCount:           pointer.String("5"),
-				ScanInterval:                  pointer.String("20s"),
-				ScaleDownDelayAfterAdd:        pointer.String("5m"),
-				ScaleDownDelayAfterDelete:     pointer.String("1m"),
-				ScaleDownDelayAfterFailure:    pointer.String("2m"),
-				ScaleDownUnneededTime:         pointer.String("5m"),
-				ScaleDownUnreadyTime:          pointer.String("10m"),
-				ScaleDownUtilizationThreshold: pointer.String("0.4"),
-				SkipNodesWithLocalStorage:     (*SkipNodesWithLocalStorage)(pointer.String(string(SkipNodesWithLocalStorageTrue))),
-				SkipNodesWithSystemPods:       (*SkipNodesWithSystemPods)(pointer.String(string(SkipNodesWithSystemPodsFalse))),
+				BalanceSimilarNodeGroups:      (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsTrue))),
+				Expander:                      (*Expander)(ptr.To(string(ExpanderLeastWaste))),
+				MaxEmptyBulkDelete:            ptr.To("5"),
+				MaxGracefulTerminationSec:     ptr.To("300"),
+				MaxNodeProvisionTime:          ptr.To("10m"),
+				MaxTotalUnreadyPercentage:     ptr.To("30"),
+				NewPodScaleUpDelay:            ptr.To("30s"),
+				OkTotalUnreadyCount:           ptr.To("5"),
+				ScanInterval:                  ptr.To("20s"),
+				ScaleDownDelayAfterAdd:        ptr.To("5m"),
+				ScaleDownDelayAfterDelete:     ptr.To("1m"),
+				ScaleDownDelayAfterFailure:    ptr.To("2m"),
+				ScaleDownUnneededTime:         ptr.To("5m"),
+				ScaleDownUnreadyTime:          ptr.To("10m"),
+				ScaleDownUtilizationThreshold: ptr.To("0.4"),
+				SkipNodesWithLocalStorage:     (*SkipNodesWithLocalStorage)(ptr.To(string(SkipNodesWithLocalStorageTrue))),
+				SkipNodesWithSystemPods:       (*SkipNodesWithSystemPods)(ptr.To(string(SkipNodesWithSystemPodsFalse))),
 			},
 		},
 	}

--- a/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -616,8 +616,8 @@ func (m *AzureManagedControlPlane) validateAutoScalerProfile(_ client.Client) er
 // validateMaxNodeProvisionTime validates update to AutoscalerProfile.MaxNodeProvisionTime.
 func (m *AzureManagedControlPlane) validateMaxNodeProvisionTime() field.ErrorList {
 	var allErrs field.ErrorList
-	if pointer.StringDeref(m.Spec.AutoScalerProfile.MaxNodeProvisionTime, "") != "" {
-		if !rMaxNodeProvisionTime.MatchString(pointer.StringDeref(m.Spec.AutoScalerProfile.MaxNodeProvisionTime, "")) {
+	if ptr.Deref(m.Spec.AutoScalerProfile.MaxNodeProvisionTime, "") != "" {
+		if !rMaxNodeProvisionTime.MatchString(ptr.Deref(m.Spec.AutoScalerProfile.MaxNodeProvisionTime, "")) {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("Spec", "AutoscalerProfile", "MaxNodeProvisionTime"), m.Spec.AutoScalerProfile.MaxNodeProvisionTime, "invalid value"))
 		}
 	}
@@ -627,8 +627,8 @@ func (m *AzureManagedControlPlane) validateMaxNodeProvisionTime() field.ErrorLis
 // validateScanInterval validates update to AutoscalerProfile.ScanInterval.
 func (m *AzureManagedControlPlane) validateScanInterval() field.ErrorList {
 	var allErrs field.ErrorList
-	if pointer.StringDeref(m.Spec.AutoScalerProfile.ScanInterval, "") != "" {
-		if !rScanInterval.MatchString(pointer.StringDeref(m.Spec.AutoScalerProfile.ScanInterval, "")) {
+	if ptr.Deref(m.Spec.AutoScalerProfile.ScanInterval, "") != "" {
+		if !rScanInterval.MatchString(ptr.Deref(m.Spec.AutoScalerProfile.ScanInterval, "")) {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("Spec", "AutoscalerProfile", "ScanInterval"), m.Spec.AutoScalerProfile.ScanInterval, "invalid value"))
 		}
 	}
@@ -638,8 +638,8 @@ func (m *AzureManagedControlPlane) validateScanInterval() field.ErrorList {
 // validateNewPodScaleUpDelay validates update to AutoscalerProfile.NewPodScaleUpDelay.
 func (m *AzureManagedControlPlane) validateNewPodScaleUpDelay() field.ErrorList {
 	var allErrs field.ErrorList
-	if pointer.StringDeref(m.Spec.AutoScalerProfile.NewPodScaleUpDelay, "") != "" {
-		_, err := time.ParseDuration(pointer.StringDeref(m.Spec.AutoScalerProfile.NewPodScaleUpDelay, ""))
+	if ptr.Deref(m.Spec.AutoScalerProfile.NewPodScaleUpDelay, "") != "" {
+		_, err := time.ParseDuration(ptr.Deref(m.Spec.AutoScalerProfile.NewPodScaleUpDelay, ""))
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("Spec", "AutoscalerProfile", "NewPodScaleUpDelay"), m.Spec.AutoScalerProfile.NewPodScaleUpDelay, "invalid value"))
 		}
@@ -650,9 +650,9 @@ func (m *AzureManagedControlPlane) validateNewPodScaleUpDelay() field.ErrorList 
 // validateScaleDownDelayAfterDelete validates update to AutoscalerProfile.ScaleDownDelayAfterDelete value.
 func (m *AzureManagedControlPlane) validateScaleDownDelayAfterDelete() field.ErrorList {
 	var allErrs field.ErrorList
-	if pointer.StringDeref(m.Spec.AutoScalerProfile.ScaleDownDelayAfterDelete, "") != "" {
-		if !rScaleDownDelayAfterDelete.MatchString(pointer.StringDeref(m.Spec.AutoScalerProfile.ScaleDownDelayAfterDelete, "")) {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("Spec", "AutoscalerProfile", "ScaleDownDelayAfterDelete"), pointer.StringDeref(m.Spec.AutoScalerProfile.ScaleDownDelayAfterDelete, ""), "invalid value"))
+	if ptr.Deref(m.Spec.AutoScalerProfile.ScaleDownDelayAfterDelete, "") != "" {
+		if !rScaleDownDelayAfterDelete.MatchString(ptr.Deref(m.Spec.AutoScalerProfile.ScaleDownDelayAfterDelete, "")) {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("Spec", "AutoscalerProfile", "ScaleDownDelayAfterDelete"), ptr.Deref(m.Spec.AutoScalerProfile.ScaleDownDelayAfterDelete, ""), "invalid value"))
 		}
 	}
 	return allErrs
@@ -661,9 +661,9 @@ func (m *AzureManagedControlPlane) validateScaleDownDelayAfterDelete() field.Err
 // validateScaleDownTime validates update to AutoscalerProfile.ScaleDown* values.
 func (m *AzureManagedControlPlane) validateScaleDownTime(scaleDownValue *string, fieldName string) field.ErrorList {
 	var allErrs field.ErrorList
-	if pointer.StringDeref(scaleDownValue, "") != "" {
-		if !rScaleDownTime.MatchString(pointer.StringDeref(scaleDownValue, "")) {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("Spec", "AutoscalerProfile", fieldName), pointer.StringDeref(scaleDownValue, ""), "invalid value"))
+	if ptr.Deref(scaleDownValue, "") != "" {
+		if !rScaleDownTime.MatchString(ptr.Deref(scaleDownValue, "")) {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("Spec", "AutoscalerProfile", fieldName), ptr.Deref(scaleDownValue, ""), "invalid value"))
 		}
 	}
 	return allErrs

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/component-base/featuregate/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capifeature "sigs.k8s.io/cluster-api/feature"
@@ -41,7 +41,7 @@ func TestDefaultingWebhook(t *testing.T) {
 			ResourceGroupName: "fooRg",
 			Location:          "fooLocation",
 			Version:           "1.17.5",
-			SSHPublicKey:      pointer.String(""),
+			SSHPublicKey:      ptr.To(""),
 		},
 	}
 	mcpw := &azureManagedControlPlaneWebhook{}
@@ -98,7 +98,7 @@ func TestValidatingWebhook(t *testing.T) {
 			name: "Testing valid DNSServiceIP",
 			amcp: AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.17.8",
 				},
 			},
@@ -108,7 +108,7 @@ func TestValidatingWebhook(t *testing.T) {
 			name: "Testing invalid DNSServiceIP",
 			amcp: AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0.3"),
+					DNSServiceIP: ptr.To("192.168.0.0.3"),
 					Version:      "v1.17.8",
 				},
 			},
@@ -118,7 +118,7 @@ func TestValidatingWebhook(t *testing.T) {
 			name: "Invalid Version",
 			amcp: AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "honk",
 				},
 			},
@@ -128,7 +128,7 @@ func TestValidatingWebhook(t *testing.T) {
 			name: "not following the Kubernetes Version pattern",
 			amcp: AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "1.19.0",
 				},
 			},
@@ -138,7 +138,7 @@ func TestValidatingWebhook(t *testing.T) {
 			name: "Version not set",
 			amcp: AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "",
 				},
 			},
@@ -148,7 +148,7 @@ func TestValidatingWebhook(t *testing.T) {
 			name: "Valid Version",
 			amcp: AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.17.8",
 				},
 			},
@@ -175,9 +175,9 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.21.2",
 					LoadBalancerProfile: &LoadBalancerProfile{
-						ManagedOutboundIPs:     pointer.Int32(10),
-						AllocatedOutboundPorts: pointer.Int32(1000),
-						IdleTimeoutInMinutes:   pointer.Int32(60),
+						ManagedOutboundIPs:     ptr.To[int32](10),
+						AllocatedOutboundPorts: ptr.To[int32](1000),
+						IdleTimeoutInMinutes:   ptr.To[int32](60),
 					},
 				},
 			},
@@ -189,7 +189,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.21.2",
 					LoadBalancerProfile: &LoadBalancerProfile{
-						ManagedOutboundIPs: pointer.Int32(200),
+						ManagedOutboundIPs: ptr.To[int32](200),
 					},
 				},
 			},
@@ -201,7 +201,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.21.2",
 					LoadBalancerProfile: &LoadBalancerProfile{
-						AllocatedOutboundPorts: pointer.Int32(80000),
+						AllocatedOutboundPorts: ptr.To[int32](80000),
 					},
 				},
 			},
@@ -213,7 +213,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.21.2",
 					LoadBalancerProfile: &LoadBalancerProfile{
-						IdleTimeoutInMinutes: pointer.Int32(600),
+						IdleTimeoutInMinutes: ptr.To[int32](600),
 					},
 				},
 			},
@@ -225,7 +225,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.21.2",
 					LoadBalancerProfile: &LoadBalancerProfile{
-						ManagedOutboundIPs: pointer.Int32(1),
+						ManagedOutboundIPs: ptr.To[int32](1),
 						OutboundIPs: []string{
 							"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo-bar/providers/Microsoft.Network/publicIPAddresses/my-public-ip",
 						},
@@ -252,23 +252,23 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						BalanceSimilarNodeGroups:      (*BalanceSimilarNodeGroups)(pointer.String(string(BalanceSimilarNodeGroupsFalse))),
-						Expander:                      (*Expander)(pointer.String(string(ExpanderRandom))),
-						MaxEmptyBulkDelete:            pointer.String("10"),
-						MaxGracefulTerminationSec:     pointer.String("600"),
-						MaxNodeProvisionTime:          pointer.String("10m"),
-						MaxTotalUnreadyPercentage:     pointer.String("45"),
-						NewPodScaleUpDelay:            pointer.String("10m"),
-						OkTotalUnreadyCount:           pointer.String("3"),
-						ScanInterval:                  pointer.String("60s"),
-						ScaleDownDelayAfterAdd:        pointer.String("10m"),
-						ScaleDownDelayAfterDelete:     pointer.String("10s"),
-						ScaleDownDelayAfterFailure:    pointer.String("10m"),
-						ScaleDownUnneededTime:         pointer.String("10m"),
-						ScaleDownUnreadyTime:          pointer.String("10m"),
-						ScaleDownUtilizationThreshold: pointer.String("0.5"),
-						SkipNodesWithLocalStorage:     (*SkipNodesWithLocalStorage)(pointer.String(string(SkipNodesWithLocalStorageTrue))),
-						SkipNodesWithSystemPods:       (*SkipNodesWithSystemPods)(pointer.String(string(SkipNodesWithSystemPodsTrue))),
+						BalanceSimilarNodeGroups:      (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsFalse))),
+						Expander:                      (*Expander)(ptr.To(string(ExpanderRandom))),
+						MaxEmptyBulkDelete:            ptr.To("10"),
+						MaxGracefulTerminationSec:     ptr.To("600"),
+						MaxNodeProvisionTime:          ptr.To("10m"),
+						MaxTotalUnreadyPercentage:     ptr.To("45"),
+						NewPodScaleUpDelay:            ptr.To("10m"),
+						OkTotalUnreadyCount:           ptr.To("3"),
+						ScanInterval:                  ptr.To("60s"),
+						ScaleDownDelayAfterAdd:        ptr.To("10m"),
+						ScaleDownDelayAfterDelete:     ptr.To("10s"),
+						ScaleDownDelayAfterFailure:    ptr.To("10m"),
+						ScaleDownUnneededTime:         ptr.To("10m"),
+						ScaleDownUnreadyTime:          ptr.To("10m"),
+						ScaleDownUtilizationThreshold: ptr.To("0.5"),
+						SkipNodesWithLocalStorage:     (*SkipNodesWithLocalStorage)(ptr.To(string(SkipNodesWithLocalStorageTrue))),
+						SkipNodesWithSystemPods:       (*SkipNodesWithSystemPods)(ptr.To(string(SkipNodesWithSystemPodsTrue))),
 					},
 				},
 			},
@@ -280,7 +280,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						Expander: (*Expander)(pointer.String(string(ExpanderRandom))),
+						Expander: (*Expander)(ptr.To(string(ExpanderRandom))),
 					},
 				},
 			},
@@ -292,7 +292,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						Expander: (*Expander)(pointer.String(string(ExpanderLeastWaste))),
+						Expander: (*Expander)(ptr.To(string(ExpanderLeastWaste))),
 					},
 				},
 			},
@@ -304,7 +304,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						Expander: (*Expander)(pointer.String(string(ExpanderMostPods))),
+						Expander: (*Expander)(ptr.To(string(ExpanderMostPods))),
 					},
 				},
 			},
@@ -316,7 +316,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						Expander: (*Expander)(pointer.String(string(ExpanderPriority))),
+						Expander: (*Expander)(ptr.To(string(ExpanderPriority))),
 					},
 				},
 			},
@@ -328,7 +328,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						BalanceSimilarNodeGroups: (*BalanceSimilarNodeGroups)(pointer.String(string(BalanceSimilarNodeGroupsTrue))),
+						BalanceSimilarNodeGroups: (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsTrue))),
 					},
 				},
 			},
@@ -340,7 +340,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						BalanceSimilarNodeGroups: (*BalanceSimilarNodeGroups)(pointer.String(string(BalanceSimilarNodeGroupsFalse))),
+						BalanceSimilarNodeGroups: (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsFalse))),
 					},
 				},
 			},
@@ -352,7 +352,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						MaxEmptyBulkDelete: pointer.String("invalid"),
+						MaxEmptyBulkDelete: ptr.To("invalid"),
 					},
 				},
 			},
@@ -364,7 +364,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						MaxGracefulTerminationSec: pointer.String("invalid"),
+						MaxGracefulTerminationSec: ptr.To("invalid"),
 					},
 				},
 			},
@@ -376,7 +376,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						MaxNodeProvisionTime: pointer.String("invalid"),
+						MaxNodeProvisionTime: ptr.To("invalid"),
 					},
 				},
 			},
@@ -388,7 +388,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						MaxTotalUnreadyPercentage: pointer.String("invalid"),
+						MaxTotalUnreadyPercentage: ptr.To("invalid"),
 					},
 				},
 			},
@@ -400,7 +400,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						NewPodScaleUpDelay: pointer.String("invalid"),
+						NewPodScaleUpDelay: ptr.To("invalid"),
 					},
 				},
 			},
@@ -412,7 +412,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						OkTotalUnreadyCount: pointer.String("invalid"),
+						OkTotalUnreadyCount: ptr.To("invalid"),
 					},
 				},
 			},
@@ -424,7 +424,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						ScanInterval: pointer.String("invalid"),
+						ScanInterval: ptr.To("invalid"),
 					},
 				},
 			},
@@ -436,7 +436,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						ScaleDownDelayAfterAdd: pointer.String("invalid"),
+						ScaleDownDelayAfterAdd: ptr.To("invalid"),
 					},
 				},
 			},
@@ -448,7 +448,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						ScaleDownDelayAfterDelete: pointer.String("invalid"),
+						ScaleDownDelayAfterDelete: ptr.To("invalid"),
 					},
 				},
 			},
@@ -460,7 +460,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						ScaleDownDelayAfterFailure: pointer.String("invalid"),
+						ScaleDownDelayAfterFailure: ptr.To("invalid"),
 					},
 				},
 			},
@@ -472,7 +472,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						ScaleDownUnneededTime: pointer.String("invalid"),
+						ScaleDownUnneededTime: ptr.To("invalid"),
 					},
 				},
 			},
@@ -484,7 +484,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						ScaleDownUnreadyTime: pointer.String("invalid"),
+						ScaleDownUnreadyTime: ptr.To("invalid"),
 					},
 				},
 			},
@@ -496,7 +496,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						ScaleDownUtilizationThreshold: pointer.String("invalid"),
+						ScaleDownUtilizationThreshold: ptr.To("invalid"),
 					},
 				},
 			},
@@ -508,7 +508,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						SkipNodesWithLocalStorage: (*SkipNodesWithLocalStorage)(pointer.String(string(SkipNodesWithLocalStorageTrue))),
+						SkipNodesWithLocalStorage: (*SkipNodesWithLocalStorage)(ptr.To(string(SkipNodesWithLocalStorageTrue))),
 					},
 				},
 			},
@@ -520,7 +520,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						SkipNodesWithLocalStorage: (*SkipNodesWithLocalStorage)(pointer.String(string(SkipNodesWithLocalStorageFalse))),
+						SkipNodesWithLocalStorage: (*SkipNodesWithLocalStorage)(ptr.To(string(SkipNodesWithLocalStorageFalse))),
 					},
 				},
 			},
@@ -532,7 +532,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						SkipNodesWithSystemPods: (*SkipNodesWithSystemPods)(pointer.String(string(SkipNodesWithSystemPodsTrue))),
+						SkipNodesWithSystemPods: (*SkipNodesWithSystemPods)(ptr.To(string(SkipNodesWithSystemPodsTrue))),
 					},
 				},
 			},
@@ -544,7 +544,7 @@ func TestValidatingWebhook(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
-						SkipNodesWithSystemPods: (*SkipNodesWithSystemPods)(pointer.String(string(SkipNodesWithSystemPodsFalse))),
+						SkipNodesWithSystemPods: (*SkipNodesWithSystemPods)(ptr.To(string(SkipNodesWithSystemPodsFalse))),
 					},
 				},
 			},
@@ -663,8 +663,8 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 					Name: "microsoft-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					SSHPublicKey: pointer.String(generateSSHPublicKey(true)),
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.23.5",
 				},
 			},
@@ -678,8 +678,8 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 					Name: "a-windows-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					SSHPublicKey: pointer.String(generateSSHPublicKey(true)),
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.23.5",
 				},
 			},
@@ -693,9 +693,9 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 					ControlPlaneEndpoint: clusterv1.APIEndpoint{
 						Host: "my-host",
 					},
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
-					SSHPublicKey: pointer.String(generateSSHPublicKey(true)),
+					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
 					AADProfile: &AADProfile{
 						Managed: true,
 						AdminGroupObjectIDs: []string{
@@ -713,9 +713,9 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 					ControlPlaneEndpoint: clusterv1.APIEndpoint{
 						Port: 444,
 					},
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
-					SSHPublicKey: pointer.String(generateSSHPublicKey(true)),
+					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
 					AADProfile: &AADProfile{
 						Managed: true,
 						AdminGroupObjectIDs: []string{
@@ -809,14 +809,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane SubscriptionID is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:   pointer.String("192.168.0.0"),
+					DNSServiceIP:   ptr.To("192.168.0.0"),
 					SubscriptionID: "212ec1q8",
 					Version:        "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:   pointer.String("192.168.0.0"),
+					DNSServiceIP:   ptr.To("192.168.0.0"),
 					SubscriptionID: "212ec1q9",
 					Version:        "v1.18.0",
 				},
@@ -827,14 +827,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane ResourceGroupName is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:      pointer.String("192.168.0.0"),
+					DNSServiceIP:      ptr.To("192.168.0.0"),
 					ResourceGroupName: "hello-1",
 					Version:           "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:      pointer.String("192.168.0.0"),
+					DNSServiceIP:      ptr.To("192.168.0.0"),
 					ResourceGroupName: "hello-2",
 					Version:           "v1.18.0",
 				},
@@ -845,14 +845,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane NodeResourceGroupName is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:          pointer.String("192.168.0.0"),
+					DNSServiceIP:          ptr.To("192.168.0.0"),
 					NodeResourceGroupName: "hello-1",
 					Version:               "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:          pointer.String("192.168.0.0"),
+					DNSServiceIP:          ptr.To("192.168.0.0"),
 					NodeResourceGroupName: "hello-2",
 					Version:               "v1.18.0",
 				},
@@ -863,14 +863,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane Location is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Location:     "westeurope",
 					Version:      "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Location:     "eastus",
 					Version:      "v1.18.0",
 				},
@@ -881,15 +881,15 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane SSHPublicKey is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
-					SSHPublicKey: pointer.String(generateSSHPublicKey(true)),
+					DNSServiceIP: ptr.To("192.168.0.0"),
+					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
 					Version:      "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
-					SSHPublicKey: pointer.String(generateSSHPublicKey(true)),
+					DNSServiceIP: ptr.To("192.168.0.0"),
+					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
 					Version:      "v1.18.0",
 				},
 			},
@@ -899,13 +899,13 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane DNSServiceIP is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.1"),
+					DNSServiceIP: ptr.To("192.168.0.1"),
 					Version:      "v1.18.0",
 				},
 			},
@@ -915,7 +915,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane DNSServiceIP is immutable, unsetting is not allowed",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 				},
 			},
@@ -930,15 +930,15 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane NetworkPlugin is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:  pointer.String("192.168.0.0"),
-					NetworkPlugin: pointer.String("azure"),
+					DNSServiceIP:  ptr.To("192.168.0.0"),
+					NetworkPlugin: ptr.To("azure"),
 					Version:       "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:  pointer.String("192.168.0.0"),
-					NetworkPlugin: pointer.String("kubenet"),
+					DNSServiceIP:  ptr.To("192.168.0.0"),
+					NetworkPlugin: ptr.To("kubenet"),
 					Version:       "v1.18.0",
 				},
 			},
@@ -948,14 +948,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane NetworkPlugin is immutable, unsetting is not allowed",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:  pointer.String("192.168.0.0"),
-					NetworkPlugin: pointer.String("azure"),
+					DNSServiceIP:  ptr.To("192.168.0.0"),
+					NetworkPlugin: ptr.To("azure"),
 					Version:       "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 				},
 			},
@@ -965,15 +965,15 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane NetworkPolicy is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:  pointer.String("192.168.0.0"),
-					NetworkPolicy: pointer.String("azure"),
+					DNSServiceIP:  ptr.To("192.168.0.0"),
+					NetworkPolicy: ptr.To("azure"),
 					Version:       "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:  pointer.String("192.168.0.0"),
-					NetworkPolicy: pointer.String("calico"),
+					DNSServiceIP:  ptr.To("192.168.0.0"),
+					NetworkPolicy: ptr.To("calico"),
 					Version:       "v1.18.0",
 				},
 			},
@@ -983,14 +983,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane NetworkPolicy is immutable, unsetting is not allowed",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:  pointer.String("192.168.0.0"),
-					NetworkPolicy: pointer.String("azure"),
+					DNSServiceIP:  ptr.To("192.168.0.0"),
+					NetworkPolicy: ptr.To("azure"),
 					Version:       "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 				},
 			},
@@ -1000,15 +1000,15 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane LoadBalancerSKU is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:    pointer.String("192.168.0.0"),
-					LoadBalancerSKU: pointer.String("Standard"),
+					DNSServiceIP:    ptr.To("192.168.0.0"),
+					LoadBalancerSKU: ptr.To("Standard"),
 					Version:         "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:    pointer.String("192.168.0.0"),
-					LoadBalancerSKU: pointer.String("Basic"),
+					DNSServiceIP:    ptr.To("192.168.0.0"),
+					LoadBalancerSKU: ptr.To("Basic"),
 					Version:         "v1.18.0",
 				},
 			},
@@ -1018,14 +1018,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane LoadBalancerSKU is immutable, unsetting is not allowed",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:    pointer.String("192.168.0.0"),
-					LoadBalancerSKU: pointer.String("Standard"),
+					DNSServiceIP:    ptr.To("192.168.0.0"),
+					LoadBalancerSKU: ptr.To("Standard"),
 					Version:         "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 				},
 			},
@@ -1146,16 +1146,16 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane EnablePrivateCluster is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 					APIServerAccessProfile: &APIServerAccessProfile{
-						EnablePrivateCluster: pointer.Bool(true),
+						EnablePrivateCluster: ptr.To(true),
 					},
 				},
 			},
@@ -1165,13 +1165,13 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane AuthorizedIPRanges is mutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 					APIServerAccessProfile: &APIServerAccessProfile{
 						AuthorizedIPRanges: []string{"192.168.0.1/32"},
@@ -1187,7 +1187,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 					VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 						Name:          "test-network",
@@ -1205,7 +1205,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 				},
 			},
@@ -1218,7 +1218,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 				},
 			},
@@ -1227,7 +1227,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 					VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 						Name:          "test-network",
@@ -1249,7 +1249,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 					VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 						Name:          "test-network",
@@ -1267,7 +1267,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: pointer.String("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.0"),
 					Version:      "v1.18.0",
 					VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 						Name:          "test-network",
@@ -1289,7 +1289,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					OutboundType: (*ManagedControlPlaneOutboundType)(pointer.String(string(ManagedControlPlaneOutboundTypeUserDefinedRouting))),
+					OutboundType: (*ManagedControlPlaneOutboundType)(ptr.To(string(ManagedControlPlaneOutboundTypeUserDefinedRouting))),
 				},
 			},
 			amcp: &AzureManagedControlPlane{
@@ -1297,7 +1297,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					OutboundType: (*ManagedControlPlaneOutboundType)(pointer.String(string(ManagedControlPlaneOutboundTypeLoadBalancer))),
+					OutboundType: (*ManagedControlPlaneOutboundType)(ptr.To(string(ManagedControlPlaneOutboundTypeLoadBalancer))),
 				},
 			},
 			wantErr: true,
@@ -1320,7 +1320,7 @@ func createAzureManagedControlPlane(serviceIP, version, sshKey string) *AzureMan
 	return &AzureManagedControlPlane{
 		Spec: AzureManagedControlPlaneSpec{
 			SSHPublicKey: &sshKey,
-			DNSServiceIP: pointer.String(serviceIP),
+			DNSServiceIP: ptr.To(serviceIP),
 			Version:      version,
 		},
 	}
@@ -1329,9 +1329,9 @@ func createAzureManagedControlPlane(serviceIP, version, sshKey string) *AzureMan
 func getKnownValidAzureManagedControlPlane() *AzureManagedControlPlane {
 	return &AzureManagedControlPlane{
 		Spec: AzureManagedControlPlaneSpec{
-			DNSServiceIP: pointer.String("192.168.0.0"),
+			DNSServiceIP: ptr.To("192.168.0.0"),
 			Version:      "v1.18.0",
-			SSHPublicKey: pointer.String(generateSSHPublicKey(true)),
+			SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
 			AADProfile: &AADProfile{
 				Managed: true,
 				AdminGroupObjectIDs: []string{

--- a/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/maps"
@@ -75,7 +75,7 @@ func (mw *azureManagedMachinePoolWebhook) Default(ctx context.Context, obj runti
 	}
 
 	if m.Spec.OSType == nil {
-		m.Spec.OSType = pointer.String(DefaultOSType)
+		m.Spec.OSType = ptr.To(DefaultOSType)
 	}
 
 	return nil
@@ -338,7 +338,7 @@ func (m *AzureManagedMachinePool) validateLastSystemNodePool(cli client.Client) 
 
 func (m *AzureManagedMachinePool) validateMaxPods() error {
 	if m.Spec.MaxPods != nil {
-		if pointer.Int32Deref(m.Spec.MaxPods, 0) < 10 || pointer.Int32Deref(m.Spec.MaxPods, 0) > 250 {
+		if ptr.Deref[int32](m.Spec.MaxPods, 0) < 10 || ptr.Deref[int32](m.Spec.MaxPods, 0) > 250 {
 			return field.Invalid(
 				field.NewPath("Spec", "MaxPods"),
 				m.Spec.MaxPods,
@@ -411,7 +411,7 @@ func (m *AzureManagedMachinePool) validateSubnetName() error {
 	if m.Spec.SubnetName != nil {
 		subnetRegex := "^[a-zA-Z0-9][a-zA-Z0-9-]{0,78}[a-zA-Z0-9]$"
 		regex := regexp.MustCompile(subnetRegex)
-		if success := regex.MatchString(pointer.StringDeref(m.Spec.SubnetName, "")); !success {
+		if success := regex.MatchString(ptr.Deref(m.Spec.SubnetName, "")); !success {
 			return field.Invalid(field.NewPath("Spec", "SubnetName"), m.Spec.SubnetName,
 				fmt.Sprintf("name of subnet doesn't match regex %s", subnetRegex))
 		}
@@ -431,7 +431,7 @@ func (m *AzureManagedMachinePool) validateKubeletConfig() error {
 	}
 	if m.Spec.KubeletConfig != nil {
 		if m.Spec.KubeletConfig.CPUCfsQuotaPeriod != nil {
-			if !strings.HasSuffix(pointer.StringDeref(m.Spec.KubeletConfig.CPUCfsQuotaPeriod, ""), "ms") {
+			if !strings.HasSuffix(ptr.Deref(m.Spec.KubeletConfig.CPUCfsQuotaPeriod, ""), "ms") {
 				return field.Invalid(
 					field.NewPath("Spec", "KubeletConfig", "CPUCfsQuotaPeriod"),
 					m.Spec.KubeletConfig.CPUCfsQuotaPeriod,
@@ -439,12 +439,12 @@ func (m *AzureManagedMachinePool) validateKubeletConfig() error {
 			}
 		}
 		if m.Spec.KubeletConfig.ImageGcHighThreshold != nil && m.Spec.KubeletConfig.ImageGcLowThreshold != nil {
-			if pointer.Int32Deref(m.Spec.KubeletConfig.ImageGcLowThreshold, 0) > pointer.Int32Deref(m.Spec.KubeletConfig.ImageGcHighThreshold, 0) {
+			if ptr.Deref[int32](m.Spec.KubeletConfig.ImageGcLowThreshold, 0) > ptr.Deref[int32](m.Spec.KubeletConfig.ImageGcHighThreshold, 0) {
 				return field.Invalid(
 					field.NewPath("Spec", "KubeletConfig", "ImageGcLowThreshold"),
 					m.Spec.KubeletConfig.ImageGcLowThreshold,
 					fmt.Sprintf("must not be greater than ImageGcHighThreshold, ImageGcLowThreshold=%d, ImageGcHighThreshold=%d",
-						pointer.Int32Deref(m.Spec.KubeletConfig.ImageGcLowThreshold, 0), pointer.Int32Deref(m.Spec.KubeletConfig.ImageGcHighThreshold, 0)))
+						ptr.Deref[int32](m.Spec.KubeletConfig.ImageGcLowThreshold, 0), ptr.Deref[int32](m.Spec.KubeletConfig.ImageGcHighThreshold, 0)))
 			}
 		}
 		for _, val := range m.Spec.KubeletConfig.AllowedUnsafeSysctls {
@@ -475,7 +475,7 @@ func (m *AzureManagedMachinePool) validateLinuxOSConfig() error {
 	}
 
 	if m.Spec.LinuxOSConfig.SwapFileSizeMB != nil {
-		if m.Spec.KubeletConfig == nil || pointer.BoolDeref(m.Spec.KubeletConfig.FailSwapOn, true) {
+		if m.Spec.KubeletConfig == nil || ptr.Deref(m.Spec.KubeletConfig.FailSwapOn, true) {
 			errs = append(errs, field.Invalid(
 				field.NewPath("Spec", "LinuxOSConfig", "SwapFileSizeMB"),
 				m.Spec.LinuxOSConfig.SwapFileSizeMB,

--- a/api/v1beta1/azuremanagedmachinepool_webhook_test.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/component-base/featuregate/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capifeature "sigs.k8s.io/cluster-api/feature"
@@ -44,7 +44,7 @@ func TestAzureManagedMachinePoolDefaultingWebhook(t *testing.T) {
 		Spec: AzureManagedMachinePoolSpec{
 			Mode:         "System",
 			SKU:          "StandardD2S_V3",
-			OSDiskSizeGB: pointer.Int32(512),
+			OSDiskSizeGB: ptr.To[int32](512),
 		},
 	}
 	var client client.Client
@@ -97,12 +97,12 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			name: "Cannot change Name of the agentpool",
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					Name: pointer.String("pool-new"),
+					Name: ptr.To("pool-new"),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					Name: pointer.String("pool-old"),
+					Name: ptr.To("pool-old"),
 				},
 			},
 			wantErr: true,
@@ -113,14 +113,14 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:         "System",
 					SKU:          "StandardD2S_V3",
-					OSDiskSizeGB: pointer.Int32(512),
+					OSDiskSizeGB: ptr.To[int32](512),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:         "System",
 					SKU:          "StandardD2S_V4",
-					OSDiskSizeGB: pointer.Int32(512),
+					OSDiskSizeGB: ptr.To[int32](512),
 				},
 			},
 			wantErr: true,
@@ -129,18 +129,18 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			name: "Cannot change OSType of the agentpool",
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					OSType:       pointer.String(LinuxOS),
+					OSType:       ptr.To(LinuxOS),
 					Mode:         "System",
 					SKU:          "StandardD2S_V3",
-					OSDiskSizeGB: pointer.Int32(512),
+					OSDiskSizeGB: ptr.To[int32](512),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					OSType:       pointer.String(WindowsOS),
+					OSType:       ptr.To(WindowsOS),
 					Mode:         "System",
 					SKU:          "StandardD2S_V4",
-					OSDiskSizeGB: pointer.Int32(512),
+					OSDiskSizeGB: ptr.To[int32](512),
 				},
 			},
 			wantErr: true,
@@ -151,14 +151,14 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:         "System",
 					SKU:          "StandardD2S_V3",
-					OSDiskSizeGB: pointer.Int32(512),
+					OSDiskSizeGB: ptr.To[int32](512),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:         "System",
 					SKU:          "StandardD2S_V3",
-					OSDiskSizeGB: pointer.Int32(1024),
+					OSDiskSizeGB: ptr.To[int32](1024),
 				},
 			},
 			wantErr: true,
@@ -169,7 +169,7 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:              "System",
 					SKU:               "StandardD2S_V3",
-					OSDiskSizeGB:      pointer.Int32(512),
+					OSDiskSizeGB:      ptr.To[int32](512),
 					AvailabilityZones: []string{"1", "2", "3"},
 				},
 			},
@@ -177,7 +177,7 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:         "System",
 					SKU:          "StandardD2S_V3",
-					OSDiskSizeGB: pointer.Int32(512),
+					OSDiskSizeGB: ptr.To[int32](512),
 				},
 			},
 			wantErr: true,
@@ -188,14 +188,14 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:         "System",
 					SKU:          "StandardD2S_V3",
-					OSDiskSizeGB: pointer.Int32(512),
+					OSDiskSizeGB: ptr.To[int32](512),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:              "System",
 					SKU:               "StandardD2S_V3",
-					OSDiskSizeGB:      pointer.Int32(512),
+					OSDiskSizeGB:      ptr.To[int32](512),
 					AvailabilityZones: []string{"1", "2", "3"},
 				},
 			},
@@ -207,7 +207,7 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:              "System",
 					SKU:               "StandardD2S_V3",
-					OSDiskSizeGB:      pointer.Int32(512),
+					OSDiskSizeGB:      ptr.To[int32](512),
 					AvailabilityZones: []string{"1", "2"},
 				},
 			},
@@ -215,7 +215,7 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:              "System",
 					SKU:               "StandardD2S_V3",
-					OSDiskSizeGB:      pointer.Int32(512),
+					OSDiskSizeGB:      ptr.To[int32](512),
 					AvailabilityZones: []string{"1", "2", "3"},
 				},
 			},
@@ -227,7 +227,7 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:              "System",
 					SKU:               "StandardD2S_V3",
-					OSDiskSizeGB:      pointer.Int32(512),
+					OSDiskSizeGB:      ptr.To[int32](512),
 					AvailabilityZones: []string{"1", "3", "2"},
 				},
 			},
@@ -235,7 +235,7 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:              "System",
 					SKU:               "StandardD2S_V3",
-					OSDiskSizeGB:      pointer.Int32(512),
+					OSDiskSizeGB:      ptr.To[int32](512),
 					AvailabilityZones: []string{"1", "2", "3"},
 				},
 			},
@@ -247,16 +247,16 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:         "System",
 					SKU:          "StandardD2S_V3",
-					OSDiskSizeGB: pointer.Int32(512),
-					MaxPods:      pointer.Int32(24),
+					OSDiskSizeGB: ptr.To[int32](512),
+					MaxPods:      ptr.To[int32](24),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:         "System",
 					SKU:          "StandardD2S_V3",
-					OSDiskSizeGB: pointer.Int32(512),
-					MaxPods:      pointer.Int32(25),
+					OSDiskSizeGB: ptr.To[int32](512),
+					MaxPods:      ptr.To[int32](25),
 				},
 			},
 			wantErr: true,
@@ -267,16 +267,16 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:         "System",
 					SKU:          "StandardD2S_V3",
-					OSDiskSizeGB: pointer.Int32(512),
-					MaxPods:      pointer.Int32(30),
+					OSDiskSizeGB: ptr.To[int32](512),
+					MaxPods:      ptr.To[int32](30),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:         "System",
 					SKU:          "StandardD2S_V3",
-					OSDiskSizeGB: pointer.Int32(512),
-					MaxPods:      pointer.Int32(30),
+					OSDiskSizeGB: ptr.To[int32](512),
+					MaxPods:      ptr.To[int32](30),
 				},
 			},
 			wantErr: false,
@@ -287,18 +287,18 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:         "System",
 					SKU:          "StandardD2S_V3",
-					OSDiskSizeGB: pointer.Int32(512),
-					MaxPods:      pointer.Int32(24),
-					OsDiskType:   pointer.String(string(containerservice.OSDiskTypeEphemeral)),
+					OSDiskSizeGB: ptr.To[int32](512),
+					MaxPods:      ptr.To[int32](24),
+					OsDiskType:   ptr.To(string(containerservice.OSDiskTypeEphemeral)),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:         "System",
 					SKU:          "StandardD2S_V3",
-					OSDiskSizeGB: pointer.Int32(512),
-					MaxPods:      pointer.Int32(24),
-					OsDiskType:   pointer.String(string(containerservice.OSDiskTypeManaged)),
+					OSDiskSizeGB: ptr.To[int32](512),
+					MaxPods:      ptr.To[int32](24),
+					OsDiskType:   ptr.To(string(containerservice.OSDiskTypeManaged)),
 				},
 			},
 			wantErr: true,
@@ -390,18 +390,18 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:         "System",
 					SKU:          "StandardD2S_V3",
-					OSDiskSizeGB: pointer.Int32(512),
-					MaxPods:      pointer.Int32(30),
-					OsDiskType:   pointer.String(string(containerservice.OSDiskTypeManaged)),
+					OSDiskSizeGB: ptr.To[int32](512),
+					MaxPods:      ptr.To[int32](30),
+					OsDiskType:   ptr.To(string(containerservice.OSDiskTypeManaged)),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:         "System",
 					SKU:          "StandardD2S_V3",
-					OSDiskSizeGB: pointer.Int32(512),
-					MaxPods:      pointer.Int32(30),
-					OsDiskType:   pointer.String(string(containerservice.OSDiskTypeManaged)),
+					OSDiskSizeGB: ptr.To[int32](512),
+					MaxPods:      ptr.To[int32](30),
+					OsDiskType:   ptr.To(string(containerservice.OSDiskTypeManaged)),
 				},
 			},
 			wantErr: false,
@@ -410,12 +410,12 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			name: "Unexpected error, value EnableUltraSSD is unchanged",
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableUltraSSD: pointer.Bool(true),
+					EnableUltraSSD: ptr.To(true),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableUltraSSD: pointer.Bool(true),
+					EnableUltraSSD: ptr.To(true),
 				},
 			},
 			wantErr: false,
@@ -424,12 +424,12 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			name: "EnableUltraSSD feature is immutable and currently enabled on this agentpool",
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableUltraSSD: pointer.Bool(false),
+					EnableUltraSSD: ptr.To(false),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableUltraSSD: pointer.Bool(true),
+					EnableUltraSSD: ptr.To(true),
 				},
 			},
 			wantErr: true,
@@ -438,12 +438,12 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			name: "Unexpected error, value EnableNodePublicIP is unchanged",
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableNodePublicIP: pointer.Bool(true),
+					EnableNodePublicIP: ptr.To(true),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableNodePublicIP: pointer.Bool(true),
+					EnableNodePublicIP: ptr.To(true),
 				},
 			},
 			wantErr: false,
@@ -452,12 +452,12 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			name: "EnableNodePublicIP feature is immutable and currently enabled on this agentpool",
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableNodePublicIP: pointer.Bool(false),
+					EnableNodePublicIP: ptr.To(false),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableNodePublicIP: pointer.Bool(true),
+					EnableNodePublicIP: ptr.To(true),
 				},
 			},
 			wantErr: true,
@@ -512,14 +512,14 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					KubeletConfig: &KubeletConfig{
-						CPUCfsQuota: pointer.Bool(true),
+						CPUCfsQuota: ptr.To(true),
 					},
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					KubeletConfig: &KubeletConfig{
-						CPUCfsQuota: pointer.Bool(false),
+						CPUCfsQuota: ptr.To(false),
 					},
 				},
 			},
@@ -530,14 +530,14 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					LinuxOSConfig: &LinuxOSConfig{
-						SwapFileSizeMB: pointer.Int32(10),
+						SwapFileSizeMB: ptr.To[int32](10),
 					},
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					LinuxOSConfig: &LinuxOSConfig{
-						SwapFileSizeMB: pointer.Int32(5),
+						SwapFileSizeMB: ptr.To[int32](5),
 					},
 				},
 			},
@@ -547,12 +547,12 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			name: "Can't update SubnetName with error",
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("my-subnet"),
+					SubnetName: ptr.To("my-subnet"),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("my-subnet-1"),
+					SubnetName: ptr.To("my-subnet-1"),
 				},
 			},
 			wantErr: true,
@@ -561,7 +561,7 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			name: "Can update SubnetName if subnetName is empty",
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("my-subnet"),
+					SubnetName: ptr.To("my-subnet"),
 				},
 			},
 			old: &AzureManagedMachinePool{
@@ -575,12 +575,12 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			name: "Can't update SubnetName without error",
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("my-subnet"),
+					SubnetName: ptr.To("my-subnet"),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("my-subnet"),
+					SubnetName: ptr.To("my-subnet"),
 				},
 			},
 			wantErr: false,
@@ -589,12 +589,12 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			name: "Cannot update enableFIPS",
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableFIPS: pointer.Bool(true),
+					EnableFIPS: ptr.To(true),
 				},
 			},
 			old: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableFIPS: pointer.Bool(false),
+					EnableFIPS: ptr.To(false),
 				},
 			},
 			wantErr: true,
@@ -637,8 +637,8 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "another valid permutation",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					MaxPods:    pointer.Int32(249),
-					OsDiskType: pointer.String(string(containerservice.OSDiskTypeManaged)),
+					MaxPods:    ptr.To[int32](249),
+					OsDiskType: ptr.To(string(containerservice.OSDiskTypeManaged)),
 				},
 			},
 			wantErr: false,
@@ -654,7 +654,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "too many MaxPods",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					MaxPods: pointer.Int32(251),
+					MaxPods: ptr.To[int32](251),
 				},
 			},
 			wantErr:  true,
@@ -664,7 +664,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "invalid subnetname",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("1+subnet"),
+					SubnetName: ptr.To("1+subnet"),
 				},
 			},
 			wantErr:  true,
@@ -674,7 +674,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "invalid subnetname",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("1"),
+					SubnetName: ptr.To("1"),
 				},
 			},
 			wantErr:  true,
@@ -684,7 +684,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "invalid subnetname",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("-a_b-c"),
+					SubnetName: ptr.To("-a_b-c"),
 				},
 			},
 			wantErr:  true,
@@ -694,7 +694,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "invalid subnetname",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("E-a_b-c"),
+					SubnetName: ptr.To("E-a_b-c"),
 				},
 			},
 			wantErr:  true,
@@ -704,7 +704,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "invalid subnetname",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("-_-_"),
+					SubnetName: ptr.To("-_-_"),
 				},
 			},
 			wantErr:  true,
@@ -714,7 +714,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "invalid subnetname",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("abc@#$"),
+					SubnetName: ptr.To("abc@#$"),
 				},
 			},
 			wantErr:  true,
@@ -724,7 +724,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "invalid subnetname with character length 81",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("3DgIb8EZMkLs0KlyPaTcNxoJU9ufmW6jvXrweqz1hVp5nS4RtH2QY7AFOiC5nS4RtH2QY7AFOiC3DgIb8"),
+					SubnetName: ptr.To("3DgIb8EZMkLs0KlyPaTcNxoJU9ufmW6jvXrweqz1hVp5nS4RtH2QY7AFOiC5nS4RtH2QY7AFOiC3DgIb8"),
 				},
 			},
 			wantErr:  true,
@@ -734,7 +734,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "valid subnetname with character length 80",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("3DgIb8EZMkLs0KlyPaTcNxoJU9ufmW6jvXrweqz1hVp5nS4RtH2QY7AFOiC5nS4RtH2QY7AFOiC3DgIb"),
+					SubnetName: ptr.To("3DgIb8EZMkLs0KlyPaTcNxoJU9ufmW6jvXrweqz1hVp5nS4RtH2QY7AFOiC5nS4RtH2QY7AFOiC3DgIb"),
 				},
 			},
 			wantErr: false,
@@ -743,7 +743,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "valid subnetname",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("1abc"),
+					SubnetName: ptr.To("1abc"),
 				},
 			},
 			wantErr: false,
@@ -752,7 +752,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "valid subnetname",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("1-a-b-c"),
+					SubnetName: ptr.To("1-a-b-c"),
 				},
 			},
 			wantErr: false,
@@ -761,7 +761,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "valid subnetname",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					SubnetName: pointer.String("my-subnet"),
+					SubnetName: ptr.To("my-subnet"),
 				},
 			},
 			wantErr: false,
@@ -770,7 +770,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "too few MaxPods",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					MaxPods: pointer.Int32(9),
+					MaxPods: ptr.To[int32](9),
 				},
 			},
 			wantErr:  true,
@@ -781,7 +781,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:   "System",
-					OSType: pointer.String(WindowsOS),
+					OSType: ptr.To(WindowsOS),
 				},
 			},
 			wantErr:  true,
@@ -792,7 +792,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:   "User",
-					OSType: pointer.String(WindowsOS),
+					OSType: ptr.To(WindowsOS),
 				},
 			},
 			wantErr: false,
@@ -805,7 +805,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 				},
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:   "User",
-					OSType: pointer.String(WindowsOS),
+					OSType: ptr.To(WindowsOS),
 				},
 			},
 			wantErr: false,
@@ -814,9 +814,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "Windows clusters with more than 6char names are not allowed",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					Name:   pointer.String("pool0-name-too-long"),
+					Name:   ptr.To("pool0-name-too-long"),
 					Mode:   "User",
-					OSType: pointer.String(WindowsOS),
+					OSType: ptr.To(WindowsOS),
 				},
 			},
 			wantErr:  true,
@@ -827,7 +827,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:   "User",
-					OSType: pointer.String(LinuxOS),
+					OSType: ptr.To(LinuxOS),
 					NodeLabels: map[string]string{
 						"foo": "bar",
 					},
@@ -840,7 +840,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					Mode:   "User",
-					OSType: pointer.String(LinuxOS),
+					OSType: ptr.To(LinuxOS),
 					NodeLabels: map[string]string{
 						"kubernetes.azure.com/scalesetpriority": "spot",
 					},
@@ -853,8 +853,8 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "pool with invalid public ip prefix",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableNodePublicIP:   pointer.Bool(true),
-					NodePublicIPPrefixID: pointer.String("not a valid resource ID"),
+					EnableNodePublicIP:   ptr.To(true),
+					NodePublicIPPrefixID: ptr.To("not a valid resource ID"),
 				},
 			},
 			wantErr:  true,
@@ -865,7 +865,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					EnableNodePublicIP:   nil,
-					NodePublicIPPrefixID: pointer.String("subscriptions/11111111-2222-aaaa-bbbb-cccccccccccc/resourceGroups/public-ip-test/providers/Microsoft.Network/publicipprefixes/public-ip-prefix"),
+					NodePublicIPPrefixID: ptr.To("subscriptions/11111111-2222-aaaa-bbbb-cccccccccccc/resourceGroups/public-ip-test/providers/Microsoft.Network/publicipprefixes/public-ip-prefix"),
 				},
 			},
 			wantErr:  true,
@@ -875,8 +875,8 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "pool with public ip prefix cannot disable node public IP",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableNodePublicIP:   pointer.Bool(false),
-					NodePublicIPPrefixID: pointer.String("subscriptions/11111111-2222-aaaa-bbbb-cccccccccccc/resourceGroups/public-ip-test/providers/Microsoft.Network/publicipprefixes/public-ip-prefix"),
+					EnableNodePublicIP:   ptr.To(false),
+					NodePublicIPPrefixID: ptr.To("subscriptions/11111111-2222-aaaa-bbbb-cccccccccccc/resourceGroups/public-ip-test/providers/Microsoft.Network/publicipprefixes/public-ip-prefix"),
 				},
 			},
 			wantErr:  true,
@@ -886,8 +886,8 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "pool with public ip prefix with node public IP enabled ok",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableNodePublicIP:   pointer.Bool(true),
-					NodePublicIPPrefixID: pointer.String("subscriptions/11111111-2222-aaaa-bbbb-cccccccccccc/resourceGroups/public-ip-test/providers/Microsoft.Network/publicipprefixes/public-ip-prefix"),
+					EnableNodePublicIP:   ptr.To(true),
+					NodePublicIPPrefixID: ptr.To("subscriptions/11111111-2222-aaaa-bbbb-cccccccccccc/resourceGroups/public-ip-test/providers/Microsoft.Network/publicipprefixes/public-ip-prefix"),
 				},
 			},
 			wantErr: false,
@@ -896,8 +896,8 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "pool with public ip prefix with leading slash with node public IP enabled ok",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableNodePublicIP:   pointer.Bool(true),
-					NodePublicIPPrefixID: pointer.String("/subscriptions/11111111-2222-aaaa-bbbb-cccccccccccc/resourceGroups/public-ip-test/providers/Microsoft.Network/publicipprefixes/public-ip-prefix"),
+					EnableNodePublicIP:   ptr.To(true),
+					NodePublicIPPrefixID: ptr.To("/subscriptions/11111111-2222-aaaa-bbbb-cccccccccccc/resourceGroups/public-ip-test/providers/Microsoft.Network/publicipprefixes/public-ip-prefix"),
 				},
 			},
 			wantErr: false,
@@ -915,7 +915,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "pool without public ip prefix with node public IP enabled ok",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableNodePublicIP: pointer.Bool(true),
+					EnableNodePublicIP: ptr.To(true),
 				},
 			},
 			wantErr: false,
@@ -924,7 +924,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			name: "pool without public ip prefix with node public IP disabled ok",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
-					EnableNodePublicIP: pointer.Bool(false),
+					EnableNodePublicIP: ptr.To(false),
 				},
 			},
 			wantErr: false,
@@ -934,7 +934,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					KubeletConfig: &KubeletConfig{
-						CPUCfsQuotaPeriod: pointer.String("100"),
+						CPUCfsQuotaPeriod: ptr.To("100"),
 					},
 				},
 			},
@@ -946,7 +946,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					KubeletConfig: &KubeletConfig{
-						CPUCfsQuotaPeriod: pointer.String("100ms"),
+						CPUCfsQuotaPeriod: ptr.To("100ms"),
 					},
 				},
 			},
@@ -957,8 +957,8 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					KubeletConfig: &KubeletConfig{
-						ImageGcLowThreshold:  pointer.Int32(100),
-						ImageGcHighThreshold: pointer.Int32(99),
+						ImageGcLowThreshold:  ptr.To[int32](100),
+						ImageGcHighThreshold: ptr.To[int32](99),
 					},
 				},
 			},
@@ -970,8 +970,8 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					KubeletConfig: &KubeletConfig{
-						ImageGcLowThreshold:  pointer.Int32(99),
-						ImageGcHighThreshold: pointer.Int32(100),
+						ImageGcLowThreshold:  ptr.To[int32](99),
+						ImageGcHighThreshold: ptr.To[int32](100),
 					},
 				},
 			},
@@ -1036,7 +1036,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					LinuxOSConfig: &LinuxOSConfig{
 						Sysctls: &SysctlConfig{
-							NetIpv4IPLocalPortRange: pointer.String("2000 33000"),
+							NetIpv4IPLocalPortRange: ptr.To("2000 33000"),
 						},
 					},
 				},
@@ -1049,7 +1049,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					LinuxOSConfig: &LinuxOSConfig{
 						Sysctls: &SysctlConfig{
-							NetIpv4IPLocalPortRange: pointer.String("wrong 33000"),
+							NetIpv4IPLocalPortRange: ptr.To("wrong 33000"),
 						},
 					},
 				},
@@ -1063,7 +1063,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					LinuxOSConfig: &LinuxOSConfig{
 						Sysctls: &SysctlConfig{
-							NetIpv4IPLocalPortRange: pointer.String("2000 wrong"),
+							NetIpv4IPLocalPortRange: ptr.To("2000 wrong"),
 						},
 					},
 				},
@@ -1077,7 +1077,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					LinuxOSConfig: &LinuxOSConfig{
 						Sysctls: &SysctlConfig{
-							NetIpv4IPLocalPortRange: pointer.String("1020 32999"),
+							NetIpv4IPLocalPortRange: ptr.To("1020 32999"),
 						},
 					},
 				},
@@ -1091,7 +1091,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					LinuxOSConfig: &LinuxOSConfig{
 						Sysctls: &SysctlConfig{
-							NetIpv4IPLocalPortRange: pointer.String("1024 32000"),
+							NetIpv4IPLocalPortRange: ptr.To("1024 32000"),
 						},
 					},
 				},
@@ -1105,7 +1105,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					LinuxOSConfig: &LinuxOSConfig{
 						Sysctls: &SysctlConfig{
-							NetIpv4IPLocalPortRange: pointer.String("33000 32999"),
+							NetIpv4IPLocalPortRange: ptr.To("33000 32999"),
 						},
 					},
 				},
@@ -1118,10 +1118,10 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					KubeletConfig: &KubeletConfig{
-						FailSwapOn: pointer.Bool(false),
+						FailSwapOn: ptr.To(false),
 					},
 					LinuxOSConfig: &LinuxOSConfig{
-						SwapFileSizeMB: pointer.Int32(1500),
+						SwapFileSizeMB: ptr.To[int32](1500),
 					},
 				},
 			},
@@ -1132,10 +1132,10 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					KubeletConfig: &KubeletConfig{
-						FailSwapOn: pointer.Bool(true),
+						FailSwapOn: ptr.To(true),
 					},
 					LinuxOSConfig: &LinuxOSConfig{
-						SwapFileSizeMB: pointer.Int32(1500),
+						SwapFileSizeMB: ptr.To[int32](1500),
 					},
 				},
 			},
@@ -1147,7 +1147,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					LinuxOSConfig: &LinuxOSConfig{
-						SwapFileSizeMB: pointer.Int32(1500),
+						SwapFileSizeMB: ptr.To[int32](1500),
 					},
 				},
 			},
@@ -1287,8 +1287,8 @@ func TestAzureManagedMachinePool_validateLastSystemNodePool(t *testing.T) {
 func getKnownValidAzureManagedMachinePool() *AzureManagedMachinePool {
 	return &AzureManagedMachinePool{
 		Spec: AzureManagedMachinePoolSpec{
-			MaxPods:    pointer.Int32(30),
-			OsDiskType: pointer.String(string(containerservice.OSDiskTypeEphemeral)),
+			MaxPods:    ptr.To[int32](30),
+			OsDiskType: ptr.To(string(containerservice.OSDiskTypeEphemeral)),
 		},
 	}
 }

--- a/azure/converters/diagnostics.go
+++ b/azure/converters/diagnostics.go
@@ -18,7 +18,7 @@ package converters
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -29,19 +29,19 @@ func GetDiagnosticsProfile(diagnostics *infrav1.Diagnostics) *compute.Diagnostic
 		case infrav1.DisabledDiagnosticsStorage:
 			return &compute.DiagnosticsProfile{
 				BootDiagnostics: &compute.BootDiagnostics{
-					Enabled: pointer.Bool(false),
+					Enabled: ptr.To(false),
 				},
 			}
 		case infrav1.ManagedDiagnosticsStorage:
 			return &compute.DiagnosticsProfile{
 				BootDiagnostics: &compute.BootDiagnostics{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			}
 		case infrav1.UserManagedDiagnosticsStorage:
 			return &compute.DiagnosticsProfile{
 				BootDiagnostics: &compute.BootDiagnostics{
-					Enabled:    pointer.Bool(true),
+					Enabled:    ptr.To(true),
 					StorageURI: &diagnostics.Boot.UserManaged.StorageAccountURI,
 				},
 			}

--- a/azure/converters/diagnostics_test.go
+++ b/azure/converters/diagnostics_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -40,7 +40,7 @@ func TestGetDiagnosticsProfile(t *testing.T) {
 			},
 			want: &compute.DiagnosticsProfile{
 				BootDiagnostics: &compute.BootDiagnostics{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			},
 		},
@@ -56,8 +56,8 @@ func TestGetDiagnosticsProfile(t *testing.T) {
 			},
 			want: &compute.DiagnosticsProfile{
 				BootDiagnostics: &compute.BootDiagnostics{
-					Enabled:    pointer.Bool(true),
-					StorageURI: pointer.String("https://fake"),
+					Enabled:    ptr.To(true),
+					StorageURI: ptr.To("https://fake"),
 				},
 			},
 		},
@@ -70,7 +70,7 @@ func TestGetDiagnosticsProfile(t *testing.T) {
 			},
 			want: &compute.DiagnosticsProfile{
 				BootDiagnostics: &compute.BootDiagnostics{
-					Enabled: pointer.Bool(false),
+					Enabled: ptr.To(false),
 				},
 			},
 		},

--- a/azure/converters/extendedlocation.go
+++ b/azure/converters/extendedlocation.go
@@ -19,7 +19,7 @@ package converters
 import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -29,7 +29,7 @@ func ExtendedLocationToNetworkSDK(src *infrav1.ExtendedLocationSpec) *network.Ex
 		return nil
 	}
 	return &network.ExtendedLocation{
-		Name: pointer.String(src.Name),
+		Name: ptr.To(src.Name),
 		Type: network.ExtendedLocationTypes(src.Type),
 	}
 }
@@ -40,7 +40,7 @@ func ExtendedLocationToComputeSDK(src *infrav1.ExtendedLocationSpec) *compute.Ex
 		return nil
 	}
 	return &compute.ExtendedLocation{
-		Name: pointer.String(src.Name),
+		Name: ptr.To(src.Name),
 		Type: compute.ExtendedLocationTypes(src.Type),
 	}
 }

--- a/azure/converters/extendedlocation_test.go
+++ b/azure/converters/extendedlocation_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -39,7 +39,7 @@ func TestExtendedLocationToNetworkSDK(t *testing.T) {
 				Type: "Edge",
 			},
 			want: &network.ExtendedLocation{
-				Name: pointer.String("value"),
+				Name: ptr.To("value"),
 				Type: network.ExtendedLocationTypes("Edge"),
 			},
 		},
@@ -71,7 +71,7 @@ func TestExtendedLocationToComputeSDK(t *testing.T) {
 				Type: "Edge",
 			},
 			want: &compute.ExtendedLocation{
-				Name: pointer.String("value"),
+				Name: ptr.To("value"),
 				Type: compute.ExtendedLocationTypes("Edge"),
 			},
 		},

--- a/azure/converters/image.go
+++ b/azure/converters/image.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -57,7 +57,7 @@ func computeImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 	idTemplate := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s/versions/%s"
 	if image.SharedGallery != nil {
 		return &compute.ImageReference{
-			ID: pointer.String(fmt.Sprintf(idTemplate,
+			ID: ptr.To(fmt.Sprintf(idTemplate,
 				image.SharedGallery.SubscriptionID,
 				image.SharedGallery.ResourceGroup,
 				image.SharedGallery.Gallery,
@@ -71,9 +71,9 @@ func computeImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 	// If they are not, we assume use of community gallery.
 	if image.ComputeGallery.ResourceGroup != nil && image.ComputeGallery.SubscriptionID != nil {
 		return &compute.ImageReference{
-			ID: pointer.String(fmt.Sprintf(idTemplate,
-				pointer.StringDeref(image.ComputeGallery.SubscriptionID, ""),
-				pointer.StringDeref(image.ComputeGallery.ResourceGroup, ""),
+			ID: ptr.To(fmt.Sprintf(idTemplate,
+				ptr.Deref(image.ComputeGallery.SubscriptionID, ""),
+				ptr.Deref(image.ComputeGallery.ResourceGroup, ""),
 				image.ComputeGallery.Gallery,
 				image.ComputeGallery.Name,
 				image.ComputeGallery.Version,
@@ -82,7 +82,7 @@ func computeImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 	}
 
 	return &compute.ImageReference{
-		CommunityGalleryImageID: pointer.String(fmt.Sprintf("/CommunityGalleries/%s/Images/%s/Versions/%s",
+		CommunityGalleryImageID: ptr.To(fmt.Sprintf("/CommunityGalleries/%s/Images/%s/Versions/%s",
 			image.ComputeGallery.Gallery,
 			image.ComputeGallery.Name,
 			image.ComputeGallery.Version)),
@@ -109,18 +109,18 @@ func ImageToPlan(image *infrav1.Image) *compute.Plan {
 	// Plan is needed for third party Marketplace images.
 	if image.Marketplace != nil && image.Marketplace.ThirdPartyImage {
 		return &compute.Plan{
-			Publisher: pointer.String(image.Marketplace.Publisher),
-			Name:      pointer.String(image.Marketplace.SKU),
-			Product:   pointer.String(image.Marketplace.Offer),
+			Publisher: ptr.To(image.Marketplace.Publisher),
+			Name:      ptr.To(image.Marketplace.SKU),
+			Product:   ptr.To(image.Marketplace.Offer),
 		}
 	}
 
 	// Plan is needed when using a Azure Compute Gallery image with Plan details.
 	if image.ComputeGallery != nil && image.ComputeGallery.Plan != nil {
 		return &compute.Plan{
-			Publisher: pointer.String(image.ComputeGallery.Plan.Publisher),
-			Name:      pointer.String(image.ComputeGallery.Plan.SKU),
-			Product:   pointer.String(image.ComputeGallery.Plan.Offer),
+			Publisher: ptr.To(image.ComputeGallery.Plan.Publisher),
+			Name:      ptr.To(image.ComputeGallery.Plan.SKU),
+			Product:   ptr.To(image.ComputeGallery.Plan.Offer),
 		}
 	}
 

--- a/azure/converters/image_test.go
+++ b/azure/converters/image_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -44,9 +44,9 @@ func Test_ImageToPlan(t *testing.T) {
 			},
 			expect: func(g *GomegaWithT, result *compute.Plan) {
 				g.Expect(result).To(Equal(&compute.Plan{
-					Name:      pointer.String("my-sku"),
-					Publisher: pointer.String("my-publisher"),
-					Product:   pointer.String("my-offer"),
+					Name:      ptr.To("my-sku"),
+					Publisher: ptr.To("my-publisher"),
+					Product:   ptr.To("my-offer"),
 				}))
 			},
 		},
@@ -59,16 +59,16 @@ func Test_ImageToPlan(t *testing.T) {
 					Gallery:        "fake-gallery-name",
 					Name:           "fake-image-name",
 					Version:        "v1.0.0",
-					Publisher:      pointer.String("my-publisher"),
-					Offer:          pointer.String("my-offer"),
-					SKU:            pointer.String("my-sku"),
+					Publisher:      ptr.To("my-publisher"),
+					Offer:          ptr.To("my-offer"),
+					SKU:            ptr.To("my-sku"),
 				},
 			},
 			expect: func(g *GomegaWithT, result *compute.Plan) {
 				g.Expect(result).To(Equal(&compute.Plan{
-					Name:      pointer.String("my-sku"),
-					Publisher: pointer.String("my-publisher"),
-					Product:   pointer.String("my-offer"),
+					Name:      ptr.To("my-sku"),
+					Publisher: ptr.To("my-publisher"),
+					Product:   ptr.To("my-offer"),
 				}))
 			},
 		},
@@ -119,16 +119,16 @@ func Test_ImageToPlan(t *testing.T) {
 			},
 			expect: func(g *GomegaWithT, result *compute.Plan) {
 				g.Expect(result).To(Equal(&compute.Plan{
-					Name:      pointer.String("my-sku"),
-					Publisher: pointer.String("my-publisher"),
-					Product:   pointer.String("my-offer"),
+					Name:      ptr.To("my-sku"),
+					Publisher: ptr.To("my-publisher"),
+					Product:   ptr.To("my-offer"),
 				}))
 			},
 		},
 		{
 			name: "Should return nil for an image ID",
 			image: &infrav1.Image{
-				ID: pointer.String("fake/image/id"),
+				ID: ptr.To("fake/image/id"),
 			},
 			expect: func(g *GomegaWithT, result *compute.Plan) {
 				g.Expect(result).To(BeNil())
@@ -157,8 +157,8 @@ func Test_ComputeImageToSDK(t *testing.T) {
 			name: "Should return parsed compute gallery image id",
 			image: &infrav1.Image{
 				ComputeGallery: &infrav1.AzureComputeGalleryImage{
-					ResourceGroup:  pointer.String("my-resourcegroup"),
-					SubscriptionID: pointer.String("my-subscription-id"),
+					ResourceGroup:  ptr.To("my-resourcegroup"),
+					SubscriptionID: ptr.To("my-subscription-id"),
 					Gallery:        "my-gallery",
 					Name:           "my-image",
 					Version:        "my-version",
@@ -167,7 +167,7 @@ func Test_ComputeImageToSDK(t *testing.T) {
 			expect: func(g *GomegaWithT, result *compute.ImageReference, err error) {
 				g.Expect(err).Should(BeNil())
 				g.Expect(result).To(Equal(&compute.ImageReference{
-					ID: pointer.String("/subscriptions/my-subscription-id/resourceGroups/my-resourcegroup/providers/Microsoft.Compute/galleries/my-gallery/images/my-image/versions/my-version"),
+					ID: ptr.To("/subscriptions/my-subscription-id/resourceGroups/my-resourcegroup/providers/Microsoft.Compute/galleries/my-gallery/images/my-image/versions/my-version"),
 				}))
 			},
 		},
@@ -185,7 +185,7 @@ func Test_ComputeImageToSDK(t *testing.T) {
 			expect: func(g *GomegaWithT, result *compute.ImageReference, err error) {
 				g.Expect(err).Should(BeNil())
 				g.Expect(result).To(Equal(&compute.ImageReference{
-					ID: pointer.String("/subscriptions/my-subscription-id/resourceGroups/my-resourcegroup/providers/Microsoft.Compute/galleries/my-gallery/images/my-image/versions/my-version"),
+					ID: ptr.To("/subscriptions/my-subscription-id/resourceGroups/my-resourcegroup/providers/Microsoft.Compute/galleries/my-gallery/images/my-image/versions/my-version"),
 				}))
 			},
 		},
@@ -201,7 +201,7 @@ func Test_ComputeImageToSDK(t *testing.T) {
 			expect: func(g *GomegaWithT, result *compute.ImageReference, err error) {
 				g.Expect(err).Should(BeNil())
 				g.Expect(result).To(Equal(&compute.ImageReference{
-					CommunityGalleryImageID: pointer.String("/CommunityGalleries/my-gallery/Images/my-image/Versions/my-version"),
+					CommunityGalleryImageID: ptr.To("/CommunityGalleries/my-gallery/Images/my-image/Versions/my-version"),
 				}))
 			},
 		},

--- a/azure/converters/managedagentpool_test.go
+++ b/azure/converters/managedagentpool_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2022-03-01/containerservice"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
@@ -34,58 +34,58 @@ func Test_AgentPoolToManagedClusterAgentPoolProfile(t *testing.T) {
 		{
 			name: "Should set all values correctly",
 			pool: containerservice.AgentPool{
-				Name: pointer.String("agentpool1"),
+				Name: ptr.To("agentpool1"),
 				ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
-					VMSize:              pointer.String("Standard_D2s_v3"),
+					VMSize:              ptr.To("Standard_D2s_v3"),
 					OsType:              azure.LinuxOS,
-					OsDiskSizeGB:        pointer.Int32(100),
-					Count:               pointer.Int32(2),
+					OsDiskSizeGB:        ptr.To[int32](100),
+					Count:               ptr.To[int32](2),
 					Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
-					OrchestratorVersion: pointer.String("1.22.6"),
-					VnetSubnetID:        pointer.String("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-123/providers/Microsoft.Network/virtualNetworks/vnet-123/subnets/subnet-123"),
+					OrchestratorVersion: ptr.To("1.22.6"),
+					VnetSubnetID:        ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-123/providers/Microsoft.Network/virtualNetworks/vnet-123/subnets/subnet-123"),
 					Mode:                containerservice.AgentPoolModeUser,
-					EnableAutoScaling:   pointer.Bool(true),
-					MaxCount:            pointer.Int32(5),
-					MinCount:            pointer.Int32(2),
+					EnableAutoScaling:   ptr.To(true),
+					MaxCount:            ptr.To[int32](5),
+					MinCount:            ptr.To[int32](2),
 					NodeTaints:          &[]string{"key1=value1:NoSchedule"},
 					AvailabilityZones:   &[]string{"zone1"},
-					MaxPods:             pointer.Int32(60),
+					MaxPods:             ptr.To[int32](60),
 					OsDiskType:          containerservice.OSDiskTypeManaged,
 					NodeLabels: map[string]*string{
-						"custom": pointer.String("default"),
+						"custom": ptr.To("default"),
 					},
 					Tags: map[string]*string{
-						"custom": pointer.String("default"),
+						"custom": ptr.To("default"),
 					},
-					EnableFIPS: pointer.Bool(true),
+					EnableFIPS: ptr.To(true),
 				},
 			},
 
 			expect: func(g *GomegaWithT, result containerservice.ManagedClusterAgentPoolProfile) {
 				g.Expect(result).To(Equal(containerservice.ManagedClusterAgentPoolProfile{
-					Name:                pointer.String("agentpool1"),
-					VMSize:              pointer.String("Standard_D2s_v3"),
+					Name:                ptr.To("agentpool1"),
+					VMSize:              ptr.To("Standard_D2s_v3"),
 					OsType:              azure.LinuxOS,
-					OsDiskSizeGB:        pointer.Int32(100),
-					Count:               pointer.Int32(2),
+					OsDiskSizeGB:        ptr.To[int32](100),
+					Count:               ptr.To[int32](2),
 					Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
-					OrchestratorVersion: pointer.String("1.22.6"),
-					VnetSubnetID:        pointer.String("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-123/providers/Microsoft.Network/virtualNetworks/vnet-123/subnets/subnet-123"),
+					OrchestratorVersion: ptr.To("1.22.6"),
+					VnetSubnetID:        ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-123/providers/Microsoft.Network/virtualNetworks/vnet-123/subnets/subnet-123"),
 					Mode:                containerservice.AgentPoolModeUser,
-					EnableAutoScaling:   pointer.Bool(true),
-					MaxCount:            pointer.Int32(5),
-					MinCount:            pointer.Int32(2),
+					EnableAutoScaling:   ptr.To(true),
+					MaxCount:            ptr.To[int32](5),
+					MinCount:            ptr.To[int32](2),
 					NodeTaints:          &[]string{"key1=value1:NoSchedule"},
 					AvailabilityZones:   &[]string{"zone1"},
-					MaxPods:             pointer.Int32(60),
+					MaxPods:             ptr.To[int32](60),
 					OsDiskType:          containerservice.OSDiskTypeManaged,
 					NodeLabels: map[string]*string{
-						"custom": pointer.String("default"),
+						"custom": ptr.To("default"),
 					},
 					Tags: map[string]*string{
-						"custom": pointer.String("default"),
+						"custom": ptr.To("default"),
 					},
-					EnableFIPS: pointer.Bool(true),
+					EnableFIPS: ptr.To(true),
 				}))
 			},
 		},

--- a/azure/converters/publicips.go
+++ b/azure/converters/publicips.go
@@ -18,7 +18,7 @@ package converters
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -30,8 +30,8 @@ func IPTagsToSDK(ipTags []infrav1.IPTag) *[]network.IPTag {
 	skdIPTags := make([]network.IPTag, len(ipTags))
 	for i, ipTag := range ipTags {
 		skdIPTags[i] = network.IPTag{
-			IPTagType: pointer.String(ipTag.Type),
-			Tag:       pointer.String(ipTag.Tag),
+			IPTagType: ptr.To(ipTag.Type),
+			Tag:       ptr.To(ipTag.Tag),
 		}
 	}
 	return &skdIPTags

--- a/azure/converters/publicips_test.go
+++ b/azure/converters/publicips_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -50,12 +50,12 @@ func TestIPTagsToSDK(t *testing.T) {
 			},
 			want: &[]network.IPTag{
 				{
-					IPTagType: pointer.String("tag"),
-					Tag:       pointer.String("value"),
+					IPTagType: ptr.To("tag"),
+					Tag:       ptr.To("value"),
 				},
 				{
-					IPTagType: pointer.String("internal"),
-					Tag:       pointer.String("foo"),
+					IPTagType: ptr.To("internal"),
+					Tag:       ptr.To("foo"),
 				},
 			},
 		},

--- a/azure/converters/resourcehealth_test.go
+++ b/azure/converters/resourcehealth_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/resourcehealth/mgmt/2020-05-01/resourcehealth"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -55,8 +55,8 @@ func TestAzureAvailabilityStatusToCondition(t *testing.T) {
 			avail: resourcehealth.AvailabilityStatus{
 				Properties: &resourcehealth.AvailabilityStatusProperties{
 					AvailabilityState: resourcehealth.AvailabilityStateValuesUnavailable,
-					ReasonType:        pointer.String("this Is  a reason "),
-					Summary:           pointer.String("The Summary"),
+					ReasonType:        ptr.To("this Is  a reason "),
+					Summary:           ptr.To("The Summary"),
 				},
 			},
 			expected: &clusterv1.Condition{
@@ -71,8 +71,8 @@ func TestAzureAvailabilityStatusToCondition(t *testing.T) {
 			avail: resourcehealth.AvailabilityStatus{
 				Properties: &resourcehealth.AvailabilityStatusProperties{
 					AvailabilityState: resourcehealth.AvailabilityStateValuesDegraded,
-					ReasonType:        pointer.String("TheReason"),
-					Summary:           pointer.String("The Summary"),
+					ReasonType:        ptr.To("TheReason"),
+					Summary:           ptr.To("The Summary"),
 				},
 			},
 			expected: &clusterv1.Condition{

--- a/azure/converters/rules.go
+++ b/azure/converters/rules.go
@@ -18,22 +18,22 @@ package converters
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 // SecurityRuleToSDK converts a CAPZ security rule to an Azure network security rule.
 func SecurityRuleToSDK(rule infrav1.SecurityRule) network.SecurityRule {
 	secRule := network.SecurityRule{
-		Name: pointer.String(rule.Name),
+		Name: ptr.To(rule.Name),
 		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-			Description:              pointer.String(rule.Description),
+			Description:              ptr.To(rule.Description),
 			SourceAddressPrefix:      rule.Source,
 			SourcePortRange:          rule.SourcePorts,
 			DestinationAddressPrefix: rule.Destination,
 			DestinationPortRange:     rule.DestinationPorts,
 			Access:                   network.SecurityRuleAccessAllow,
-			Priority:                 pointer.Int32(rule.Priority),
+			Priority:                 ptr.To[int32](rule.Priority),
 		},
 	}
 

--- a/azure/converters/spotinstances_test.go
+++ b/azure/converters/spotinstances_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -75,7 +75,7 @@ func TestGetSpotVMOptions(t *testing.T) {
 				vmPriorityTypes:       compute.VirtualMachinePriorityTypesSpot,
 				vmEvictionPolicyTypes: "",
 				billingProfile: &compute.BillingProfile{
-					MaxPrice: pointer.Float64(1000),
+					MaxPrice: ptr.To[float64](1000),
 				},
 			},
 		},

--- a/azure/converters/subnets.go
+++ b/azure/converters/subnets.go
@@ -18,7 +18,7 @@ package converters
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
@@ -26,7 +26,7 @@ import (
 func GetSubnetAddresses(subnet network.Subnet) []string {
 	var addresses []string
 	if subnet.SubnetPropertiesFormat != nil && subnet.SubnetPropertiesFormat.AddressPrefix != nil {
-		addresses = []string{pointer.StringDeref(subnet.SubnetPropertiesFormat.AddressPrefix, "")}
+		addresses = []string{ptr.Deref(subnet.SubnetPropertiesFormat.AddressPrefix, "")}
 	} else if subnet.SubnetPropertiesFormat != nil && subnet.SubnetPropertiesFormat.AddressPrefixes != nil {
 		addresses = azure.StringSlice(subnet.SubnetPropertiesFormat.AddressPrefixes)
 	}

--- a/azure/converters/subnets_test.go
+++ b/azure/converters/subnets_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestGetSubnetAddresses(t *testing.T) {
@@ -39,7 +39,7 @@ func TestGetSubnetAddresses(t *testing.T) {
 			name: "subnet with single address prefix",
 			subnet: network.Subnet{
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-					AddressPrefix: pointer.String("test-address-prefix"),
+					AddressPrefix: ptr.To("test-address-prefix"),
 				},
 			},
 			want: []string{"test-address-prefix"},

--- a/azure/converters/tags.go
+++ b/azure/converters/tags.go
@@ -17,7 +17,7 @@ limitations under the License.
 package converters
 
 import (
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
@@ -31,7 +31,7 @@ func MapToTags(src map[string]*string) infrav1.Tags {
 	tags := make(infrav1.Tags, len(src))
 
 	for k, v := range src {
-		tags[k] = pointer.StringDeref(v, "")
+		tags[k] = ptr.Deref(v, "")
 	}
 
 	return tags

--- a/azure/converters/tags_test.go
+++ b/azure/converters/tags_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -39,7 +39,7 @@ func Test_TagsToMap(t *testing.T) {
 		},
 		{
 			tags:   infrav1.Tags{"env": "prod"},
-			expect: map[string]*string{"env": pointer.String("prod")},
+			expect: map[string]*string{"env": ptr.To("prod")},
 		},
 	}
 
@@ -68,7 +68,7 @@ func Test_MapToTags(t *testing.T) {
 			expect: infrav1.Tags{},
 		},
 		{
-			tags:   map[string]*string{"env": pointer.String("prod")},
+			tags:   map[string]*string{"env": ptr.To("prod")},
 			expect: infrav1.Tags{"env": "prod"},
 		},
 	}
@@ -134,8 +134,8 @@ func Test_MapToTagsMapRoundTrip(t *testing.T) {
 			expect: map[string]*string{},
 		},
 		{
-			tags:   map[string]*string{"env": pointer.String("prod")},
-			expect: map[string]*string{"env": pointer.String("prod")},
+			tags:   map[string]*string{"env": ptr.To("prod")},
+			expect: map[string]*string{"env": ptr.To("prod")},
 		},
 	}
 

--- a/azure/converters/vm.go
+++ b/azure/converters/vm.go
@@ -19,7 +19,7 @@ package converters
 import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
@@ -49,9 +49,9 @@ type VM struct {
 // SDKToVM converts an Azure SDK VirtualMachine to the CAPZ VM type.
 func SDKToVM(v compute.VirtualMachine) *VM {
 	vm := &VM{
-		ID:    pointer.StringDeref(v.ID, ""),
-		Name:  pointer.StringDeref(v.Name, ""),
-		State: infrav1.ProvisioningState(pointer.StringDeref(v.ProvisioningState, "")),
+		ID:    ptr.Deref(v.ID, ""),
+		Name:  ptr.Deref(v.Name, ""),
+		State: infrav1.ProvisioningState(ptr.Deref(v.ProvisioningState, "")),
 	}
 
 	if v.VirtualMachineProperties != nil && v.VirtualMachineProperties.HardwareProfile != nil {

--- a/azure/converters/vm_test.go
+++ b/azure/converters/vm_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -35,10 +35,10 @@ func TestSDKToVM(t *testing.T) {
 		{
 			name: "Basic conversion with required fields",
 			sdk: compute.VirtualMachine{
-				ID:   pointer.String("test-vm-id"),
-				Name: pointer.String("test-vm-name"),
+				ID:   ptr.To("test-vm-id"),
+				Name: ptr.To("test-vm-name"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
-					ProvisioningState: pointer.String("Succeeded"),
+					ProvisioningState: ptr.To("Succeeded"),
 				},
 			},
 			want: &VM{
@@ -50,10 +50,10 @@ func TestSDKToVM(t *testing.T) {
 		{
 			name: "Should convert and populate with VMSize",
 			sdk: compute.VirtualMachine{
-				ID:   pointer.String("test-vm-id"),
-				Name: pointer.String("test-vm-name"),
+				ID:   ptr.To("test-vm-id"),
+				Name: ptr.To("test-vm-name"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
-					ProvisioningState: pointer.String("Succeeded"),
+					ProvisioningState: ptr.To("Succeeded"),
 					HardwareProfile: &compute.HardwareProfile{
 						VMSize: compute.VirtualMachineSizeTypesStandardA1,
 					},
@@ -69,10 +69,10 @@ func TestSDKToVM(t *testing.T) {
 		{
 			name: "Should convert and populate with availability zones",
 			sdk: compute.VirtualMachine{
-				ID:   pointer.String("test-vm-id"),
-				Name: pointer.String("test-vm-name"),
+				ID:   ptr.To("test-vm-id"),
+				Name: ptr.To("test-vm-name"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
-					ProvisioningState: pointer.String("Succeeded"),
+					ProvisioningState: ptr.To("Succeeded"),
 				},
 				Zones: &[]string{"1", "2"},
 			},
@@ -86,12 +86,12 @@ func TestSDKToVM(t *testing.T) {
 		{
 			name: "Should convert and populate with tags",
 			sdk: compute.VirtualMachine{
-				ID:   pointer.String("test-vm-id"),
-				Name: pointer.String("test-vm-name"),
+				ID:   ptr.To("test-vm-id"),
+				Name: ptr.To("test-vm-name"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
-					ProvisioningState: pointer.String("Succeeded"),
+					ProvisioningState: ptr.To("Succeeded"),
 				},
-				Tags: map[string]*string{"foo": pointer.String("bar")},
+				Tags: map[string]*string{"foo": ptr.To("bar")},
 			},
 			want: &VM{
 				ID:    "test-vm-id",
@@ -103,16 +103,16 @@ func TestSDKToVM(t *testing.T) {
 		{
 			name: "Should convert and populate with all fields",
 			sdk: compute.VirtualMachine{
-				ID:   pointer.String("test-vm-id"),
-				Name: pointer.String("test-vm-name"),
+				ID:   ptr.To("test-vm-id"),
+				Name: ptr.To("test-vm-name"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
-					ProvisioningState: pointer.String("Succeeded"),
+					ProvisioningState: ptr.To("Succeeded"),
 					HardwareProfile: &compute.HardwareProfile{
 						VMSize: compute.VirtualMachineSizeTypesStandardA1,
 					},
 				},
 				Zones: &[]string{"1"},
-				Tags:  map[string]*string{"foo": pointer.String("bar")},
+				Tags:  map[string]*string{"foo": ptr.To("bar")},
 			},
 			want: &VM{
 				ID:               "test-vm-id",

--- a/azure/converters/vmss_test.go
+++ b/azure/converters/vmss_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -38,47 +38,47 @@ func Test_SDKToVMSS(t *testing.T) {
 			Name: "ShouldPopulateWithData",
 			SubjectFactory: func(g *gomega.GomegaWithT) (compute.VirtualMachineScaleSet, []compute.VirtualMachineScaleSetVM) {
 				tags := map[string]*string{
-					"foo": pointer.String("bazz"),
+					"foo": ptr.To("bazz"),
 				}
 				zones := []string{"zone0", "zone1"}
 				return compute.VirtualMachineScaleSet{
 						Sku: &compute.Sku{
-							Name:     pointer.String("skuName"),
-							Tier:     pointer.String("skuTier"),
-							Capacity: pointer.Int64(2),
+							Name:     ptr.To("skuName"),
+							Tier:     ptr.To("skuTier"),
+							Capacity: ptr.To[int64](2),
 						},
 						Zones:    &zones,
-						ID:       pointer.String("vmssID"),
-						Name:     pointer.String("vmssName"),
-						Location: pointer.String("westus2"),
+						ID:       ptr.To("vmssID"),
+						Name:     ptr.To("vmssName"),
+						Location: ptr.To("westus2"),
 						Tags:     tags,
 						VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-							SinglePlacementGroup: pointer.Bool(false),
-							ProvisioningState:    pointer.String(string(compute.ProvisioningState1Succeeded)),
+							SinglePlacementGroup: ptr.To(false),
+							ProvisioningState:    ptr.To(string(compute.ProvisioningState1Succeeded)),
 						},
 					},
 					[]compute.VirtualMachineScaleSetVM{
 						{
-							InstanceID: pointer.String("0"),
-							ID:         pointer.String("vm/0"),
-							Name:       pointer.String("vm0"),
+							InstanceID: ptr.To("0"),
+							ID:         ptr.To("vm/0"),
+							Name:       ptr.To("vm0"),
 							Zones:      &[]string{"zone0"},
 							VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-								ProvisioningState: pointer.String(string(compute.ProvisioningState1Succeeded)),
+								ProvisioningState: ptr.To(string(compute.ProvisioningState1Succeeded)),
 								OsProfile: &compute.OSProfile{
-									ComputerName: pointer.String("instance-000000"),
+									ComputerName: ptr.To("instance-000000"),
 								},
 							},
 						},
 						{
-							InstanceID: pointer.String("1"),
-							ID:         pointer.String("vm/1"),
-							Name:       pointer.String("vm1"),
+							InstanceID: ptr.To("1"),
+							ID:         ptr.To("vm/1"),
+							Name:       ptr.To("vm1"),
 							Zones:      &[]string{"zone1"},
 							VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-								ProvisioningState: pointer.String(string(compute.ProvisioningState1Succeeded)),
+								ProvisioningState: ptr.To(string(compute.ProvisioningState1Succeeded)),
 								OsProfile: &compute.OSProfile{
-									ComputerName: pointer.String("instance-000001"),
+									ComputerName: ptr.To("instance-000001"),
 								},
 							},
 						},
@@ -133,7 +133,7 @@ func Test_SDKToVMSSVM(t *testing.T) {
 		{
 			Name: "minimal VM",
 			SDKInstance: compute.VirtualMachineScaleSetVM{
-				ID: pointer.String("vm/0"),
+				ID: ptr.To("vm/0"),
 			},
 			VMSSVM: &azure.VMSSVM{
 				ID: "vm/0",
@@ -142,7 +142,7 @@ func Test_SDKToVMSSVM(t *testing.T) {
 		{
 			Name: "VM with nil properties",
 			SDKInstance: compute.VirtualMachineScaleSetVM{
-				ID:                                 pointer.String("vm/0.5"),
+				ID:                                 ptr.To("vm/0.5"),
 				VirtualMachineScaleSetVMProperties: nil,
 			},
 			VMSSVM: &azure.VMSSVM{
@@ -152,10 +152,10 @@ func Test_SDKToVMSSVM(t *testing.T) {
 		{
 			Name: "VM with state",
 			SDKInstance: compute.VirtualMachineScaleSetVM{
-				ID: pointer.String("/subscriptions/foo/resourceGroups/MY_RESOURCE_GROUP/providers/bar"),
+				ID: ptr.To("/subscriptions/foo/resourceGroups/MY_RESOURCE_GROUP/providers/bar"),
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					ProvisioningState: pointer.String(string(compute.ProvisioningState1Succeeded)),
-					OsProfile:         &compute.OSProfile{ComputerName: pointer.String("instance-000000")},
+					ProvisioningState: ptr.To(string(compute.ProvisioningState1Succeeded)),
+					OsProfile:         &compute.OSProfile{ComputerName: ptr.To("instance-000000")},
 				},
 			},
 			VMSSVM: &azure.VMSSVM{
@@ -167,12 +167,12 @@ func Test_SDKToVMSSVM(t *testing.T) {
 		{
 			Name: "VM with storage",
 			SDKInstance: compute.VirtualMachineScaleSetVM{
-				ID: pointer.String("/subscriptions/foo/resourceGroups/MY_RESOURCE_GROUP/providers/bar"),
+				ID: ptr.To("/subscriptions/foo/resourceGroups/MY_RESOURCE_GROUP/providers/bar"),
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: pointer.String("instance-000001")},
+					OsProfile: &compute.OSProfile{ComputerName: ptr.To("instance-000001")},
 					StorageProfile: &compute.StorageProfile{
 						ImageReference: &compute.ImageReference{
-							ID: pointer.String("imageID"),
+							ID: ptr.To("imageID"),
 						},
 					},
 				},
@@ -181,7 +181,7 @@ func Test_SDKToVMSSVM(t *testing.T) {
 				ID:   "/subscriptions/foo/resourceGroups/my_resource_group/providers/bar",
 				Name: "instance-000001",
 				Image: infrav1.Image{
-					ID: pointer.String("imageID"),
+					ID: ptr.To("imageID"),
 				},
 				State: "Creating",
 			},
@@ -189,9 +189,9 @@ func Test_SDKToVMSSVM(t *testing.T) {
 		{
 			Name: "VM with zones",
 			SDKInstance: compute.VirtualMachineScaleSetVM{
-				ID: pointer.String("/subscriptions/foo/resourceGroups/MY_RESOURCE_GROUP/providers/bar"),
+				ID: ptr.To("/subscriptions/foo/resourceGroups/MY_RESOURCE_GROUP/providers/bar"),
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: pointer.String("instance-000002")},
+					OsProfile: &compute.OSProfile{ComputerName: ptr.To("instance-000002")},
 				},
 				Zones: &[]string{"zone0", "zone1"},
 			},
@@ -224,20 +224,20 @@ func Test_SDKImageToImage(t *testing.T) {
 		{
 			Name: "id image",
 			SDKImageRef: &compute.ImageReference{
-				ID: pointer.String("imageID"),
+				ID: ptr.To("imageID"),
 			},
 			IsThirdParty: false,
 			Image: infrav1.Image{
-				ID: pointer.String("imageID"),
+				ID: ptr.To("imageID"),
 			},
 		},
 		{
 			Name: "marketplace image",
 			SDKImageRef: &compute.ImageReference{
-				Publisher: pointer.String("publisher"),
-				Offer:     pointer.String("offer"),
-				Sku:       pointer.String("sku"),
-				Version:   pointer.String("version"),
+				Publisher: ptr.To("publisher"),
+				Offer:     ptr.To("offer"),
+				Sku:       ptr.To("sku"),
+				Version:   ptr.To("version"),
 			},
 			IsThirdParty: true,
 			Image: infrav1.Image{
@@ -255,7 +255,7 @@ func Test_SDKImageToImage(t *testing.T) {
 		{
 			Name: "shared gallery image",
 			SDKImageRef: &compute.ImageReference{
-				SharedGalleryImageID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/galleries/gallery/images/image/versions/version"),
+				SharedGalleryImageID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/galleries/gallery/images/image/versions/version"),
 			},
 			Image: infrav1.Image{
 				SharedGallery: &infrav1.AzureSharedGalleryImage{
@@ -270,7 +270,7 @@ func Test_SDKImageToImage(t *testing.T) {
 		{
 			Name: "community gallery image",
 			SDKImageRef: &compute.ImageReference{
-				CommunityGalleryImageID: pointer.String("/CommunityGalleries/gallery/Images/image/Versions/version"),
+				CommunityGalleryImageID: ptr.To("/CommunityGalleries/gallery/Images/image/Versions/version"),
 			},
 			Image: infrav1.Image{
 				ComputeGallery: &infrav1.AzureComputeGalleryImage{
@@ -283,31 +283,31 @@ func Test_SDKImageToImage(t *testing.T) {
 		{
 			Name: "compute gallery image",
 			SDKImageRef: &compute.ImageReference{
-				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/galleries/gallery/images/image/versions/version"),
+				ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/galleries/gallery/images/image/versions/version"),
 			},
 			Image: infrav1.Image{
 				ComputeGallery: &infrav1.AzureComputeGalleryImage{
 					Gallery:        "gallery",
 					Name:           "image",
 					Version:        "version",
-					SubscriptionID: pointer.String("subscription"),
-					ResourceGroup:  pointer.String("rg"),
+					SubscriptionID: ptr.To("subscription"),
+					ResourceGroup:  ptr.To("rg"),
 				},
 			},
 		},
 		{
 			Name: "compute gallery image not formatted as expected",
 			SDKImageRef: &compute.ImageReference{
-				ID: pointer.String("/compute/gallery/not/formatted/as/expected"),
+				ID: ptr.To("/compute/gallery/not/formatted/as/expected"),
 			},
 			Image: infrav1.Image{
-				ID: pointer.String("/compute/gallery/not/formatted/as/expected"),
+				ID: ptr.To("/compute/gallery/not/formatted/as/expected"),
 			},
 		},
 		{
 			Name: "community gallery image not formatted as expected",
 			SDKImageRef: &compute.ImageReference{
-				CommunityGalleryImageID: pointer.String("/community/gallery/not/formatted/as/expected"),
+				CommunityGalleryImageID: ptr.To("/community/gallery/not/formatted/as/expected"),
 			},
 			Image: infrav1.Image{},
 		},
@@ -332,7 +332,7 @@ func Test_SDKVMToVMSSVM(t *testing.T) {
 		{
 			Name: "minimal VM",
 			Subject: compute.VirtualMachine{
-				ID: pointer.String("vmID1"),
+				ID: ptr.To("vmID1"),
 			},
 			Expected: &azure.VMSSVM{
 				ID: "vmID1",
@@ -341,10 +341,10 @@ func Test_SDKVMToVMSSVM(t *testing.T) {
 		{
 			Name: "VM with zones",
 			Subject: compute.VirtualMachine{
-				ID: pointer.String("vmID2"),
+				ID: ptr.To("vmID2"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					OsProfile: &compute.OSProfile{
-						ComputerName: pointer.String("vmwithzones"),
+						ComputerName: ptr.To("vmwithzones"),
 					},
 				},
 				Zones: &[]string{"zone0", "zone1"},
@@ -359,14 +359,14 @@ func Test_SDKVMToVMSSVM(t *testing.T) {
 		{
 			Name: "VM with storage",
 			Subject: compute.VirtualMachine{
-				ID: pointer.String("vmID3"),
+				ID: ptr.To("vmID3"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					OsProfile: &compute.OSProfile{
-						ComputerName: pointer.String("vmwithstorage"),
+						ComputerName: ptr.To("vmwithstorage"),
 					},
 					StorageProfile: &compute.StorageProfile{
 						ImageReference: &compute.ImageReference{
-							ID: pointer.String("imageID"),
+							ID: ptr.To("imageID"),
 						},
 					},
 				},
@@ -374,7 +374,7 @@ func Test_SDKVMToVMSSVM(t *testing.T) {
 			Expected: &azure.VMSSVM{
 				ID: "vmID3",
 				Image: infrav1.Image{
-					ID: pointer.String("imageID"),
+					ID: ptr.To("imageID"),
 				},
 				Name:  "vmwithstorage",
 				State: "Creating",
@@ -383,12 +383,12 @@ func Test_SDKVMToVMSSVM(t *testing.T) {
 		{
 			Name: "VM with provisioning state",
 			Subject: compute.VirtualMachine{
-				ID: pointer.String("vmID4"),
+				ID: ptr.To("vmID4"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					OsProfile: &compute.OSProfile{
-						ComputerName: pointer.String("vmwithstate"),
+						ComputerName: ptr.To("vmwithstate"),
 					},
-					ProvisioningState: pointer.String("Succeeded"),
+					ProvisioningState: ptr.To("Succeeded"),
 				},
 			},
 			Expected: &azure.VMSSVM{

--- a/azure/pointers.go
+++ b/azure/pointers.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package azure
 
-import "k8s.io/utils/pointer"
+import "k8s.io/utils/ptr"
 
 // StringSlice returns a string slice value for the passed string slice pointer. It returns a nil
 // slice if the pointer is nil.
@@ -34,7 +34,7 @@ func StringMapPtr(m map[string]string) map[string]*string {
 	}
 	msp := make(map[string]*string, len(m))
 	for k, v := range m {
-		msp[k] = pointer.String(v)
+		msp[k] = ptr.To(v)
 	}
 	return msp
 }

--- a/azure/pointers_test.go
+++ b/azure/pointers_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestStringSlice(t *testing.T) {
@@ -64,7 +64,7 @@ func TestStringMapPtr(t *testing.T) {
 		{
 			Name:     "Should convert to a map[string]*string",
 			Arg:      map[string]string{"foo": "baz", "bar": "qux"},
-			Expected: map[string]*string{"foo": pointer.String("baz"), "bar": pointer.String("qux")},
+			Expected: map[string]*string{"foo": ptr.To("baz"), "bar": ptr.To("qux")},
 		},
 	}
 	for _, tc := range cases {

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/net"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asogroups"
@@ -577,10 +577,10 @@ func (s *ClusterScope) Vnet() *infrav1.VnetSpec {
 // IsVnetManaged returns true if the vnet is managed.
 func (s *ClusterScope) IsVnetManaged() bool {
 	if s.cache.isVnetManaged != nil {
-		return pointer.BoolDeref(s.cache.isVnetManaged, false)
+		return ptr.Deref(s.cache.isVnetManaged, false)
 	}
 	isVnetManaged := s.Vnet().ID == "" || s.Vnet().Tags.HasOwned(s.ClusterName())
-	s.cache.isVnetManaged = pointer.Bool(isVnetManaged)
+	s.cache.isVnetManaged = ptr.To(isVnetManaged)
 	return isVnetManaged
 }
 
@@ -919,10 +919,10 @@ func (s *ClusterScope) SetControlPlaneSecurityRules() {
 				Priority:         2200,
 				Protocol:         infrav1.SecurityGroupProtocolTCP,
 				Direction:        infrav1.SecurityRuleDirectionInbound,
-				Source:           pointer.String("*"),
-				SourcePorts:      pointer.String("*"),
-				Destination:      pointer.String("*"),
-				DestinationPorts: pointer.String("22"),
+				Source:           ptr.To("*"),
+				SourcePorts:      ptr.To("*"),
+				Destination:      ptr.To("*"),
+				DestinationPorts: ptr.To("22"),
 			},
 			infrav1.SecurityRule{
 				Name:             "allow_apiserver",
@@ -930,10 +930,10 @@ func (s *ClusterScope) SetControlPlaneSecurityRules() {
 				Priority:         2201,
 				Protocol:         infrav1.SecurityGroupProtocolTCP,
 				Direction:        infrav1.SecurityRuleDirectionInbound,
-				Source:           pointer.String("*"),
-				SourcePorts:      pointer.String("*"),
-				Destination:      pointer.String("*"),
-				DestinationPorts: pointer.String(strconv.Itoa(int(s.APIServerPort()))),
+				Source:           ptr.To("*"),
+				SourcePorts:      ptr.To("*"),
+				Destination:      ptr.To("*"),
+				DestinationPorts: ptr.To(strconv.Itoa(int(s.APIServerPort()))),
 			},
 		}
 		s.AzureCluster.Spec.NetworkSpec.UpdateControlPlaneSubnet(subnet)

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/bastionhosts"
@@ -327,7 +327,7 @@ func TestPublicIPSpecs(t *testing.T) {
 					},
 					NetworkSpec: infrav1.NetworkSpec{
 						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
-							FrontendIPsCount: pointer.Int32(0),
+							FrontendIPsCount: ptr.To[int32](0),
 						},
 						APIServerLB: infrav1.LoadBalancerSpec{
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
@@ -371,7 +371,7 @@ func TestPublicIPSpecs(t *testing.T) {
 					},
 					NetworkSpec: infrav1.NetworkSpec{
 						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
-							FrontendIPsCount: pointer.Int32(1),
+							FrontendIPsCount: ptr.To[int32](1),
 							FrontendIPs: []infrav1.FrontendIP{
 								{
 									Name: "my-frontend-ip",
@@ -438,7 +438,7 @@ func TestPublicIPSpecs(t *testing.T) {
 					},
 					NetworkSpec: infrav1.NetworkSpec{
 						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
-							FrontendIPsCount: pointer.Int32(3),
+							FrontendIPsCount: ptr.To[int32](3),
 							FrontendIPs: []infrav1.FrontendIP{
 								{
 									Name: "my-frontend-ip-1",
@@ -1499,7 +1499,7 @@ func TestIsVnetManaged(t *testing.T) {
 					Spec: infrav1.AzureClusterSpec{},
 				},
 				cache: &ClusterCache{
-					isVnetManaged: pointer.Bool(false),
+					isVnetManaged: ptr.To(false),
 				},
 			},
 			want: false,
@@ -1511,7 +1511,7 @@ func TestIsVnetManaged(t *testing.T) {
 					Spec: infrav1.AzureClusterSpec{},
 				},
 				cache: &ClusterCache{
-					isVnetManaged: pointer.Bool(true),
+					isVnetManaged: ptr.To(true),
 				},
 			},
 			want: true,
@@ -1526,8 +1526,8 @@ func TestIsVnetManaged(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("IsVnetManaged() = \n%t, want \n%t", got, tt.want)
 			}
-			if pointer.BoolDeref(tt.clusterScope.cache.isVnetManaged, false) != got {
-				t.Errorf("IsVnetManaged() = \n%t, cache = \n%t", got, pointer.BoolDeref(tt.clusterScope.cache.isVnetManaged, false))
+			if ptr.Deref(tt.clusterScope.cache.isVnetManaged, false) != got {
+				t.Errorf("IsVnetManaged() = \n%t, cache = \n%t", got, ptr.Deref(tt.clusterScope.cache.isVnetManaged, false))
 			}
 		})
 	}
@@ -2553,7 +2553,7 @@ func TestAPIServerPort(t *testing.T) {
 			name:        "Non nil cluster network and non nil apiserverport",
 			clusterName: "my-cluster",
 			clusterNetowrk: &clusterv1.ClusterNetwork{
-				APIServerPort: pointer.Int32(7000),
+				APIServerPort: ptr.To[int32](7000),
 			},
 			expectAPIServerPort: 7000,
 		},
@@ -2741,7 +2741,7 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 							},
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 								Type:                 infrav1.Public,
-								IdleTimeoutInMinutes: pointer.Int32(30),
+								IdleTimeoutInMinutes: ptr.To[int32](30),
 								SKU:                  infrav1.SKUStandard,
 							},
 							FrontendIPs: []infrav1.FrontendIP{
@@ -2760,7 +2760,7 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 							},
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 								Type:                 infrav1.Public,
-								IdleTimeoutInMinutes: pointer.Int32(15),
+								IdleTimeoutInMinutes: ptr.To[int32](15),
 								SKU:                  infrav1.SKUStandard,
 							},
 							FrontendIPs: []infrav1.FrontendIP{
@@ -2779,7 +2779,7 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 							},
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 								Type:                 infrav1.Public,
-								IdleTimeoutInMinutes: pointer.Int32(50),
+								IdleTimeoutInMinutes: ptr.To[int32](50),
 								SKU:                  infrav1.SKUStandard,
 							},
 							FrontendIPs: []infrav1.FrontendIP{
@@ -2817,7 +2817,7 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 					SKU:                  infrav1.SKUStandard,
 					Role:                 infrav1.APIServerRole,
 					BackendPoolName:      "api-server-lb-backend-pool",
-					IdleTimeoutInMinutes: pointer.Int32(30),
+					IdleTimeoutInMinutes: ptr.To[int32](30),
 					AdditionalTags: infrav1.Tags{
 						"foo": "bar",
 					},
@@ -2842,7 +2842,7 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 					SKU:                  infrav1.SKUStandard,
 					Role:                 infrav1.NodeOutboundRole,
 					BackendPoolName:      "node-outbound-backend-pool",
-					IdleTimeoutInMinutes: pointer.Int32(50),
+					IdleTimeoutInMinutes: ptr.To[int32](50),
 					AdditionalTags: infrav1.Tags{
 						"foo": "bar",
 					},
@@ -2866,7 +2866,7 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 					Type:                 infrav1.Public,
 					SKU:                  infrav1.SKUStandard,
 					BackendPoolName:      "cp-outbound-backend-pool",
-					IdleTimeoutInMinutes: pointer.Int32(15),
+					IdleTimeoutInMinutes: ptr.To[int32](15),
 					Role:                 infrav1.ControlPlaneOutboundRole,
 					AdditionalTags: infrav1.Tags{
 						"foo": "bar",
@@ -2912,7 +2912,7 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 							},
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 								Type:                 infrav1.Internal,
-								IdleTimeoutInMinutes: pointer.Int32(30),
+								IdleTimeoutInMinutes: ptr.To[int32](30),
 								SKU:                  infrav1.SKUStandard,
 							},
 						},
@@ -2934,7 +2934,7 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 					SKU:                  infrav1.SKUStandard,
 					Role:                 infrav1.APIServerRole,
 					BackendPoolName:      "api-server-lb-backend-pool",
-					IdleTimeoutInMinutes: pointer.Int32(30),
+					IdleTimeoutInMinutes: ptr.To[int32](30),
 					AdditionalTags:       infrav1.Tags{},
 				},
 			},
@@ -3195,14 +3195,14 @@ func TestVNetPeerings(t *testing.T) {
 							ResourceGroup:  "rg2",
 							RemoteVnetName: "vnet2",
 							ForwardPeeringProperties: infrav1.VnetPeeringProperties{
-								AllowForwardedTraffic: pointer.Bool(true),
-								AllowGatewayTransit:   pointer.Bool(false),
-								UseRemoteGateways:     pointer.Bool(true),
+								AllowForwardedTraffic: ptr.To(true),
+								AllowGatewayTransit:   ptr.To(false),
+								UseRemoteGateways:     ptr.To(true),
 							},
 							ReversePeeringProperties: infrav1.VnetPeeringProperties{
-								AllowForwardedTraffic: pointer.Bool(true),
-								AllowGatewayTransit:   pointer.Bool(true),
-								UseRemoteGateways:     pointer.Bool(false),
+								AllowForwardedTraffic: ptr.To(true),
+								AllowGatewayTransit:   ptr.To(true),
+								UseRemoteGateways:     ptr.To(false),
 							},
 						},
 					},
@@ -3216,9 +3216,9 @@ func TestVNetPeerings(t *testing.T) {
 					RemoteResourceGroup:   "rg2",
 					RemoteVnetName:        "vnet2",
 					SubscriptionID:        fakeSubscriptionID,
-					AllowForwardedTraffic: pointer.Bool(true),
-					AllowGatewayTransit:   pointer.Bool(false),
-					UseRemoteGateways:     pointer.Bool(true),
+					AllowForwardedTraffic: ptr.To(true),
+					AllowGatewayTransit:   ptr.To(false),
+					UseRemoteGateways:     ptr.To(true),
 				},
 				&vnetpeerings.VnetPeeringSpec{
 					PeeringName:           "vnet2-To-vnet1",
@@ -3227,9 +3227,9 @@ func TestVNetPeerings(t *testing.T) {
 					RemoteResourceGroup:   "rg1",
 					RemoteVnetName:        "vnet1",
 					SubscriptionID:        fakeSubscriptionID,
-					AllowForwardedTraffic: pointer.Bool(true),
-					AllowGatewayTransit:   pointer.Bool(true),
-					UseRemoteGateways:     pointer.Bool(false),
+					AllowForwardedTraffic: ptr.To(true),
+					AllowGatewayTransit:   ptr.To(true),
+					UseRemoteGateways:     ptr.To(false),
 				},
 			},
 		},
@@ -3245,14 +3245,14 @@ func TestVNetPeerings(t *testing.T) {
 							ResourceGroup:  "rg2",
 							RemoteVnetName: "vnet2",
 							ForwardPeeringProperties: infrav1.VnetPeeringProperties{
-								AllowForwardedTraffic: pointer.Bool(true),
-								AllowGatewayTransit:   pointer.Bool(false),
-								UseRemoteGateways:     pointer.Bool(true),
+								AllowForwardedTraffic: ptr.To(true),
+								AllowGatewayTransit:   ptr.To(false),
+								UseRemoteGateways:     ptr.To(true),
 							},
 							ReversePeeringProperties: infrav1.VnetPeeringProperties{
-								AllowForwardedTraffic: pointer.Bool(true),
-								AllowGatewayTransit:   pointer.Bool(true),
-								UseRemoteGateways:     pointer.Bool(false),
+								AllowForwardedTraffic: ptr.To(true),
+								AllowGatewayTransit:   ptr.To(true),
+								UseRemoteGateways:     ptr.To(false),
 							},
 						},
 					},
@@ -3272,9 +3272,9 @@ func TestVNetPeerings(t *testing.T) {
 					RemoteResourceGroup:   "rg2",
 					RemoteVnetName:        "vnet2",
 					SubscriptionID:        fakeSubscriptionID,
-					AllowForwardedTraffic: pointer.Bool(true),
-					AllowGatewayTransit:   pointer.Bool(false),
-					UseRemoteGateways:     pointer.Bool(true),
+					AllowForwardedTraffic: ptr.To(true),
+					AllowGatewayTransit:   ptr.To(false),
+					UseRemoteGateways:     ptr.To(true),
 				},
 				&vnetpeerings.VnetPeeringSpec{
 					PeeringName:           "vnet2-To-vnet1",
@@ -3283,9 +3283,9 @@ func TestVNetPeerings(t *testing.T) {
 					RemoteResourceGroup:   "rg1",
 					RemoteVnetName:        "vnet1",
 					SubscriptionID:        fakeSubscriptionID,
-					AllowForwardedTraffic: pointer.Bool(true),
-					AllowGatewayTransit:   pointer.Bool(true),
-					UseRemoteGateways:     pointer.Bool(false),
+					AllowForwardedTraffic: ptr.To(true),
+					AllowGatewayTransit:   ptr.To(true),
+					UseRemoteGateways:     ptr.To(false),
 				},
 				&vnetpeerings.VnetPeeringSpec{
 					PeeringName:         "vnet1-To-vnet3",

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/availabilitysets"
@@ -220,7 +220,7 @@ func (m *MachineScope) InboundNatSpecs() []azure.ResourceSpecGetter {
 		if frontEndIPs := m.APIServerLB().FrontendIPs; len(frontEndIPs) > 0 {
 			ipConfig := frontEndIPs[0].Name
 			id := azure.FrontendIPConfigID(m.SubscriptionID(), m.ResourceGroup(), m.APIServerLBName(), ipConfig)
-			spec.FrontendIPConfigurationID = pointer.String(id)
+			spec.FrontendIPConfigurationID = ptr.To(id)
 		}
 
 		return []azure.ResourceSpecGetter{spec}
@@ -458,7 +458,7 @@ func (m *MachineScope) GetVMID() string {
 
 // ProviderID returns the AzureMachine providerID from the spec.
 func (m *MachineScope) ProviderID() string {
-	return pointer.StringDeref(m.AzureMachine.Spec.ProviderID, "")
+	return ptr.Deref(m.AzureMachine.Spec.ProviderID, "")
 }
 
 // AvailabilitySetSpec returns the availability set spec for this machine if available.
@@ -543,7 +543,7 @@ func (m *MachineScope) SystemAssignedIdentityDefinitionID() string {
 
 // SetProviderID sets the AzureMachine providerID in spec.
 func (m *MachineScope) SetProviderID(v string) {
-	m.AzureMachine.Spec.ProviderID = pointer.String(v)
+	m.AzureMachine.Spec.ProviderID = ptr.To(v)
 }
 
 // VMState returns the AzureMachine VM state.
@@ -571,7 +571,7 @@ func (m *MachineScope) SetNotReady() {
 
 // SetFailureMessage sets the AzureMachine status failure message.
 func (m *MachineScope) SetFailureMessage(v error) {
-	m.AzureMachine.Status.FailureMessage = pointer.String(v.Error())
+	m.AzureMachine.Status.FailureMessage = ptr.To(v.Error())
 }
 
 // SetFailureReason sets the AzureMachine status failure reason.
@@ -695,11 +695,11 @@ func (m *MachineScope) GetVMImage(ctx context.Context) (*infrav1.Image, error) {
 		runtime := m.AzureMachine.Annotations["runtime"]
 		windowsServerVersion := m.AzureMachine.Annotations["windowsServerVersion"]
 		log.Info("No image specified for machine, using default Windows Image", "machine", m.AzureMachine.GetName(), "runtime", runtime, "windowsServerVersion", windowsServerVersion)
-		return svc.GetDefaultWindowsImage(ctx, m.Location(), pointer.StringDeref(m.Machine.Spec.Version, ""), runtime, windowsServerVersion)
+		return svc.GetDefaultWindowsImage(ctx, m.Location(), ptr.Deref(m.Machine.Spec.Version, ""), runtime, windowsServerVersion)
 	}
 
 	log.Info("No image specified for machine, using default Linux Image", "machine", m.AzureMachine.GetName())
-	return svc.GetDefaultUbuntuImage(ctx, m.Location(), pointer.StringDeref(m.Machine.Spec.Version, ""))
+	return svc.GetDefaultUbuntuImage(ctx, m.Location(), ptr.Deref(m.Machine.Spec.Version, ""))
 }
 
 // SetSubnetName defaults the AzureMachine subnet name to the name of one the subnets with the machine role when there is only one of them.

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
@@ -58,7 +58,7 @@ func TestMachineScope_Name(t *testing.T) {
 						Name: "machine-with-a-long-name",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID: pointer.String("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
+						ProviderID: ptr.To("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
 						OSDisk: infrav1.OSDisk{
 							OSType: "Windows",
 						},
@@ -164,7 +164,7 @@ func TestMachineScope_GetVMID(t *testing.T) {
 						Name: "not-this-name",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID: pointer.String("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
+						ProviderID: ptr.To("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
 					},
 				},
 			},
@@ -178,7 +178,7 @@ func TestMachineScope_GetVMID(t *testing.T) {
 						Name: "machine-name",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID: pointer.String("foo"),
+						ProviderID: ptr.To("foo"),
 					},
 				},
 			},
@@ -209,7 +209,7 @@ func TestMachineScope_ProviderID(t *testing.T) {
 						Name: "not-this-name",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID: pointer.String("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
+						ProviderID: ptr.To("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
 					},
 				},
 			},
@@ -223,7 +223,7 @@ func TestMachineScope_ProviderID(t *testing.T) {
 						Name: "machine-name",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID: pointer.String(""),
+						ProviderID: ptr.To(""),
 					},
 				},
 			},
@@ -402,7 +402,7 @@ func TestMachineScope_InboundNatSpecs(t *testing.T) {
 					Name:                      "machine-name",
 					LoadBalancerName:          "foo-loadbalancer",
 					ResourceGroup:             "my-rg",
-					FrontendIPConfigurationID: pointer.String(azure.FrontendIPConfigID("123", "my-rg", "foo-loadbalancer", "foo-frontend-ip")),
+					FrontendIPConfigurationID: ptr.To(azure.FrontendIPConfigID("123", "my-rg", "foo-loadbalancer", "foo-frontend-ip")),
 				},
 			},
 		},
@@ -475,7 +475,7 @@ func TestMachineScope_RoleAssignmentSpecs(t *testing.T) {
 					MachineName:   "machine-name",
 					Name:          "azure-role-assignment-name",
 					ResourceGroup: "my-rg",
-					PrincipalID:   pointer.String("fakePrincipalID"),
+					PrincipalID:   ptr.To("fakePrincipalID"),
 				},
 			},
 		},
@@ -522,14 +522,14 @@ func TestMachineScope_RoleAssignmentSpecs(t *testing.T) {
 					ResourceGroup:    "my-rg",
 					Scope:            "/subscriptions/123/resourceGroups/my-rg",
 					RoleDefinitionID: "/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Authorization/roleAssignments/123",
-					PrincipalID:      pointer.String("fakePrincipalID"),
+					PrincipalID:      ptr.To("fakePrincipalID"),
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.machineScope.RoleAssignmentSpecs(pointer.String("fakePrincipalID")); !reflect.DeepEqual(got, tt.want) {
+			if got := tt.machineScope.RoleAssignmentSpecs(ptr.To("fakePrincipalID")); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("RoleAssignmentSpecs() = %v, want %v", got, tt.want)
 			}
 		})
@@ -1008,7 +1008,7 @@ func TestMachineScope_AvailabilityZone(t *testing.T) {
 			machineScope: MachineScope{
 				Machine: &clusterv1.Machine{
 					Spec: clusterv1.MachineSpec{
-						FailureDomain: pointer.String("dummy-failure-domain-from-machine-spec"),
+						FailureDomain: ptr.To("dummy-failure-domain-from-machine-spec"),
 					},
 				},
 				AzureMachine: &infrav1.AzureMachine{
@@ -1016,7 +1016,7 @@ func TestMachineScope_AvailabilityZone(t *testing.T) {
 						Name: "machine-name",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						FailureDomain: pointer.String("dummy-failure-domain-from-azuremachine-spec"),
+						FailureDomain: ptr.To("dummy-failure-domain-from-azuremachine-spec"),
 					},
 				},
 			},
@@ -1033,7 +1033,7 @@ func TestMachineScope_AvailabilityZone(t *testing.T) {
 						Name: "machine-name",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						FailureDomain: pointer.String("dummy-failure-domain-from-azuremachine-spec"),
+						FailureDomain: ptr.To("dummy-failure-domain-from-azuremachine-spec"),
 					},
 				},
 			},
@@ -1418,13 +1418,13 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 					},
 					Spec: infrav1.AzureMachineSpec{
 						Image: &infrav1.Image{
-							ID: pointer.String("1"),
+							ID: ptr.To("1"),
 						},
 					},
 				},
 			},
 			want: &infrav1.Image{
-				ID: pointer.String("1"),
+				ID: ptr.To("1"),
 			},
 			expectedErr: "",
 		},
@@ -1436,7 +1436,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 						Name: "machine-name",
 					},
 					Spec: clusterv1.MachineSpec{
-						Version: pointer.String("1.20.1"),
+						Version: ptr.To("1.20.1"),
 					},
 				},
 				AzureMachine: &infrav1.AzureMachine{
@@ -1465,7 +1465,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 						Name: "machine-name",
 					},
 					Spec: clusterv1.MachineSpec{
-						Version: pointer.String("1.22.1"),
+						Version: ptr.To("1.22.1"),
 					},
 				},
 				AzureMachine: &infrav1.AzureMachine{
@@ -1494,7 +1494,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 						Name: "machine-name",
 					},
 					Spec: clusterv1.MachineSpec{
-						Version: pointer.String("1.22.1"),
+						Version: ptr.To("1.22.1"),
 					},
 				},
 				AzureMachine: &infrav1.AzureMachine{
@@ -1526,7 +1526,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 						Name: "machine-name",
 					},
 					Spec: clusterv1.MachineSpec{
-						Version: pointer.String("1.21.1"),
+						Version: ptr.To("1.21.1"),
 					},
 				},
 				AzureMachine: &infrav1.AzureMachine{
@@ -1558,7 +1558,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 						Name: "machine-name",
 					},
 					Spec: clusterv1.MachineSpec{
-						Version: pointer.String("1.21.1"),
+						Version: ptr.To("1.21.1"),
 					},
 				},
 				AzureMachine: &infrav1.AzureMachine{
@@ -1587,7 +1587,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 						Name: "machine-name",
 					},
 					Spec: clusterv1.MachineSpec{
-						Version: pointer.String("1.23.3"),
+						Version: ptr.To("1.23.3"),
 					},
 				},
 				AzureMachine: &infrav1.AzureMachine{
@@ -1619,7 +1619,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 						Name: "machine-name",
 					},
 					Spec: clusterv1.MachineSpec{
-						Version: pointer.String("1.23.3"),
+						Version: ptr.To("1.23.3"),
 					},
 				},
 				AzureMachine: &infrav1.AzureMachine{
@@ -1651,7 +1651,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 						Name: "machine-name",
 					},
 					Spec: clusterv1.MachineSpec{
-						Version: pointer.String("1.20.1"),
+						Version: ptr.To("1.20.1"),
 					},
 				},
 				AzureMachine: &infrav1.AzureMachine{
@@ -1749,7 +1749,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						Name: "machine",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID: pointer.String("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
+						ProviderID: ptr.To("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
 						NetworkInterfaces: []infrav1.NetworkInterface{{
 							SubnetName:       "subnet1",
 							PrivateIPConfigs: 1,
@@ -1856,7 +1856,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						Name: "machine",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID: pointer.String("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
+						ProviderID: ptr.To("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
 						NetworkInterfaces: []infrav1.NetworkInterface{{
 							SubnetName:       "subnet1",
 							PrivateIPConfigs: 1,
@@ -1873,7 +1873,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 				},
 				cache: &MachineCache{
 					VMSKU: resourceskus.SKU{
-						Name: pointer.String("Standard_D2v2"),
+						Name: ptr.To("Standard_D2v2"),
 					},
 				},
 			},
@@ -1899,7 +1899,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 					IPv6Enabled:               false,
 					EnableIPForwarding:        false,
 					SKU: &resourceskus.SKU{
-						Name: pointer.String("Standard_D2v2"),
+						Name: ptr.To("Standard_D2v2"),
 					},
 					ClusterName: "cluster",
 					AdditionalTags: infrav1.Tags{
@@ -1972,7 +1972,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						Name: "machine",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID: pointer.String("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
+						ProviderID: ptr.To("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
 						NetworkInterfaces: []infrav1.NetworkInterface{{
 							SubnetName:       "subnet1",
 							PrivateIPConfigs: 1,
@@ -2076,7 +2076,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						Name: "machine",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID: pointer.String("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
+						ProviderID: ptr.To("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
 						NetworkInterfaces: []infrav1.NetworkInterface{{
 							SubnetName:       "subnet1",
 							PrivateIPConfigs: 1,
@@ -2190,7 +2190,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						Name: "machine",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID: pointer.String("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
+						ProviderID: ptr.To("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
 						NetworkInterfaces: []infrav1.NetworkInterface{{
 							SubnetName:       "subnet1",
 							PrivateIPConfigs: 1,
@@ -2300,7 +2300,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						Name: "machine",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID: pointer.String("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
+						ProviderID: ptr.To("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
 						NetworkInterfaces: []infrav1.NetworkInterface{{
 							SubnetName:       "subnet1",
 							PrivateIPConfigs: 1,
@@ -2410,7 +2410,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						Name: "machine",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID: pointer.String("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
+						ProviderID: ptr.To("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
 						NetworkInterfaces: []infrav1.NetworkInterface{{
 							SubnetName:       "subnet1",
 							PrivateIPConfigs: 1,
@@ -2521,16 +2521,16 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						Name: "machine",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID: pointer.String("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
+						ProviderID: ptr.To("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
 						NetworkInterfaces: []infrav1.NetworkInterface{
 							{
 								SubnetName:            "subnet1",
-								AcceleratedNetworking: pointer.Bool(true),
+								AcceleratedNetworking: ptr.To(true),
 								PrivateIPConfigs:      1,
 							},
 							{
 								SubnetName:            "subnet2",
-								AcceleratedNetworking: pointer.Bool(true),
+								AcceleratedNetworking: ptr.To(true),
 								PrivateIPConfigs:      2,
 							},
 						},
@@ -2560,7 +2560,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 					InternalLBName:            "",
 					InternalLBAddressPoolName: "",
 					PublicIPName:              "",
-					AcceleratedNetworking:     pointer.Bool(true),
+					AcceleratedNetworking:     ptr.To(true),
 					IPv6Enabled:               false,
 					EnableIPForwarding:        false,
 					SKU:                       nil,
@@ -2585,7 +2585,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 					InternalLBName:            "",
 					InternalLBAddressPoolName: "",
 					PublicIPName:              "",
-					AcceleratedNetworking:     pointer.Bool(true),
+					AcceleratedNetworking:     ptr.To(true),
 					IPv6Enabled:               false,
 					EnableIPForwarding:        false,
 					SKU:                       nil,
@@ -2658,17 +2658,17 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						Name: "machine",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID:       pointer.String("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
+						ProviderID:       ptr.To("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
 						AllocatePublicIP: true,
 						NetworkInterfaces: []infrav1.NetworkInterface{
 							{
 								SubnetName:            "subnet1",
-								AcceleratedNetworking: pointer.Bool(true),
+								AcceleratedNetworking: ptr.To(true),
 								PrivateIPConfigs:      1,
 							},
 							{
 								SubnetName:            "subnet2",
-								AcceleratedNetworking: pointer.Bool(true),
+								AcceleratedNetworking: ptr.To(true),
 								PrivateIPConfigs:      2,
 							},
 						},
@@ -2698,7 +2698,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 					InternalLBName:            "",
 					InternalLBAddressPoolName: "",
 					PublicIPName:              "pip-machine-name",
-					AcceleratedNetworking:     pointer.Bool(true),
+					AcceleratedNetworking:     ptr.To(true),
 					IPv6Enabled:               false,
 					EnableIPForwarding:        false,
 					SKU:                       nil,
@@ -2723,7 +2723,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 					InternalLBName:            "",
 					InternalLBAddressPoolName: "",
 					PublicIPName:              "",
-					AcceleratedNetworking:     pointer.Bool(true),
+					AcceleratedNetworking:     ptr.To(true),
 					IPv6Enabled:               false,
 					EnableIPForwarding:        false,
 					SKU:                       nil,
@@ -2799,11 +2799,11 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 						Name: "machine",
 					},
 					Spec: infrav1.AzureMachineSpec{
-						ProviderID: pointer.String("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
+						ProviderID: ptr.To("azure:///subscriptions/1234-5678/resourceGroups/my-cluster/providers/Microsoft.Compute/virtualMachines/machine-name"),
 						NetworkInterfaces: []infrav1.NetworkInterface{
 							{
 								SubnetName:            "subnet1",
-								AcceleratedNetworking: pointer.Bool(true),
+								AcceleratedNetworking: ptr.To(true),
 								PrivateIPConfigs:      10,
 							},
 						},
@@ -2833,7 +2833,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 					InternalLBName:            "",
 					InternalLBAddressPoolName: "",
 					PublicIPName:              "",
-					AcceleratedNetworking:     pointer.Bool(true),
+					AcceleratedNetworking:     ptr.To(true),
 					IPv6Enabled:               false,
 					EnableIPForwarding:        false,
 					SKU:                       nil,
@@ -2887,7 +2887,7 @@ func TestDiskSpecs(t *testing.T) {
 					},
 					Spec: infrav1.AzureMachineSpec{
 						OSDisk: infrav1.OSDisk{
-							DiskSizeGB: pointer.Int32(30),
+							DiskSizeGB: ptr.To[int32](30),
 							OSType:     "Linux",
 						},
 					},
@@ -2929,7 +2929,7 @@ func TestDiskSpecs(t *testing.T) {
 					},
 					Spec: infrav1.AzureMachineSpec{
 						OSDisk: infrav1.OSDisk{
-							DiskSizeGB: pointer.Int32(30),
+							DiskSizeGB: ptr.To[int32](30),
 							OSType:     "Linux",
 						},
 						DataDisks: []infrav1.DataDisk{
@@ -2979,7 +2979,7 @@ func TestDiskSpecs(t *testing.T) {
 					},
 					Spec: infrav1.AzureMachineSpec{
 						OSDisk: infrav1.OSDisk{
-							DiskSizeGB: pointer.Int32(30),
+							DiskSizeGB: ptr.To[int32](30),
 							OSType:     "Linux",
 						},
 						DataDisks: []infrav1.DataDisk{

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -28,7 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	machinepool "sigs.k8s.io/cluster-api-provider-azure/azure/scope/strategies/machinepool_deployments"
@@ -152,7 +152,7 @@ func (m *MachinePoolScope) ScaleSetSpec() azure.ScaleSetSpec {
 	return azure.ScaleSetSpec{
 		Name:                         m.Name(),
 		Size:                         m.AzureMachinePool.Spec.Template.VMSize,
-		Capacity:                     int64(pointer.Int32Deref(m.MachinePool.Spec.Replicas, 0)),
+		Capacity:                     int64(ptr.Deref[int32](m.MachinePool.Spec.Replicas, 0)),
 		SSHKeyData:                   m.AzureMachinePool.Spec.Template.SSHPublicKey,
 		OSDisk:                       m.AzureMachinePool.Spec.Template.OSDisk,
 		DataDisks:                    m.AzureMachinePool.Spec.Template.DataDisks,
@@ -253,7 +253,7 @@ func (m *MachinePoolScope) NeedsRequeue() bool {
 
 // DesiredReplicas returns the replica count on machine pool or 0 if machine pool replicas is nil.
 func (m MachinePoolScope) DesiredReplicas() int32 {
-	return pointer.Int32Deref(m.MachinePool.Spec.Replicas, 0)
+	return ptr.Deref[int32](m.MachinePool.Spec.Replicas, 0)
 }
 
 // MaxSurge returns the number of machines to surge, or 0 if the deployment strategy does not support surge.
@@ -423,7 +423,7 @@ func (m *MachinePoolScope) createMachine(ctx context.Context, machine azure.VMSS
 					APIVersion:         infrav1exp.GroupVersion.String(),
 					Kind:               "AzureMachinePool",
 					Name:               m.AzureMachinePool.Name,
-					BlockOwnerDeletion: pointer.Bool(true),
+					BlockOwnerDeletion: ptr.To(true),
 					UID:                m.AzureMachinePool.UID,
 				},
 			},
@@ -511,7 +511,7 @@ func (m *MachinePoolScope) SetNotReady() {
 
 // SetFailureMessage sets the AzureMachinePool status failure message.
 func (m *MachinePoolScope) SetFailureMessage(v error) {
-	m.AzureMachinePool.Status.FailureMessage = pointer.String(v.Error())
+	m.AzureMachinePool.Status.FailureMessage = ptr.To(v.Error())
 }
 
 // SetFailureReason sets the AzureMachinePool status failure reason.
@@ -666,9 +666,9 @@ func (m *MachinePoolScope) GetVMImage(ctx context.Context) (*infrav1.Image, erro
 		runtime := m.AzureMachinePool.Annotations["runtime"]
 		windowsServerVersion := m.AzureMachinePool.Annotations["windowsServerVersion"]
 		log.V(4).Info("No image specified for machine, using default Windows Image", "machine", m.MachinePool.GetName(), "runtime", runtime, "windowsServerVersion", windowsServerVersion)
-		defaultImage, err = svc.GetDefaultWindowsImage(ctx, m.Location(), pointer.StringDeref(m.MachinePool.Spec.Template.Spec.Version, ""), runtime, windowsServerVersion)
+		defaultImage, err = svc.GetDefaultWindowsImage(ctx, m.Location(), ptr.Deref(m.MachinePool.Spec.Template.Spec.Version, ""), runtime, windowsServerVersion)
 	} else {
-		defaultImage, err = svc.GetDefaultUbuntuImage(ctx, m.Location(), pointer.StringDeref(m.MachinePool.Spec.Template.Spec.Version, ""))
+		defaultImage, err = svc.GetDefaultUbuntuImage(ctx, m.Location(), ptr.Deref(m.MachinePool.Spec.Template.Spec.Version, ""))
 	}
 
 	if err != nil {

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
@@ -189,7 +189,7 @@ func TestMachinePoolScope_NetworkInterfaces(t *testing.T) {
 					},
 					Spec: infrav1exp.AzureMachinePoolSpec{
 						Template: infrav1exp.AzureMachinePoolMachineTemplate{
-							AcceleratedNetworking: pointer.Bool(true),
+							AcceleratedNetworking: ptr.To(true),
 							SubnetName:            "node-subnet",
 						},
 					},
@@ -273,7 +273,7 @@ func TestMachinePoolScope_MaxSurge(t *testing.T) {
 		{
 			Name: "default surge should be 1 regardless of replica count with no surger",
 			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool) {
-				mp.Spec.Replicas = pointer.Int32(3)
+				mp.Spec.Replicas = ptr.To[int32](3)
 			},
 			Verify: func(g *WithT, surge int, err error) {
 				g.Expect(surge).To(Equal(1))
@@ -283,7 +283,7 @@ func TestMachinePoolScope_MaxSurge(t *testing.T) {
 		{
 			Name: "default surge should be 2 as specified by the surger",
 			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool) {
-				mp.Spec.Replicas = pointer.Int32(3)
+				mp.Spec.Replicas = ptr.To[int32](3)
 				two := intstr.FromInt(2)
 				amp.Spec.Strategy = infrav1exp.AzureMachinePoolDeploymentStrategy{
 					Type: infrav1exp.RollingUpdateAzureMachinePoolDeploymentStrategyType,
@@ -300,7 +300,7 @@ func TestMachinePoolScope_MaxSurge(t *testing.T) {
 		{
 			Name: "default surge should be 2 (50%) of the desired replicas",
 			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool) {
-				mp.Spec.Replicas = pointer.Int32(4)
+				mp.Spec.Replicas = ptr.To[int32](4)
 				fiftyPercent := intstr.FromString("50%")
 				amp.Spec.Strategy = infrav1exp.AzureMachinePoolDeploymentStrategy{
 					Type: infrav1exp.RollingUpdateAzureMachinePoolDeploymentStrategyType,
@@ -412,7 +412,7 @@ func TestMachinePoolScope_GetVMImage(t *testing.T) {
 		{
 			Name: "should set and default the image if no image is specified for the AzureMachinePool",
 			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool) {
-				mp.Spec.Template.Spec.Version = pointer.String("v1.19.11")
+				mp.Spec.Template.Spec.Version = ptr.To("v1.19.11")
 			},
 			Verify: func(g *WithT, amp *infrav1exp.AzureMachinePool, vmImage *infrav1.Image, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
@@ -434,7 +434,7 @@ func TestMachinePoolScope_GetVMImage(t *testing.T) {
 		{
 			Name: "should not default or set the image on the AzureMachinePool if it already exists",
 			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool) {
-				mp.Spec.Template.Spec.Version = pointer.String("v1.19.11")
+				mp.Spec.Template.Spec.Version = ptr.To("v1.19.11")
 				amp.Spec.Template.Image = &infrav1.Image{
 					Marketplace: &infrav1.AzureMarketplaceImage{
 						ImagePlan: infrav1.ImagePlan{
@@ -518,7 +518,7 @@ func TestMachinePoolScope_NeedsRequeue(t *testing.T) {
 			Name: "should requeue if the machine is not in succeeded state",
 			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
 				creating := infrav1.Creating
-				mp.Spec.Replicas = pointer.Int32(0)
+				mp.Spec.Replicas = ptr.To[int32](0)
 				amp.Status.ProvisioningState = &creating
 			},
 			Verify: func(g *WithT, requeue bool) {
@@ -529,7 +529,7 @@ func TestMachinePoolScope_NeedsRequeue(t *testing.T) {
 			Name: "should not requeue if the machine is in succeeded state",
 			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
 				succeeded := infrav1.Succeeded
-				mp.Spec.Replicas = pointer.Int32(0)
+				mp.Spec.Replicas = ptr.To[int32](0)
 				amp.Status.ProvisioningState = &succeeded
 			},
 			Verify: func(g *WithT, requeue bool) {
@@ -540,7 +540,7 @@ func TestMachinePoolScope_NeedsRequeue(t *testing.T) {
 			Name: "should requeue if the machine is in succeeded state but desired replica count does not match",
 			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
 				succeeded := infrav1.Succeeded
-				mp.Spec.Replicas = pointer.Int32(1)
+				mp.Spec.Replicas = ptr.To[int32](1)
 				amp.Status.ProvisioningState = &succeeded
 			},
 			Verify: func(g *WithT, requeue bool) {
@@ -551,7 +551,7 @@ func TestMachinePoolScope_NeedsRequeue(t *testing.T) {
 			Name: "should not requeue if the machine is in succeeded state but desired replica count does match",
 			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
 				succeeded := infrav1.Succeeded
-				mp.Spec.Replicas = pointer.Int32(1)
+				mp.Spec.Replicas = ptr.To[int32](1)
 				amp.Status.ProvisioningState = &succeeded
 				vmss.Instances = []azure.VMSSVM{
 					{
@@ -567,7 +567,7 @@ func TestMachinePoolScope_NeedsRequeue(t *testing.T) {
 			Name: "should requeue if an instance VM image does not match the VM image of the VMSS",
 			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool, vmss *azure.VMSS) {
 				succeeded := infrav1.Succeeded
-				mp.Spec.Replicas = pointer.Int32(1)
+				mp.Spec.Replicas = ptr.To[int32](1)
 				amp.Status.ProvisioningState = &succeeded
 				vmss.Instances = []azure.VMSSVM{
 					{
@@ -790,7 +790,7 @@ func TestMachinePoolScope_RoleAssignmentSpecs(t *testing.T) {
 					MachineName:   "machine-name",
 					Name:          "role-assignment-name",
 					ResourceGroup: "my-rg",
-					PrincipalID:   pointer.String("fakePrincipalID"),
+					PrincipalID:   ptr.To("fakePrincipalID"),
 				},
 			},
 		},
@@ -837,14 +837,14 @@ func TestMachinePoolScope_RoleAssignmentSpecs(t *testing.T) {
 					ResourceGroup:    "my-rg",
 					Scope:            "scope",
 					RoleDefinitionID: "role-definition-id",
-					PrincipalID:      pointer.String("fakePrincipalID"),
+					PrincipalID:      ptr.To("fakePrincipalID"),
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.machinePoolScope.RoleAssignmentSpecs(pointer.String("fakePrincipalID")); !reflect.DeepEqual(got, tt.want) {
+			if got := tt.machinePoolScope.RoleAssignmentSpecs(ptr.To("fakePrincipalID")); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("RoleAssignmentSpecs() = %v, want %v", got, tt.want)
 			}
 		})
@@ -1240,7 +1240,7 @@ func TestMachinePoolScope_applyAzureMachinePoolMachines(t *testing.T) {
 			Name: "if MachinePool is externally managed and overProvisionCount > 0, do not try to reduce replicas",
 			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool, vmssState *azure.VMSS, cb *fake.ClientBuilder) {
 				mp.Annotations = map[string]string{clusterv1.ReplicasManagedByAnnotation: "cluster-autoscaler"}
-				mp.Spec.Replicas = pointer.Int32(1)
+				mp.Spec.Replicas = ptr.To[int32](1)
 
 				for _, machine := range getReadyAzureMachinePoolMachines(2) {
 					obj := machine
@@ -1267,7 +1267,7 @@ func TestMachinePoolScope_applyAzureMachinePoolMachines(t *testing.T) {
 		{
 			Name: "if MachinePool is not externally managed and overProvisionCount > 0, reduce replicas",
 			Setup: func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool, vmssState *azure.VMSS, cb *fake.ClientBuilder) {
-				mp.Spec.Replicas = pointer.Int32(1)
+				mp.Spec.Replicas = ptr.To[int32](1)
 
 				for _, machine := range getReadyAzureMachinePoolMachines(2) {
 					obj := machine

--- a/azure/scope/machinepoolmachine.go
+++ b/azure/scope/machinepoolmachine.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	kubedrain "k8s.io/kubectl/pkg/drain"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -242,7 +242,7 @@ func (s *MachinePoolMachineScope) IsReady() bool {
 
 // SetFailureMessage sets the AzureMachinePoolMachine status failure message.
 func (s *MachinePoolMachineScope) SetFailureMessage(v error) {
-	s.AzureMachinePoolMachine.Status.FailureMessage = pointer.String(v.Error())
+	s.AzureMachinePoolMachine.Status.FailureMessage = ptr.To(v.Error())
 }
 
 // SetFailureReason sets the AzureMachinePoolMachine status failure reason.

--- a/azure/scope/machinepoolmachine_test.go
+++ b/azure/scope/machinepoolmachine_test.go
@@ -26,7 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
 	mock_scope "sigs.k8s.io/cluster-api-provider-azure/azure/scope/mocks"
@@ -237,7 +237,7 @@ func TestMachineScope_UpdateNodeStatus(t *testing.T) {
 						Spec: expv1.MachinePoolSpec{
 							Template: clusterv1.MachineTemplateSpec{
 								Spec: clusterv1.MachineSpec{
-									Version: pointer.String("v1.19.11"),
+									Version: ptr.To("v1.19.11"),
 								},
 							},
 						},
@@ -335,7 +335,7 @@ func TestMachinePoolMachineScope_CordonAndDrain(t *testing.T) {
 						Spec: expv1.MachinePoolSpec{
 							Template: clusterv1.MachineTemplateSpec{
 								Spec: clusterv1.MachineSpec{
-									Version: pointer.String("v1.19.11"),
+									Version: ptr.To("v1.19.11"),
 								},
 							},
 						},

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/mod/semver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asogroups"
@@ -386,7 +386,7 @@ func (s *ManagedControlPlaneScope) IsIPv6Enabled() bool {
 // IsVnetManaged returns true if the vnet is managed.
 func (s *ManagedControlPlaneScope) IsVnetManaged() bool {
 	if s.cache.isVnetManaged != nil {
-		return pointer.BoolDeref(s.cache.isVnetManaged, false)
+		return ptr.Deref(s.cache.isVnetManaged, false)
 	}
 	// TODO refactor `IsVnetManaged` so that it is able to use an upstream context
 	// see https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2581
@@ -397,7 +397,7 @@ func (s *ManagedControlPlaneScope) IsVnetManaged() bool {
 	if err != nil {
 		log.Error(err, "Unable to determine if ManagedControlPlaneScope VNET is managed by capz", "AzureManagedCluster", s.ClusterName())
 	}
-	s.cache.isVnetManaged = pointer.Bool(isManaged)
+	s.cache.isVnetManaged = ptr.To(isManaged)
 	return isManaged
 }
 

--- a/azure/scope/managedcontrolplane_test.go
+++ b/azure/scope/managedcontrolplane_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/agentpools"
@@ -181,7 +181,7 @@ func TestManagedControlPlaneScope_PoolVersion(t *testing.T) {
 					SKU:          "Standard_D2s_v3",
 					Mode:         "System",
 					Replicas:     1,
-					Version:      pointer.String("1.21.1"),
+					Version:      ptr.To("1.21.1"),
 					Cluster:      "cluster1",
 					VnetSubnetID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups//providers/Microsoft.Network/virtualNetworks//subnets/",
 					Headers:      map[string]string{},
@@ -397,7 +397,7 @@ func TestManagedControlPlaneScope_OSType(t *testing.T) {
 					Replicas:     1,
 					Cluster:      "cluster1",
 					VnetSubnetID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups//providers/Microsoft.Network/virtualNetworks//subnets/",
-					OSType:       pointer.String(azure.LinuxOS),
+					OSType:       ptr.To(azure.LinuxOS),
 					Headers:      map[string]string{},
 				},
 				&agentpools.AgentPoolSpec{
@@ -407,7 +407,7 @@ func TestManagedControlPlaneScope_OSType(t *testing.T) {
 					Replicas:     1,
 					Cluster:      "cluster1",
 					VnetSubnetID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups//providers/Microsoft.Network/virtualNetworks//subnets/",
-					OSType:       pointer.String(azure.WindowsOS),
+					OSType:       ptr.To(azure.WindowsOS),
 					Headers:      map[string]string{},
 				},
 			},
@@ -545,7 +545,7 @@ func TestManagedControlPlaneScope_IsVnetManagedCache(t *testing.T) {
 					},
 				},
 				Cache: &ManagedControlPlaneCache{
-					isVnetManaged: pointer.Bool(true),
+					isVnetManaged: ptr.To(true),
 				},
 			},
 			Expected: true,
@@ -583,7 +583,7 @@ func TestManagedControlPlaneScope_IsVnetManagedCache(t *testing.T) {
 					},
 				},
 				Cache: &ManagedControlPlaneCache{
-					isVnetManaged: pointer.Bool(false),
+					isVnetManaged: ptr.To(false),
 				},
 			},
 			Expected: false,

--- a/azure/scope/managedmachinepool.go
+++ b/azure/scope/managedmachinepool.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/agentpools"
@@ -146,7 +146,7 @@ func (s *ManagedMachinePoolScope) AgentPoolSpec() azure.ResourceSpecGetter {
 
 func getAgentPoolSubnet(controlPlane *infrav1.AzureManagedControlPlane, infraMachinePool *infrav1.AzureManagedMachinePool) *string {
 	if infraMachinePool.Spec.SubnetName == nil {
-		return pointer.String(controlPlane.Spec.VirtualNetwork.Subnet.Name)
+		return ptr.To(controlPlane.Spec.VirtualNetwork.Subnet.Name)
 	}
 	return infraMachinePool.Spec.SubnetName
 }
@@ -167,7 +167,7 @@ func buildAgentPoolSpec(managedControlPlane *infrav1.AzureManagedControlPlane,
 	}
 
 	agentPoolSpec := &agentpools.AgentPoolSpec{
-		Name:          pointer.StringDeref(managedMachinePool.Spec.Name, ""),
+		Name:          ptr.Deref(managedMachinePool.Spec.Name, ""),
 		ResourceGroup: managedControlPlane.Spec.ResourceGroupName,
 		Cluster:       managedControlPlane.Name,
 		SKU:           managedMachinePool.Spec.SKU,
@@ -178,7 +178,7 @@ func buildAgentPoolSpec(managedControlPlane *infrav1.AzureManagedControlPlane,
 			managedControlPlane.Spec.SubscriptionID,
 			managedControlPlane.Spec.VirtualNetwork.ResourceGroup,
 			managedControlPlane.Spec.VirtualNetwork.Name,
-			pointer.StringDeref(getAgentPoolSubnet(managedControlPlane, managedMachinePool), ""),
+			ptr.Deref(getAgentPoolSubnet(managedControlPlane, managedMachinePool), ""),
 		),
 		Mode:                 managedMachinePool.Spec.Mode,
 		MaxPods:              managedMachinePool.Spec.MaxPods,
@@ -218,7 +218,7 @@ func buildAgentPoolSpec(managedControlPlane *infrav1.AzureManagedControlPlane,
 	if len(managedMachinePool.Spec.NodeLabels) > 0 {
 		agentPoolSpec.NodeLabels = make(map[string]*string, len(managedMachinePool.Spec.NodeLabels))
 		for k, v := range managedMachinePool.Spec.NodeLabels {
-			agentPoolSpec.NodeLabels[k] = pointer.String(v)
+			agentPoolSpec.NodeLabels[k] = ptr.To(v)
 		}
 	}
 

--- a/azure/scope/managedmachinepool_test.go
+++ b/azure/scope/managedmachinepool_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/agentpools"
@@ -109,8 +109,8 @@ func TestManagedMachinePoolScope_Autoscaling(t *testing.T) {
 				Cluster:           "cluster1",
 				Replicas:          1,
 				EnableAutoScaling: true,
-				MinCount:          pointer.Int32(2),
-				MaxCount:          pointer.Int32(10),
+				MinCount:          ptr.To[int32](2),
+				MaxCount:          ptr.To[int32](10),
 				VnetSubnetID:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups//providers/Microsoft.Network/virtualNetworks//subnets/",
 				Headers:           map[string]string{},
 			},
@@ -208,7 +208,7 @@ func TestManagedMachinePoolScope_NodeLabels(t *testing.T) {
 				Cluster:  "cluster1",
 				Replicas: 1,
 				NodeLabels: map[string]*string{
-					"custom": pointer.String("default"),
+					"custom": ptr.To("default"),
 				},
 				VnetSubnetID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups//providers/Microsoft.Network/virtualNetworks//subnets/",
 				Headers:      map[string]string{},
@@ -403,7 +403,7 @@ func TestManagedMachinePoolScope_MaxPods(t *testing.T) {
 				Mode:         "System",
 				Cluster:      "cluster1",
 				Replicas:     1,
-				MaxPods:      pointer.Int32(12),
+				MaxPods:      ptr.To[int32](12),
 				VnetSubnetID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups//providers/Microsoft.Network/virtualNetworks//subnets/",
 				Headers:      map[string]string{},
 			},
@@ -600,7 +600,7 @@ func TestManagedMachinePoolScope_OSDiskType(t *testing.T) {
 				Mode:         "User",
 				Cluster:      "cluster1",
 				Replicas:     1,
-				OsDiskType:   pointer.String(string(containerservice.OSDiskTypeEphemeral)),
+				OsDiskType:   ptr.To(string(containerservice.OSDiskTypeEphemeral)),
 				VnetSubnetID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups//providers/Microsoft.Network/virtualNetworks//subnets/",
 				Headers:      map[string]string{},
 			},
@@ -733,7 +733,7 @@ func TestManagedMachinePoolScope_SubnetName(t *testing.T) {
 				},
 				ManagedMachinePool: ManagedMachinePool{
 					MachinePool:      getMachinePool("pool1"),
-					InfraMachinePool: getAzureMachinePoolWithSubnetName("pool1", pointer.String("my-subnet")),
+					InfraMachinePool: getAzureMachinePoolWithSubnetName("pool1", ptr.To("my-subnet")),
 				},
 			},
 			Expected: &agentpools.AgentPoolSpec{
@@ -828,7 +828,7 @@ func TestManagedMachinePoolScope_KubeletDiskType(t *testing.T) {
 				},
 				ManagedMachinePool: ManagedMachinePool{
 					MachinePool:      getMachinePool("pool1"),
-					InfraMachinePool: getAzureMachinePoolWithKubeletDiskType("pool1", (*infrav1.KubeletDiskType)(pointer.String("Temporary"))),
+					InfraMachinePool: getAzureMachinePoolWithKubeletDiskType("pool1", (*infrav1.KubeletDiskType)(ptr.To("Temporary"))),
 				},
 			},
 			Expected: &agentpools.AgentPoolSpec{
@@ -837,7 +837,7 @@ func TestManagedMachinePoolScope_KubeletDiskType(t *testing.T) {
 				Mode:            "User",
 				Cluster:         "cluster1",
 				Replicas:        1,
-				KubeletDiskType: (*infrav1.KubeletDiskType)(pointer.String("Temporary")),
+				KubeletDiskType: (*infrav1.KubeletDiskType)(ptr.To("Temporary")),
 				VnetSubnetID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups//providers/Microsoft.Network/virtualNetworks//subnets/",
 				Headers:         map[string]string{},
 			},
@@ -879,7 +879,7 @@ func getAzureMachinePool(name string, mode infrav1.NodePoolMode) *infrav1.AzureM
 		Spec: infrav1.AzureManagedMachinePoolSpec{
 			Mode: string(mode),
 			SKU:  "Standard_D2s_v3",
-			Name: pointer.String(name),
+			Name: ptr.To(name),
 		},
 	}
 }
@@ -887,15 +887,15 @@ func getAzureMachinePool(name string, mode infrav1.NodePoolMode) *infrav1.AzureM
 func getAzureMachinePoolWithScaling(name string, min, max int32) *infrav1.AzureManagedMachinePool {
 	managedPool := getAzureMachinePool(name, infrav1.NodePoolModeUser)
 	managedPool.Spec.Scaling = &infrav1.ManagedMachinePoolScaling{
-		MinSize: pointer.Int32(min),
-		MaxSize: pointer.Int32(max),
+		MinSize: ptr.To[int32](min),
+		MaxSize: ptr.To[int32](max),
 	}
 	return managedPool
 }
 
 func getAzureMachinePoolWithMaxPods(name string, maxPods int32) *infrav1.AzureManagedMachinePool {
 	managedPool := getAzureMachinePool(name, infrav1.NodePoolModeSystem)
-	managedPool.Spec.MaxPods = pointer.Int32(maxPods)
+	managedPool.Spec.MaxPods = ptr.To[int32](maxPods)
 	return managedPool
 }
 
@@ -913,7 +913,7 @@ func getAzureMachinePoolWithSubnetName(name string, subnetName *string) *infrav1
 
 func getAzureMachinePoolWithOsDiskType(name string, osDiskType string) *infrav1.AzureManagedMachinePool {
 	managedPool := getAzureMachinePool(name, infrav1.NodePoolModeUser)
-	managedPool.Spec.OsDiskType = pointer.String(osDiskType)
+	managedPool.Spec.OsDiskType = ptr.To(osDiskType)
 	return managedPool
 }
 
@@ -952,18 +952,18 @@ func getMachinePool(name string) *expv1.MachinePool {
 
 func getLinuxAzureMachinePool(name string) *infrav1.AzureManagedMachinePool {
 	managedPool := getAzureMachinePool(name, infrav1.NodePoolModeUser)
-	managedPool.Spec.OSType = pointer.String(azure.LinuxOS)
+	managedPool.Spec.OSType = ptr.To(azure.LinuxOS)
 	return managedPool
 }
 
 func getWindowsAzureMachinePool(name string) *infrav1.AzureManagedMachinePool {
 	managedPool := getAzureMachinePool(name, infrav1.NodePoolModeUser)
-	managedPool.Spec.OSType = pointer.String(azure.WindowsOS)
+	managedPool.Spec.OSType = ptr.To(azure.WindowsOS)
 	return managedPool
 }
 
 func getMachinePoolWithVersion(name, version string) *expv1.MachinePool {
 	machine := getMachinePool(name)
-	machine.Spec.Template.Spec.Version = pointer.String(version)
+	machine.Spec.Template.Spec.Version = ptr.To(version)
 	return machine
 }

--- a/azure/services/agentpools/agentpools.go
+++ b/azure/services/agentpools/agentpools.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2022-03-01/containerservice"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async"
@@ -85,7 +85,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 				return errors.Errorf("%T is not a containerservice.AgentPool", result)
 			}
 			// When autoscaling is set, add the annotation to the machine pool and update the replica count.
-			if pointer.BoolDeref(agentPool.EnableAutoScaling, false) {
+			if ptr.Deref(agentPool.EnableAutoScaling, false) {
 				s.scope.SetCAPIMachinePoolAnnotation(clusterv1.ReplicasManagedByAnnotation, "true")
 				s.scope.SetCAPIMachinePoolReplicas(agentPool.Count)
 			} else { // Otherwise, remove the annotation.

--- a/azure/services/agentpools/agentpools_test.go
+++ b/azure/services/agentpools/agentpools_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/agentpools/mock_agentpools"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
@@ -48,7 +48,7 @@ func TestReconcileAgentPools(t *testing.T) {
 				s.AgentPoolSpec().Return(&fakeAgentPoolSpec)
 				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeAgentPoolSpec, serviceName).Return(sdkFakeAgentPool(sdkWithAutoscaling(true), sdkWithCount(1)), nil)
 				s.SetCAPIMachinePoolAnnotation(clusterv1.ReplicasManagedByAnnotation, "true")
-				s.SetCAPIMachinePoolReplicas(pointer.Int32(1))
+				s.SetCAPIMachinePoolReplicas(ptr.To[int32](1))
 				s.UpdatePutStatus(infrav1.AgentPoolsReadyCondition, serviceName, nil)
 			},
 		},

--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -214,12 +214,12 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (p
 				Count:               &s.Replicas,
 				OrchestratorVersion: s.Version,
 				Mode:                containerservice.AgentPoolMode(s.Mode),
-				EnableAutoScaling:   pointer.Bool(s.EnableAutoScaling),
+				EnableAutoScaling:   ptr.To(s.EnableAutoScaling),
 				MinCount:            s.MinCount,
 				MaxCount:            s.MaxCount,
 				NodeLabels:          s.NodeLabels,
 				NodeTaints:          &s.NodeTaints,
-				ScaleDownMode:       containerservice.ScaleDownMode(pointer.StringDeref(s.ScaleDownMode, "")),
+				ScaleDownMode:       containerservice.ScaleDownMode(ptr.Deref(s.ScaleDownMode, "")),
 				Tags:                converters.TagsToMap(s.AdditionalTags),
 			},
 		}
@@ -228,7 +228,7 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (p
 		}
 
 		if s.SpotMaxPrice != nil {
-			normalizedProfile.SpotMaxPrice = pointer.Float64(s.SpotMaxPrice.AsApproximateFloat64())
+			normalizedProfile.SpotMaxPrice = ptr.To[float64](s.SpotMaxPrice.AsApproximateFloat64())
 		}
 
 		if s.KubeletConfig != nil {
@@ -286,7 +286,7 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (p
 	}
 	var spotMaxPrice *float64
 	if s.SpotMaxPrice != nil {
-		spotMaxPrice = pointer.Float64(s.SpotMaxPrice.AsApproximateFloat64())
+		spotMaxPrice = ptr.To[float64](s.SpotMaxPrice.AsApproximateFloat64())
 	}
 	tags := converters.TagsToMap(s.AdditionalTags)
 	if tags == nil {
@@ -360,10 +360,10 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (p
 		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
 			AvailabilityZones:    availabilityZones,
 			Count:                &s.Replicas,
-			EnableAutoScaling:    pointer.Bool(s.EnableAutoScaling),
+			EnableAutoScaling:    ptr.To(s.EnableAutoScaling),
 			EnableUltraSSD:       s.EnableUltraSSD,
 			KubeletConfig:        kubeletConfig,
-			KubeletDiskType:      containerservice.KubeletDiskType(pointer.StringDeref((*string)(s.KubeletDiskType), "")),
+			KubeletDiskType:      containerservice.KubeletDiskType(ptr.Deref((*string)(s.KubeletDiskType), "")),
 			MaxCount:             s.MaxCount,
 			MaxPods:              s.MaxPods,
 			MinCount:             s.MinCount,
@@ -372,10 +372,10 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (p
 			NodeTaints:           nodeTaints,
 			OrchestratorVersion:  s.Version,
 			OsDiskSizeGB:         &s.OSDiskSizeGB,
-			OsDiskType:           containerservice.OSDiskType(pointer.StringDeref(s.OsDiskType, "")),
-			OsType:               containerservice.OSType(pointer.StringDeref(s.OSType, "")),
-			ScaleSetPriority:     containerservice.ScaleSetPriority(pointer.StringDeref(s.ScaleSetPriority, "")),
-			ScaleDownMode:        containerservice.ScaleDownMode(pointer.StringDeref(s.ScaleDownMode, "")),
+			OsDiskType:           containerservice.OSDiskType(ptr.Deref(s.OsDiskType, "")),
+			OsType:               containerservice.OSType(ptr.Deref(s.OSType, "")),
+			ScaleSetPriority:     containerservice.ScaleSetPriority(ptr.Deref(s.ScaleSetPriority, "")),
+			ScaleDownMode:        containerservice.ScaleDownMode(ptr.Deref(s.ScaleDownMode, "")),
 			SpotMaxPrice:         spotMaxPrice,
 			Type:                 containerservice.AgentPoolTypeVirtualMachineScaleSets,
 			VMSize:               sku,

--- a/azure/services/agentpools/spec_test.go
+++ b/azure/services/agentpools/spec_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
@@ -39,20 +39,20 @@ func fakeAgentPool(changes ...func(*AgentPoolSpec)) AgentPoolSpec {
 		Cluster:           "fake-cluster",
 		AvailabilityZones: []string{"fake-zone"},
 		EnableAutoScaling: true,
-		EnableUltraSSD:    pointer.Bool(true),
-		KubeletDiskType:   (*infrav1.KubeletDiskType)(pointer.String("fake-kubelet-disk-type")),
-		MaxCount:          pointer.Int32(5),
-		MaxPods:           pointer.Int32(10),
-		MinCount:          pointer.Int32(1),
+		EnableUltraSSD:    ptr.To(true),
+		KubeletDiskType:   (*infrav1.KubeletDiskType)(ptr.To("fake-kubelet-disk-type")),
+		MaxCount:          ptr.To[int32](5),
+		MaxPods:           ptr.To[int32](10),
+		MinCount:          ptr.To[int32](1),
 		Mode:              "fake-mode",
-		NodeLabels:        map[string]*string{"fake-label": pointer.String("fake-value")},
+		NodeLabels:        map[string]*string{"fake-label": ptr.To("fake-value")},
 		NodeTaints:        []string{"fake-taint"},
 		OSDiskSizeGB:      2,
-		OsDiskType:        pointer.String("fake-os-disk-type"),
-		OSType:            pointer.String("fake-os-type"),
+		OsDiskType:        ptr.To("fake-os-disk-type"),
+		OSType:            ptr.To("fake-os-type"),
 		Replicas:          1,
 		SKU:               "fake-sku",
-		Version:           pointer.String("fake-version"),
+		Version:           ptr.To("fake-version"),
 		VnetSubnetID:      "fake-vnet-subnet-id",
 		Headers:           map[string]string{"fake-header": "fake-value"},
 		AdditionalTags:    infrav1.Tags{"fake": "tag"},
@@ -88,24 +88,24 @@ func sdkFakeAgentPool(changes ...func(*containerservice.AgentPool)) containerser
 	pool := containerservice.AgentPool{
 		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
 			AvailabilityZones:   &[]string{"fake-zone"},
-			Count:               pointer.Int32(1),   // updates if changed
-			EnableAutoScaling:   pointer.Bool(true), // updates if changed
-			EnableUltraSSD:      pointer.Bool(true),
+			Count:               ptr.To[int32](1), // updates if changed
+			EnableAutoScaling:   ptr.To(true),     // updates if changed
+			EnableUltraSSD:      ptr.To(true),
 			KubeletDiskType:     containerservice.KubeletDiskType("fake-kubelet-disk-type"),
-			MaxCount:            pointer.Int32(5), // updates if changed
-			MaxPods:             pointer.Int32(10),
-			MinCount:            pointer.Int32(1),                                               // updates if changed
-			Mode:                containerservice.AgentPoolMode("fake-mode"),                    // updates if changed
-			NodeLabels:          map[string]*string{"fake-label": pointer.String("fake-value")}, // updates if changed
-			NodeTaints:          &[]string{"fake-taint"},                                        // updates if changed
-			OrchestratorVersion: pointer.String("fake-version"),                                 // updates if changed
-			OsDiskSizeGB:        pointer.Int32(2),
+			MaxCount:            ptr.To[int32](5), // updates if changed
+			MaxPods:             ptr.To[int32](10),
+			MinCount:            ptr.To[int32](1),                                       // updates if changed
+			Mode:                containerservice.AgentPoolMode("fake-mode"),            // updates if changed
+			NodeLabels:          map[string]*string{"fake-label": ptr.To("fake-value")}, // updates if changed
+			NodeTaints:          &[]string{"fake-taint"},                                // updates if changed
+			OrchestratorVersion: ptr.To("fake-version"),                                 // updates if changed
+			OsDiskSizeGB:        ptr.To[int32](2),
 			OsDiskType:          containerservice.OSDiskType("fake-os-disk-type"),
 			OsType:              containerservice.OSType("fake-os-type"),
-			Tags:                map[string]*string{"fake": pointer.String("tag")},
+			Tags:                map[string]*string{"fake": ptr.To("tag")},
 			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
-			VMSize:              pointer.String("fake-sku"),
-			VnetSubnetID:        pointer.String("fake-vnet-subnet-id"),
+			VMSize:              ptr.To("fake-sku"),
+			VnetSubnetID:        ptr.To("fake-vnet-subnet-id"),
 		},
 	}
 
@@ -118,7 +118,7 @@ func sdkFakeAgentPool(changes ...func(*containerservice.AgentPool)) containerser
 
 func sdkWithAutoscaling(enableAutoscaling bool) func(*containerservice.AgentPool) {
 	return func(pool *containerservice.AgentPool) {
-		pool.ManagedClusterAgentPoolProfileProperties.EnableAutoScaling = pointer.Bool(enableAutoscaling)
+		pool.ManagedClusterAgentPoolProfileProperties.EnableAutoScaling = ptr.To(enableAutoscaling)
 	}
 }
 
@@ -136,13 +136,13 @@ func sdkWithSpotMaxPrice(spotMaxPrice float64) func(*containerservice.AgentPool)
 
 func sdkWithCount(count int32) func(*containerservice.AgentPool) {
 	return func(pool *containerservice.AgentPool) {
-		pool.ManagedClusterAgentPoolProfileProperties.Count = pointer.Int32(count)
+		pool.ManagedClusterAgentPoolProfileProperties.Count = ptr.To[int32](count)
 	}
 }
 
 func sdkWithProvisioningState(state string) func(*containerservice.AgentPool) {
 	return func(pool *containerservice.AgentPool) {
-		pool.ManagedClusterAgentPoolProfileProperties.ProvisioningState = pointer.String(state)
+		pool.ManagedClusterAgentPoolProfileProperties.ProvisioningState = ptr.To(state)
 	}
 }
 
@@ -272,7 +272,7 @@ func TestParameters(t *testing.T) {
 			name: "parameters with an existing agent pool and update needed on max count",
 			spec: fakeAgentPool(),
 			existing: sdkFakeAgentPool(
-				func(pool *containerservice.AgentPool) { pool.MaxCount = pointer.Int32(3) },
+				func(pool *containerservice.AgentPool) { pool.MaxCount = ptr.To[int32](3) },
 				sdkWithProvisioningState("Succeeded"),
 			),
 			expected:      sdkFakeAgentPool(),
@@ -282,7 +282,7 @@ func TestParameters(t *testing.T) {
 			name: "parameters with an existing agent pool and update needed on min count",
 			spec: fakeAgentPool(),
 			existing: sdkFakeAgentPool(
-				func(pool *containerservice.AgentPool) { pool.MinCount = pointer.Int32(3) },
+				func(pool *containerservice.AgentPool) { pool.MinCount = ptr.To[int32](3) },
 				sdkWithProvisioningState("Succeeded"),
 			),
 			expected:      sdkFakeAgentPool(),
@@ -304,8 +304,8 @@ func TestParameters(t *testing.T) {
 			existing: sdkFakeAgentPool(
 				func(pool *containerservice.AgentPool) {
 					pool.NodeLabels = map[string]*string{
-						"fake-label":     pointer.String("fake-value"),
-						"fake-old-label": pointer.String("fake-old-value"),
+						"fake-label":     ptr.To("fake-value"),
+						"fake-old-label": ptr.To("fake-old-value"),
 					}
 				},
 				sdkWithProvisioningState("Succeeded"),
@@ -318,15 +318,15 @@ func TestParameters(t *testing.T) {
 			spec: fakeAgentPool(
 				func(pool *AgentPoolSpec) {
 					pool.NodeLabels = map[string]*string{
-						"fake-label": pointer.String("fake-value"),
+						"fake-label": ptr.To("fake-value"),
 					}
 				},
 			),
 			existing: sdkFakeAgentPool(
 				func(pool *containerservice.AgentPool) {
 					pool.NodeLabels = map[string]*string{
-						"fake-label":                            pointer.String("fake-value"),
-						"kubernetes.azure.com/scalesetpriority": pointer.String("spot"),
+						"fake-label":                            ptr.To("fake-value"),
+						"kubernetes.azure.com/scalesetpriority": ptr.To("spot"),
 					}
 				},
 				sdkWithProvisioningState("Succeeded"),
@@ -404,58 +404,58 @@ func TestMergeSystemNodeLabels(t *testing.T) {
 		{
 			name: "update an existing label",
 			capzLabels: map[string]*string{
-				"foo": pointer.String("bar"),
+				"foo": ptr.To("bar"),
 			},
 			aksLabels: map[string]*string{
-				"foo": pointer.String("baz"),
+				"foo": ptr.To("baz"),
 			},
 			expected: map[string]*string{
-				"foo": pointer.String("bar"),
+				"foo": ptr.To("bar"),
 			},
 		},
 		{
 			name:       "delete labels",
 			capzLabels: map[string]*string{},
 			aksLabels: map[string]*string{
-				"foo":   pointer.String("bar"),
-				"hello": pointer.String("world"),
+				"foo":   ptr.To("bar"),
+				"hello": ptr.To("world"),
 			},
 			expected: map[string]*string{},
 		},
 		{
 			name: "delete one label",
 			capzLabels: map[string]*string{
-				"foo": pointer.String("bar"),
+				"foo": ptr.To("bar"),
 			},
 			aksLabels: map[string]*string{
-				"foo":   pointer.String("bar"),
-				"hello": pointer.String("world"),
+				"foo":   ptr.To("bar"),
+				"hello": ptr.To("world"),
 			},
 			expected: map[string]*string{
-				"foo": pointer.String("bar"),
+				"foo": ptr.To("bar"),
 			},
 		},
 		{
 			name: "retain system label during update",
 			capzLabels: map[string]*string{
-				"foo": pointer.String("bar"),
+				"foo": ptr.To("bar"),
 			},
 			aksLabels: map[string]*string{
-				"kubernetes.azure.com/scalesetpriority": pointer.String("spot"),
+				"kubernetes.azure.com/scalesetpriority": ptr.To("spot"),
 			},
 			expected: map[string]*string{
-				"foo":                                   pointer.String("bar"),
-				"kubernetes.azure.com/scalesetpriority": pointer.String("spot"),
+				"foo":                                   ptr.To("bar"),
+				"kubernetes.azure.com/scalesetpriority": ptr.To("spot"),
 			},
 		},
 		{
 			name:       "retain system label during delete",
 			capzLabels: map[string]*string{},
 			aksLabels: map[string]*string{
-				"kubernetes.azure.com/scalesetpriority": pointer.String("spot"),
+				"kubernetes.azure.com/scalesetpriority": ptr.To("spot"),
 			},
 			expected: map[string]*string{
-				"kubernetes.azure.com/scalesetpriority": pointer.String("spot"),
+				"kubernetes.azure.com/scalesetpriority": ptr.To("spot"),
 			},
 		},
 	}

--- a/azure/services/aso/aso_test.go
+++ b/azure/services/aso/aso_test.go
@@ -29,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
@@ -127,7 +127,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})
 		specMock.EXPECT().Parameters(gomockinternal.AContext(), gomock.Nil()).Return(&asoresourcesv1.ResourceGroup{
 			Spec: asoresourcesv1.ResourceGroup_Spec{
-				Location: pointer.String("location"),
+				Location: ptr.To("location"),
 			},
 		}, nil)
 
@@ -151,7 +151,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			ReconcilePolicyAnnotation: ReconcilePolicySkip,
 		}))
 		g.Expect(created.Spec).To(Equal(asoresourcesv1.ResourceGroup_Spec{
-			Location: pointer.String("location"),
+			Location: ptr.To("location"),
 		}))
 	})
 
@@ -342,7 +342,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})
 		specMock.EXPECT().Parameters(gomockinternal.AContext(), gomock.Not(gomock.Nil())).DoAndReturn(func(_ context.Context, object genruntime.MetaObject) (genruntime.MetaObject, error) {
 			group := object.DeepCopyObject().(*asoresourcesv1.ResourceGroup)
-			group.Spec.Location = pointer.String("location")
+			group.Spec.Location = ptr.To("location")
 			return group, nil
 		})
 		specMock.EXPECT().WasManaged(gomock.Any()).Return(false)
@@ -606,7 +606,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 				},
 			},
 			Spec: asoresourcesv1.ResourceGroup_Spec{
-				Location: pointer.String("location"),
+				Location: ptr.To("location"),
 			},
 			Status: asoresourcesv1.ResourceGroup_STATUS{
 				Conditions: []conditions.Condition{
@@ -624,7 +624,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		g.Expect(result.GetName()).To(Equal("name"))
 		g.Expect(result.GetNamespace()).To(Equal("namespace"))
-		g.Expect(result.(*asoresourcesv1.ResourceGroup).Spec.Location).To(Equal(pointer.String("location")))
+		g.Expect(result.(*asoresourcesv1.ResourceGroup).Spec.Location).To(Equal(ptr.To("location")))
 	})
 
 	t.Run("error updating", func(t *testing.T) {
@@ -647,7 +647,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})
 		specMock.EXPECT().Parameters(gomockinternal.AContext(), gomock.Any()).DoAndReturn(func(_ context.Context, object genruntime.MetaObject) (genruntime.MetaObject, error) {
 			group := object.DeepCopyObject().(*asoresourcesv1.ResourceGroup)
-			group.Spec.Location = pointer.String("location")
+			group.Spec.Location = ptr.To("location")
 			return group, nil
 		})
 		specMock.EXPECT().WasManaged(gomock.Any()).Return(false)

--- a/azure/services/asogroups/groups_test.go
+++ b/azure/services/asogroups/groups_test.go
@@ -26,7 +26,7 @@ import (
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/aso"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/aso/mock_aso"
@@ -51,7 +51,7 @@ var (
 			Namespace: "test-group-ns",
 		},
 		Spec: asoresourcesv1.ResourceGroup_Spec{
-			Location: pointer.String("test-location"),
+			Location: ptr.To("test-location"),
 		},
 	}
 )

--- a/azure/services/asogroups/spec.go
+++ b/azure/services/asogroups/spec.go
@@ -22,7 +22,7 @@ import (
 	asoresourcesv1 "github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/aso"
 )
@@ -58,12 +58,12 @@ func (s *GroupSpec) Parameters(ctx context.Context, object genruntime.MetaObject
 			OwnerReferences: []metav1.OwnerReference{s.Owner},
 		},
 		Spec: asoresourcesv1.ResourceGroup_Spec{
-			Location: pointer.String(s.Location),
+			Location: ptr.To(s.Location),
 			Tags: infrav1.Build(infrav1.BuildParams{
 				ClusterName: s.ClusterName,
 				Lifecycle:   infrav1.ResourceLifecycleOwned,
-				Name:        pointer.String(s.Name),
-				Role:        pointer.String(infrav1.CommonRole),
+				Name:        ptr.To(s.Name),
+				Role:        ptr.To(infrav1.CommonRole),
 				Additional:  s.AdditionalTags,
 			}),
 		},

--- a/azure/services/asogroups/spec_test.go
+++ b/azure/services/asogroups/spec_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -56,7 +56,7 @@ func TestParameters(t *testing.T) {
 					},
 				},
 				Spec: asoresourcesv1.ResourceGroup_Spec{
-					Location: pointer.String("location"),
+					Location: ptr.To("location"),
 					Tags: map[string]string{
 						"some": "tags",
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_cluster": "owned",

--- a/azure/services/availabilitysets/availabilitysets_test.go
+++ b/azure/services/availabilitysets/availabilitysets_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/availabilitysets/mock_availabilitysets"
@@ -40,8 +40,8 @@ var (
 	fakeSku              = resourceskus.SKU{
 		Capabilities: &[]compute.ResourceSkuCapabilities{
 			{
-				Name:  pointer.String(resourceskus.MaximumPlatformFaultDomainCount),
-				Value: pointer.String(strconv.Itoa(fakeFaultDomainCount)),
+				Name:  ptr.To(resourceskus.MaximumPlatformFaultDomainCount),
+				Value: ptr.To(strconv.Itoa(fakeFaultDomainCount)),
 			},
 		},
 	}
@@ -67,7 +67,7 @@ var (
 	fakeSetWithVMs = compute.AvailabilitySet{
 		AvailabilitySetProperties: &compute.AvailabilitySetProperties{
 			VirtualMachines: &[]compute.SubResource{
-				{ID: pointer.String("vm-id")},
+				{ID: ptr.To("vm-id")},
 			},
 		},
 	}

--- a/azure/services/availabilitysets/spec.go
+++ b/azure/services/availabilitysets/spec.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
@@ -76,11 +76,11 @@ func (s *AvailabilitySetSpec) Parameters(ctx context.Context, existing interface
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse availability set fault domain count")
 	}
-	faultDomainCount = pointer.Int32(int32(count))
+	faultDomainCount = ptr.To[int32](int32(count))
 
 	asParams := compute.AvailabilitySet{
 		Sku: &compute.Sku{
-			Name: pointer.String(string(compute.AvailabilitySetSkuTypesAligned)),
+			Name: ptr.To(string(compute.AvailabilitySetSkuTypesAligned)),
 		},
 		AvailabilitySetProperties: &compute.AvailabilitySetProperties{
 			PlatformFaultDomainCount: faultDomainCount,
@@ -88,11 +88,11 @@ func (s *AvailabilitySetSpec) Parameters(ctx context.Context, existing interface
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
-			Name:        pointer.String(s.Name),
-			Role:        pointer.String(infrav1.CommonRole),
+			Name:        ptr.To(s.Name),
+			Role:        ptr.To(infrav1.CommonRole),
 			Additional:  s.AdditionalTags,
 		})),
-		Location: pointer.String(s.Location),
+		Location: ptr.To(s.Location),
 	}
 
 	return asParams, nil

--- a/azure/services/availabilitysets/spec_test.go
+++ b/azure/services/availabilitysets/spec_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
 )
 
@@ -69,7 +69,7 @@ func TestParameters(t *testing.T) {
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.AvailabilitySet{}))
-				g.Expect(result.(compute.AvailabilitySet).PlatformFaultDomainCount).To(Equal(pointer.Int32(int32(fakeFaultDomainCount))))
+				g.Expect(result.(compute.AvailabilitySet).PlatformFaultDomainCount).To(Equal(ptr.To[int32](int32(fakeFaultDomainCount))))
 			},
 			expectedError: "",
 		},

--- a/azure/services/bastionhosts/spec.go
+++ b/azure/services/bastionhosts/spec.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 )
@@ -75,23 +75,23 @@ func (s *AzureBastionSpec) Parameters(ctx context.Context, existing interface{})
 	bastionHostIPConfigName := fmt.Sprintf("%s-%s", s.Name, "bastionIP")
 
 	return network.BastionHost{
-		Name:     pointer.String(s.Name),
-		Location: pointer.String(s.Location),
+		Name:     ptr.To(s.Name),
+		Location: ptr.To(s.Location),
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
-			Name:        pointer.String(s.Name),
-			Role:        pointer.String("Bastion"),
+			Name:        ptr.To(s.Name),
+			Role:        ptr.To("Bastion"),
 		})),
 		Sku: &network.Sku{
 			Name: network.BastionHostSkuName(s.Sku),
 		},
 		BastionHostPropertiesFormat: &network.BastionHostPropertiesFormat{
-			EnableTunneling: pointer.Bool(s.EnableTunneling),
-			DNSName:         pointer.String(fmt.Sprintf("%s-bastion", strings.ToLower(s.Name))),
+			EnableTunneling: ptr.To(s.EnableTunneling),
+			DNSName:         ptr.To(fmt.Sprintf("%s-bastion", strings.ToLower(s.Name))),
 			IPConfigurations: &[]network.BastionHostIPConfiguration{
 				{
-					Name: pointer.String(bastionHostIPConfigName),
+					Name: ptr.To(bastionHostIPConfigName),
 					BastionHostIPConfigurationPropertiesFormat: &network.BastionHostIPConfigurationPropertiesFormat{
 						Subnet: &network.SubResource{
 							ID: &s.SubnetID,

--- a/azure/services/groups/groups_test.go
+++ b/azure/services/groups/groups_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/groups/mock_groups"
@@ -42,16 +42,16 @@ var (
 	internalError      = autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error")
 	notFoundError      = autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusNotFound}, "Not Found")
 	sampleManagedGroup = resources.Group{
-		Name:       pointer.String("test-group"),
-		Location:   pointer.String("test-location"),
+		Name:       ptr.To("test-group"),
+		Location:   ptr.To("test-location"),
 		Properties: &resources.GroupProperties{},
-		Tags:       map[string]*string{"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": pointer.String("owned")},
+		Tags:       map[string]*string{"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": ptr.To("owned")},
 	}
 	sampleBYOGroup = resources.Group{
-		Name:       pointer.String("test-group"),
-		Location:   pointer.String("test-location"),
+		Name:       ptr.To("test-group"),
+		Location:   ptr.To("test-location"),
 		Properties: &resources.GroupProperties{},
-		Tags:       map[string]*string{"foo": pointer.String("bar")},
+		Tags:       map[string]*string{"foo": ptr.To("bar")},
 	}
 )
 

--- a/azure/services/groups/spec.go
+++ b/azure/services/groups/spec.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 )
@@ -57,13 +57,13 @@ func (s *GroupSpec) Parameters(ctx context.Context, existing interface{}) (param
 		return nil, nil
 	}
 	return resources.Group{
-		Location: pointer.String(s.Location),
+		Location: ptr.To(s.Location),
 		// User defined additional tags are created with the resource group and updated using tags service.
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
-			Name:        pointer.String(s.Name),
-			Role:        pointer.String(infrav1.CommonRole),
+			Name:        ptr.To(s.Name),
+			Role:        ptr.To(infrav1.CommonRole),
 			Additional:  s.AdditionalTags,
 		})),
 	}, nil

--- a/azure/services/inboundnatrules/inboundnatrules_test.go
+++ b/azure/services/inboundnatrules/inboundnatrules_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
@@ -40,17 +40,17 @@ var (
 	noExistingRules   = []network.InboundNatRule{}
 	fakeExistingRules = []network.InboundNatRule{
 		{
-			Name: pointer.String("other-machine-nat-rule"),
-			ID:   pointer.String("some-natrules-id"),
+			Name: ptr.To("other-machine-nat-rule"),
+			ID:   ptr.To("some-natrules-id"),
 			InboundNatRulePropertiesFormat: &network.InboundNatRulePropertiesFormat{
-				FrontendPort: pointer.Int32(22),
+				FrontendPort: ptr.To[int32](22),
 			},
 		},
 		{
-			Name: pointer.String("other-machine-nat-rule-2"),
-			ID:   pointer.String("some-natrules-id-2"),
+			Name: ptr.To("other-machine-nat-rule-2"),
+			ID:   ptr.To("some-natrules-id-2"),
 			InboundNatRulePropertiesFormat: &network.InboundNatRulePropertiesFormat{
-				FrontendPort: pointer.Int32(2201),
+				FrontendPort: ptr.To[int32](2201),
 			},
 		},
 	}
@@ -59,13 +59,13 @@ var (
 		Name:                      "my-machine-1",
 		LoadBalancerName:          "my-lb-1",
 		ResourceGroup:             fakeGroupName,
-		FrontendIPConfigurationID: pointer.String("frontend-ip-config-id-1"),
+		FrontendIPConfigurationID: ptr.To("frontend-ip-config-id-1"),
 	}
 	fakeNatSpec2 = InboundNatSpec{
 		Name:                      "my-machine-2",
 		LoadBalancerName:          "my-lb-1",
 		ResourceGroup:             fakeGroupName,
-		FrontendIPConfigurationID: pointer.String("frontend-ip-config-id-2"),
+		FrontendIPConfigurationID: ptr.To("frontend-ip-config-id-2"),
 	}
 
 	internalError = autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error")
@@ -78,7 +78,7 @@ func getFakeNatSpecWithoutPort(spec InboundNatSpec) *InboundNatSpec {
 
 func getFakeNatSpecWithPort(spec InboundNatSpec, port int32) *InboundNatSpec {
 	newSpec := spec
-	newSpec.SSHFrontendPort = pointer.Int32(port)
+	newSpec.SSHFrontendPort = ptr.To[int32](port)
 	return &newSpec
 }
 

--- a/azure/services/inboundnatrules/spec.go
+++ b/azure/services/inboundnatrules/spec.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // InboundNatSpec defines the specification for an inbound NAT rule.
@@ -63,11 +63,11 @@ func (s *InboundNatSpec) Parameters(ctx context.Context, existing interface{}) (
 	}
 
 	rule := network.InboundNatRule{
-		Name: pointer.String(s.ResourceName()),
+		Name: ptr.To(s.ResourceName()),
 		InboundNatRulePropertiesFormat: &network.InboundNatRulePropertiesFormat{
-			BackendPort:          pointer.Int32(22),
-			EnableFloatingIP:     pointer.Bool(false),
-			IdleTimeoutInMinutes: pointer.Int32(4),
+			BackendPort:          ptr.To[int32](22),
+			EnableFloatingIP:     ptr.To(false),
+			IdleTimeoutInMinutes: ptr.To[int32](4),
 			FrontendIPConfiguration: &network.SubResource{
 				ID: s.FrontendIPConfigurationID,
 			},

--- a/azure/services/loadbalancers/loadbalancers_test.go
+++ b/azure/services/loadbalancers/loadbalancers_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
@@ -44,7 +44,7 @@ var (
 		SKU:                  infrav1.SKUStandard,
 		SubnetName:           "my-cp-subnet",
 		BackendPoolName:      "my-publiclb-backendPool",
-		IdleTimeoutInMinutes: pointer.Int32(4),
+		IdleTimeoutInMinutes: ptr.To[int32](4),
 		FrontendIPConfigs: []infrav1.FrontendIP{
 			{
 				Name: "my-publiclb-frontEnd",
@@ -68,7 +68,7 @@ var (
 		SKU:                  infrav1.SKUStandard,
 		SubnetName:           "my-cp-subnet",
 		BackendPoolName:      "my-private-lb-backendPool",
-		IdleTimeoutInMinutes: pointer.Int32(4),
+		IdleTimeoutInMinutes: ptr.To[int32](4),
 		FrontendIPConfigs: []infrav1.FrontendIP{
 			{
 				Name: "my-private-lb-frontEnd",
@@ -90,7 +90,7 @@ var (
 		Type:                 infrav1.Public,
 		SKU:                  infrav1.SKUStandard,
 		BackendPoolName:      "my-cluster-outboundBackendPool",
-		IdleTimeoutInMinutes: pointer.Int32(30),
+		IdleTimeoutInMinutes: ptr.To[int32](30),
 		FrontendIPConfigs: []infrav1.FrontendIP{
 			{
 				Name: "my-cluster-frontEnd",

--- a/azure/services/loadbalancers/spec_test.go
+++ b/azure/services/loadbalancers/spec_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -168,39 +168,39 @@ func TestParameters(t *testing.T) {
 func newDefaultNodeOutboundLB() network.LoadBalancer {
 	return network.LoadBalancer{
 		Tags: map[string]*string{
-			"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
-			"sigs.k8s.io_cluster-api-provider-azure_role":               pointer.String(infrav1.NodeOutboundRole),
+			"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
+			"sigs.k8s.io_cluster-api-provider-azure_role":               ptr.To(infrav1.NodeOutboundRole),
 		},
 		Sku:      &network.LoadBalancerSku{Name: network.LoadBalancerSkuNameStandard},
-		Location: pointer.String("my-location"),
+		Location: ptr.To("my-location"),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 				{
-					Name: pointer.String("my-cluster-frontEnd"),
+					Name: ptr.To("my-cluster-frontEnd"),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-						PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/outbound-publicip")},
+						PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/outbound-publicip")},
 					},
 				},
 			},
 			BackendAddressPools: &[]network.BackendAddressPool{
 				{
-					Name: pointer.String("my-cluster-outboundBackendPool"),
+					Name: ptr.To("my-cluster-outboundBackendPool"),
 				},
 			},
 			LoadBalancingRules: &[]network.LoadBalancingRule{},
 			Probes:             &[]network.Probe{},
 			OutboundRules: &[]network.OutboundRule{
 				{
-					Name: pointer.String("OutboundNATAllProtocols"),
+					Name: ptr.To("OutboundNATAllProtocols"),
 					OutboundRulePropertiesFormat: &network.OutboundRulePropertiesFormat{
 						FrontendIPConfigurations: &[]network.SubResource{
-							{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-cluster/frontendIPConfigurations/my-cluster-frontEnd")},
+							{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-cluster/frontendIPConfigurations/my-cluster-frontEnd")},
 						},
 						BackendAddressPool: &network.SubResource{
-							ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-cluster/backendAddressPools/my-cluster-outboundBackendPool"),
+							ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-cluster/backendAddressPools/my-cluster-outboundBackendPool"),
 						},
 						Protocol:             network.LoadBalancerOutboundRuleProtocolAll,
-						IdleTimeoutInMinutes: pointer.Int32(30),
+						IdleTimeoutInMinutes: ptr.To[int32](30),
 					},
 				},
 			},
@@ -211,97 +211,97 @@ func newDefaultNodeOutboundLB() network.LoadBalancer {
 func newSamplePublicAPIServerLB(verifyFrontendIP bool, verifyBackendAddressPools bool, verifyLBRules bool, verifyProbes bool, verifyOutboundRules bool) network.LoadBalancer {
 	var subnet *network.Subnet
 	var backendAddressPoolProps *network.BackendAddressPoolPropertiesFormat
-	enableFloatingIP := pointer.Bool(false)
-	numProbes := pointer.Int32(4)
-	idleTimeout := pointer.Int32(4)
+	enableFloatingIP := ptr.To(false)
+	numProbes := ptr.To[int32](4)
+	idleTimeout := ptr.To[int32](4)
 
 	if verifyFrontendIP {
 		subnet = &network.Subnet{
-			Name: pointer.String("fake-test-subnet"),
+			Name: ptr.To("fake-test-subnet"),
 		}
 	}
 	if verifyBackendAddressPools {
 		backendAddressPoolProps = &network.BackendAddressPoolPropertiesFormat{
-			Location: pointer.String("fake-test-location"),
+			Location: ptr.To("fake-test-location"),
 		}
 	}
 	if verifyLBRules {
-		enableFloatingIP = pointer.Bool(true)
+		enableFloatingIP = ptr.To(true)
 	}
 	if verifyProbes {
-		numProbes = pointer.Int32(999)
+		numProbes = ptr.To[int32](999)
 	}
 	if verifyOutboundRules {
-		idleTimeout = pointer.Int32(1000)
+		idleTimeout = ptr.To[int32](1000)
 	}
 
 	return network.LoadBalancer{
 		Tags: map[string]*string{
-			"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
-			"sigs.k8s.io_cluster-api-provider-azure_role":               pointer.String(infrav1.APIServerRole),
+			"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
+			"sigs.k8s.io_cluster-api-provider-azure_role":               ptr.To(infrav1.APIServerRole),
 		},
 		Sku:      &network.LoadBalancerSku{Name: network.LoadBalancerSkuNameStandard},
-		Location: pointer.String("my-location"),
+		Location: ptr.To("my-location"),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 				{
-					Name: pointer.String("my-publiclb-frontEnd"),
+					Name: ptr.To("my-publiclb-frontEnd"),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-						PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/my-publicip")},
+						PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/my-publicip")},
 						Subnet:          subnet, // Add to verify that FrontendIPConfigurations aren't overwritten on update
 					},
 				},
 			},
 			BackendAddressPools: &[]network.BackendAddressPool{
 				{
-					Name:                               pointer.String("my-publiclb-backendPool"),
+					Name:                               ptr.To("my-publiclb-backendPool"),
 					BackendAddressPoolPropertiesFormat: backendAddressPoolProps, // Add to verify that BackendAddressPools aren't overwritten on update
 				},
 			},
 			LoadBalancingRules: &[]network.LoadBalancingRule{
 				{
-					Name: pointer.String(lbRuleHTTPS),
+					Name: ptr.To(lbRuleHTTPS),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						DisableOutboundSnat:  pointer.Bool(true),
+						DisableOutboundSnat:  ptr.To(true),
 						Protocol:             network.TransportProtocolTCP,
-						FrontendPort:         pointer.Int32(6443),
-						BackendPort:          pointer.Int32(6443),
-						IdleTimeoutInMinutes: pointer.Int32(4),
+						FrontendPort:         ptr.To[int32](6443),
+						BackendPort:          ptr.To[int32](6443),
+						IdleTimeoutInMinutes: ptr.To[int32](4),
 						EnableFloatingIP:     enableFloatingIP, // Add to verify that LoadBalancingRules aren't overwritten on update
 						LoadDistribution:     network.LoadDistributionDefault,
 						FrontendIPConfiguration: &network.SubResource{
-							ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/frontendIPConfigurations/my-publiclb-frontEnd"),
+							ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/frontendIPConfigurations/my-publiclb-frontEnd"),
 						},
 						BackendAddressPool: &network.SubResource{
-							ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/backendAddressPools/my-publiclb-backendPool"),
+							ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/backendAddressPools/my-publiclb-backendPool"),
 						},
 						Probe: &network.SubResource{
-							ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/probes/HTTPSProbe"),
+							ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/probes/HTTPSProbe"),
 						},
 					},
 				},
 			},
 			Probes: &[]network.Probe{
 				{
-					Name: pointer.String(httpsProbe),
+					Name: ptr.To(httpsProbe),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
 						Protocol:          network.ProbeProtocolHTTPS,
-						Port:              pointer.Int32(6443),
-						RequestPath:       pointer.String(httpsProbeRequestPath),
-						IntervalInSeconds: pointer.Int32(15),
+						Port:              ptr.To[int32](6443),
+						RequestPath:       ptr.To(httpsProbeRequestPath),
+						IntervalInSeconds: ptr.To[int32](15),
 						NumberOfProbes:    numProbes, // Add to verify that Probes aren't overwritten on update
 					},
 				},
 			},
 			OutboundRules: &[]network.OutboundRule{
 				{
-					Name: pointer.String("OutboundNATAllProtocols"),
+					Name: ptr.To("OutboundNATAllProtocols"),
 					OutboundRulePropertiesFormat: &network.OutboundRulePropertiesFormat{
 						FrontendIPConfigurations: &[]network.SubResource{
-							{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/frontendIPConfigurations/my-publiclb-frontEnd")},
+							{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/frontendIPConfigurations/my-publiclb-frontEnd")},
 						},
 						BackendAddressPool: &network.SubResource{
-							ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/backendAddressPools/my-publiclb-backendPool"),
+							ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/backendAddressPools/my-publiclb-backendPool"),
 						},
 						Protocol:             network.LoadBalancerOutboundRuleProtocolAll,
 						IdleTimeoutInMinutes: idleTimeout, // Add to verify that OutboundRules aren't overwritten on update
@@ -315,48 +315,48 @@ func newSamplePublicAPIServerLB(verifyFrontendIP bool, verifyBackendAddressPools
 func newDefaultInternalAPIServerLB() network.LoadBalancer {
 	return network.LoadBalancer{
 		Tags: map[string]*string{
-			"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
-			"sigs.k8s.io_cluster-api-provider-azure_role":               pointer.String(infrav1.APIServerRole),
+			"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
+			"sigs.k8s.io_cluster-api-provider-azure_role":               ptr.To(infrav1.APIServerRole),
 		},
 		Sku:      &network.LoadBalancerSku{Name: network.LoadBalancerSkuNameStandard},
-		Location: pointer.String("my-location"),
+		Location: ptr.To("my-location"),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 				{
-					Name: pointer.String("my-private-lb-frontEnd"),
+					Name: ptr.To("my-private-lb-frontEnd"),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 						PrivateIPAllocationMethod: network.IPAllocationMethodStatic,
 						Subnet: &network.Subnet{
-							ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-cp-subnet"),
+							ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-cp-subnet"),
 						},
-						PrivateIPAddress: pointer.String("10.0.0.10"),
+						PrivateIPAddress: ptr.To("10.0.0.10"),
 					},
 				},
 			},
 			BackendAddressPools: &[]network.BackendAddressPool{
 				{
-					Name: pointer.String("my-private-lb-backendPool"),
+					Name: ptr.To("my-private-lb-backendPool"),
 				},
 			},
 			LoadBalancingRules: &[]network.LoadBalancingRule{
 				{
-					Name: pointer.String(lbRuleHTTPS),
+					Name: ptr.To(lbRuleHTTPS),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						DisableOutboundSnat:  pointer.Bool(true),
+						DisableOutboundSnat:  ptr.To(true),
 						Protocol:             network.TransportProtocolTCP,
-						FrontendPort:         pointer.Int32(6443),
-						BackendPort:          pointer.Int32(6443),
-						IdleTimeoutInMinutes: pointer.Int32(4),
-						EnableFloatingIP:     pointer.Bool(false),
+						FrontendPort:         ptr.To[int32](6443),
+						BackendPort:          ptr.To[int32](6443),
+						IdleTimeoutInMinutes: ptr.To[int32](4),
+						EnableFloatingIP:     ptr.To(false),
 						LoadDistribution:     network.LoadDistributionDefault,
 						FrontendIPConfiguration: &network.SubResource{
-							ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-private-lb/frontendIPConfigurations/my-private-lb-frontEnd"),
+							ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-private-lb/frontendIPConfigurations/my-private-lb-frontEnd"),
 						},
 						BackendAddressPool: &network.SubResource{
-							ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-private-lb/backendAddressPools/my-private-lb-backendPool"),
+							ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-private-lb/backendAddressPools/my-private-lb-backendPool"),
 						},
 						Probe: &network.SubResource{
-							ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-private-lb/probes/HTTPSProbe"),
+							ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-private-lb/probes/HTTPSProbe"),
 						},
 					},
 				},
@@ -364,13 +364,13 @@ func newDefaultInternalAPIServerLB() network.LoadBalancer {
 			OutboundRules: &[]network.OutboundRule{},
 			Probes: &[]network.Probe{
 				{
-					Name: pointer.String(httpsProbe),
+					Name: ptr.To(httpsProbe),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
 						Protocol:          network.ProbeProtocolHTTPS,
-						Port:              pointer.Int32(6443),
-						RequestPath:       pointer.String(httpsProbeRequestPath),
-						IntervalInSeconds: pointer.Int32(15),
-						NumberOfProbes:    pointer.Int32(4),
+						Port:              ptr.To[int32](6443),
+						RequestPath:       ptr.To(httpsProbeRequestPath),
+						IntervalInSeconds: ptr.To[int32](15),
+						NumberOfProbes:    ptr.To[int32](4),
 					},
 				},
 			},

--- a/azure/services/managedclusters/managedclusters.go
+++ b/azure/services/managedclusters/managedclusters.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2022-03-01/containerservice"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async"
@@ -90,7 +90,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		}
 		// Update control plane endpoint.
 		endpoint := clusterv1.APIEndpoint{
-			Host: pointer.StringDeref(managedCluster.ManagedClusterProperties.Fqdn, ""),
+			Host: ptr.Deref(managedCluster.ManagedClusterProperties.Fqdn, ""),
 			Port: 443,
 		}
 		s.Scope.SetControlPlaneEndpoint(endpoint)

--- a/azure/services/managedclusters/managedclusters_test.go
+++ b/azure/services/managedclusters/managedclusters_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2022-03-01/containerservice"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/managedclusters/mock_managedclusters"
@@ -63,11 +63,11 @@ func TestReconcile(t *testing.T) {
 				s.ManagedClusterSpec().Return(fakeManagedClusterSpec)
 				r.CreateOrUpdateResource(gomockinternal.AContext(), fakeManagedClusterSpec, serviceName).Return(containerservice.ManagedCluster{
 					ManagedClusterProperties: &containerservice.ManagedClusterProperties{
-						Fqdn:              pointer.String("my-managedcluster-fqdn"),
-						ProvisioningState: pointer.String("Succeeded"),
+						Fqdn:              ptr.To("my-managedcluster-fqdn"),
+						ProvisioningState: ptr.To("Succeeded"),
 						IdentityProfile: map[string]*containerservice.UserAssignedIdentity{
 							kubeletIdentityKey: {
-								ResourceID: pointer.String("kubelet-id"),
+								ResourceID: ptr.To("kubelet-id"),
 							},
 						},
 					},
@@ -89,8 +89,8 @@ func TestReconcile(t *testing.T) {
 				s.ManagedClusterSpec().Return(fakeManagedClusterSpec)
 				r.CreateOrUpdateResource(gomockinternal.AContext(), fakeManagedClusterSpec, serviceName).Return(containerservice.ManagedCluster{
 					ManagedClusterProperties: &containerservice.ManagedClusterProperties{
-						Fqdn:              pointer.String("my-managedcluster-fqdn"),
-						ProvisioningState: pointer.String("Succeeded"),
+						Fqdn:              ptr.To("my-managedcluster-fqdn"),
+						ProvisioningState: ptr.To("Succeeded"),
 					},
 				}, nil)
 				s.SetControlPlaneEndpoint(clusterv1.APIEndpoint{

--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2022-03-01/containerservice"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -289,18 +289,18 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existing interface{
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
 			ClusterName: s.ClusterName,
-			Name:        pointer.String(s.Name),
-			Role:        pointer.String(infrav1.CommonRole),
+			Name:        ptr.To(s.Name),
+			Role:        ptr.To(infrav1.CommonRole),
 			Additional:  s.Tags,
 		})),
 		ManagedClusterProperties: &containerservice.ManagedClusterProperties{
 			NodeResourceGroup: &s.NodeResourceGroup,
-			EnableRBAC:        pointer.Bool(true),
+			EnableRBAC:        ptr.To(true),
 			DNSPrefix:         &s.Name,
 			KubernetesVersion: &s.Version,
 
 			ServicePrincipalProfile: &containerservice.ManagedClusterServicePrincipalProfile{
-				ClientID: pointer.String("msi"),
+				ClientID: ptr.To("msi"),
 			},
 			AgentPoolProfiles: &[]containerservice.ManagedClusterAgentPoolProfile{},
 			NetworkProfile: &containerservice.NetworkProfile{
@@ -313,11 +313,11 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existing interface{
 
 	if decodedSSHPublicKey != nil {
 		managedCluster.LinuxProfile = &containerservice.LinuxProfile{
-			AdminUsername: pointer.String(azure.DefaultAKSUserName),
+			AdminUsername: ptr.To(azure.DefaultAKSUserName),
 			SSH: &containerservice.SSHConfiguration{
 				PublicKeys: &[]containerservice.SSHPublicKey{
 					{
-						KeyData: pointer.String(string(decodedSSHPublicKey)),
+						KeyData: ptr.To(string(decodedSSHPublicKey)),
 					},
 				},
 			},
@@ -409,7 +409,7 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existing interface{
 	if s.KubeletUserAssignedIdentity != "" {
 		managedCluster.ManagedClusterProperties.IdentityProfile = map[string]*containerservice.UserAssignedIdentity{
 			kubeletIdentityKey: {
-				ResourceID: pointer.String(s.KubeletUserAssignedIdentity),
+				ResourceID: ptr.To(s.KubeletUserAssignedIdentity),
 			},
 		}
 	}
@@ -470,7 +470,7 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existing interface{
 			if !ok {
 				return nil, fmt.Errorf("%T is not a containerservice.AgentPool", agentPool)
 			}
-			agentPool.Name = pointer.String(spec.ResourceName())
+			agentPool.Name = ptr.To(spec.ResourceName())
 			profile := converters.AgentPoolToManagedClusterAgentPoolProfile(agentPool)
 			*managedCluster.AgentPoolProfiles = append(*managedCluster.AgentPoolProfiles, profile)
 		}

--- a/azure/services/managedclusters/spec_test.go
+++ b/azure/services/managedclusters/spec_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -45,7 +45,7 @@ func TestParameters(t *testing.T) {
 			name: "managedcluster in non-terminal provisioning state",
 			existing: containerservice.ManagedCluster{
 				ManagedClusterProperties: &containerservice.ManagedClusterProperties{
-					ProvisioningState: pointer.String("Deleting"),
+					ProvisioningState: ptr.To("Deleting"),
 				},
 			},
 			spec: &ManagedClusterSpec{
@@ -89,9 +89,9 @@ func TestParameters(t *testing.T) {
 							Replicas:          int32(4),
 							Cluster:           "test-managedcluster",
 							SKU:               "test_SKU",
-							Version:           pointer.String("v1.22.0"),
+							Version:           ptr.To("v1.22.0"),
 							VnetSubnetID:      "fake/subnet/id",
-							MaxPods:           pointer.Int32(int32(32)),
+							MaxPods:           ptr.To[int32](int32(32)),
 							AvailabilityZones: []string{"1", "2"},
 							AdditionalTags: map[string]string{
 								"test-tag": "test-value",
@@ -142,10 +142,10 @@ func TestParameters(t *testing.T) {
 			},
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(containerservice.ManagedCluster{}))
-				g.Expect(result.(containerservice.ManagedCluster).KubernetesVersion).To(Equal(pointer.String("v1.22.99")))
+				g.Expect(result.(containerservice.ManagedCluster).KubernetesVersion).To(Equal(ptr.To("v1.22.99")))
 				g.Expect(result.(containerservice.ManagedCluster).Identity.Type).To(Equal(containerservice.ResourceIdentityType("UserAssigned")))
 				g.Expect(result.(containerservice.ManagedCluster).Identity.UserAssignedIdentities).To(Equal(map[string]*containerservice.ManagedClusterIdentityUserAssignedIdentitiesValue{"/resource/ID": {}}))
-				g.Expect(result.(containerservice.ManagedCluster).IdentityProfile).To(Equal(map[string]*containerservice.UserAssignedIdentity{kubeletIdentityKey: {ResourceID: pointer.String("/resource/ID")}}))
+				g.Expect(result.(containerservice.ManagedCluster).IdentityProfile).To(Equal(map[string]*containerservice.UserAssignedIdentity{kubeletIdentityKey: {ResourceID: ptr.To("/resource/ID")}}))
 			},
 		},
 		{
@@ -382,65 +382,65 @@ func TestGetIdentity(t *testing.T) {
 func getExistingClusterWithAPIServerAccessProfile() containerservice.ManagedCluster {
 	mc := getExistingCluster()
 	mc.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
-		EnablePrivateCluster: pointer.Bool(false),
+		EnablePrivateCluster: ptr.To(false),
 	}
 	return mc
 }
 
 func getExistingCluster() containerservice.ManagedCluster {
 	mc := getSampleManagedCluster()
-	mc.ProvisioningState = pointer.String("Succeeded")
-	mc.ID = pointer.String("test-id")
+	mc.ProvisioningState = ptr.To("Succeeded")
+	mc.ID = ptr.To("test-id")
 	return mc
 }
 
 func getSampleManagedCluster() containerservice.ManagedCluster {
 	return containerservice.ManagedCluster{
 		ManagedClusterProperties: &containerservice.ManagedClusterProperties{
-			KubernetesVersion: pointer.String("v1.22.0"),
-			DNSPrefix:         pointer.String("test-managedcluster"),
+			KubernetesVersion: ptr.To("v1.22.0"),
+			DNSPrefix:         ptr.To("test-managedcluster"),
 			AgentPoolProfiles: &[]containerservice.ManagedClusterAgentPoolProfile{
 				{
-					Name:         pointer.String("test-agentpool-0"),
+					Name:         ptr.To("test-agentpool-0"),
 					Mode:         containerservice.AgentPoolMode(infrav1.NodePoolModeSystem),
-					Count:        pointer.Int32(2),
+					Count:        ptr.To[int32](2),
 					Type:         containerservice.AgentPoolTypeVirtualMachineScaleSets,
-					OsDiskSizeGB: pointer.Int32(0),
+					OsDiskSizeGB: ptr.To[int32](0),
 					Tags: map[string]*string{
-						"test-tag": pointer.String("test-value"),
+						"test-tag": ptr.To("test-value"),
 					},
-					EnableAutoScaling: pointer.Bool(false),
+					EnableAutoScaling: ptr.To(false),
 				},
 				{
-					Name:                pointer.String("test-agentpool-1"),
+					Name:                ptr.To("test-agentpool-1"),
 					Mode:                containerservice.AgentPoolMode(infrav1.NodePoolModeUser),
-					Count:               pointer.Int32(4),
+					Count:               ptr.To[int32](4),
 					Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
-					OsDiskSizeGB:        pointer.Int32(0),
-					VMSize:              pointer.String("test_SKU"),
-					OrchestratorVersion: pointer.String("v1.22.0"),
-					VnetSubnetID:        pointer.String("fake/subnet/id"),
-					MaxPods:             pointer.Int32(int32(32)),
+					OsDiskSizeGB:        ptr.To[int32](0),
+					VMSize:              ptr.To("test_SKU"),
+					OrchestratorVersion: ptr.To("v1.22.0"),
+					VnetSubnetID:        ptr.To("fake/subnet/id"),
+					MaxPods:             ptr.To[int32](int32(32)),
 					AvailabilityZones:   &[]string{"1", "2"},
 					Tags: map[string]*string{
-						"test-tag": pointer.String("test-value"),
+						"test-tag": ptr.To("test-value"),
 					},
-					EnableAutoScaling: pointer.Bool(false),
+					EnableAutoScaling: ptr.To(false),
 				},
 			},
 			LinuxProfile: &containerservice.LinuxProfile{
-				AdminUsername: pointer.String(azure.DefaultAKSUserName),
+				AdminUsername: ptr.To(azure.DefaultAKSUserName),
 				SSH: &containerservice.SSHConfiguration{
 					PublicKeys: &[]containerservice.SSHPublicKey{
 						{
-							KeyData: pointer.String("test-ssh-key"),
+							KeyData: ptr.To("test-ssh-key"),
 						},
 					},
 				},
 			},
-			ServicePrincipalProfile: &containerservice.ManagedClusterServicePrincipalProfile{ClientID: pointer.String("msi")},
-			NodeResourceGroup:       pointer.String("test-node-rg"),
-			EnableRBAC:              pointer.Bool(true),
+			ServicePrincipalProfile: &containerservice.ManagedClusterServicePrincipalProfile{ClientID: ptr.To("msi")},
+			NodeResourceGroup:       ptr.To("test-node-rg"),
+			EnableRBAC:              ptr.To(true),
 			NetworkProfile: &containerservice.NetworkProfile{
 				LoadBalancerSku: "Standard",
 			},
@@ -448,12 +448,12 @@ func getSampleManagedCluster() containerservice.ManagedCluster {
 		Identity: &containerservice.ManagedClusterIdentity{
 			Type: containerservice.ResourceIdentityTypeSystemAssigned,
 		},
-		Location: pointer.String("test-location"),
+		Location: ptr.To("test-location"),
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
 			ClusterName: "test-cluster",
-			Name:        pointer.String("test-managedcluster"),
-			Role:        pointer.String(infrav1.CommonRole),
+			Name:        ptr.To("test-managedcluster"),
+			Role:        ptr.To(infrav1.CommonRole),
 			Additional: infrav1.Tags{
 				"test-tag": "test-value",
 			},

--- a/azure/services/natgateways/natgateways_test.go
+++ b/azure/services/natgateways/natgateways_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
@@ -49,7 +49,7 @@ var (
 		NatGatewayIP:   infrav1.PublicIPSpec{Name: "pip-node-subnet"},
 	}
 	natGateway1 = network.NatGateway{
-		ID: pointer.String("/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.Network/natGateways/my-node-natgateway-1"),
+		ID: ptr.To("/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.Network/natGateways/my-node-natgateway-1"),
 	}
 	customVNetTags = infrav1.Tags{
 		"Name": "my-vnet",

--- a/azure/services/natgateways/spec.go
+++ b/azure/services/natgateways/spec.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -69,20 +69,20 @@ func (s *NatGatewaySpec) Parameters(ctx context.Context, existing interface{}) (
 	}
 
 	natGatewayToCreate := network.NatGateway{
-		Name:     pointer.String(s.Name),
-		Location: pointer.String(s.Location),
+		Name:     ptr.To(s.Name),
+		Location: ptr.To(s.Location),
 		Sku:      &network.NatGatewaySku{Name: network.NatGatewaySkuNameStandard},
 		NatGatewayPropertiesFormat: &network.NatGatewayPropertiesFormat{
 			PublicIPAddresses: &[]network.SubResource{
 				{
-					ID: pointer.String(azure.PublicIPID(s.SubscriptionID, s.ResourceGroupName(), s.NatGatewayIP.Name)),
+					ID: ptr.To(azure.PublicIPID(s.SubscriptionID, s.ResourceGroupName(), s.NatGatewayIP.Name)),
 				},
 			},
 		},
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
-			Name:        pointer.String(s.Name),
+			Name:        ptr.To(s.Name),
 			Additional:  s.AdditionalTags,
 		})),
 	}

--- a/azure/services/networkinterfaces/spec_test.go
+++ b/azure/services/networkinterfaces/spec_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
 )
 
@@ -43,21 +43,21 @@ var (
 		ClusterName:           "my-cluster",
 	}
 	fakeSku = resourceskus.SKU{
-		Name: pointer.String("Standard_D2v2"),
-		Kind: pointer.String(string(resourceskus.VirtualMachines)),
+		Name: ptr.To("Standard_D2v2"),
+		Kind: ptr.To(string(resourceskus.VirtualMachines)),
 		Locations: &[]string{
 			"fake-location",
 		},
 		LocationInfo: &[]compute.ResourceSkuLocationInfo{
 			{
-				Location: pointer.String("fake-location"),
+				Location: ptr.To("fake-location"),
 				Zones:    &[]string{"1"},
 			},
 		},
 		Capabilities: &[]compute.ResourceSkuCapabilities{
 			{
-				Name:  pointer.String(resourceskus.AcceleratedNetworking),
-				Value: pointer.String(string(resourceskus.CapabilitySupported)),
+				Name:  ptr.To(resourceskus.AcceleratedNetworking),
+				Value: ptr.To(string(resourceskus.CapabilitySupported)),
 			},
 		},
 	}
@@ -141,7 +141,7 @@ var (
 		VNetName:              "my-vnet",
 		VNetResourceGroup:     "my-rg",
 		PublicLBName:          "my-public-lb",
-		AcceleratedNetworking: pointer.Bool(false),
+		AcceleratedNetworking: ptr.To(false),
 		ClusterName:           "my-cluster",
 	}
 
@@ -276,24 +276,24 @@ func TestParameters(t *testing.T) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
 					Tags: map[string]*string{
-						"Name": pointer.String("my-net-interface"),
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+						"Name": ptr.To("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
-					Location: pointer.String("fake-location"),
+					Location: ptr.To("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 						Primary:                     nil,
-						EnableAcceleratedNetworking: pointer.Bool(true),
-						EnableIPForwarding:          pointer.Bool(false),
+						EnableAcceleratedNetworking: ptr.To(true),
+						EnableIPForwarding:          ptr.To(false),
 						DNSSettings:                 &network.InterfaceDNSSettings{},
 						IPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: pointer.String("pipConfig"),
+								Name: ptr.To("pipConfig"),
 								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Primary:                         pointer.Bool(true),
-									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/cluster-name-outboundBackendPool")}},
+									Primary:                         ptr.To(true),
+									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/cluster-name-outboundBackendPool")}},
 									PrivateIPAllocationMethod:       network.IPAllocationMethodStatic,
-									PrivateIPAddress:                pointer.String("fake.static.ip"),
-									Subnet:                          &network.Subnet{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAddress:                ptr.To("fake.static.ip"),
+									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 								},
 							},
 						},
@@ -310,23 +310,23 @@ func TestParameters(t *testing.T) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
 					Tags: map[string]*string{
-						"Name": pointer.String("my-net-interface"),
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+						"Name": ptr.To("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
-					Location: pointer.String("fake-location"),
+					Location: ptr.To("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
-						EnableAcceleratedNetworking: pointer.Bool(true),
-						EnableIPForwarding:          pointer.Bool(false),
+						EnableAcceleratedNetworking: ptr.To(true),
+						EnableIPForwarding:          ptr.To(false),
 						DNSSettings:                 &network.InterfaceDNSSettings{},
 						Primary:                     nil,
 						IPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: pointer.String("pipConfig"),
+								Name: ptr.To("pipConfig"),
 								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Primary:                         pointer.Bool(true),
-									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/cluster-name-outboundBackendPool")}},
+									Primary:                         ptr.To(true),
+									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/cluster-name-outboundBackendPool")}},
 									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
-									Subnet:                          &network.Subnet{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 								},
 							},
 						},
@@ -343,26 +343,26 @@ func TestParameters(t *testing.T) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
 					Tags: map[string]*string{
-						"Name": pointer.String("my-net-interface"),
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+						"Name": ptr.To("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
-					Location: pointer.String("fake-location"),
+					Location: ptr.To("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
-						EnableAcceleratedNetworking: pointer.Bool(true),
-						EnableIPForwarding:          pointer.Bool(false),
+						EnableAcceleratedNetworking: ptr.To(true),
+						EnableIPForwarding:          ptr.To(false),
 						DNSSettings:                 &network.InterfaceDNSSettings{},
 						Primary:                     nil,
 						IPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: pointer.String("pipConfig"),
+								Name: ptr.To("pipConfig"),
 								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Primary:                     pointer.Bool(true),
-									Subnet:                      &network.Subnet{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Primary:                     ptr.To(true),
+									Subnet:                      &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 									PrivateIPAllocationMethod:   network.IPAllocationMethodDynamic,
-									LoadBalancerInboundNatRules: &[]network.InboundNatRule{{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/inboundNatRules/azure-test1")}},
+									LoadBalancerInboundNatRules: &[]network.InboundNatRule{{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/inboundNatRules/azure-test1")}},
 									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{
-										{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/my-public-lb-backendPool")},
-										{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-internal-lb/backendAddressPools/my-internal-lb-backendPool")}},
+										{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/my-public-lb-backendPool")},
+										{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-internal-lb/backendAddressPools/my-internal-lb-backendPool")}},
 								},
 							},
 						},
@@ -379,21 +379,21 @@ func TestParameters(t *testing.T) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
 					Tags: map[string]*string{
-						"Name": pointer.String("my-net-interface"),
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+						"Name": ptr.To("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
-					Location: pointer.String("fake-location"),
+					Location: ptr.To("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 						Primary:                     nil,
-						EnableAcceleratedNetworking: pointer.Bool(true),
-						EnableIPForwarding:          pointer.Bool(false),
+						EnableAcceleratedNetworking: ptr.To(true),
+						EnableIPForwarding:          ptr.To(false),
 						DNSSettings:                 &network.InterfaceDNSSettings{},
 						IPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: pointer.String("pipConfig"),
+								Name: ptr.To("pipConfig"),
 								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Primary:                         pointer.Bool(true),
-									Subnet:                          &network.Subnet{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Primary:                         ptr.To(true),
+									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
 									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
 								},
@@ -412,21 +412,21 @@ func TestParameters(t *testing.T) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
 					Tags: map[string]*string{
-						"Name": pointer.String("my-net-interface"),
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+						"Name": ptr.To("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
-					Location: pointer.String("fake-location"),
+					Location: ptr.To("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 						Primary:                     nil,
-						EnableAcceleratedNetworking: pointer.Bool(false),
-						EnableIPForwarding:          pointer.Bool(false),
+						EnableAcceleratedNetworking: ptr.To(false),
+						EnableIPForwarding:          ptr.To(false),
 						DNSSettings:                 &network.InterfaceDNSSettings{},
 						IPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: pointer.String("pipConfig"),
+								Name: ptr.To("pipConfig"),
 								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Primary:                         pointer.Bool(true),
-									Subnet:                          &network.Subnet{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Primary:                         ptr.To(true),
+									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
 									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
 								},
@@ -445,30 +445,30 @@ func TestParameters(t *testing.T) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
 					Tags: map[string]*string{
-						"Name": pointer.String("my-net-interface"),
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+						"Name": ptr.To("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
-					Location: pointer.String("fake-location"),
+					Location: ptr.To("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 						Primary:                     nil,
-						EnableAcceleratedNetworking: pointer.Bool(true),
-						EnableIPForwarding:          pointer.Bool(true),
+						EnableAcceleratedNetworking: ptr.To(true),
+						EnableIPForwarding:          ptr.To(true),
 						DNSSettings:                 &network.InterfaceDNSSettings{},
 						IPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: pointer.String("pipConfig"),
+								Name: ptr.To("pipConfig"),
 								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Primary:                         pointer.Bool(true),
-									Subnet:                          &network.Subnet{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Primary:                         ptr.To(true),
+									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
 									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
 								},
 							},
 							{
-								Name: pointer.String("ipConfigv6"),
+								Name: ptr.To("ipConfigv6"),
 								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Subnet:                  &network.Subnet{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
-									Primary:                 pointer.Bool(false),
+									Subnet:                  &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Primary:                 ptr.To(false),
 									PrivateIPAddressVersion: "IPv6",
 								},
 							},
@@ -486,21 +486,21 @@ func TestParameters(t *testing.T) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
 					Tags: map[string]*string{
-						"Name": pointer.String("my-net-interface"),
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+						"Name": ptr.To("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
-					Location: pointer.String("fake-location"),
+					Location: ptr.To("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 						Primary:                     nil,
-						EnableAcceleratedNetworking: pointer.Bool(true),
-						EnableIPForwarding:          pointer.Bool(true),
+						EnableAcceleratedNetworking: ptr.To(true),
+						EnableIPForwarding:          ptr.To(true),
 						DNSSettings:                 &network.InterfaceDNSSettings{},
 						IPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: pointer.String("pipConfig"),
+								Name: ptr.To("pipConfig"),
 								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Primary:                         pointer.Bool(true),
-									Subnet:                          &network.Subnet{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Primary:                         ptr.To(true),
+									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
 									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
 								},
@@ -519,21 +519,21 @@ func TestParameters(t *testing.T) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
 					Tags: map[string]*string{
-						"Name": pointer.String("my-net-interface"),
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+						"Name": ptr.To("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
-					Location: pointer.String("fake-location"),
+					Location: ptr.To("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 						Primary:                     nil,
-						EnableAcceleratedNetworking: pointer.Bool(true),
-						EnableIPForwarding:          pointer.Bool(true),
+						EnableAcceleratedNetworking: ptr.To(true),
+						EnableIPForwarding:          ptr.To(true),
 						DNSSettings:                 &network.InterfaceDNSSettings{},
 						IPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: pointer.String("pipConfig"),
+								Name: ptr.To("pipConfig"),
 								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Primary:                         pointer.Bool(true),
-									Subnet:                          &network.Subnet{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Primary:                         ptr.To(true),
+									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
 									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
 								},
@@ -552,30 +552,30 @@ func TestParameters(t *testing.T) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
 					Tags: map[string]*string{
-						"Name": pointer.String("my-net-interface"),
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+						"Name": ptr.To("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
-					Location: pointer.String("fake-location"),
+					Location: ptr.To("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 						Primary:                     nil,
-						EnableAcceleratedNetworking: pointer.Bool(true),
-						EnableIPForwarding:          pointer.Bool(true),
+						EnableAcceleratedNetworking: ptr.To(true),
+						EnableIPForwarding:          ptr.To(true),
 						DNSSettings:                 &network.InterfaceDNSSettings{},
 						IPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: pointer.String("pipConfig"),
+								Name: ptr.To("pipConfig"),
 								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Primary:                         pointer.Bool(true),
-									Subnet:                          &network.Subnet{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Primary:                         ptr.To(true),
+									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
 									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
 								},
 							},
 							{
-								Name: pointer.String("my-net-interface-1"),
+								Name: ptr.To("my-net-interface-1"),
 								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Primary:                         pointer.Bool(false),
-									Subnet:                          &network.Subnet{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Primary:                         ptr.To(false),
+									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
 									LoadBalancerBackendAddressPools: nil,
 								},
@@ -594,33 +594,33 @@ func TestParameters(t *testing.T) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
 					Tags: map[string]*string{
-						"Name": pointer.String("my-net-interface"),
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+						"Name": ptr.To("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
-					Location: pointer.String("fake-location"),
+					Location: ptr.To("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 						Primary:                     nil,
-						EnableAcceleratedNetworking: pointer.Bool(true),
-						EnableIPForwarding:          pointer.Bool(true),
+						EnableAcceleratedNetworking: ptr.To(true),
+						EnableIPForwarding:          ptr.To(true),
 						DNSSettings:                 &network.InterfaceDNSSettings{},
 						IPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: pointer.String("pipConfig"),
+								Name: ptr.To("pipConfig"),
 								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Primary:                   pointer.Bool(true),
-									Subnet:                    &network.Subnet{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Primary:                   ptr.To(true),
+									Subnet:                    &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 									PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
 									PublicIPAddress: &network.PublicIPAddress{
-										ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/pip-azure-test1"),
+										ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/pip-azure-test1"),
 									},
 									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
 								},
 							},
 							{
-								Name: pointer.String("my-net-interface-1"),
+								Name: ptr.To("my-net-interface-1"),
 								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Primary:                         pointer.Bool(false),
-									Subnet:                          &network.Subnet{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Primary:                         ptr.To(false),
+									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
 									LoadBalancerBackendAddressPools: nil,
 								},
@@ -639,27 +639,27 @@ func TestParameters(t *testing.T) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
 				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
 					Tags: map[string]*string{
-						"Name": pointer.String("my-net-interface"),
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+						"Name": ptr.To("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
-					Location: pointer.String("fake-location"),
+					Location: ptr.To("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
-						EnableAcceleratedNetworking: pointer.Bool(true),
-						EnableIPForwarding:          pointer.Bool(false),
+						EnableAcceleratedNetworking: ptr.To(true),
+						EnableIPForwarding:          ptr.To(false),
 						DNSSettings: &network.InterfaceDNSSettings{
 							DNSServers: &[]string{"123.123.123.123", "124.124.124.124"},
 						},
 						IPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: pointer.String("pipConfig"),
+								Name: ptr.To("pipConfig"),
 								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Subnet:                      &network.Subnet{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
-									Primary:                     pointer.Bool(true),
+									Subnet:                      &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Primary:                     ptr.To(true),
 									PrivateIPAllocationMethod:   network.IPAllocationMethodDynamic,
-									LoadBalancerInboundNatRules: &[]network.InboundNatRule{{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/inboundNatRules/azure-test1")}},
+									LoadBalancerInboundNatRules: &[]network.InboundNatRule{{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/inboundNatRules/azure-test1")}},
 									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{
-										{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/my-public-lb-backendPool")},
-										{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-internal-lb/backendAddressPools/my-internal-lb-backendPool")}},
+										{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/my-public-lb-backendPool")},
+										{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-internal-lb/backendAddressPools/my-internal-lb-backendPool")}},
 								},
 							},
 						},

--- a/azure/services/privatedns/link_spec.go
+++ b/azure/services/privatedns/link_spec.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -67,11 +67,11 @@ func (s LinkSpec) Parameters(ctx context.Context, existing interface{}) (params 
 	return privatedns.VirtualNetworkLink{
 		VirtualNetworkLinkProperties: &privatedns.VirtualNetworkLinkProperties{
 			VirtualNetwork: &privatedns.SubResource{
-				ID: pointer.String(azure.VNetID(s.SubscriptionID, s.VNetResourceGroup, s.VNetName)),
+				ID: ptr.To(azure.VNetID(s.SubscriptionID, s.VNetResourceGroup, s.VNetName)),
 			},
-			RegistrationEnabled: pointer.Bool(false),
+			RegistrationEnabled: ptr.To(false),
 		},
-		Location: pointer.String(azure.Global),
+		Location: ptr.To(azure.Global),
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,
 			Lifecycle:   infrav1.ResourceLifecycleOwned,

--- a/azure/services/privatedns/link_spec_test.go
+++ b/azure/services/privatedns/link_spec_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
@@ -70,13 +70,13 @@ func TestLinkSpec_Parameters(t *testing.T) {
 				g.Expect(result).To(Equal(privatedns.VirtualNetworkLink{
 					VirtualNetworkLinkProperties: &privatedns.VirtualNetworkLinkProperties{
 						VirtualNetwork: &privatedns.SubResource{
-							ID: pointer.String("/subscriptions/123/resourceGroups/my-vnet-rg/providers/Microsoft.Network/virtualNetworks/my-vnet"),
+							ID: ptr.To("/subscriptions/123/resourceGroups/my-vnet-rg/providers/Microsoft.Network/virtualNetworks/my-vnet"),
 						},
-						RegistrationEnabled: pointer.Bool(false),
+						RegistrationEnabled: ptr.To(false),
 					},
-					Location: pointer.String(azure.Global),
+					Location: ptr.To(azure.Global),
 					Tags: map[string]*string{
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
 				}))
 			},
@@ -86,7 +86,7 @@ func TestLinkSpec_Parameters(t *testing.T) {
 			expectedError: "",
 			spec:          linkSpec,
 			existing: privatedns.VirtualNetworkLink{Tags: map[string]*string{
-				"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+				"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 			}},
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeNil())

--- a/azure/services/privatedns/privatedns_test.go
+++ b/azure/services/privatedns/privatedns_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
@@ -83,8 +83,8 @@ var (
 	managedTags = resources.TagsResource{
 		Properties: &resources.Tags{
 			Tags: map[string]*string{
-				"foo": pointer.String("bar"),
-				"sigs.k8s.io_cluster-api-provider-azure_cluster_" + clusterName: pointer.String("owned"),
+				"foo": ptr.To("bar"),
+				"sigs.k8s.io_cluster-api-provider-azure_cluster_" + clusterName: ptr.To("owned"),
 			},
 		},
 	}

--- a/azure/services/privatedns/record_spec.go
+++ b/azure/services/privatedns/record_spec.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 )
@@ -57,7 +57,7 @@ func (s RecordSpec) Parameters(ctx context.Context, existing interface{}) (param
 	}
 	set := privatedns.RecordSet{
 		RecordSetProperties: &privatedns.RecordSetProperties{
-			TTL: pointer.Int64(300),
+			TTL: ptr.To[int64](300),
 		},
 	}
 	recordType := converters.GetRecordType(s.Record.IP)

--- a/azure/services/privatedns/record_spec_test.go
+++ b/azure/services/privatedns/record_spec_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -70,10 +70,10 @@ func TestRecordSpec_Parameters(t *testing.T) {
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(Equal(privatedns.RecordSet{
 					RecordSetProperties: &privatedns.RecordSetProperties{
-						TTL: pointer.Int64(300),
+						TTL: ptr.To[int64](300),
 						ARecords: &[]privatedns.ARecord{
 							{
-								Ipv4Address: pointer.String("10.0.0.8"),
+								Ipv4Address: ptr.To("10.0.0.8"),
 							},
 						},
 					},
@@ -87,10 +87,10 @@ func TestRecordSpec_Parameters(t *testing.T) {
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(Equal(privatedns.RecordSet{
 					RecordSetProperties: &privatedns.RecordSetProperties{
-						TTL: pointer.Int64(300),
+						TTL: ptr.To[int64](300),
 						AaaaRecords: &[]privatedns.AaaaRecord{
 							{
-								Ipv6Address: pointer.String("2603:1030:805:2::b"),
+								Ipv6Address: ptr.To("2603:1030:805:2::b"),
 							},
 						},
 					},

--- a/azure/services/privatedns/zone_spec.go
+++ b/azure/services/privatedns/zone_spec.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -61,7 +61,7 @@ func (s ZoneSpec) Parameters(ctx context.Context, existing interface{}) (params 
 	}
 
 	return privatedns.PrivateZone{
-		Location: pointer.String(azure.Global),
+		Location: ptr.To(azure.Global),
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,
 			Lifecycle:   infrav1.ResourceLifecycleOwned,

--- a/azure/services/privatedns/zone_spec_test.go
+++ b/azure/services/privatedns/zone_spec_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
@@ -64,9 +64,9 @@ func TestZoneSpec_Parameters(t *testing.T) {
 			spec:          zoneSpec,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(Equal(privatedns.PrivateZone{
-					Location: pointer.String(azure.Global),
+					Location: ptr.To(azure.Global),
 					Tags: map[string]*string{
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
 				}))
 			},
@@ -76,7 +76,7 @@ func TestZoneSpec_Parameters(t *testing.T) {
 			expectedError: "",
 			spec:          zoneSpec,
 			existing: privatedns.PrivateZone{Tags: map[string]*string{
-				"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+				"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 			}},
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeNil())

--- a/azure/services/privateendpoints/spec.go
+++ b/azure/services/privateendpoints/spec.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-05-01/network"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -85,13 +85,13 @@ func (s *PrivateEndpointSpec) Parameters(ctx context.Context, existing interface
 	}
 
 	if s.CustomNetworkInterfaceName != "" {
-		privateEndpointProperties.CustomNetworkInterfaceName = pointer.String(s.CustomNetworkInterfaceName)
+		privateEndpointProperties.CustomNetworkInterfaceName = ptr.To(s.CustomNetworkInterfaceName)
 	}
 
 	if len(s.PrivateIPAddresses) > 0 {
 		privateIPAddresses := make([]network.PrivateEndpointIPConfiguration, 0, len(s.PrivateIPAddresses))
 		for _, address := range s.PrivateIPAddresses {
-			ipConfig := &network.PrivateEndpointIPConfigurationProperties{PrivateIPAddress: pointer.String(address)}
+			ipConfig := &network.PrivateEndpointIPConfigurationProperties{PrivateIPAddress: ptr.To(address)}
 
 			privateIPAddresses = append(privateIPAddresses, network.PrivateEndpointIPConfiguration{
 				PrivateEndpointIPConfigurationProperties: ipConfig,
@@ -103,9 +103,9 @@ func (s *PrivateEndpointSpec) Parameters(ctx context.Context, existing interface
 	privateLinkServiceConnections := make([]network.PrivateLinkServiceConnection, 0, len(s.PrivateLinkServiceConnections))
 	for _, privateLinkServiceConnection := range s.PrivateLinkServiceConnections {
 		linkServiceConnection := network.PrivateLinkServiceConnection{
-			Name: pointer.String(privateLinkServiceConnection.Name),
+			Name: ptr.To(privateLinkServiceConnection.Name),
 			PrivateLinkServiceConnectionProperties: &network.PrivateLinkServiceConnectionProperties{
-				PrivateLinkServiceID: pointer.String(privateLinkServiceConnection.PrivateLinkServiceID),
+				PrivateLinkServiceID: ptr.To(privateLinkServiceConnection.PrivateLinkServiceID),
 			},
 		}
 
@@ -114,7 +114,7 @@ func (s *PrivateEndpointSpec) Parameters(ctx context.Context, existing interface
 		}
 
 		if privateLinkServiceConnection.RequestMessage != "" {
-			linkServiceConnection.PrivateLinkServiceConnectionProperties.RequestMessage = pointer.String(privateLinkServiceConnection.RequestMessage)
+			linkServiceConnection.PrivateLinkServiceConnectionProperties.RequestMessage = ptr.To(privateLinkServiceConnection.RequestMessage)
 		}
 		privateLinkServiceConnections = append(privateLinkServiceConnections, linkServiceConnection)
 	}
@@ -131,25 +131,25 @@ func (s *PrivateEndpointSpec) Parameters(ctx context.Context, existing interface
 
 	for _, applicationSecurityGroup := range s.ApplicationSecurityGroups {
 		applicationSecurityGroups = append(applicationSecurityGroups, network.ApplicationSecurityGroup{
-			ID: pointer.String(applicationSecurityGroup),
+			ID: ptr.To(applicationSecurityGroup),
 		})
 	}
 
 	privateEndpointProperties.ApplicationSecurityGroups = &applicationSecurityGroups
 
 	newPrivateEndpoint := network.PrivateEndpoint{
-		Name:                      pointer.String(s.Name),
+		Name:                      ptr.To(s.Name),
 		PrivateEndpointProperties: &privateEndpointProperties,
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
-			Name:        pointer.String(s.Name),
+			Name:        ptr.To(s.Name),
 			Additional:  s.AdditionalTags,
 		})),
 	}
 
 	if s.Location != "" {
-		newPrivateEndpoint.Location = pointer.String(s.Location)
+		newPrivateEndpoint.Location = ptr.To(s.Location)
 	}
 
 	if existing != nil {

--- a/azure/services/privateendpoints/spec_test.go
+++ b/azure/services/privateendpoints/spec_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-05-01/network"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -80,30 +80,30 @@ func TestParameters(t *testing.T) {
 			},
 			// See https://learn.microsoft.com/en-us/rest/api/virtualnetwork/private-endpoints/get?tabs=Go for more options
 			existing: network.PrivateEndpoint{
-				Name: pointer.String("test-private-endpoint1"),
+				Name: ptr.To("test-private-endpoint1"),
 				PrivateEndpointProperties: &network.PrivateEndpointProperties{
 					Subnet: &network.Subnet{
-						ID: pointer.String("test-subnet"),
+						ID: ptr.To("test-subnet"),
 						SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 							PrivateEndpointNetworkPolicies:    network.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled,
 							PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled,
 						},
 					},
 					ApplicationSecurityGroups: &[]network.ApplicationSecurityGroup{{
-						ID: pointer.String("asg1"),
+						ID: ptr.To("asg1"),
 					}},
 					PrivateLinkServiceConnections: &[]network.PrivateLinkServiceConnection{{
-						Name: pointer.String(privateEndpoint1.PrivateLinkServiceConnections[0].Name),
+						Name: ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].Name),
 						PrivateLinkServiceConnectionProperties: &network.PrivateLinkServiceConnectionProperties{
-							PrivateLinkServiceID: pointer.String(privateEndpoint1.PrivateLinkServiceConnections[0].PrivateLinkServiceID),
+							PrivateLinkServiceID: ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].PrivateLinkServiceID),
 							GroupIds:             nil,
-							RequestMessage:       pointer.String(privateEndpoint1.PrivateLinkServiceConnections[0].RequestMessage),
+							RequestMessage:       ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].RequestMessage),
 						},
 					}},
 					ManualPrivateLinkServiceConnections: &[]network.PrivateLinkServiceConnection{},
 					ProvisioningState:                   "Succeeded",
 				},
-				Tags: map[string]*string{"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"), "Name": pointer.String("test-private-endpoint1")},
+				Tags: map[string]*string{"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"), "Name": ptr.To("test-private-endpoint1")},
 			},
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeNil())
@@ -127,30 +127,30 @@ func TestParameters(t *testing.T) {
 			},
 			// See https://learn.microsoft.com/en-us/rest/api/virtualnetwork/private-endpoints/get?tabs=Go for more options
 			existing: network.PrivateEndpoint{
-				Name: pointer.String("test-private-endpoint-manual"),
+				Name: ptr.To("test-private-endpoint-manual"),
 				PrivateEndpointProperties: &network.PrivateEndpointProperties{
 					Subnet: &network.Subnet{
-						ID: pointer.String("test-subnet"),
+						ID: ptr.To("test-subnet"),
 						SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 							PrivateEndpointNetworkPolicies:    network.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled,
 							PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled,
 						},
 					},
 					ApplicationSecurityGroups: &[]network.ApplicationSecurityGroup{{
-						ID: pointer.String("asg1"),
+						ID: ptr.To("asg1"),
 					}},
 					ManualPrivateLinkServiceConnections: &[]network.PrivateLinkServiceConnection{{
-						Name: pointer.String(privateEndpoint1Manual.PrivateLinkServiceConnections[0].Name),
+						Name: ptr.To(privateEndpoint1Manual.PrivateLinkServiceConnections[0].Name),
 						PrivateLinkServiceConnectionProperties: &network.PrivateLinkServiceConnectionProperties{
-							PrivateLinkServiceID: pointer.String(privateEndpoint1Manual.PrivateLinkServiceConnections[0].PrivateLinkServiceID),
+							PrivateLinkServiceID: ptr.To(privateEndpoint1Manual.PrivateLinkServiceConnections[0].PrivateLinkServiceID),
 							GroupIds:             &[]string{"aa", "bb"},
-							RequestMessage:       pointer.String(privateEndpoint1Manual.PrivateLinkServiceConnections[0].RequestMessage),
+							RequestMessage:       ptr.To(privateEndpoint1Manual.PrivateLinkServiceConnections[0].RequestMessage),
 						},
 					}},
 					PrivateLinkServiceConnections: &[]network.PrivateLinkServiceConnection{},
 					ProvisioningState:             "Succeeded",
 				},
-				Tags: map[string]*string{"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"), "Name": pointer.String("test-private-endpoint-manual")},
+				Tags: map[string]*string{"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"), "Name": ptr.To("test-private-endpoint-manual")},
 			},
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeNil())
@@ -175,25 +175,25 @@ func TestParameters(t *testing.T) {
 				CustomNetworkInterfaceName: "test-if-name",
 			},
 			existing: network.PrivateEndpoint{
-				Name:     pointer.String("test-private-endpoint2"),
-				Location: pointer.String("test-location"),
+				Name:     ptr.To("test-private-endpoint2"),
+				Location: ptr.To("test-location"),
 				PrivateEndpointProperties: &network.PrivateEndpointProperties{
 					Subnet: &network.Subnet{
-						ID: pointer.String("test-subnet"),
+						ID: ptr.To("test-subnet"),
 						SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 							PrivateEndpointNetworkPolicies:    network.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled,
 							PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled,
 						},
 					},
 					ApplicationSecurityGroups: &[]network.ApplicationSecurityGroup{{
-						ID: pointer.String("asg1"),
+						ID: ptr.To("asg1"),
 					}},
 					PrivateLinkServiceConnections: &[]network.PrivateLinkServiceConnection{{
-						Name: pointer.String(privateEndpoint1.PrivateLinkServiceConnections[0].Name),
+						Name: ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].Name),
 						PrivateLinkServiceConnectionProperties: &network.PrivateLinkServiceConnectionProperties{
-							PrivateLinkServiceID: pointer.String(privateEndpoint1.PrivateLinkServiceConnections[0].PrivateLinkServiceID),
+							PrivateLinkServiceID: ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].PrivateLinkServiceID),
 							GroupIds:             &[]string{"aa", "bb"},
-							RequestMessage:       pointer.String(privateEndpoint1.PrivateLinkServiceConnections[0].RequestMessage),
+							RequestMessage:       ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].RequestMessage),
 						},
 					}},
 					ManualPrivateLinkServiceConnections: &[]network.PrivateLinkServiceConnection{},
@@ -201,54 +201,54 @@ func TestParameters(t *testing.T) {
 					IPConfigurations: &[]network.PrivateEndpointIPConfiguration{
 						{
 							PrivateEndpointIPConfigurationProperties: &network.PrivateEndpointIPConfigurationProperties{
-								PrivateIPAddress: pointer.String("10.0.0.1"),
+								PrivateIPAddress: ptr.To("10.0.0.1"),
 							},
 						},
 					},
-					CustomNetworkInterfaceName: pointer.String("test-if-name"),
+					CustomNetworkInterfaceName: ptr.To("test-if-name"),
 				},
-				Tags: map[string]*string{"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"), "Name": pointer.String("test-private-endpoint2")},
+				Tags: map[string]*string{"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"), "Name": ptr.To("test-private-endpoint2")},
 			},
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.PrivateEndpoint{}))
 				g.Expect(result).To(Equal(network.PrivateEndpoint{
-					Name:     pointer.String("test-private-endpoint2"),
-					Location: pointer.String("test-location"),
+					Name:     ptr.To("test-private-endpoint2"),
+					Location: ptr.To("test-location"),
 					PrivateEndpointProperties: &network.PrivateEndpointProperties{
 						Subnet: &network.Subnet{
-							ID: pointer.String("test-subnet"),
+							ID: ptr.To("test-subnet"),
 							SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 								PrivateEndpointNetworkPolicies:    network.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled,
 								PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled,
 							},
 						},
 						ApplicationSecurityGroups: &[]network.ApplicationSecurityGroup{{
-							ID: pointer.String("asg1"),
+							ID: ptr.To("asg1"),
 						}},
 						PrivateLinkServiceConnections: &[]network.PrivateLinkServiceConnection{{
-							Name: pointer.String(privateEndpoint1.PrivateLinkServiceConnections[0].Name),
+							Name: ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].Name),
 							PrivateLinkServiceConnectionProperties: &network.PrivateLinkServiceConnectionProperties{
-								PrivateLinkServiceID: pointer.String(privateEndpoint1.PrivateLinkServiceConnections[0].PrivateLinkServiceID),
+								PrivateLinkServiceID: ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].PrivateLinkServiceID),
 								GroupIds:             &[]string{"aa", "bb"},
-								RequestMessage:       pointer.String(privateEndpoint1.PrivateLinkServiceConnections[0].RequestMessage),
+								RequestMessage:       ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].RequestMessage),
 							},
 						}},
 						ManualPrivateLinkServiceConnections: &[]network.PrivateLinkServiceConnection{},
 						IPConfigurations: &[]network.PrivateEndpointIPConfiguration{
 							{
 								PrivateEndpointIPConfigurationProperties: &network.PrivateEndpointIPConfigurationProperties{
-									PrivateIPAddress: pointer.String("10.0.0.1"),
+									PrivateIPAddress: ptr.To("10.0.0.1"),
 								},
 							},
 							{
 								PrivateEndpointIPConfigurationProperties: &network.PrivateEndpointIPConfigurationProperties{
-									PrivateIPAddress: pointer.String("10.0.0.2"),
+									PrivateIPAddress: ptr.To("10.0.0.2"),
 								},
 							},
 						},
-						CustomNetworkInterfaceName: pointer.String("test-if-name"),
+						CustomNetworkInterfaceName: ptr.To("test-if-name"),
 					},
-					Tags: map[string]*string{"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"), "Name": pointer.String("test-private-endpoint2")},
+					Tags: map[string]*string{"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"), "Name": ptr.To("test-private-endpoint2")},
 				}))
 			},
 		},
@@ -274,43 +274,43 @@ func TestParameters(t *testing.T) {
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.PrivateEndpoint{}))
 				g.Expect(result).To(Equal(network.PrivateEndpoint{
-					Name:     pointer.String("test-private-endpoint2"),
-					Location: pointer.String("test-location"),
+					Name:     ptr.To("test-private-endpoint2"),
+					Location: ptr.To("test-location"),
 					PrivateEndpointProperties: &network.PrivateEndpointProperties{
 						Subnet: &network.Subnet{
-							ID: pointer.String("test-subnet"),
+							ID: ptr.To("test-subnet"),
 							SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 								PrivateEndpointNetworkPolicies:    network.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled,
 								PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled,
 							},
 						},
 						ApplicationSecurityGroups: &[]network.ApplicationSecurityGroup{{
-							ID: pointer.String("asg1"),
+							ID: ptr.To("asg1"),
 						}},
 						PrivateLinkServiceConnections: &[]network.PrivateLinkServiceConnection{{
-							Name: pointer.String(privateEndpoint1.PrivateLinkServiceConnections[0].Name),
+							Name: ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].Name),
 							PrivateLinkServiceConnectionProperties: &network.PrivateLinkServiceConnectionProperties{
-								PrivateLinkServiceID: pointer.String(privateEndpoint1.PrivateLinkServiceConnections[0].PrivateLinkServiceID),
+								PrivateLinkServiceID: ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].PrivateLinkServiceID),
 								GroupIds:             &[]string{"aa", "bb"},
-								RequestMessage:       pointer.String(privateEndpoint1.PrivateLinkServiceConnections[0].RequestMessage),
+								RequestMessage:       ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].RequestMessage),
 							},
 						}},
 						ManualPrivateLinkServiceConnections: &[]network.PrivateLinkServiceConnection{},
 						IPConfigurations: &[]network.PrivateEndpointIPConfiguration{
 							{
 								PrivateEndpointIPConfigurationProperties: &network.PrivateEndpointIPConfigurationProperties{
-									PrivateIPAddress: pointer.String("10.0.0.1"),
+									PrivateIPAddress: ptr.To("10.0.0.1"),
 								},
 							},
 							{
 								PrivateEndpointIPConfigurationProperties: &network.PrivateEndpointIPConfigurationProperties{
-									PrivateIPAddress: pointer.String("10.0.0.2"),
+									PrivateIPAddress: ptr.To("10.0.0.2"),
 								},
 							},
 						},
-						CustomNetworkInterfaceName: pointer.String("test-if-name"),
+						CustomNetworkInterfaceName: ptr.To("test-if-name"),
 					},
-					Tags: map[string]*string{"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"), "Name": pointer.String("test-private-endpoint2")},
+					Tags: map[string]*string{"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"), "Name": ptr.To("test-private-endpoint2")},
 				}))
 			},
 		},

--- a/azure/services/publicips/publicips_test.go
+++ b/azure/services/publicips/publicips_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
@@ -97,8 +97,8 @@ var (
 	managedTags = resources.TagsResource{
 		Properties: &resources.Tags{
 			Tags: map[string]*string{
-				"foo": pointer.String("bar"),
-				"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
+				"foo": ptr.To("bar"),
+				"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 			},
 		},
 	}
@@ -106,8 +106,8 @@ var (
 	unmanagedTags = resources.TagsResource{
 		Properties: &resources.Tags{
 			Tags: map[string]*string{
-				"foo":       pointer.String("bar"),
-				"something": pointer.String("else"),
+				"foo":       ptr.To("bar"),
+				"something": ptr.To("else"),
 			},
 		},
 	}

--- a/azure/services/publicips/spec.go
+++ b/azure/services/publicips/spec.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 )
@@ -75,8 +75,8 @@ func (s *PublicIPSpec) Parameters(ctx context.Context, existing interface{}) (pa
 	var dnsSettings *network.PublicIPAddressDNSSettings
 	if s.DNSName != "" {
 		dnsSettings = &network.PublicIPAddressDNSSettings{
-			DomainNameLabel: pointer.String(strings.Split(s.DNSName, ".")[0]),
-			Fqdn:            pointer.String(s.DNSName),
+			DomainNameLabel: ptr.To(strings.Split(s.DNSName, ".")[0]),
+			Fqdn:            ptr.To(s.DNSName),
 		}
 	}
 
@@ -84,12 +84,12 @@ func (s *PublicIPSpec) Parameters(ctx context.Context, existing interface{}) (pa
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
-			Name:        pointer.String(s.Name),
+			Name:        ptr.To(s.Name),
 			Additional:  s.AdditionalTags,
 		})),
 		Sku:              &network.PublicIPAddressSku{Name: network.PublicIPAddressSkuNameStandard},
-		Name:             pointer.String(s.Name),
-		Location:         pointer.String(s.Location),
+		Name:             ptr.To(s.Name),
+		Location:         ptr.To(s.Location),
 		ExtendedLocation: converters.ExtendedLocationToNetworkSDK(s.ExtendedLocation),
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAddressVersion:   addressVersion,

--- a/azure/services/publicips/spec_test.go
+++ b/azure/services/publicips/spec_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -51,33 +51,33 @@ var (
 	}
 
 	fakePublicIPWithDNS = network.PublicIPAddress{
-		Name:     pointer.String("my-publicip"),
+		Name:     ptr.To("my-publicip"),
 		Sku:      &network.PublicIPAddressSku{Name: network.PublicIPAddressSkuNameStandard},
-		Location: pointer.String("centralIndia"),
+		Location: ptr.To("centralIndia"),
 		Tags: map[string]*string{
-			"Name": pointer.String("my-publicip"),
-			"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
-			"foo": pointer.String("bar"),
+			"Name": ptr.To("my-publicip"),
+			"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
+			"foo": ptr.To("bar"),
 		},
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAddressVersion:   network.IPVersionIPv4,
 			PublicIPAllocationMethod: network.IPAllocationMethodStatic,
 			DNSSettings: &network.PublicIPAddressDNSSettings{
-				DomainNameLabel: pointer.String("fakedns"),
-				Fqdn:            pointer.String("fakedns.mydomain.io"),
+				DomainNameLabel: ptr.To("fakedns"),
+				Fqdn:            ptr.To("fakedns.mydomain.io"),
 			},
 		},
 		Zones: &[]string{"failure-domain-id-1", "failure-domain-id-2", "failure-domain-id-3"},
 	}
 
 	fakePublicIPWithoutDNS = network.PublicIPAddress{
-		Name:     pointer.String("my-publicip-2"),
+		Name:     ptr.To("my-publicip-2"),
 		Sku:      &network.PublicIPAddressSku{Name: network.PublicIPAddressSkuNameStandard},
-		Location: pointer.String("centralIndia"),
+		Location: ptr.To("centralIndia"),
 		Tags: map[string]*string{
-			"Name": pointer.String("my-publicip-2"),
-			"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
-			"foo": pointer.String("bar"),
+			"Name": ptr.To("my-publicip-2"),
+			"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
+			"foo": ptr.To("bar"),
 		},
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAddressVersion:   network.IPVersionIPv4,
@@ -87,20 +87,20 @@ var (
 	}
 
 	fakePublicIPIpv6 = network.PublicIPAddress{
-		Name:     pointer.String("my-publicip-ipv6"),
+		Name:     ptr.To("my-publicip-ipv6"),
 		Sku:      &network.PublicIPAddressSku{Name: network.PublicIPAddressSkuNameStandard},
-		Location: pointer.String("centralIndia"),
+		Location: ptr.To("centralIndia"),
 		Tags: map[string]*string{
-			"Name": pointer.String("my-publicip-ipv6"),
-			"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
-			"foo": pointer.String("bar"),
+			"Name": ptr.To("my-publicip-ipv6"),
+			"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
+			"foo": ptr.To("bar"),
 		},
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAddressVersion:   network.IPVersionIPv6,
 			PublicIPAllocationMethod: network.IPAllocationMethodStatic,
 			DNSSettings: &network.PublicIPAddressDNSSettings{
-				DomainNameLabel: pointer.String("fakename"),
-				Fqdn:            pointer.String("fakename.mydomain.io"),
+				DomainNameLabel: ptr.To("fakename"),
+				Fqdn:            ptr.To("fakename.mydomain.io"),
 			},
 		},
 		Zones: &[]string{"failure-domain-id-1", "failure-domain-id-2", "failure-domain-id-3"},

--- a/azure/services/resourcehealth/resourcehealth_test.go
+++ b/azure/services/resourcehealth/resourcehealth_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
 	utilfeature "k8s.io/component-base/featuregate/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourcehealth/mock_resourcehealth"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
@@ -62,7 +62,7 @@ func TestReconcileResourceHealth(t *testing.T) {
 				m.GetByResource(gomockinternal.AContext(), gomock.Any()).Times(1).Return(resourcehealth.AvailabilityStatus{
 					Properties: &resourcehealth.AvailabilityStatusProperties{
 						AvailabilityState: resourcehealth.AvailabilityStateValuesUnavailable,
-						Summary:           pointer.String("summary"),
+						Summary:           ptr.To("summary"),
 					},
 				}, nil)
 			},
@@ -85,7 +85,7 @@ func TestReconcileResourceHealth(t *testing.T) {
 				m.GetByResource(gomockinternal.AContext(), gomock.Any()).Times(1).Return(resourcehealth.AvailabilityStatus{
 					Properties: &resourcehealth.AvailabilityStatusProperties{
 						AvailabilityState: resourcehealth.AvailabilityStateValuesUnavailable,
-						Summary:           pointer.String("summary"),
+						Summary:           ptr.To("summary"),
 					},
 				}, nil)
 				// ignore the above status

--- a/azure/services/resourceskus/cache_test.go
+++ b/azure/services/resourceskus/cache_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestCacheGet(t *testing.T) {
@@ -40,12 +40,12 @@ func TestCacheGet(t *testing.T) {
 			resourceType: "bar",
 			have: []compute.ResourceSku{
 				{
-					Name:         pointer.String("other"),
-					ResourceType: pointer.String("baz"),
+					Name:         ptr.To("other"),
+					ResourceType: ptr.To("baz"),
 				},
 				{
-					Name:         pointer.String("foo"),
-					ResourceType: pointer.String("bar"),
+					Name:         ptr.To("foo"),
+					ResourceType: ptr.To("bar"),
 				},
 			},
 		},
@@ -55,7 +55,7 @@ func TestCacheGet(t *testing.T) {
 			resourceType: "bar",
 			have: []compute.ResourceSku{
 				{
-					Name: pointer.String("other"),
+					Name: ptr.To("other"),
 				},
 			},
 			err: "reconcile error that cannot be recovered occurred: resource sku with name 'foo' and category 'bar' not found in location 'test'. Object will not be requeued",
@@ -110,14 +110,14 @@ func TestCacheGetZones(t *testing.T) {
 		"should find 1 result": {
 			have: []compute.ResourceSku{
 				{
-					Name:         pointer.String("foo"),
-					ResourceType: pointer.String(string(VirtualMachines)),
+					Name:         ptr.To("foo"),
+					ResourceType: ptr.To(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
 					LocationInfo: &[]compute.ResourceSkuLocationInfo{
 						{
-							Location: pointer.String("baz"),
+							Location: ptr.To("baz"),
 							Zones:    &[]string{"1"},
 						},
 					},
@@ -128,27 +128,27 @@ func TestCacheGetZones(t *testing.T) {
 		"should find 2 results": {
 			have: []compute.ResourceSku{
 				{
-					Name:         pointer.String("foo"),
-					ResourceType: pointer.String(string(VirtualMachines)),
+					Name:         ptr.To("foo"),
+					ResourceType: ptr.To(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
 					LocationInfo: &[]compute.ResourceSkuLocationInfo{
 						{
-							Location: pointer.String("baz"),
+							Location: ptr.To("baz"),
 							Zones:    &[]string{"1"},
 						},
 					},
 				},
 				{
-					Name:         pointer.String("foo"),
-					ResourceType: pointer.String(string(VirtualMachines)),
+					Name:         ptr.To("foo"),
+					ResourceType: ptr.To(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
 					LocationInfo: &[]compute.ResourceSkuLocationInfo{
 						{
-							Location: pointer.String("baz"),
+							Location: ptr.To("baz"),
 							Zones:    &[]string{"2"},
 						},
 					},
@@ -159,14 +159,14 @@ func TestCacheGetZones(t *testing.T) {
 		"should not find due to location mismatch": {
 			have: []compute.ResourceSku{
 				{
-					Name:         pointer.String("foo"),
-					ResourceType: pointer.String(string(VirtualMachines)),
+					Name:         ptr.To("foo"),
+					ResourceType: ptr.To(string(VirtualMachines)),
 					Locations: &[]string{
 						"foobar",
 					},
 					LocationInfo: &[]compute.ResourceSkuLocationInfo{
 						{
-							Location: pointer.String("foobar"),
+							Location: ptr.To("foobar"),
 							Zones:    &[]string{"1"},
 						},
 					},
@@ -177,14 +177,14 @@ func TestCacheGetZones(t *testing.T) {
 		"should not find due to location restriction": {
 			have: []compute.ResourceSku{
 				{
-					Name:         pointer.String("foo"),
-					ResourceType: pointer.String(string(VirtualMachines)),
+					Name:         ptr.To("foo"),
+					ResourceType: ptr.To(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
 					LocationInfo: &[]compute.ResourceSkuLocationInfo{
 						{
-							Location: pointer.String("baz"),
+							Location: ptr.To("baz"),
 							Zones:    &[]string{"1"},
 						},
 					},
@@ -201,14 +201,14 @@ func TestCacheGetZones(t *testing.T) {
 		"should not find due to zone restriction": {
 			have: []compute.ResourceSku{
 				{
-					Name:         pointer.String("foo"),
-					ResourceType: pointer.String(string(VirtualMachines)),
+					Name:         ptr.To("foo"),
+					ResourceType: ptr.To(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
 					LocationInfo: &[]compute.ResourceSkuLocationInfo{
 						{
-							Location: pointer.String("baz"),
+							Location: ptr.To("baz"),
 							Zones:    &[]string{"1"},
 						},
 					},
@@ -254,14 +254,14 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 		"should find 1 result": {
 			have: []compute.ResourceSku{
 				{
-					Name:         pointer.String("foo"),
-					ResourceType: pointer.String(string(VirtualMachines)),
+					Name:         ptr.To("foo"),
+					ResourceType: ptr.To(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
 					LocationInfo: &[]compute.ResourceSkuLocationInfo{
 						{
-							Location: pointer.String("baz"),
+							Location: ptr.To("baz"),
 							Zones:    &[]string{"1"},
 						},
 					},
@@ -272,14 +272,14 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 		"should find 2 results": {
 			have: []compute.ResourceSku{
 				{
-					Name:         pointer.String("foo"),
-					ResourceType: pointer.String(string(VirtualMachines)),
+					Name:         ptr.To("foo"),
+					ResourceType: ptr.To(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
 					LocationInfo: &[]compute.ResourceSkuLocationInfo{
 						{
-							Location: pointer.String("baz"),
+							Location: ptr.To("baz"),
 							Zones:    &[]string{"1", "2"},
 						},
 					},
@@ -290,14 +290,14 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 		"should not find due to size mismatch": {
 			have: []compute.ResourceSku{
 				{
-					Name:         pointer.String("foobar"),
-					ResourceType: pointer.String(string(VirtualMachines)),
+					Name:         ptr.To("foobar"),
+					ResourceType: ptr.To(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
 					LocationInfo: &[]compute.ResourceSkuLocationInfo{
 						{
-							Location: pointer.String("baz"),
+							Location: ptr.To("baz"),
 							Zones:    &[]string{"1"},
 						},
 					},
@@ -308,14 +308,14 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 		"should not find due to location mismatch": {
 			have: []compute.ResourceSku{
 				{
-					Name:         pointer.String("foo"),
-					ResourceType: pointer.String(string(VirtualMachines)),
+					Name:         ptr.To("foo"),
+					ResourceType: ptr.To(string(VirtualMachines)),
 					Locations: &[]string{
 						"foobar",
 					},
 					LocationInfo: &[]compute.ResourceSkuLocationInfo{
 						{
-							Location: pointer.String("foobar"),
+							Location: ptr.To("foobar"),
 							Zones:    &[]string{"1"},
 						},
 					},
@@ -326,14 +326,14 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 		"should not find due to location restriction": {
 			have: []compute.ResourceSku{
 				{
-					Name:         pointer.String("foo"),
-					ResourceType: pointer.String(string(VirtualMachines)),
+					Name:         ptr.To("foo"),
+					ResourceType: ptr.To(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
 					LocationInfo: &[]compute.ResourceSkuLocationInfo{
 						{
-							Location: pointer.String("baz"),
+							Location: ptr.To("baz"),
 							Zones:    &[]string{"1"},
 						},
 					},
@@ -350,14 +350,14 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 		"should not find due to zone restriction": {
 			have: []compute.ResourceSku{
 				{
-					Name:         pointer.String("foo"),
-					ResourceType: pointer.String(string(VirtualMachines)),
+					Name:         ptr.To("foo"),
+					ResourceType: ptr.To(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
 					LocationInfo: &[]compute.ResourceSkuLocationInfo{
 						{
-							Location: pointer.String("baz"),
+							Location: ptr.To("baz"),
 							Zones:    &[]string{"1"},
 						},
 					},

--- a/azure/services/roleassignments/roleassignments_test.go
+++ b/azure/services/roleassignments/roleassignments_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/roleassignments/mock_roleassignments"
@@ -45,7 +45,7 @@ var (
 		MachineName:   "test-vm",
 		ResourceGroup: "my-rg",
 		ResourceType:  azure.VirtualMachine,
-		PrincipalID:   pointer.String("fake-principal-id"),
+		PrincipalID:   ptr.To("fake-principal-id"),
 	}
 	fakeRoleAssignment2 = RoleAssignmentSpec{
 		MachineName:   "test-vmss",

--- a/azure/services/roleassignments/spec.go
+++ b/azure/services/roleassignments/spec.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2019-03-01/authorization/mgmt/authorization"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // RoleAssignmentSpec defines the specification for a role assignment.
@@ -63,7 +63,7 @@ func (s *RoleAssignmentSpec) Parameters(ctx context.Context, existing interface{
 	return authorization.RoleAssignmentCreateParameters{
 		Properties: &authorization.RoleAssignmentProperties{
 			PrincipalID:      s.PrincipalID,
-			RoleDefinitionID: pointer.String(s.RoleDefinitionID),
+			RoleDefinitionID: ptr.To(s.RoleDefinitionID),
 		},
 	}, nil
 }

--- a/azure/services/routetables/spec.go
+++ b/azure/services/routetables/spec.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 )
@@ -61,12 +61,12 @@ func (s *RouteTableSpec) Parameters(ctx context.Context, existing interface{}) (
 		return nil, nil
 	}
 	return network.RouteTable{
-		Location:                   pointer.String(s.Location),
+		Location:                   ptr.To(s.Location),
 		RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{},
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
-			Name:        pointer.String(s.Name),
+			Name:        ptr.To(s.Name),
 			Additional:  s.AdditionalTags,
 		})),
 	}, nil

--- a/azure/services/scalesets/client.go
+++ b/azure/services/scalesets/client.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -295,7 +295,7 @@ func (ac *AzureClient) DeleteAsync(ctx context.Context, resourceGroupName, vmssN
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.AzureClient.DeleteAsync")
 	defer done()
 
-	future, err := ac.scalesets.Delete(ctx, resourceGroupName, vmssName, pointer.Bool(false))
+	future, err := ac.scalesets.Delete(ctx, resourceGroupName, vmssName, ptr.To(false))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed deleting vmss named %q", vmssName)
 	}

--- a/azure/services/scalesets/vmssextension_spec.go
+++ b/azure/services/scalesets/vmssextension_spec.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
@@ -59,11 +59,11 @@ func (s *VMSSExtensionSpec) Parameters(ctx context.Context, existing interface{}
 	}
 
 	return compute.VirtualMachineScaleSetExtension{
-		Name: pointer.String(s.Name),
+		Name: ptr.To(s.Name),
 		VirtualMachineScaleSetExtensionProperties: &compute.VirtualMachineScaleSetExtensionProperties{
-			Publisher:          pointer.String(s.Publisher),
-			Type:               pointer.String(s.Name),
-			TypeHandlerVersion: pointer.String(s.Version),
+			Publisher:          ptr.To(s.Publisher),
+			Type:               ptr.To(s.Name),
+			TypeHandlerVersion: ptr.To(s.Version),
 			Settings:           s.Settings,
 			ProtectedSettings:  s.ProtectedSettings,
 		},

--- a/azure/services/scalesets/vmssextension_spec_test.go
+++ b/azure/services/scalesets/vmssextension_spec_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
@@ -40,11 +40,11 @@ var (
 	}
 
 	fakeVMSSExtensionParams = compute.VirtualMachineScaleSetExtension{
-		Name: pointer.String("my-vm-extension"),
+		Name: ptr.To("my-vm-extension"),
 		VirtualMachineScaleSetExtensionProperties: &compute.VirtualMachineScaleSetExtensionProperties{
-			Publisher:          pointer.String("my-publisher"),
-			Type:               pointer.String("my-vm-extension"),
-			TypeHandlerVersion: pointer.String("1.0"),
+			Publisher:          ptr.To("my-publisher"),
+			Type:               ptr.To("my-vm-extension"),
+			TypeHandlerVersion: ptr.To("1.0"),
 			Settings:           map[string]string{"my-setting": "my-value"},
 			ProtectedSettings:  map[string]string{"my-protected-setting": "my-protected-value"},
 		},

--- a/azure/services/scalesetvms/client.go
+++ b/azure/services/scalesetvms/client.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -136,7 +136,7 @@ func (ac *azureClient) DeleteAsync(ctx context.Context, resourceGroupName, vmssN
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesetvms.azureClient.DeleteAsync")
 	defer done()
 
-	future, err := ac.scalesetvms.Delete(ctx, resourceGroupName, vmssName, instanceID, pointer.Bool(false))
+	future, err := ac.scalesetvms.Delete(ctx, resourceGroupName, vmssName, instanceID, ptr.To(false))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed deleting vmss named %q", vmssName)
 	}

--- a/azure/services/scalesetvms/scalesetvms_test.go
+++ b/azure/services/scalesetvms/scalesetvms_test.go
@@ -30,7 +30,7 @@ import (
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -108,7 +108,7 @@ func TestService_Reconcile(t *testing.T) {
 				s.ProviderID().Return("foo")
 				s.ScaleSetName().Return("scaleset")
 				vm := compute.VirtualMachineScaleSetVM{
-					InstanceID: pointer.String("0"),
+					InstanceID: ptr.To("0"),
 				}
 				m.Get(gomock2.AContext(), "rg", "scaleset", "0").Return(vm, nil)
 				s.SetVMSSVM(converters.SDKToVMSSVM(vm))

--- a/azure/services/securitygroups/securitygroups_test.go
+++ b/azure/services/securitygroups/securitygroups_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
@@ -66,10 +66,10 @@ var (
 		Priority:         2200,
 		Protocol:         infrav1.SecurityGroupProtocolTCP,
 		Direction:        infrav1.SecurityRuleDirectionInbound,
-		Source:           pointer.String("*"),
-		SourcePorts:      pointer.String("*"),
-		Destination:      pointer.String("*"),
-		DestinationPorts: pointer.String("22"),
+		Source:           ptr.To("*"),
+		SourcePorts:      ptr.To("*"),
+		Destination:      ptr.To("*"),
+		DestinationPorts: ptr.To("22"),
 	}
 	securityRule2 = infrav1.SecurityRule{
 		Name:             "other_rule",
@@ -77,10 +77,10 @@ var (
 		Priority:         500,
 		Protocol:         infrav1.SecurityGroupProtocolTCP,
 		Direction:        infrav1.SecurityRuleDirectionInbound,
-		Source:           pointer.String("*"),
-		SourcePorts:      pointer.String("*"),
-		Destination:      pointer.String("*"),
-		DestinationPorts: pointer.String("80"),
+		Source:           ptr.To("*"),
+		SourcePorts:      ptr.To("*"),
+		Destination:      ptr.To("*"),
+		DestinationPorts: ptr.To("80"),
 	}
 	errFake      = errors.New("this is an error")
 	notDoneError = azure.NewOperationNotDoneError(&infrav1.Future{})
@@ -286,41 +286,41 @@ func TestDeleteSecurityGroups(t *testing.T) {
 
 var (
 	ruleA = network.SecurityRule{
-		Name: pointer.String("A"),
+		Name: ptr.To("A"),
 		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-			Description:              pointer.String("this is rule A"),
+			Description:              ptr.To("this is rule A"),
 			Protocol:                 network.SecurityRuleProtocolTCP,
-			DestinationPortRange:     pointer.String("*"),
-			SourcePortRange:          pointer.String("*"),
-			DestinationAddressPrefix: pointer.String("*"),
-			SourceAddressPrefix:      pointer.String("*"),
-			Priority:                 pointer.Int32(100),
+			DestinationPortRange:     ptr.To("*"),
+			SourcePortRange:          ptr.To("*"),
+			DestinationAddressPrefix: ptr.To("*"),
+			SourceAddressPrefix:      ptr.To("*"),
+			Priority:                 ptr.To[int32](100),
 			Direction:                network.SecurityRuleDirectionInbound,
 		},
 	}
 	ruleB = network.SecurityRule{
-		Name: pointer.String("B"),
+		Name: ptr.To("B"),
 		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-			Description:              pointer.String("this is rule B"),
+			Description:              ptr.To("this is rule B"),
 			Protocol:                 network.SecurityRuleProtocolTCP,
-			DestinationPortRange:     pointer.String("*"),
-			SourcePortRange:          pointer.String("*"),
-			DestinationAddressPrefix: pointer.String("*"),
-			SourceAddressPrefix:      pointer.String("*"),
-			Priority:                 pointer.Int32(100),
+			DestinationPortRange:     ptr.To("*"),
+			SourcePortRange:          ptr.To("*"),
+			DestinationAddressPrefix: ptr.To("*"),
+			SourceAddressPrefix:      ptr.To("*"),
+			Priority:                 ptr.To[int32](100),
 			Direction:                network.SecurityRuleDirectionOutbound,
 		},
 	}
 	ruleBModified = network.SecurityRule{
-		Name: pointer.String("B"),
+		Name: ptr.To("B"),
 		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-			Description:              pointer.String("this is rule B"),
+			Description:              ptr.To("this is rule B"),
 			Protocol:                 network.SecurityRuleProtocolTCP,
-			DestinationPortRange:     pointer.String("80"),
-			SourcePortRange:          pointer.String("*"),
-			DestinationAddressPrefix: pointer.String("*"),
-			SourceAddressPrefix:      pointer.String("*"),
-			Priority:                 pointer.Int32(100),
+			DestinationPortRange:     ptr.To("80"),
+			SourcePortRange:          ptr.To("*"),
+			DestinationAddressPrefix: ptr.To("*"),
+			SourceAddressPrefix:      ptr.To("*"),
+			Priority:                 ptr.To[int32](100),
 			Direction:                network.SecurityRuleDirectionOutbound,
 		},
 	}

--- a/azure/services/securitygroups/spec.go
+++ b/azure/services/securitygroups/spec.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 )
@@ -104,7 +104,7 @@ func (s *NSGSpec) Parameters(ctx context.Context, existing interface{}) (interfa
 	}
 
 	return network.SecurityGroup{
-		Location: pointer.String(s.Location),
+		Location: ptr.To(s.Location),
 		SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 			SecurityRules: &securityRules,
 		},
@@ -112,7 +112,7 @@ func (s *NSGSpec) Parameters(ctx context.Context, existing interface{}) (interfa
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
-			Name:        pointer.String(s.Name),
+			Name:        ptr.To(s.Name),
 			Additional:  s.AdditionalTags,
 		})),
 	}, nil
@@ -121,10 +121,10 @@ func (s *NSGSpec) Parameters(ctx context.Context, existing interface{}) (interfa
 // TODO: review this logic and make sure it is what we want. It seems incorrect to skip rules that don't have a certain protocol, etc.
 func ruleExists(rules []network.SecurityRule, rule network.SecurityRule) bool {
 	for _, existingRule := range rules {
-		if !strings.EqualFold(pointer.StringDeref(existingRule.Name, ""), pointer.StringDeref(rule.Name, "")) {
+		if !strings.EqualFold(ptr.Deref(existingRule.Name, ""), ptr.Deref(rule.Name, "")) {
 			continue
 		}
-		if !strings.EqualFold(pointer.StringDeref(existingRule.DestinationPortRange, ""), pointer.StringDeref(rule.DestinationPortRange, "")) {
+		if !strings.EqualFold(ptr.Deref(existingRule.DestinationPortRange, ""), ptr.Deref(rule.DestinationPortRange, "")) {
 			continue
 		}
 		if existingRule.Protocol != network.SecurityRuleProtocolTCP &&
@@ -132,9 +132,9 @@ func ruleExists(rules []network.SecurityRule, rule network.SecurityRule) bool {
 			existingRule.Direction != network.SecurityRuleDirectionInbound {
 			continue
 		}
-		if !strings.EqualFold(pointer.StringDeref(existingRule.SourcePortRange, ""), "*") &&
-			!strings.EqualFold(pointer.StringDeref(existingRule.SourceAddressPrefix, ""), "*") &&
-			!strings.EqualFold(pointer.StringDeref(existingRule.DestinationAddressPrefix, ""), "*") {
+		if !strings.EqualFold(ptr.Deref(existingRule.SourcePortRange, ""), "*") &&
+			!strings.EqualFold(ptr.Deref(existingRule.SourceAddressPrefix, ""), "*") &&
+			!strings.EqualFold(ptr.Deref(existingRule.DestinationAddressPrefix, ""), "*") {
 			continue
 		}
 		return true

--- a/azure/services/securitygroups/spec_test.go
+++ b/azure/services/securitygroups/spec_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 )
@@ -34,10 +34,10 @@ var (
 		Priority:         2200,
 		Protocol:         infrav1.SecurityGroupProtocolTCP,
 		Direction:        infrav1.SecurityRuleDirectionInbound,
-		Source:           pointer.String("*"),
-		SourcePorts:      pointer.String("*"),
-		Destination:      pointer.String("*"),
-		DestinationPorts: pointer.String("22"),
+		Source:           ptr.To("*"),
+		SourcePorts:      ptr.To("*"),
+		Destination:      ptr.To("*"),
+		DestinationPorts: ptr.To("22"),
 	}
 	otherRule = infrav1.SecurityRule{
 		Name:             "other_rule",
@@ -45,10 +45,10 @@ var (
 		Priority:         500,
 		Protocol:         infrav1.SecurityGroupProtocolTCP,
 		Direction:        infrav1.SecurityRuleDirectionInbound,
-		Source:           pointer.String("*"),
-		SourcePorts:      pointer.String("*"),
-		Destination:      pointer.String("*"),
-		DestinationPorts: pointer.String("80"),
+		Source:           ptr.To("*"),
+		SourcePorts:      ptr.To("*"),
+		Destination:      ptr.To("*"),
+		DestinationPorts: ptr.To("80"),
 	}
 	customRule = infrav1.SecurityRule{
 		Name:             "custom_rule",
@@ -56,10 +56,10 @@ var (
 		Priority:         501,
 		Protocol:         infrav1.SecurityGroupProtocolTCP,
 		Direction:        infrav1.SecurityRuleDirectionOutbound,
-		Source:           pointer.String("*"),
-		SourcePorts:      pointer.String("*"),
-		Destination:      pointer.String("*"),
-		DestinationPorts: pointer.String("80"),
+		Source:           ptr.To("*"),
+		SourcePorts:      ptr.To("*"),
+		Destination:      ptr.To("*"),
+		DestinationPorts: ptr.To("80"),
 	}
 )
 
@@ -84,7 +84,7 @@ func TestParameters(t *testing.T) {
 				ClusterName:   "my-cluster",
 			},
 			existing: network.SecurityGroup{
-				Name: pointer.String("test-nsg"),
+				Name: ptr.To("test-nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						converters.SecurityRuleToSDK(sshRule),
@@ -109,9 +109,9 @@ func TestParameters(t *testing.T) {
 				ClusterName:   "my-cluster",
 			},
 			existing: network.SecurityGroup{
-				Name:     pointer.String("test-nsg"),
-				Location: pointer.String("test-location"),
-				Etag:     pointer.String("fake-etag"),
+				Name:     ptr.To("test-nsg"),
+				Location: ptr.To("test-location"),
+				Etag:     ptr.To("fake-etag"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						converters.SecurityRuleToSDK(sshRule),
@@ -122,8 +122,8 @@ func TestParameters(t *testing.T) {
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.SecurityGroup{}))
 				g.Expect(result).To(Equal(network.SecurityGroup{
-					Location: pointer.String("test-location"),
-					Etag:     pointer.String("fake-etag"),
+					Location: ptr.To("test-location"),
+					Etag:     ptr.To("fake-etag"),
 					SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 						SecurityRules: &[]network.SecurityRule{
 							converters.SecurityRuleToSDK(otherRule),
@@ -132,8 +132,8 @@ func TestParameters(t *testing.T) {
 						},
 					},
 					Tags: map[string]*string{
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
-						"Name": pointer.String("test-nsg"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
+						"Name": ptr.To("test-nsg"),
 					},
 				}))
 			},
@@ -156,9 +156,9 @@ func TestParameters(t *testing.T) {
 				},
 			},
 			existing: network.SecurityGroup{
-				Name:     pointer.String("test-nsg"),
-				Location: pointer.String("test-location"),
-				Etag:     pointer.String("fake-etag"),
+				Name:     ptr.To("test-nsg"),
+				Location: ptr.To("test-location"),
+				Etag:     ptr.To("fake-etag"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						converters.SecurityRuleToSDK(sshRule),
@@ -170,8 +170,8 @@ func TestParameters(t *testing.T) {
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(network.SecurityGroup{}))
 				g.Expect(result).To(Equal(network.SecurityGroup{
-					Location: pointer.String("test-location"),
-					Etag:     pointer.String("fake-etag"),
+					Location: ptr.To("test-location"),
+					Etag:     ptr.To("fake-etag"),
 					SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 						SecurityRules: &[]network.SecurityRule{
 							converters.SecurityRuleToSDK(sshRule),
@@ -179,8 +179,8 @@ func TestParameters(t *testing.T) {
 						},
 					},
 					Tags: map[string]*string{
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
-						"Name": pointer.String("test-nsg"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
+						"Name": ptr.To("test-nsg"),
 					},
 				}))
 			},
@@ -202,9 +202,9 @@ func TestParameters(t *testing.T) {
 				},
 			},
 			existing: network.SecurityGroup{
-				Name:     pointer.String("test-nsg"),
-				Location: pointer.String("test-location"),
-				Etag:     pointer.String("fake-etag"),
+				Name:     ptr.To("test-nsg"),
+				Location: ptr.To("test-location"),
+				Etag:     ptr.To("fake-etag"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						converters.SecurityRuleToSDK(sshRule),
@@ -239,10 +239,10 @@ func TestParameters(t *testing.T) {
 							converters.SecurityRuleToSDK(otherRule),
 						},
 					},
-					Location: pointer.String("test-location"),
+					Location: ptr.To("test-location"),
 					Tags: map[string]*string{
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": pointer.String("owned"),
-						"Name": pointer.String("test-nsg"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
+						"Name": ptr.To("test-nsg"),
 					},
 				}))
 			},

--- a/azure/services/subnets/spec.go
+++ b/azure/services/subnets/spec.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
@@ -88,26 +88,26 @@ func (s *SubnetSpec) Parameters(ctx context.Context, existing interface{}) (para
 
 	if s.RouteTableName != "" {
 		subnetProperties.RouteTable = &network.RouteTable{
-			ID: pointer.String(azure.RouteTableID(s.SubscriptionID, s.ResourceGroup, s.RouteTableName)),
+			ID: ptr.To(azure.RouteTableID(s.SubscriptionID, s.ResourceGroup, s.RouteTableName)),
 		}
 	}
 
 	if s.NatGatewayName != "" {
 		subnetProperties.NatGateway = &network.SubResource{
-			ID: pointer.String(azure.NatGatewayID(s.SubscriptionID, s.ResourceGroup, s.NatGatewayName)),
+			ID: ptr.To(azure.NatGatewayID(s.SubscriptionID, s.ResourceGroup, s.NatGatewayName)),
 		}
 	}
 
 	if s.SecurityGroupName != "" {
 		subnetProperties.NetworkSecurityGroup = &network.SecurityGroup{
-			ID: pointer.String(azure.SecurityGroupID(s.SubscriptionID, s.ResourceGroup, s.SecurityGroupName)),
+			ID: ptr.To(azure.SecurityGroupID(s.SubscriptionID, s.ResourceGroup, s.SecurityGroupName)),
 		}
 	}
 
 	serviceEndpoints := make([]network.ServiceEndpointPropertiesFormat, 0, len(s.ServiceEndpoints))
 	for _, se := range s.ServiceEndpoints {
 		se := se
-		serviceEndpoints = append(serviceEndpoints, network.ServiceEndpointPropertiesFormat{Service: pointer.String(se.Service), Locations: &se.Locations})
+		serviceEndpoints = append(serviceEndpoints, network.ServiceEndpointPropertiesFormat{Service: ptr.To(se.Service), Locations: &se.Locations})
 	}
 	subnetProperties.ServiceEndpoints = &serviceEndpoints
 
@@ -139,7 +139,7 @@ func (s *SubnetSpec) shouldUpdate(existingSubnet network.Subnet) bool {
 		newServiceEndpoints := make([]network.ServiceEndpointPropertiesFormat, len(s.ServiceEndpoints))
 		for _, se := range s.ServiceEndpoints {
 			se := se
-			newServiceEndpoints = append(newServiceEndpoints, network.ServiceEndpointPropertiesFormat{Service: pointer.String(se.Service), Locations: &se.Locations})
+			newServiceEndpoints = append(newServiceEndpoints, network.ServiceEndpointPropertiesFormat{Service: ptr.To(se.Service), Locations: &se.Locations})
 		}
 
 		diff := cmp.Diff(newServiceEndpoints, existingServiceEndpoints)

--- a/azure/services/subnets/spec_test.go
+++ b/azure/services/subnets/spec_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -43,10 +43,10 @@ var (
 
 	fakeSubnetOneCidrParams = network.Subnet{
 		SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-			AddressPrefix:        pointer.String("10.0.0.0/16"),
-			RouteTable:           &network.RouteTable{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
-			NetworkSecurityGroup: &network.SecurityGroup{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
-			NatGateway:           &network.SubResource{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/natGateways/my-nat-gateway")},
+			AddressPrefix:        ptr.To("10.0.0.0/16"),
+			RouteTable:           &network.RouteTable{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
+			NetworkSecurityGroup: &network.SecurityGroup{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
+			NatGateway:           &network.SubResource{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/natGateways/my-nat-gateway")},
 			ServiceEndpoints:     &[]network.ServiceEndpointPropertiesFormat{},
 		},
 	}
@@ -72,9 +72,9 @@ var (
 				"10.1.0.0/16",
 				"10.2.0.0/16",
 			},
-			RouteTable:           &network.RouteTable{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
-			NetworkSecurityGroup: &network.SecurityGroup{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
-			NatGateway:           &network.SubResource{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/natGateways/my-nat-gateway")},
+			RouteTable:           &network.RouteTable{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
+			NetworkSecurityGroup: &network.SecurityGroup{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
+			NatGateway:           &network.SubResource{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/natGateways/my-nat-gateway")},
 			ServiceEndpoints:     &[]network.ServiceEndpointPropertiesFormat{},
 		},
 	}
@@ -93,15 +93,15 @@ var (
 	}
 
 	fakeIpv6SubnetNotManaged = network.Subnet{
-		ID:   pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-ipv6-subnet"),
-		Name: pointer.String("my-ipv6-subnet"),
+		ID:   ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-ipv6-subnet"),
+		Name: ptr.To("my-ipv6-subnet"),
 		SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 			AddressPrefixes: &[]string{
 				"10.0.0.0/16",
 				"2001:1234:5678:9abd::/64",
 			},
-			RouteTable:           &network.RouteTable{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
-			NetworkSecurityGroup: &network.SecurityGroup{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
+			RouteTable:           &network.RouteTable{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
+			NetworkSecurityGroup: &network.SecurityGroup{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
 		},
 	}
 )
@@ -221,7 +221,7 @@ func TestSubnetSpec_shouldUpdate(t *testing.T) {
 			},
 			args: args{
 				existingSubnet: network.Subnet{
-					Name: pointer.String("my-subnet"),
+					Name: ptr.To("my-subnet"),
 				},
 			},
 			want: false,
@@ -237,7 +237,7 @@ func TestSubnetSpec_shouldUpdate(t *testing.T) {
 			},
 			args: args{
 				existingSubnet: network.Subnet{
-					Name: pointer.String("my-subnet"),
+					Name: ptr.To("my-subnet"),
 					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 						NatGateway: nil,
 					},
@@ -260,7 +260,7 @@ func TestSubnetSpec_shouldUpdate(t *testing.T) {
 			},
 			args: args{
 				existingSubnet: network.Subnet{
-					Name: pointer.String("my-subnet"),
+					Name: ptr.To("my-subnet"),
 					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 						ServiceEndpoints: nil,
 					},
@@ -279,7 +279,7 @@ func TestSubnetSpec_shouldUpdate(t *testing.T) {
 			},
 			args: args{
 				existingSubnet: network.Subnet{
-					Name: pointer.String("my-subnet"),
+					Name: ptr.To("my-subnet"),
 					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 						AddressPrefixes: &[]string{"10.1.0.0/8"},
 					},

--- a/azure/services/subnets/subnets.go
+++ b/azure/services/subnets/subnets.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -90,7 +90,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			if !ok {
 				return errors.Errorf("%T is not a network.Subnet", result)
 			}
-			s.Scope.UpdateSubnetID(subnetSpec.ResourceName(), pointer.StringDeref(subnet.ID, ""))
+			s.Scope.UpdateSubnetID(subnetSpec.ResourceName(), ptr.Deref(subnet.ID, ""))
 			s.Scope.UpdateSubnetCIDRs(subnetSpec.ResourceName(), converters.GetSubnetAddresses(subnet))
 		}
 	}

--- a/azure/services/subnets/subnets_test.go
+++ b/azure/services/subnets/subnets_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
@@ -49,17 +49,17 @@ var (
 	}
 
 	fakeSubnet1 = network.Subnet{
-		ID:   pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet-1"),
-		Name: pointer.String("my-subnet-1"),
+		ID:   ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet-1"),
+		Name: ptr.To("my-subnet-1"),
 		SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-			AddressPrefix: pointer.String("10.0.0.0/16"),
+			AddressPrefix: ptr.To("10.0.0.0/16"),
 			RouteTable: &network.RouteTable{
-				ID:   pointer.String("rt-id"),
-				Name: pointer.String("my-subnet_route_table"),
+				ID:   ptr.To("rt-id"),
+				Name: ptr.To("my-subnet_route_table"),
 			},
 			NetworkSecurityGroup: &network.SecurityGroup{
-				ID:   pointer.String("sg-id-1"),
-				Name: pointer.String("my-sg-1"),
+				ID:   ptr.To("sg-id-1"),
+				Name: ptr.To("my-sg-1"),
 			},
 		},
 	}
@@ -78,17 +78,17 @@ var (
 	}
 
 	fakeSubnet2 = network.Subnet{
-		ID:   pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet-2"),
-		Name: pointer.String("my-subnet-2"),
+		ID:   ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet-2"),
+		Name: ptr.To("my-subnet-2"),
 		SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-			AddressPrefix: pointer.String("10.2.0.0/16"),
+			AddressPrefix: ptr.To("10.2.0.0/16"),
 			RouteTable: &network.RouteTable{
-				ID:   pointer.String("rt-id"),
-				Name: pointer.String("my-subnet_route_table"),
+				ID:   ptr.To("rt-id"),
+				Name: ptr.To("my-subnet_route_table"),
 			},
 			NetworkSecurityGroup: &network.SecurityGroup{
-				ID:   pointer.String("sg-id-2"),
-				Name: pointer.String("my-sg-2"),
+				ID:   ptr.To("sg-id-2"),
+				Name: ptr.To("my-sg-2"),
 			},
 		},
 	}
@@ -106,17 +106,17 @@ var (
 		Role:              infrav1.SubnetNode,
 	}
 	fakeSubnetNotManaged = network.Subnet{
-		ID:   pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet-1"),
-		Name: pointer.String("my-subnet-1"),
+		ID:   ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet-1"),
+		Name: ptr.To("my-subnet-1"),
 		SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-			AddressPrefix: pointer.String("10.0.0.0/16"),
+			AddressPrefix: ptr.To("10.0.0.0/16"),
 			RouteTable: &network.RouteTable{
-				ID:   pointer.String("rt-id"),
-				Name: pointer.String("my-subnet_route_table"),
+				ID:   ptr.To("rt-id"),
+				Name: ptr.To("my-subnet_route_table"),
 			},
 			NetworkSecurityGroup: &network.SecurityGroup{
-				ID:   pointer.String("sg-id-1"),
-				Name: pointer.String("my-sg-1"),
+				ID:   ptr.To("sg-id-1"),
+				Name: ptr.To("my-sg-1"),
 			},
 		},
 	}
@@ -148,15 +148,15 @@ var (
 	}
 
 	fakeIpv6Subnet = network.Subnet{
-		ID:   pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-ipv6-subnet"),
-		Name: pointer.String("my-ipv6-subnet"),
+		ID:   ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-ipv6-subnet"),
+		Name: ptr.To("my-ipv6-subnet"),
 		SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 			AddressPrefixes: &[]string{
 				"10.0.0.0/16",
 				"2001:1234:5678:9abd::/64",
 			},
-			RouteTable:           &network.RouteTable{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
-			NetworkSecurityGroup: &network.SecurityGroup{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
+			RouteTable:           &network.RouteTable{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
+			NetworkSecurityGroup: &network.SecurityGroup{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
 		},
 	}
 
@@ -174,15 +174,15 @@ var (
 	}
 
 	fakeIpv6SubnetCP = network.Subnet{
-		ID:   pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-ipv6-subnet-cp"),
-		Name: pointer.String("my-ipv6-subnet-cp"),
+		ID:   ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-ipv6-subnet-cp"),
+		Name: ptr.To("my-ipv6-subnet-cp"),
 		SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 			AddressPrefixes: &[]string{
 				"10.2.0.0/16",
 				"2001:1234:5678:9abc::/64",
 			},
-			RouteTable:           &network.RouteTable{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
-			NetworkSecurityGroup: &network.SecurityGroup{ID: pointer.String("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
+			RouteTable:           &network.RouteTable{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
+			NetworkSecurityGroup: &network.SecurityGroup{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
 		},
 	}
 
@@ -211,8 +211,8 @@ func TestReconcileSubnets(t *testing.T) {
 				s.SubnetSpecs().Return([]azure.ResourceSpecGetter{&fakeSubnetSpec1})
 
 				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeSubnetSpec1, serviceName).Return(fakeSubnet1, nil)
-				s.UpdateSubnetID(fakeSubnetSpec1.Name, pointer.StringDeref(fakeSubnet1.ID, ""))
-				s.UpdateSubnetCIDRs(fakeSubnetSpec1.Name, []string{pointer.StringDeref(fakeSubnet1.AddressPrefix, "")})
+				s.UpdateSubnetID(fakeSubnetSpec1.Name, ptr.Deref(fakeSubnet1.ID, ""))
+				s.UpdateSubnetCIDRs(fakeSubnetSpec1.Name, []string{ptr.Deref(fakeSubnet1.AddressPrefix, "")})
 
 				s.IsVnetManaged().AnyTimes().Return(true)
 				s.UpdatePutStatus(infrav1.SubnetsReadyCondition, serviceName, nil)
@@ -225,12 +225,12 @@ func TestReconcileSubnets(t *testing.T) {
 				s.SubnetSpecs().Return([]azure.ResourceSpecGetter{&fakeSubnetSpec1, &fakeSubnetSpec2})
 
 				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeSubnetSpec1, serviceName).Return(fakeSubnet1, nil)
-				s.UpdateSubnetID(fakeSubnetSpec1.Name, pointer.StringDeref(fakeSubnet1.ID, ""))
-				s.UpdateSubnetCIDRs(fakeSubnetSpec1.Name, []string{pointer.StringDeref(fakeSubnet1.AddressPrefix, "")})
+				s.UpdateSubnetID(fakeSubnetSpec1.Name, ptr.Deref(fakeSubnet1.ID, ""))
+				s.UpdateSubnetCIDRs(fakeSubnetSpec1.Name, []string{ptr.Deref(fakeSubnet1.AddressPrefix, "")})
 
 				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeSubnetSpec2, serviceName).Return(fakeSubnet2, nil)
-				s.UpdateSubnetID(fakeSubnetSpec2.Name, pointer.StringDeref(fakeSubnet2.ID, ""))
-				s.UpdateSubnetCIDRs(fakeSubnetSpec2.Name, []string{pointer.StringDeref(fakeSubnet2.AddressPrefix, "")})
+				s.UpdateSubnetID(fakeSubnetSpec2.Name, ptr.Deref(fakeSubnet2.ID, ""))
+				s.UpdateSubnetCIDRs(fakeSubnetSpec2.Name, []string{ptr.Deref(fakeSubnet2.AddressPrefix, "")})
 
 				s.IsVnetManaged().AnyTimes().Return(true)
 				s.UpdatePutStatus(infrav1.SubnetsReadyCondition, serviceName, nil)
@@ -243,8 +243,8 @@ func TestReconcileSubnets(t *testing.T) {
 				s.SubnetSpecs().Return([]azure.ResourceSpecGetter{&fakeSubnetSpecNotManaged})
 
 				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeSubnetSpecNotManaged, serviceName).Return(fakeSubnetNotManaged, nil)
-				s.UpdateSubnetID(fakeSubnetSpecNotManaged.Name, pointer.StringDeref(fakeSubnetNotManaged.ID, ""))
-				s.UpdateSubnetCIDRs(fakeSubnetSpecNotManaged.Name, []string{pointer.StringDeref(fakeSubnetNotManaged.AddressPrefix, "")})
+				s.UpdateSubnetID(fakeSubnetSpecNotManaged.Name, ptr.Deref(fakeSubnetNotManaged.ID, ""))
+				s.UpdateSubnetCIDRs(fakeSubnetSpecNotManaged.Name, []string{ptr.Deref(fakeSubnetNotManaged.AddressPrefix, "")})
 
 				s.IsVnetManaged().AnyTimes().Return(false)
 			},
@@ -256,7 +256,7 @@ func TestReconcileSubnets(t *testing.T) {
 				s.SubnetSpecs().Return([]azure.ResourceSpecGetter{&fakeIpv6SubnetSpec})
 
 				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeIpv6SubnetSpec, serviceName).Return(fakeIpv6Subnet, nil)
-				s.UpdateSubnetID(fakeIpv6SubnetSpec.Name, pointer.StringDeref(fakeIpv6Subnet.ID, ""))
+				s.UpdateSubnetID(fakeIpv6SubnetSpec.Name, ptr.Deref(fakeIpv6Subnet.ID, ""))
 				s.UpdateSubnetCIDRs(fakeIpv6SubnetSpec.Name, azure.StringSlice(fakeIpv6Subnet.AddressPrefixes))
 
 				s.IsVnetManaged().AnyTimes().Return(true)
@@ -270,11 +270,11 @@ func TestReconcileSubnets(t *testing.T) {
 				s.SubnetSpecs().Return([]azure.ResourceSpecGetter{&fakeIpv6SubnetSpec, &fakeIpv6SubnetSpecCP})
 
 				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeIpv6SubnetSpec, serviceName).Return(fakeIpv6Subnet, nil)
-				s.UpdateSubnetID(fakeIpv6SubnetSpec.Name, pointer.StringDeref(fakeIpv6Subnet.ID, ""))
+				s.UpdateSubnetID(fakeIpv6SubnetSpec.Name, ptr.Deref(fakeIpv6Subnet.ID, ""))
 				s.UpdateSubnetCIDRs(fakeIpv6SubnetSpec.Name, azure.StringSlice(fakeIpv6Subnet.AddressPrefixes))
 
 				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeIpv6SubnetSpecCP, serviceName).Return(fakeIpv6SubnetCP, nil)
-				s.UpdateSubnetID(fakeIpv6SubnetSpecCP.Name, pointer.StringDeref(fakeIpv6SubnetCP.ID, ""))
+				s.UpdateSubnetID(fakeIpv6SubnetSpecCP.Name, ptr.Deref(fakeIpv6SubnetCP.ID, ""))
 				s.UpdateSubnetCIDRs(fakeIpv6SubnetSpecCP.Name, azure.StringSlice(fakeIpv6SubnetCP.AddressPrefixes))
 
 				s.IsVnetManaged().AnyTimes().Return(true)
@@ -308,8 +308,8 @@ func TestReconcileSubnets(t *testing.T) {
 				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeSubnetSpec1, serviceName).Return(nil, internalError)
 
 				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeSubnetSpec2, serviceName).Return(fakeSubnet2, nil)
-				s.UpdateSubnetID(fakeSubnetSpec2.Name, pointer.StringDeref(fakeSubnet2.ID, ""))
-				s.UpdateSubnetCIDRs(fakeSubnetSpec2.Name, []string{pointer.StringDeref(fakeSubnet2.AddressPrefix, "")})
+				s.UpdateSubnetID(fakeSubnetSpec2.Name, ptr.Deref(fakeSubnet2.ID, ""))
+				s.UpdateSubnetCIDRs(fakeSubnetSpec2.Name, []string{ptr.Deref(fakeSubnet2.AddressPrefix, "")})
 
 				s.IsVnetManaged().AnyTimes().Return(true)
 				s.UpdatePutStatus(infrav1.SubnetsReadyCondition, serviceName, internalError)

--- a/azure/services/tags/tags.go
+++ b/azure/services/tags/tags.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
@@ -95,7 +95,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			if len(createdOrUpdated) > 0 {
 				createdOrUpdatedTags := make(map[string]*string)
 				for k, v := range createdOrUpdated {
-					createdOrUpdatedTags[k] = pointer.String(v)
+					createdOrUpdatedTags[k] = ptr.To(v)
 				}
 
 				if _, err := s.client.UpdateAtScope(ctx, tagsSpec.Scope, resources.TagsPatchResource{Operation: "Merge", Properties: &resources.Tags{Tags: createdOrUpdatedTags}}); err != nil {
@@ -106,7 +106,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			if len(deleted) > 0 {
 				deletedTags := make(map[string]*string)
 				for k, v := range deleted {
-					deletedTags[k] = pointer.String(v)
+					deletedTags[k] = ptr.To(v)
 				}
 
 				if _, err := s.client.UpdateAtScope(ctx, tagsSpec.Scope, resources.TagsPatchResource{Operation: "Delete", Properties: &resources.Tags{Tags: deletedTags}}); err != nil {

--- a/azure/services/tags/tags_test.go
+++ b/azure/services/tags/tags_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/tags/mock_tags"
 	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
@@ -62,8 +62,8 @@ func TestReconcileTags(t *testing.T) {
 					}),
 					m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(resources.TagsResource{Properties: &resources.Tags{
 						Tags: map[string]*string{
-							"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": pointer.String("owned"),
-							"externalSystemTag": pointer.String("randomValue"),
+							"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": ptr.To("owned"),
+							"externalSystemTag": ptr.To("randomValue"),
 						},
 					}}, nil),
 					s.AnnotationJSON("my-annotation"),
@@ -71,16 +71,16 @@ func TestReconcileTags(t *testing.T) {
 						Operation: "Merge",
 						Properties: &resources.Tags{
 							Tags: map[string]*string{
-								"foo":   pointer.String("bar"),
-								"thing": pointer.String("stuff"),
+								"foo":   ptr.To("bar"),
+								"thing": ptr.To("stuff"),
 							},
 						},
 					}),
 					s.UpdateAnnotationJSON("my-annotation", map[string]interface{}{"foo": "bar", "thing": "stuff"}),
 					m.GetAtScope(gomockinternal.AContext(), "/sub/123/other/scope").Return(resources.TagsResource{Properties: &resources.Tags{
 						Tags: map[string]*string{
-							"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": pointer.String("owned"),
-							"externalSystem2Tag": pointer.String("randomValue2"),
+							"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": ptr.To("owned"),
+							"externalSystem2Tag": ptr.To("randomValue2"),
 						},
 					}}, nil),
 					s.AnnotationJSON("my-annotation-2"),
@@ -88,7 +88,7 @@ func TestReconcileTags(t *testing.T) {
 						Operation: "Merge",
 						Properties: &resources.Tags{
 							Tags: map[string]*string{
-								"tag1": pointer.String("value1"),
+								"tag1": ptr.To("value1"),
 							},
 						},
 					}),
@@ -137,8 +137,8 @@ func TestReconcileTags(t *testing.T) {
 						Operation: "Merge",
 						Properties: &resources.Tags{
 							Tags: map[string]*string{
-								"foo":   pointer.String("bar"),
-								"thing": pointer.String("stuff"),
+								"foo":   ptr.To("bar"),
+								"thing": ptr.To("stuff"),
 							},
 						},
 					}),
@@ -163,9 +163,9 @@ func TestReconcileTags(t *testing.T) {
 					}),
 					m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(resources.TagsResource{Properties: &resources.Tags{
 						Tags: map[string]*string{
-							"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": pointer.String("owned"),
-							"foo":   pointer.String("bar"),
-							"thing": pointer.String("stuff"),
+							"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": ptr.To("owned"),
+							"foo":   ptr.To("bar"),
+							"thing": ptr.To("stuff"),
 						},
 					}}, nil),
 					s.AnnotationJSON("my-annotation").Return(map[string]interface{}{"foo": "bar", "thing": "stuff"}, nil),
@@ -173,7 +173,7 @@ func TestReconcileTags(t *testing.T) {
 						Operation: "Delete",
 						Properties: &resources.Tags{
 							Tags: map[string]*string{
-								"thing": pointer.String("stuff"),
+								"thing": ptr.To("stuff"),
 							},
 						},
 					}),
@@ -215,7 +215,7 @@ func TestReconcileTags(t *testing.T) {
 				})
 				m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(resources.TagsResource{Properties: &resources.Tags{
 					Tags: map[string]*string{
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": pointer.String("owned"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": ptr.To("owned"),
 					},
 				}}, nil)
 				s.AnnotationJSON("my-annotation")
@@ -223,7 +223,7 @@ func TestReconcileTags(t *testing.T) {
 					Operation: "Merge",
 					Properties: &resources.Tags{
 						Tags: map[string]*string{
-							"key": pointer.String("value"),
+							"key": ptr.To("value"),
 						},
 					},
 				}).Return(resources.TagsResource{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error"))
@@ -245,8 +245,8 @@ func TestReconcileTags(t *testing.T) {
 				})
 				m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(resources.TagsResource{Properties: &resources.Tags{
 					Tags: map[string]*string{
-						"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": pointer.String("owned"),
-						"key": pointer.String("value"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": ptr.To("owned"),
+						"key": ptr.To("value"),
 					},
 				}}, nil)
 				s.AnnotationJSON("my-annotation").Return(map[string]interface{}{"key": "value"}, nil)
@@ -303,7 +303,7 @@ func TestTagsChanged(t *testing.T) {
 				"foo": "hello",
 			},
 			currentTags: map[string]*string{
-				"foo": pointer.String("hello"),
+				"foo": ptr.To("hello"),
 			},
 			expectedResult:           false,
 			expectedCreatedOrUpdated: map[string]string{},
@@ -319,7 +319,7 @@ func TestTagsChanged(t *testing.T) {
 				"foo": "goodbye",
 			},
 			currentTags: map[string]*string{
-				"foo": pointer.String("hello"),
+				"foo": ptr.To("hello"),
 			},
 			expectedResult: true,
 			expectedCreatedOrUpdated: map[string]string{
@@ -335,7 +335,7 @@ func TestTagsChanged(t *testing.T) {
 			},
 			desiredTags: map[string]string{},
 			currentTags: map[string]*string{
-				"foo": pointer.String("hello"),
+				"foo": ptr.To("hello"),
 			},
 			expectedResult:           true,
 			expectedCreatedOrUpdated: map[string]string{},
@@ -352,7 +352,7 @@ func TestTagsChanged(t *testing.T) {
 				"bar": "welcome",
 			},
 			currentTags: map[string]*string{
-				"foo": pointer.String("hello"),
+				"foo": ptr.To("hello"),
 			},
 			expectedResult: true,
 			expectedCreatedOrUpdated: map[string]string{
@@ -371,7 +371,7 @@ func TestTagsChanged(t *testing.T) {
 				"bar": "welcome",
 			},
 			currentTags: map[string]*string{
-				"foo": pointer.String("hello"),
+				"foo": ptr.To("hello"),
 			},
 			expectedResult: true,
 			expectedCreatedOrUpdated: map[string]string{
@@ -394,7 +394,7 @@ func TestTagsChanged(t *testing.T) {
 				"bar": "welcome",
 			},
 			currentTags: map[string]*string{
-				"foo": pointer.String("hello"),
+				"foo": ptr.To("hello"),
 			},
 			expectedResult: true,
 			expectedCreatedOrUpdated: map[string]string{
@@ -416,8 +416,8 @@ func TestTagsChanged(t *testing.T) {
 				"bar": "welcome",
 			},
 			currentTags: map[string]*string{
-				"foo": pointer.String("hello"),
-				"bar": pointer.String("random"),
+				"foo": ptr.To("hello"),
+				"bar": ptr.To("random"),
 			},
 			expectedResult: true,
 			expectedCreatedOrUpdated: map[string]string{

--- a/azure/services/virtualmachineimages/cache_test.go
+++ b/azure/services/virtualmachineimages/cache_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/virtualmachineimages/mock_virtualmachineimages"
 )
 
@@ -41,7 +41,7 @@ func TestCacheGet(t *testing.T) {
 			location: "test", publisher: "foo", offer: "bar", sku: "baz",
 			have: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("foo")},
+					{Name: ptr.To("foo")},
 				},
 			},
 			expectedError: nil,

--- a/azure/services/virtualmachineimages/images_test.go
+++ b/azure/services/virtualmachineimages/images_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/virtualmachineimages/mock_virtualmachineimages"
@@ -88,9 +88,9 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			expectedVersion: "121.13.20220613",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("121.13.20220526")},
-					{Name: pointer.String("121.13.20220613")},
-					{Name: pointer.String("121.13.20220524")},
+					{Name: ptr.To("121.13.20220526")},
+					{Name: ptr.To("121.13.20220613")},
+					{Name: ptr.To("121.13.20220524")},
 				},
 			},
 		},
@@ -110,8 +110,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			expectedVersion: "122.10.20220613",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("122.10.20220524")},
-					{Name: pointer.String("122.10.20220613")},
+					{Name: ptr.To("122.10.20220524")},
+					{Name: ptr.To("122.10.20220613")},
 				},
 			},
 		},
@@ -121,7 +121,7 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			expectedVersion: "122.16.20221117",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("122.16.20221117")},
+					{Name: ptr.To("122.16.20221117")},
 				},
 			},
 		},
@@ -136,10 +136,10 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			expectedVersion: "123.7.20231231",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("123.7.20221124")},
-					{Name: pointer.String("123.7.20220524")},
-					{Name: pointer.String("123.7.20231231")},
-					{Name: pointer.String("123.7.20220818")},
+					{Name: ptr.To("123.7.20221124")},
+					{Name: ptr.To("123.7.20220524")},
+					{Name: ptr.To("123.7.20231231")},
+					{Name: ptr.To("123.7.20220818")},
 				},
 			},
 		},
@@ -149,7 +149,7 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			expectedVersion: "124.0.20220512",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("124.0.20220512")},
+					{Name: ptr.To("124.0.20220512")},
 				},
 			},
 		},
@@ -159,7 +159,7 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			expectedVersion: "123.12.20220921",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("123.12.20220921")},
+					{Name: ptr.To("123.12.20220921")},
 				},
 			},
 		},
@@ -169,7 +169,7 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			expectedVersion: "123.13.20221014",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("123.13.20221014")},
+					{Name: ptr.To("123.13.20221014")},
 				},
 			},
 		},
@@ -179,7 +179,7 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			expectedVersion: "124.6.20220921",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("124.6.20220921")},
+					{Name: ptr.To("124.6.20220921")},
 				},
 			},
 		},
@@ -189,7 +189,7 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			expectedVersion: "124.7.20221014",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("124.7.20221014")},
+					{Name: ptr.To("124.7.20221014")},
 				},
 			},
 		},
@@ -199,7 +199,7 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			expectedVersion: "125.2.20220921",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("125.2.20220921")},
+					{Name: ptr.To("125.2.20220921")},
 				},
 			},
 		},
@@ -209,7 +209,7 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			expectedVersion: "125.3.20221014",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("125.3.20221014")},
+					{Name: ptr.To("125.3.20221014")},
 				},
 			},
 		},
@@ -434,17 +434,17 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			osAndVersion:    "windows-2022",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("121.13.20220524")},
-					{Name: pointer.String("124.0.20220512")},
-					{Name: pointer.String("121.13.20220524")},
-					{Name: pointer.String("123.13.20220524")},
-					{Name: pointer.String("121.13.20220619")},
-					{Name: pointer.String("121.13.20300524")},
-					{Name: pointer.String("121.14.20220524")},
-					{Name: pointer.String("121.12.20220524")},
-					{Name: pointer.String("121.13.20220101")},
-					{Name: pointer.String("121.13.20231231")},
-					{Name: pointer.String("121.13.19991231")},
+					{Name: ptr.To("121.13.20220524")},
+					{Name: ptr.To("124.0.20220512")},
+					{Name: ptr.To("121.13.20220524")},
+					{Name: ptr.To("123.13.20220524")},
+					{Name: ptr.To("121.13.20220619")},
+					{Name: ptr.To("121.13.20300524")},
+					{Name: ptr.To("121.14.20220524")},
+					{Name: ptr.To("121.12.20220524")},
+					{Name: ptr.To("121.13.20220101")},
+					{Name: ptr.To("121.13.20231231")},
+					{Name: ptr.To("121.13.19991231")},
 				},
 			},
 		},
@@ -484,7 +484,7 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			osAndVersion:    "ubuntu-2004",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("123.12.20220921")},
+					{Name: ptr.To("123.12.20220921")},
 				},
 			},
 		},
@@ -496,7 +496,7 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			osAndVersion:    "ubuntu-2204",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("123.13.20220524")},
+					{Name: ptr.To("123.13.20220524")},
 				},
 			},
 		},
@@ -516,7 +516,7 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			osAndVersion:    "ubuntu-2004",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("124.0.20220512")},
+					{Name: ptr.To("124.0.20220512")},
 				},
 			},
 		},
@@ -528,7 +528,7 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			osAndVersion:    "windows-2022-containerd",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("124.0.20220606")},
+					{Name: ptr.To("124.0.20220606")},
 				},
 			},
 		},
@@ -538,7 +538,7 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			osAndVersion:  "windows-2022-containerd",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("124.0.20220606")},
+					{Name: ptr.To("124.0.20220606")},
 				},
 			},
 		},
@@ -550,7 +550,7 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			osAndVersion:    "ubuntu-2204",
 			versions: compute.ListVirtualMachineImageResource{
 				Value: &[]compute.VirtualMachineImageResource{
-					{Name: pointer.String("125.4.20221011")},
+					{Name: ptr.To("125.4.20221011")},
 				},
 			},
 		},

--- a/azure/services/virtualmachines/client.go
+++ b/azure/services/virtualmachines/client.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
@@ -138,7 +138,7 @@ func (ac *AzureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecG
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.AzureClient.Delete")
 	defer done()
 
-	forceDelete := pointer.Bool(true)
+	forceDelete := ptr.To(true)
 	deleteFuture, err := ac.virtualmachines.Delete(ctx, spec.ResourceGroupName(), spec.ResourceName(), forceDelete)
 	if err != nil {
 		return nil, err

--- a/azure/services/virtualmachines/spec_test.go
+++ b/azure/services/virtualmachines/spec_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
@@ -33,127 +33,127 @@ import (
 
 var (
 	validSKU = resourceskus.SKU{
-		Name: pointer.String("Standard_D2v3"),
-		Kind: pointer.String(string(resourceskus.VirtualMachines)),
+		Name: ptr.To("Standard_D2v3"),
+		Kind: ptr.To(string(resourceskus.VirtualMachines)),
 		Locations: &[]string{
 			"test-location",
 		},
 		Capabilities: &[]compute.ResourceSkuCapabilities{
 			{
-				Name:  pointer.String(resourceskus.VCPUs),
-				Value: pointer.String("2"),
+				Name:  ptr.To(resourceskus.VCPUs),
+				Value: ptr.To("2"),
 			},
 			{
-				Name:  pointer.String(resourceskus.MemoryGB),
-				Value: pointer.String("4"),
+				Name:  ptr.To(resourceskus.MemoryGB),
+				Value: ptr.To("4"),
 			},
 		},
 	}
 
 	validSKUWithEncryptionAtHost = resourceskus.SKU{
-		Name: pointer.String("Standard_D2v3"),
-		Kind: pointer.String(string(resourceskus.VirtualMachines)),
+		Name: ptr.To("Standard_D2v3"),
+		Kind: ptr.To(string(resourceskus.VirtualMachines)),
 		Locations: &[]string{
 			"test-location",
 		},
 		Capabilities: &[]compute.ResourceSkuCapabilities{
 			{
-				Name:  pointer.String(resourceskus.VCPUs),
-				Value: pointer.String("2"),
+				Name:  ptr.To(resourceskus.VCPUs),
+				Value: ptr.To("2"),
 			},
 			{
-				Name:  pointer.String(resourceskus.MemoryGB),
-				Value: pointer.String("4"),
+				Name:  ptr.To(resourceskus.MemoryGB),
+				Value: ptr.To("4"),
 			},
 			{
-				Name:  pointer.String(resourceskus.EncryptionAtHost),
-				Value: pointer.String(string(resourceskus.CapabilitySupported)),
+				Name:  ptr.To(resourceskus.EncryptionAtHost),
+				Value: ptr.To(string(resourceskus.CapabilitySupported)),
 			},
 		},
 	}
 
 	validSKUWithTrustedLaunchDisabled = resourceskus.SKU{
-		Name: pointer.String("Standard_D2v3"),
-		Kind: pointer.String(string(resourceskus.VirtualMachines)),
+		Name: ptr.To("Standard_D2v3"),
+		Kind: ptr.To(string(resourceskus.VirtualMachines)),
 		Locations: &[]string{
 			"test-location",
 		},
 		Capabilities: &[]compute.ResourceSkuCapabilities{
 			{
-				Name:  pointer.String(resourceskus.VCPUs),
-				Value: pointer.String("2"),
+				Name:  ptr.To(resourceskus.VCPUs),
+				Value: ptr.To("2"),
 			},
 			{
-				Name:  pointer.String(resourceskus.MemoryGB),
-				Value: pointer.String("4"),
+				Name:  ptr.To(resourceskus.MemoryGB),
+				Value: ptr.To("4"),
 			},
 			{
-				Name:  pointer.String(resourceskus.TrustedLaunchDisabled),
-				Value: pointer.String(string(resourceskus.CapabilitySupported)),
+				Name:  ptr.To(resourceskus.TrustedLaunchDisabled),
+				Value: ptr.To(string(resourceskus.CapabilitySupported)),
 			},
 		},
 	}
 
 	validSKUWithConfidentialComputingType = resourceskus.SKU{
-		Name: pointer.String("Standard_D2v3"),
-		Kind: pointer.String(string(resourceskus.VirtualMachines)),
+		Name: ptr.To("Standard_D2v3"),
+		Kind: ptr.To(string(resourceskus.VirtualMachines)),
 		Locations: &[]string{
 			"test-location",
 		},
 		Capabilities: &[]compute.ResourceSkuCapabilities{
 			{
-				Name:  pointer.String(resourceskus.VCPUs),
-				Value: pointer.String("2"),
+				Name:  ptr.To(resourceskus.VCPUs),
+				Value: ptr.To("2"),
 			},
 			{
-				Name:  pointer.String(resourceskus.MemoryGB),
-				Value: pointer.String("4"),
+				Name:  ptr.To(resourceskus.MemoryGB),
+				Value: ptr.To("4"),
 			},
 			{
-				Name:  pointer.String(resourceskus.ConfidentialComputingType),
-				Value: pointer.String(string(resourceskus.CapabilitySupported)),
+				Name:  ptr.To(resourceskus.ConfidentialComputingType),
+				Value: ptr.To(string(resourceskus.CapabilitySupported)),
 			},
 		},
 	}
 
 	validSKUWithEphemeralOS = resourceskus.SKU{
-		Name: pointer.String("Standard_D2v3"),
-		Kind: pointer.String(string(resourceskus.VirtualMachines)),
+		Name: ptr.To("Standard_D2v3"),
+		Kind: ptr.To(string(resourceskus.VirtualMachines)),
 		Locations: &[]string{
 			"test-location",
 		},
 		Capabilities: &[]compute.ResourceSkuCapabilities{
 			{
-				Name:  pointer.String(resourceskus.VCPUs),
-				Value: pointer.String("2"),
+				Name:  ptr.To(resourceskus.VCPUs),
+				Value: ptr.To("2"),
 			},
 			{
-				Name:  pointer.String(resourceskus.MemoryGB),
-				Value: pointer.String("4"),
+				Name:  ptr.To(resourceskus.MemoryGB),
+				Value: ptr.To("4"),
 			},
 			{
-				Name:  pointer.String(resourceskus.EphemeralOSDisk),
-				Value: pointer.String("True"),
+				Name:  ptr.To(resourceskus.EphemeralOSDisk),
+				Value: ptr.To("True"),
 			},
 		},
 	}
 
 	validSKUWithUltraSSD = resourceskus.SKU{
-		Name: pointer.String("Standard_D2v3"),
-		Kind: pointer.String(string(resourceskus.VirtualMachines)),
+		Name: ptr.To("Standard_D2v3"),
+		Kind: ptr.To(string(resourceskus.VirtualMachines)),
 		Locations: &[]string{
 			"test-location",
 		},
 		LocationInfo: &[]compute.ResourceSkuLocationInfo{
 			{
-				Location: pointer.String("test-location"),
+				Location: ptr.To("test-location"),
 				Zones:    &[]string{"1"},
 				ZoneDetails: &[]compute.ResourceSkuZoneDetails{
 					{
 						Capabilities: &[]compute.ResourceSkuCapabilities{
 							{
-								Name:  pointer.String("UltraSSDAvailable"),
-								Value: pointer.String("True"),
+								Name:  ptr.To("UltraSSDAvailable"),
+								Value: ptr.To("True"),
 							},
 						},
 						Name: &[]string{"1"},
@@ -163,48 +163,48 @@ var (
 		},
 		Capabilities: &[]compute.ResourceSkuCapabilities{
 			{
-				Name:  pointer.String(resourceskus.VCPUs),
-				Value: pointer.String("2"),
+				Name:  ptr.To(resourceskus.VCPUs),
+				Value: ptr.To("2"),
 			},
 			{
-				Name:  pointer.String(resourceskus.MemoryGB),
-				Value: pointer.String("4"),
+				Name:  ptr.To(resourceskus.MemoryGB),
+				Value: ptr.To("4"),
 			},
 		},
 	}
 
 	invalidCPUSKU = resourceskus.SKU{
-		Name: pointer.String("Standard_D2v3"),
-		Kind: pointer.String(string(resourceskus.VirtualMachines)),
+		Name: ptr.To("Standard_D2v3"),
+		Kind: ptr.To(string(resourceskus.VirtualMachines)),
 		Locations: &[]string{
 			"test-location",
 		},
 		Capabilities: &[]compute.ResourceSkuCapabilities{
 			{
-				Name:  pointer.String(resourceskus.VCPUs),
-				Value: pointer.String("1"),
+				Name:  ptr.To(resourceskus.VCPUs),
+				Value: ptr.To("1"),
 			},
 			{
-				Name:  pointer.String(resourceskus.MemoryGB),
-				Value: pointer.String("4"),
+				Name:  ptr.To(resourceskus.MemoryGB),
+				Value: ptr.To("4"),
 			},
 		},
 	}
 
 	invalidMemSKU = resourceskus.SKU{
-		Name: pointer.String("Standard_D2v3"),
-		Kind: pointer.String(string(resourceskus.VirtualMachines)),
+		Name: ptr.To("Standard_D2v3"),
+		Kind: ptr.To(string(resourceskus.VirtualMachines)),
 		Locations: &[]string{
 			"test-location",
 		},
 		Capabilities: &[]compute.ResourceSkuCapabilities{
 			{
-				Name:  pointer.String(resourceskus.VCPUs),
-				Value: pointer.String("2"),
+				Name:  ptr.To(resourceskus.VCPUs),
+				Value: ptr.To("2"),
 			},
 			{
-				Name:  pointer.String(resourceskus.MemoryGB),
-				Value: pointer.String("1"),
+				Name:  ptr.To(resourceskus.MemoryGB),
+				Value: ptr.To("1"),
 			},
 		},
 	}
@@ -258,7 +258,7 @@ func TestParameters(t *testing.T) {
 				SSHKeyData: "fakesshpublickey",
 				Size:       "Standard_D2v3",
 				Zone:       "1",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				Identity:   infrav1.VMIdentitySystemAssigned,
 				SKU:        validSKU,
 			},
@@ -279,7 +279,7 @@ func TestParameters(t *testing.T) {
 				SSHKeyData:             "fakesshpublickey",
 				Size:                   "Standard_D2v3",
 				Zone:                   "1",
-				Image:                  &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:                  &infrav1.Image{ID: ptr.To("fake-image-id")},
 				Identity:               infrav1.VMIdentityUserAssigned,
 				UserAssignedIdentities: []infrav1.UserAssignedIdentity{{ProviderID: "my-user-id"}},
 				SKU:                    validSKU,
@@ -301,7 +301,7 @@ func TestParameters(t *testing.T) {
 				SSHKeyData:    "fakesshpublickey",
 				Size:          "Standard_D2v3",
 				Zone:          "1",
-				Image:         &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:         &infrav1.Image{ID: ptr.To("fake-image-id")},
 				SpotVMOptions: &infrav1.SpotVMOptions{},
 				SKU:           validSKU,
 			},
@@ -323,7 +323,7 @@ func TestParameters(t *testing.T) {
 				SSHKeyData:    "fakesshpublickey",
 				Size:          "Standard_D2v3",
 				Zone:          "1",
-				Image:         &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:         &infrav1.Image{ID: ptr.To("fake-image-id")},
 				SpotVMOptions: &infrav1.SpotVMOptions{EvictionPolicy: &deletePolicy},
 				SKU:           validSKU,
 			},
@@ -345,10 +345,10 @@ func TestParameters(t *testing.T) {
 				SSHKeyData: "fakesshpublickey",
 				Size:       "Standard_D2v3",
 				Zone:       "1",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				OSDisk: infrav1.OSDisk{
 					OSType:     "Windows",
-					DiskSizeGB: pointer.Int32(128),
+					DiskSizeGB: ptr.To[int32](128),
 					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 					},
@@ -374,7 +374,7 @@ func TestParameters(t *testing.T) {
 				SSHKeyData: "fakesshpublickey",
 				Size:       "Standard_D2v3",
 				Zone:       "1",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				OSDisk: infrav1.OSDisk{
 					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
@@ -388,7 +388,7 @@ func TestParameters(t *testing.T) {
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
-				g.Expect(result.(compute.VirtualMachine).VirtualMachineProperties.StorageProfile.OsDisk.ManagedDisk.DiskEncryptionSet.ID).To(Equal(pointer.String("my-diskencryptionset-id")))
+				g.Expect(result.(compute.VirtualMachine).VirtualMachineProperties.StorageProfile.OsDisk.ManagedDisk.DiskEncryptionSet.ID).To(Equal(ptr.To("my-diskencryptionset-id")))
 			},
 			expectedError: "",
 		},
@@ -401,8 +401,8 @@ func TestParameters(t *testing.T) {
 				SSHKeyData:      "fakesshpublickey",
 				Size:            "Standard_D2v3",
 				Zone:            "1",
-				Image:           &infrav1.Image{ID: pointer.String("fake-image-id")},
-				SecurityProfile: &infrav1.SecurityProfile{EncryptionAtHost: pointer.Bool(true)},
+				Image:           &infrav1.Image{ID: ptr.To("fake-image-id")},
+				SecurityProfile: &infrav1.SecurityProfile{EncryptionAtHost: ptr.To(true)},
 				SKU:             validSKUWithEncryptionAtHost,
 			},
 			existing: nil,
@@ -422,14 +422,14 @@ func TestParameters(t *testing.T) {
 				Size:              "Standard_D2v3",
 				AvailabilitySetID: "fake-availability-set-id",
 				Zone:              "",
-				Image:             &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
 				SKU:               validSKU,
 			},
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
 				g.Expect(result.(compute.VirtualMachine).Zones).To(BeNil())
-				g.Expect(result.(compute.VirtualMachine).AvailabilitySet.ID).To(Equal(pointer.String("fake-availability-set-id")))
+				g.Expect(result.(compute.VirtualMachine).AvailabilitySet.ID).To(Equal(ptr.To("fake-availability-set-id")))
 			},
 			expectedError: "",
 		},
@@ -443,7 +443,7 @@ func TestParameters(t *testing.T) {
 				Size:       "Standard_D2v3",
 				OSDisk: infrav1.OSDisk{
 					OSType:     "Linux",
-					DiskSizeGB: pointer.Int32(128),
+					DiskSizeGB: ptr.To[int32](128),
 					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 					},
@@ -451,7 +451,7 @@ func TestParameters(t *testing.T) {
 						Option: string(compute.DiffDiskOptionsLocal),
 					},
 				},
-				Image: &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image: &infrav1.Image{ID: ptr.To("fake-image-id")},
 				SKU:   validSKUWithEphemeralOS,
 			},
 			existing: nil,
@@ -471,12 +471,12 @@ func TestParameters(t *testing.T) {
 				Size:              "Standard_D2v3",
 				AvailabilitySetID: "fake-availability-set-id",
 				Zone:              "",
-				Image:             &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
 				SecurityProfile: &infrav1.SecurityProfile{
 					SecurityType: infrav1.SecurityTypesTrustedLaunch,
 					UefiSettings: &infrav1.UefiSettings{
-						SecureBootEnabled: pointer.Bool(true),
-						VTpmEnabled:       pointer.Bool(true),
+						SecureBootEnabled: ptr.To(true),
+						VTpmEnabled:       ptr.To(true),
 					},
 				},
 				SKU: validSKU,
@@ -499,10 +499,10 @@ func TestParameters(t *testing.T) {
 				Size:              "Standard_D2v3",
 				AvailabilitySetID: "fake-availability-set-id",
 				Zone:              "",
-				Image:             &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
 				OSDisk: infrav1.OSDisk{
 					OSType:     "Linux",
-					DiskSizeGB: pointer.Int32(128),
+					DiskSizeGB: ptr.To[int32](128),
 					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 						SecurityProfile: &infrav1.VMDiskSecurityProfile{
@@ -513,8 +513,8 @@ func TestParameters(t *testing.T) {
 				SecurityProfile: &infrav1.SecurityProfile{
 					SecurityType: infrav1.SecurityTypesConfidentialVM,
 					UefiSettings: &infrav1.UefiSettings{
-						SecureBootEnabled: pointer.Bool(false),
-						VTpmEnabled:       pointer.Bool(true),
+						SecureBootEnabled: ptr.To(false),
+						VTpmEnabled:       ptr.To(true),
 					},
 				},
 				SKU: validSKUWithConfidentialComputingType,
@@ -537,10 +537,10 @@ func TestParameters(t *testing.T) {
 				Size:              "Standard_D2v3",
 				AvailabilitySetID: "fake-availability-set-id",
 				Zone:              "",
-				Image:             &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
 				OSDisk: infrav1.OSDisk{
 					OSType:     "Linux",
-					DiskSizeGB: pointer.Int32(128),
+					DiskSizeGB: ptr.To[int32](128),
 					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 						SecurityProfile: &infrav1.VMDiskSecurityProfile{
@@ -551,8 +551,8 @@ func TestParameters(t *testing.T) {
 				SecurityProfile: &infrav1.SecurityProfile{
 					SecurityType: "",
 					UefiSettings: &infrav1.UefiSettings{
-						SecureBootEnabled: pointer.Bool(false),
-						VTpmEnabled:       pointer.Bool(true),
+						SecureBootEnabled: ptr.To(false),
+						VTpmEnabled:       ptr.To(true),
 					},
 				},
 				SKU: validSKUWithConfidentialComputingType,
@@ -573,8 +573,8 @@ func TestParameters(t *testing.T) {
 				Size:              "Standard_D2v3",
 				AvailabilitySetID: "fake-availability-set-id",
 				Zone:              "",
-				Image:             &infrav1.Image{ID: pointer.String("fake-image-id")},
-				SecurityProfile:   &infrav1.SecurityProfile{EncryptionAtHost: pointer.Bool(true)},
+				Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
+				SecurityProfile:   &infrav1.SecurityProfile{EncryptionAtHost: ptr.To(true)},
 				SKU:               validSKU,
 			},
 			existing: nil,
@@ -593,10 +593,10 @@ func TestParameters(t *testing.T) {
 				Size:              "Standard_D2v3",
 				AvailabilitySetID: "fake-availability-set-id",
 				Zone:              "",
-				Image:             &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
 				OSDisk: infrav1.OSDisk{
 					OSType:     "Linux",
-					DiskSizeGB: pointer.Int32(128),
+					DiskSizeGB: ptr.To[int32](128),
 					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 					},
@@ -604,8 +604,8 @@ func TestParameters(t *testing.T) {
 				SecurityProfile: &infrav1.SecurityProfile{
 					SecurityType: "",
 					UefiSettings: &infrav1.UefiSettings{
-						SecureBootEnabled: pointer.Bool(false),
-						VTpmEnabled:       pointer.Bool(true),
+						SecureBootEnabled: ptr.To(false),
+						VTpmEnabled:       ptr.To(true),
 					},
 				},
 				SKU: validSKUWithConfidentialComputingType,
@@ -626,11 +626,11 @@ func TestParameters(t *testing.T) {
 				Size:              "Standard_D2v3",
 				AvailabilitySetID: "fake-availability-set-id",
 				Zone:              "",
-				Image:             &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
 				SecurityProfile: &infrav1.SecurityProfile{
 					SecurityType: infrav1.SecurityTypesTrustedLaunch,
 					UefiSettings: &infrav1.UefiSettings{
-						SecureBootEnabled: pointer.Bool(true),
+						SecureBootEnabled: ptr.To(true),
 					},
 				},
 				SKU: validSKUWithTrustedLaunchDisabled,
@@ -651,11 +651,11 @@ func TestParameters(t *testing.T) {
 				Size:              "Standard_D2v3",
 				AvailabilitySetID: "fake-availability-set-id",
 				Zone:              "",
-				Image:             &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
 				SecurityProfile: &infrav1.SecurityProfile{
 					SecurityType: infrav1.SecurityTypesTrustedLaunch,
 					UefiSettings: &infrav1.UefiSettings{
-						VTpmEnabled: pointer.Bool(true),
+						VTpmEnabled: ptr.To(true),
 					},
 				},
 				SKU: validSKUWithTrustedLaunchDisabled,
@@ -676,10 +676,10 @@ func TestParameters(t *testing.T) {
 				Size:              "Standard_D2v3",
 				AvailabilitySetID: "fake-availability-set-id",
 				Zone:              "",
-				Image:             &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
 				OSDisk: infrav1.OSDisk{
 					OSType:     "Linux",
-					DiskSizeGB: pointer.Int32(128),
+					DiskSizeGB: ptr.To[int32](128),
 					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 						SecurityProfile: &infrav1.VMDiskSecurityProfile{
@@ -688,10 +688,10 @@ func TestParameters(t *testing.T) {
 					},
 				},
 				SecurityProfile: &infrav1.SecurityProfile{
-					EncryptionAtHost: pointer.Bool(true),
+					EncryptionAtHost: ptr.To(true),
 					SecurityType:     infrav1.SecurityTypesConfidentialVM,
 					UefiSettings: &infrav1.UefiSettings{
-						VTpmEnabled: pointer.Bool(true),
+						VTpmEnabled: ptr.To(true),
 					},
 				},
 				SKU: validSKUWithConfidentialComputingType,
@@ -712,10 +712,10 @@ func TestParameters(t *testing.T) {
 				Size:              "Standard_D2v3",
 				AvailabilitySetID: "fake-availability-set-id",
 				Zone:              "",
-				Image:             &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
 				OSDisk: infrav1.OSDisk{
 					OSType:     "Linux",
-					DiskSizeGB: pointer.Int32(128),
+					DiskSizeGB: ptr.To[int32](128),
 					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 						SecurityProfile: &infrav1.VMDiskSecurityProfile{
@@ -726,8 +726,8 @@ func TestParameters(t *testing.T) {
 				SecurityProfile: &infrav1.SecurityProfile{
 					SecurityType: infrav1.SecurityTypesConfidentialVM,
 					UefiSettings: &infrav1.UefiSettings{
-						SecureBootEnabled: pointer.Bool(false),
-						VTpmEnabled:       pointer.Bool(true),
+						SecureBootEnabled: ptr.To(false),
+						VTpmEnabled:       ptr.To(true),
 					},
 				},
 				SKU: validSKUWithConfidentialComputingType,
@@ -748,10 +748,10 @@ func TestParameters(t *testing.T) {
 				Size:              "Standard_D2v3",
 				AvailabilitySetID: "fake-availability-set-id",
 				Zone:              "",
-				Image:             &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
 				OSDisk: infrav1.OSDisk{
 					OSType:     "Linux",
-					DiskSizeGB: pointer.Int32(128),
+					DiskSizeGB: ptr.To[int32](128),
 					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 						SecurityProfile: &infrav1.VMDiskSecurityProfile{
@@ -762,7 +762,7 @@ func TestParameters(t *testing.T) {
 				SecurityProfile: &infrav1.SecurityProfile{
 					SecurityType: infrav1.SecurityTypesConfidentialVM,
 					UefiSettings: &infrav1.UefiSettings{
-						VTpmEnabled: pointer.Bool(false),
+						VTpmEnabled: ptr.To(false),
 					},
 				},
 				SKU: validSKUWithConfidentialComputingType,
@@ -783,10 +783,10 @@ func TestParameters(t *testing.T) {
 				Size:              "Standard_D2v3",
 				AvailabilitySetID: "fake-availability-set-id",
 				Zone:              "",
-				Image:             &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
 				OSDisk: infrav1.OSDisk{
 					OSType:     "Linux",
-					DiskSizeGB: pointer.Int32(128),
+					DiskSizeGB: ptr.To[int32](128),
 					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 						SecurityProfile: &infrav1.VMDiskSecurityProfile{
@@ -797,7 +797,7 @@ func TestParameters(t *testing.T) {
 				SecurityProfile: &infrav1.SecurityProfile{
 					SecurityType: infrav1.SecurityTypesConfidentialVM,
 					UefiSettings: &infrav1.UefiSettings{
-						VTpmEnabled: pointer.Bool(true),
+						VTpmEnabled: ptr.To(true),
 					},
 				},
 				SKU: validSKU,
@@ -818,7 +818,7 @@ func TestParameters(t *testing.T) {
 				Size:       "Standard_D2v3",
 				OSDisk: infrav1.OSDisk{
 					OSType:     "Linux",
-					DiskSizeGB: pointer.Int32(128),
+					DiskSizeGB: ptr.To[int32](128),
 					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 					},
@@ -826,7 +826,7 @@ func TestParameters(t *testing.T) {
 						Option: string(compute.DiffDiskOptionsLocal),
 					},
 				},
-				Image: &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image: &infrav1.Image{ID: ptr.To("fake-image-id")},
 				SKU:   validSKU,
 			},
 			existing: nil,
@@ -843,7 +843,7 @@ func TestParameters(t *testing.T) {
 				NICIDs:     []string{"my-nic"},
 				SSHKeyData: "fakesshpublickey",
 				Size:       "Standard_D2v3",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				SKU:        invalidCPUSKU,
 			},
 			existing: nil,
@@ -860,7 +860,7 @@ func TestParameters(t *testing.T) {
 				NICIDs:     []string{"my-nic"},
 				SSHKeyData: "fakesshpublickey",
 				Size:       "Standard_D2v3",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				SKU:        invalidMemSKU,
 			},
 			existing: nil,
@@ -893,13 +893,13 @@ func TestParameters(t *testing.T) {
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
-				g.Expect(result.(compute.VirtualMachine).StorageProfile.ImageReference.Offer).To(Equal(pointer.String("my-offer")))
-				g.Expect(result.(compute.VirtualMachine).StorageProfile.ImageReference.Publisher).To(Equal(pointer.String("fake-publisher")))
-				g.Expect(result.(compute.VirtualMachine).StorageProfile.ImageReference.Sku).To(Equal(pointer.String("sku-id")))
-				g.Expect(result.(compute.VirtualMachine).StorageProfile.ImageReference.Version).To(Equal(pointer.String("1.0")))
-				g.Expect(result.(compute.VirtualMachine).Plan.Name).To(Equal(pointer.String("sku-id")))
-				g.Expect(result.(compute.VirtualMachine).Plan.Publisher).To(Equal(pointer.String("fake-publisher")))
-				g.Expect(result.(compute.VirtualMachine).Plan.Product).To(Equal(pointer.String("my-offer")))
+				g.Expect(result.(compute.VirtualMachine).StorageProfile.ImageReference.Offer).To(Equal(ptr.To("my-offer")))
+				g.Expect(result.(compute.VirtualMachine).StorageProfile.ImageReference.Publisher).To(Equal(ptr.To("fake-publisher")))
+				g.Expect(result.(compute.VirtualMachine).StorageProfile.ImageReference.Sku).To(Equal(ptr.To("sku-id")))
+				g.Expect(result.(compute.VirtualMachine).StorageProfile.ImageReference.Version).To(Equal(ptr.To("1.0")))
+				g.Expect(result.(compute.VirtualMachine).Plan.Name).To(Equal(ptr.To("sku-id")))
+				g.Expect(result.(compute.VirtualMachine).Plan.Publisher).To(Equal(ptr.To("fake-publisher")))
+				g.Expect(result.(compute.VirtualMachine).Plan.Product).To(Equal(ptr.To("my-offer")))
 			},
 			expectedError: "",
 		},
@@ -918,9 +918,9 @@ func TestParameters(t *testing.T) {
 						Gallery:        "fake-gallery",
 						Name:           "fake-name",
 						Version:        "1.0",
-						Publisher:      pointer.String("fake-publisher"),
-						Offer:          pointer.String("my-offer"),
-						SKU:            pointer.String("sku-id"),
+						Publisher:      ptr.To("fake-publisher"),
+						Offer:          ptr.To("my-offer"),
+						SKU:            ptr.To("sku-id"),
 					},
 				},
 				SKU: validSKU,
@@ -928,10 +928,10 @@ func TestParameters(t *testing.T) {
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
-				g.Expect(result.(compute.VirtualMachine).StorageProfile.ImageReference.ID).To(Equal(pointer.String("/subscriptions/fake-sub-id/resourceGroups/fake-rg/providers/Microsoft.Compute/galleries/fake-gallery/images/fake-name/versions/1.0")))
-				g.Expect(result.(compute.VirtualMachine).Plan.Name).To(Equal(pointer.String("sku-id")))
-				g.Expect(result.(compute.VirtualMachine).Plan.Publisher).To(Equal(pointer.String("fake-publisher")))
-				g.Expect(result.(compute.VirtualMachine).Plan.Product).To(Equal(pointer.String("my-offer")))
+				g.Expect(result.(compute.VirtualMachine).StorageProfile.ImageReference.ID).To(Equal(ptr.To("/subscriptions/fake-sub-id/resourceGroups/fake-rg/providers/Microsoft.Compute/galleries/fake-gallery/images/fake-name/versions/1.0")))
+				g.Expect(result.(compute.VirtualMachine).Plan.Name).To(Equal(ptr.To("sku-id")))
+				g.Expect(result.(compute.VirtualMachine).Plan.Publisher).To(Equal(ptr.To("fake-publisher")))
+				g.Expect(result.(compute.VirtualMachine).Plan.Product).To(Equal(ptr.To("my-offer")))
 			},
 			expectedError: "",
 		},
@@ -945,17 +945,17 @@ func TestParameters(t *testing.T) {
 				Size:       "Standard_D2v3",
 				Location:   "test-location",
 				Zone:       "1",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				DataDisks: []infrav1.DataDisk{
 					{
 						NameSuffix: "mydisk",
 						DiskSizeGB: 64,
-						Lun:        pointer.Int32(0),
+						Lun:        ptr.To[int32](0),
 					},
 					{
 						NameSuffix: "myDiskWithUltraDisk",
 						DiskSizeGB: 128,
-						Lun:        pointer.Int32(1),
+						Lun:        ptr.To[int32](1),
 						ManagedDisk: &infrav1.ManagedDiskParameters{
 							StorageAccountType: "UltraSSD_LRS",
 						},
@@ -963,7 +963,7 @@ func TestParameters(t *testing.T) {
 					{
 						NameSuffix: "myDiskWithManagedDisk",
 						DiskSizeGB: 128,
-						Lun:        pointer.Int32(2),
+						Lun:        ptr.To[int32](2),
 						ManagedDisk: &infrav1.ManagedDiskParameters{
 							StorageAccountType: "Premium_LRS",
 						},
@@ -971,7 +971,7 @@ func TestParameters(t *testing.T) {
 					{
 						NameSuffix: "managedDiskWithEncryption",
 						DiskSizeGB: 128,
-						Lun:        pointer.Int32(3),
+						Lun:        ptr.To[int32](3),
 						ManagedDisk: &infrav1.ManagedDiskParameters{
 							StorageAccountType: "Premium_LRS",
 							DiskEncryptionSet: &infrav1.DiskEncryptionSetParameters{
@@ -985,41 +985,41 @@ func TestParameters(t *testing.T) {
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
-				g.Expect(result.(compute.VirtualMachine).AdditionalCapabilities.UltraSSDEnabled).To(Equal(pointer.Bool(true)))
+				g.Expect(result.(compute.VirtualMachine).AdditionalCapabilities.UltraSSDEnabled).To(Equal(ptr.To(true)))
 				expectedDataDisks := &[]compute.DataDisk{
 					{
-						Lun:          pointer.Int32(0),
-						Name:         pointer.String("my-ultra-ssd-vm_mydisk"),
+						Lun:          ptr.To[int32](0),
+						Name:         ptr.To("my-ultra-ssd-vm_mydisk"),
 						CreateOption: "Empty",
-						DiskSizeGB:   pointer.Int32(64),
+						DiskSizeGB:   ptr.To[int32](64),
 					},
 					{
-						Lun:          pointer.Int32(1),
-						Name:         pointer.String("my-ultra-ssd-vm_myDiskWithUltraDisk"),
+						Lun:          ptr.To[int32](1),
+						Name:         ptr.To("my-ultra-ssd-vm_myDiskWithUltraDisk"),
 						CreateOption: "Empty",
-						DiskSizeGB:   pointer.Int32(128),
+						DiskSizeGB:   ptr.To[int32](128),
 						ManagedDisk: &compute.ManagedDiskParameters{
 							StorageAccountType: "UltraSSD_LRS",
 						},
 					},
 					{
-						Lun:          pointer.Int32(2),
-						Name:         pointer.String("my-ultra-ssd-vm_myDiskWithManagedDisk"),
+						Lun:          ptr.To[int32](2),
+						Name:         ptr.To("my-ultra-ssd-vm_myDiskWithManagedDisk"),
 						CreateOption: "Empty",
-						DiskSizeGB:   pointer.Int32(128),
+						DiskSizeGB:   ptr.To[int32](128),
 						ManagedDisk: &compute.ManagedDiskParameters{
 							StorageAccountType: "Premium_LRS",
 						},
 					},
 					{
-						Lun:          pointer.Int32(3),
-						Name:         pointer.String("my-ultra-ssd-vm_managedDiskWithEncryption"),
+						Lun:          ptr.To[int32](3),
+						Name:         ptr.To("my-ultra-ssd-vm_managedDiskWithEncryption"),
 						CreateOption: "Empty",
-						DiskSizeGB:   pointer.Int32(128),
+						DiskSizeGB:   ptr.To[int32](128),
 						ManagedDisk: &compute.ManagedDiskParameters{
 							StorageAccountType: "Premium_LRS",
 							DiskEncryptionSet: &compute.DiskEncryptionSetParameters{
-								ID: pointer.String("my_id"),
+								ID: ptr.To("my_id"),
 							},
 						},
 					},
@@ -1038,12 +1038,12 @@ func TestParameters(t *testing.T) {
 				Size:       "Standard_D2v3",
 				Location:   "test-location",
 				Zone:       "1",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				DataDisks: []infrav1.DataDisk{
 					{
 						NameSuffix: "myDiskWithUltraDisk",
 						DiskSizeGB: 128,
-						Lun:        pointer.Int32(1),
+						Lun:        ptr.To[int32](1),
 						ManagedDisk: &infrav1.ManagedDiskParameters{
 							StorageAccountType: "UltraSSD_LRS",
 						},
@@ -1067,15 +1067,15 @@ func TestParameters(t *testing.T) {
 				Size:       "Standard_D2v3",
 				Location:   "test-location",
 				Zone:       "1",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				AdditionalCapabilities: &infrav1.AdditionalCapabilities{
-					UltraSSDEnabled: pointer.Bool(false),
+					UltraSSDEnabled: ptr.To(false),
 				},
 				DataDisks: []infrav1.DataDisk{
 					{
 						NameSuffix: "myDiskWithUltraDisk",
 						DiskSizeGB: 128,
-						Lun:        pointer.Int32(1),
+						Lun:        ptr.To[int32](1),
 						ManagedDisk: &infrav1.ManagedDiskParameters{
 							StorageAccountType: "UltraSSD_LRS",
 						},
@@ -1086,13 +1086,13 @@ func TestParameters(t *testing.T) {
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
-				g.Expect(result.(compute.VirtualMachine).AdditionalCapabilities.UltraSSDEnabled).To(Equal(pointer.Bool(false)))
+				g.Expect(result.(compute.VirtualMachine).AdditionalCapabilities.UltraSSDEnabled).To(Equal(ptr.To(false)))
 				expectedDataDisks := &[]compute.DataDisk{
 					{
-						Lun:          pointer.Int32(1),
-						Name:         pointer.String("my-ultra-ssd-vm_myDiskWithUltraDisk"),
+						Lun:          ptr.To[int32](1),
+						Name:         ptr.To("my-ultra-ssd-vm_myDiskWithUltraDisk"),
 						CreateOption: "Empty",
-						DiskSizeGB:   pointer.Int32(128),
+						DiskSizeGB:   ptr.To[int32](128),
 						ManagedDisk: &compute.ManagedDiskParameters{
 							StorageAccountType: "UltraSSD_LRS",
 						},
@@ -1112,12 +1112,12 @@ func TestParameters(t *testing.T) {
 				Size:       "Standard_D2v3",
 				Location:   "test-location",
 				Zone:       "1",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				DataDisks: []infrav1.DataDisk{
 					{
 						NameSuffix: "myDiskWithUltraDisk",
 						DiskSizeGB: 128,
-						Lun:        pointer.Int32(1),
+						Lun:        ptr.To[int32](1),
 						ManagedDisk: &infrav1.ManagedDiskParameters{
 							StorageAccountType: "UltraSSD_LRS",
 						},
@@ -1128,13 +1128,13 @@ func TestParameters(t *testing.T) {
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
-				g.Expect(result.(compute.VirtualMachine).AdditionalCapabilities.UltraSSDEnabled).To(Equal(pointer.Bool(true)))
+				g.Expect(result.(compute.VirtualMachine).AdditionalCapabilities.UltraSSDEnabled).To(Equal(ptr.To(true)))
 				expectedDataDisks := &[]compute.DataDisk{
 					{
-						Lun:          pointer.Int32(1),
-						Name:         pointer.String("my-ultra-ssd-vm_myDiskWithUltraDisk"),
+						Lun:          ptr.To[int32](1),
+						Name:         ptr.To("my-ultra-ssd-vm_myDiskWithUltraDisk"),
 						CreateOption: "Empty",
-						DiskSizeGB:   pointer.Int32(128),
+						DiskSizeGB:   ptr.To[int32](128),
 						ManagedDisk: &compute.ManagedDiskParameters{
 							StorageAccountType: "UltraSSD_LRS",
 						},
@@ -1154,15 +1154,15 @@ func TestParameters(t *testing.T) {
 				Size:       "Standard_D2v3",
 				Location:   "test-location",
 				Zone:       "1",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				AdditionalCapabilities: &infrav1.AdditionalCapabilities{
-					UltraSSDEnabled: pointer.Bool(true),
+					UltraSSDEnabled: ptr.To(true),
 				},
 				DataDisks: []infrav1.DataDisk{
 					{
 						NameSuffix: "myDiskWithUltraDisk",
 						DiskSizeGB: 128,
-						Lun:        pointer.Int32(1),
+						Lun:        ptr.To[int32](1),
 						ManagedDisk: &infrav1.ManagedDiskParameters{
 							StorageAccountType: "UltraSSD_LRS",
 						},
@@ -1173,13 +1173,13 @@ func TestParameters(t *testing.T) {
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
-				g.Expect(result.(compute.VirtualMachine).AdditionalCapabilities.UltraSSDEnabled).To(Equal(pointer.Bool(true)))
+				g.Expect(result.(compute.VirtualMachine).AdditionalCapabilities.UltraSSDEnabled).To(Equal(ptr.To(true)))
 				expectedDataDisks := &[]compute.DataDisk{
 					{
-						Lun:          pointer.Int32(1),
-						Name:         pointer.String("my-ultra-ssd-vm_myDiskWithUltraDisk"),
+						Lun:          ptr.To[int32](1),
+						Name:         ptr.To("my-ultra-ssd-vm_myDiskWithUltraDisk"),
 						CreateOption: "Empty",
-						DiskSizeGB:   pointer.Int32(128),
+						DiskSizeGB:   ptr.To[int32](128),
 						ManagedDisk: &compute.ManagedDiskParameters{
 							StorageAccountType: "UltraSSD_LRS",
 						},
@@ -1199,16 +1199,16 @@ func TestParameters(t *testing.T) {
 				Size:       "Standard_D2v3",
 				Location:   "test-location",
 				Zone:       "1",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				AdditionalCapabilities: &infrav1.AdditionalCapabilities{
-					UltraSSDEnabled: pointer.Bool(true),
+					UltraSSDEnabled: ptr.To(true),
 				},
 				SKU: validSKUWithUltraSSD,
 			},
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
-				g.Expect(result.(compute.VirtualMachine).AdditionalCapabilities.UltraSSDEnabled).To(Equal(pointer.Bool(true)))
+				g.Expect(result.(compute.VirtualMachine).AdditionalCapabilities.UltraSSDEnabled).To(Equal(ptr.To(true)))
 			},
 			expectedError: "",
 		},
@@ -1222,16 +1222,16 @@ func TestParameters(t *testing.T) {
 				Size:       "Standard_D2v3",
 				Location:   "test-location",
 				Zone:       "1",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				AdditionalCapabilities: &infrav1.AdditionalCapabilities{
-					UltraSSDEnabled: pointer.Bool(false),
+					UltraSSDEnabled: ptr.To(false),
 				},
 				SKU: validSKUWithUltraSSD,
 			},
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
-				g.Expect(result.(compute.VirtualMachine).AdditionalCapabilities.UltraSSDEnabled).To(Equal(pointer.Bool(false)))
+				g.Expect(result.(compute.VirtualMachine).AdditionalCapabilities.UltraSSDEnabled).To(Equal(ptr.To(false)))
 			},
 			expectedError: "",
 		},
@@ -1245,7 +1245,7 @@ func TestParameters(t *testing.T) {
 				Size:       "Standard_D2v3",
 				Location:   "test-location",
 				Zone:       "1",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				DiagnosticsProfile: &infrav1.Diagnostics{
 					Boot: &infrav1.BootDiagnostics{
 						StorageAccountType: infrav1.DisabledDiagnosticsStorage,
@@ -1256,7 +1256,7 @@ func TestParameters(t *testing.T) {
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
-				g.Expect(result.(compute.VirtualMachine).DiagnosticsProfile.BootDiagnostics.Enabled).To(Equal(pointer.Bool(false)))
+				g.Expect(result.(compute.VirtualMachine).DiagnosticsProfile.BootDiagnostics.Enabled).To(Equal(ptr.To(false)))
 				g.Expect(result.(compute.VirtualMachine).DiagnosticsProfile.BootDiagnostics.StorageURI).To(BeNil())
 			},
 			expectedError: "",
@@ -1271,7 +1271,7 @@ func TestParameters(t *testing.T) {
 				Size:       "Standard_D2v3",
 				Location:   "test-location",
 				Zone:       "1",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				DiagnosticsProfile: &infrav1.Diagnostics{
 					Boot: &infrav1.BootDiagnostics{
 						StorageAccountType: infrav1.ManagedDiagnosticsStorage,
@@ -1282,7 +1282,7 @@ func TestParameters(t *testing.T) {
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
-				g.Expect(result.(compute.VirtualMachine).DiagnosticsProfile.BootDiagnostics.Enabled).To(Equal(pointer.Bool(true)))
+				g.Expect(result.(compute.VirtualMachine).DiagnosticsProfile.BootDiagnostics.Enabled).To(Equal(ptr.To(true)))
 				g.Expect(result.(compute.VirtualMachine).DiagnosticsProfile.BootDiagnostics.StorageURI).To(BeNil())
 			},
 			expectedError: "",
@@ -1297,7 +1297,7 @@ func TestParameters(t *testing.T) {
 				Size:       "Standard_D2v3",
 				Location:   "test-location",
 				Zone:       "1",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				DiagnosticsProfile: &infrav1.Diagnostics{
 					Boot: &infrav1.BootDiagnostics{
 						StorageAccountType: infrav1.UserManagedDiagnosticsStorage,
@@ -1311,8 +1311,8 @@ func TestParameters(t *testing.T) {
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
-				g.Expect(result.(compute.VirtualMachine).DiagnosticsProfile.BootDiagnostics.Enabled).To(Equal(pointer.Bool(true)))
-				g.Expect(result.(compute.VirtualMachine).DiagnosticsProfile.BootDiagnostics.StorageURI).To(Equal(pointer.String("aaa")))
+				g.Expect(result.(compute.VirtualMachine).DiagnosticsProfile.BootDiagnostics.Enabled).To(Equal(ptr.To(true)))
+				g.Expect(result.(compute.VirtualMachine).DiagnosticsProfile.BootDiagnostics.StorageURI).To(Equal(ptr.To("aaa")))
 			},
 			expectedError: "",
 		},
@@ -1326,7 +1326,7 @@ func TestParameters(t *testing.T) {
 				Size:       "Standard_D2v3",
 				Location:   "test-location",
 				Zone:       "1",
-				Image:      &infrav1.Image{ID: pointer.String("fake-image-id")},
+				Image:      &infrav1.Image{ID: ptr.To("fake-image-id")},
 				DiagnosticsProfile: &infrav1.Diagnostics{
 					Boot: &infrav1.BootDiagnostics{
 						StorageAccountType: infrav1.UserManagedDiagnosticsStorage,
@@ -1340,8 +1340,8 @@ func TestParameters(t *testing.T) {
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(compute.VirtualMachine{}))
-				g.Expect(result.(compute.VirtualMachine).DiagnosticsProfile.BootDiagnostics.Enabled).To(Equal(pointer.Bool(true)))
-				g.Expect(result.(compute.VirtualMachine).DiagnosticsProfile.BootDiagnostics.StorageURI).To(Equal(pointer.String("aaa")))
+				g.Expect(result.(compute.VirtualMachine).DiagnosticsProfile.BootDiagnostics.Enabled).To(Equal(ptr.To(true)))
+				g.Expect(result.(compute.VirtualMachine).DiagnosticsProfile.BootDiagnostics.StorageURI).To(Equal(ptr.To("aaa")))
 			},
 			expectedError: "",
 		},

--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	azprovider "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -191,7 +191,7 @@ func (s *Service) getAddresses(ctx context.Context, vm compute.VirtualMachine, r
 	addresses := []corev1.NodeAddress{
 		{
 			Type:    corev1.NodeInternalDNS,
-			Address: pointer.StringDeref(vm.Name, ""),
+			Address: ptr.Deref(vm.Name, ""),
 		},
 	}
 	if vm.NetworkProfile.NetworkInterfaces == nil {
@@ -204,7 +204,7 @@ func (s *Service) getAddresses(ctx context.Context, vm compute.VirtualMachine, r
 		if nicRef.ID == nil {
 			continue
 		}
-		nicName := getResourceNameByID(pointer.StringDeref(nicRef.ID, ""))
+		nicName := getResourceNameByID(ptr.Deref(nicRef.ID, ""))
 
 		// Fetch nic and append its addresses
 		existingNic, err := s.interfacesGetter.Get(ctx, &networkinterfaces.NICSpec{
@@ -228,7 +228,7 @@ func (s *Service) getAddresses(ctx context.Context, vm compute.VirtualMachine, r
 				addresses = append(addresses,
 					corev1.NodeAddress{
 						Type:    corev1.NodeInternalIP,
-						Address: pointer.StringDeref(ipConfig.PrivateIPAddress, ""),
+						Address: ptr.Deref(ipConfig.PrivateIPAddress, ""),
 					},
 				)
 			}
@@ -238,7 +238,7 @@ func (s *Service) getAddresses(ctx context.Context, vm compute.VirtualMachine, r
 			}
 			// ID is the only field populated in PublicIPAddress sub-resource.
 			// Thus, we have to go fetch the publicIP with the name.
-			publicIPName := getResourceNameByID(pointer.StringDeref(ipConfig.PublicIPAddress.ID, ""))
+			publicIPName := getResourceNameByID(ptr.Deref(ipConfig.PublicIPAddress.ID, ""))
 			publicNodeAddress, err := s.getPublicIPAddress(ctx, publicIPName, rgName)
 			if err != nil {
 				return addresses, err
@@ -270,7 +270,7 @@ func (s *Service) getPublicIPAddress(ctx context.Context, publicIPAddressName st
 	}
 
 	retAddress.Type = corev1.NodeExternalIP
-	retAddress.Address = pointer.StringDeref(publicIP.IPAddress, "")
+	retAddress.Address = ptr.Deref(publicIP.IPAddress, "")
 
 	return retAddress, nil
 }

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/identities/mock_identities"
@@ -52,18 +52,18 @@ var (
 		AvailabilitySetID: "availability-set",
 		Identity:          infrav1.VMIdentitySystemAssigned,
 		AdditionalTags:    map[string]string{"foo": "bar"},
-		Image:             &infrav1.Image{ID: pointer.String("fake-image-id")},
+		Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
 		BootstrapData:     "fake data",
 	}
 	fakeExistingVM = compute.VirtualMachine{
-		ID:   pointer.String("subscriptions/123/resourceGroups/my_resource_group/providers/Microsoft.Compute/virtualMachines/my-vm"),
-		Name: pointer.String("test-vm-name"),
+		ID:   ptr.To("subscriptions/123/resourceGroups/my_resource_group/providers/Microsoft.Compute/virtualMachines/my-vm"),
+		Name: ptr.To("test-vm-name"),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
-			ProvisioningState: pointer.String("Succeeded"),
+			ProvisioningState: ptr.To("Succeeded"),
 			NetworkProfile: &compute.NetworkProfile{
 				NetworkInterfaces: &[]compute.NetworkInterfaceReference{
 					{
-						ID: pointer.String("/subscriptions/123/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-1"),
+						ID: ptr.To("/subscriptions/123/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-1"),
 					},
 				},
 			},
@@ -78,9 +78,9 @@ var (
 			IPConfigurations: &[]network.InterfaceIPConfiguration{
 				{
 					InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-						PrivateIPAddress: pointer.String("10.0.0.5"),
+						PrivateIPAddress: ptr.To("10.0.0.5"),
 						PublicIPAddress: &network.PublicIPAddress{
-							ID: pointer.String("/subscriptions/123/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/pip-1"),
+							ID: ptr.To("/subscriptions/123/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/pip-1"),
 						},
 					},
 				},
@@ -93,7 +93,7 @@ var (
 	}
 	fakePublicIPs = network.PublicIPAddress{
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-			IPAddress: pointer.String("10.0.0.6"),
+			IPAddress: ptr.To("10.0.0.6"),
 		},
 	}
 	fakeNodeAddresses = []corev1.NodeAddress{

--- a/azure/services/virtualnetworks/spec.go
+++ b/azure/services/virtualnetworks/spec.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 )
@@ -61,11 +61,11 @@ func (s *VNetSpec) Parameters(ctx context.Context, existing interface{}) (interf
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
-			Name:        pointer.String(s.Name),
-			Role:        pointer.String(infrav1.CommonRole),
+			Name:        ptr.To(s.Name),
+			Role:        ptr.To(infrav1.CommonRole),
 			Additional:  s.AdditionalTags,
 		})),
-		Location:         pointer.String(s.Location),
+		Location:         ptr.To(s.Location),
 		ExtendedLocation: converters.ExtendedLocationToNetworkSDK(s.ExtendedLocation),
 		VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
 			AddressSpace: &network.AddressSpace{

--- a/azure/services/virtualnetworks/virtualnetworks.go
+++ b/azure/services/virtualnetworks/virtualnetworks.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -89,7 +89,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			return errors.Errorf("%T is not a network.VirtualNetwork", result)
 		}
 		vnet := s.Scope.Vnet()
-		vnet.ID = pointer.StringDeref(existingVnet.ID, "")
+		vnet.ID = ptr.Deref(existingVnet.ID, "")
 		vnet.Tags = converters.MapToTags(existingVnet.Tags)
 
 		var prefixes []string
@@ -103,7 +103,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		// Subnets that are not part of this cluster spec are silently ignored.
 		if existingVnet.Subnets != nil {
 			for _, subnet := range *existingVnet.Subnets {
-				s.Scope.UpdateSubnetCIDRs(pointer.StringDeref(subnet.Name, ""), converters.GetSubnetAddresses(subnet))
+				s.Scope.UpdateSubnetCIDRs(ptr.Deref(subnet.Name, ""), converters.GetSubnetAddresses(subnet))
 			}
 		}
 	}

--- a/azure/services/virtualnetworks/virtualnetworks_test.go
+++ b/azure/services/virtualnetworks/virtualnetworks_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
@@ -47,8 +47,8 @@ var (
 	managedTags = resources.TagsResource{
 		Properties: &resources.Tags{
 			Tags: map[string]*string{
-				"foo": pointer.String("bar"),
-				"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": pointer.String("owned"),
+				"foo": ptr.To("bar"),
+				"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": ptr.To("owned"),
 			},
 		},
 	}
@@ -56,18 +56,18 @@ var (
 	unmanagedTags = resources.TagsResource{
 		Properties: &resources.Tags{
 			Tags: map[string]*string{
-				"foo":       pointer.String("bar"),
-				"something": pointer.String("else"),
+				"foo":       ptr.To("bar"),
+				"something": ptr.To("else"),
 			},
 		},
 	}
 
 	customVnet = network.VirtualNetwork{
-		ID:   pointer.String("/subscriptions/subscription/resourceGroups/test-group/providers/Microsoft.Network/virtualNetworks/test-vnet"),
-		Name: pointer.String("test-vnet"),
+		ID:   ptr.To("/subscriptions/subscription/resourceGroups/test-group/providers/Microsoft.Network/virtualNetworks/test-vnet"),
+		Name: ptr.To("test-vnet"),
 		Tags: map[string]*string{
-			"foo":       pointer.String("bar"),
-			"something": pointer.String("else"),
+			"foo":       ptr.To("bar"),
+			"something": ptr.To("else"),
 		},
 		VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
 			AddressSpace: &network.AddressSpace{
@@ -75,13 +75,13 @@ var (
 			},
 			Subnets: &[]network.Subnet{
 				{
-					Name: pointer.String("test-subnet"),
+					Name: ptr.To("test-subnet"),
 					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-						AddressPrefix: pointer.String("subnet-cidr"),
+						AddressPrefix: ptr.To("subnet-cidr"),
 					},
 				},
 				{
-					Name: pointer.String("test-subnet-2"),
+					Name: ptr.To("test-subnet-2"),
 					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 						AddressPrefixes: &[]string{
 							"subnet-cidr-1",

--- a/azure/services/vmextensions/spec.go
+++ b/azure/services/vmextensions/spec.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
@@ -61,12 +61,12 @@ func (s *VMExtensionSpec) Parameters(ctx context.Context, existing interface{}) 
 
 	return compute.VirtualMachineExtension{
 		VirtualMachineExtensionProperties: &compute.VirtualMachineExtensionProperties{
-			Publisher:          pointer.String(s.Publisher),
-			Type:               pointer.String(s.Name),
-			TypeHandlerVersion: pointer.String(s.Version),
+			Publisher:          ptr.To(s.Publisher),
+			Type:               ptr.To(s.Name),
+			TypeHandlerVersion: ptr.To(s.Version),
 			Settings:           s.Settings,
 			ProtectedSettings:  s.ProtectedSettings,
 		},
-		Location: pointer.String(s.Location),
+		Location: ptr.To(s.Location),
 	}, nil
 }

--- a/azure/services/vmextensions/spec_test.go
+++ b/azure/services/vmextensions/spec_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
@@ -42,13 +42,13 @@ var (
 
 	fakeVMExtensionParams = compute.VirtualMachineExtension{
 		VirtualMachineExtensionProperties: &compute.VirtualMachineExtensionProperties{
-			Publisher:          pointer.String("my-publisher"),
-			Type:               pointer.String("my-vm-extension"),
-			TypeHandlerVersion: pointer.String("1.0"),
+			Publisher:          ptr.To("my-publisher"),
+			Type:               ptr.To("my-vm-extension"),
+			TypeHandlerVersion: ptr.To("1.0"),
 			Settings:           map[string]string{"my-setting": "my-value"},
 			ProtectedSettings:  map[string]string{"my-protected-setting": "my-protected-value"},
 		},
-		Location: pointer.String("my-location"),
+		Location: ptr.To("my-location"),
 	}
 )
 

--- a/azure/services/vnetpeerings/spec.go
+++ b/azure/services/vnetpeerings/spec.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/pkg/errors"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
@@ -66,7 +66,7 @@ func (s *VnetPeeringSpec) Parameters(ctx context.Context, existing interface{}) 
 	vnetID := azure.VNetID(s.SubscriptionID, s.RemoteResourceGroup, s.RemoteVnetName)
 	peeringProperties := network.VirtualNetworkPeeringPropertiesFormat{
 		RemoteVirtualNetwork: &network.SubResource{
-			ID: pointer.String(vnetID),
+			ID: ptr.To(vnetID),
 		},
 		AllowForwardedTraffic:     s.AllowForwardedTraffic,
 		AllowGatewayTransit:       s.AllowGatewayTransit,
@@ -74,7 +74,7 @@ func (s *VnetPeeringSpec) Parameters(ctx context.Context, existing interface{}) 
 		UseRemoteGateways:         s.UseRemoteGateways,
 	}
 	return network.VirtualNetworkPeering{
-		Name:                                  pointer.String(s.PeeringName),
+		Name:                                  ptr.To(s.PeeringName),
 		VirtualNetworkPeeringPropertiesFormat: &peeringProperties,
 	}, nil
 }

--- a/azure/services/vnetpeerings/vnetpeerings_test.go
+++ b/azure/services/vnetpeerings/vnetpeerings_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
@@ -73,10 +73,10 @@ var (
 		RemoteVnetName:            "spoke-vnet",
 		RemoteResourceGroup:       "spoke-group",
 		SubscriptionID:            "sub1",
-		AllowForwardedTraffic:     pointer.Bool(true),
-		AllowGatewayTransit:       pointer.Bool(true),
-		AllowVirtualNetworkAccess: pointer.Bool(true),
-		UseRemoteGateways:         pointer.Bool(false),
+		AllowForwardedTraffic:     ptr.To(true),
+		AllowGatewayTransit:       ptr.To(true),
+		AllowVirtualNetworkAccess: ptr.To(true),
+		UseRemoteGateways:         ptr.To(false),
 	}
 	fakePeeringSpokeToHub = VnetPeeringSpec{
 		PeeringName:               "spoke-to-hub",
@@ -85,10 +85,10 @@ var (
 		RemoteVnetName:            "hub-vnet",
 		RemoteResourceGroup:       "hub-group",
 		SubscriptionID:            "sub1",
-		AllowForwardedTraffic:     pointer.Bool(true),
-		AllowGatewayTransit:       pointer.Bool(false),
-		AllowVirtualNetworkAccess: pointer.Bool(true),
-		UseRemoteGateways:         pointer.Bool(true),
+		AllowForwardedTraffic:     ptr.To(true),
+		AllowGatewayTransit:       ptr.To(false),
+		AllowVirtualNetworkAccess: ptr.To(true),
+		UseRemoteGateways:         ptr.To(true),
 	}
 	fakePeeringExtra = VnetPeeringSpec{
 		PeeringName:         "extra-peering",

--- a/azure/types_test.go
+++ b/azure/types_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -107,7 +107,7 @@ func TestVMSS_HasModelChanges(t *testing.T) {
 			Factory: func() (VMSS, VMSS) {
 				l := getDefaultVMSSForModelTesting()
 				l.Image = infrav1.Image{
-					ID: pointer.String("foo"),
+					ID: ptr.To("foo"),
 				}
 				r := getDefaultVMSSForModelTesting()
 				return r, l

--- a/controllers/azuremachine_controller_test.go
+++ b/controllers/azuremachine_controller_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
@@ -312,7 +312,7 @@ func getReconcileInputs(tc TestReconcileInput) (*AzureMachineReconciler, *scope.
 	})
 	machine := getFakeMachine(azureMachine, func(m *clusterv1.Machine) {
 		m.Spec.Bootstrap = clusterv1.Bootstrap{
-			DataSecretName: pointer.String("fooSecret"),
+			DataSecretName: ptr.To("fooSecret"),
 		}
 	})
 
@@ -560,7 +560,7 @@ func getFakeMachine(azureMachine *infrav1.AzureMachine, changes ...func(*cluster
 				Name:       azureMachine.Name,
 				Namespace:  azureMachine.Namespace,
 			},
-			Version: pointer.String("v1.22.0"),
+			Version: ptr.To("v1.22.0"),
 		},
 	}
 	for _, change := range changes {

--- a/controllers/azuremanagedmachinepool_controller_test.go
+++ b/controllers/azuremanagedmachinepool_controller_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
@@ -264,20 +264,20 @@ func fakeAgentPool(changes ...func(*agentpools.AgentPoolSpec)) agentpools.AgentP
 		Cluster:           "fake-cluster",
 		AvailabilityZones: []string{"fake-zone"},
 		EnableAutoScaling: true,
-		EnableUltraSSD:    pointer.Bool(true),
-		KubeletDiskType:   (*infrav1.KubeletDiskType)(pointer.String("fake-kubelet-disk-type")),
-		MaxCount:          pointer.Int32(5),
-		MaxPods:           pointer.Int32(10),
-		MinCount:          pointer.Int32(1),
+		EnableUltraSSD:    ptr.To(true),
+		KubeletDiskType:   (*infrav1.KubeletDiskType)(ptr.To("fake-kubelet-disk-type")),
+		MaxCount:          ptr.To[int32](5),
+		MaxPods:           ptr.To[int32](10),
+		MinCount:          ptr.To[int32](1),
 		Mode:              "fake-mode",
-		NodeLabels:        map[string]*string{"fake-label": pointer.String("fake-value")},
+		NodeLabels:        map[string]*string{"fake-label": ptr.To("fake-value")},
 		NodeTaints:        []string{"fake-taint"},
 		OSDiskSizeGB:      2,
-		OsDiskType:        pointer.String("fake-os-disk-type"),
-		OSType:            pointer.String("fake-os-type"),
+		OsDiskType:        ptr.To("fake-os-disk-type"),
+		OSType:            ptr.To("fake-os-type"),
 		Replicas:          1,
 		SKU:               "fake-sku",
-		Version:           pointer.String("fake-version"),
+		Version:           ptr.To("fake-version"),
 		VnetSubnetID:      "fake-vnet-subnet-id",
 		Headers:           map[string]string{"fake-header": "fake-value"},
 		AdditionalTags:    infrav1.Tags{"fake": "tag"},
@@ -293,14 +293,14 @@ func fakeAgentPool(changes ...func(*agentpools.AgentPoolSpec)) agentpools.AgentP
 func fakeVirtualMachineScaleSetVM() []compute.VirtualMachineScaleSetVM {
 	virtualMachineScaleSetVM := []compute.VirtualMachineScaleSetVM{
 		{
-			InstanceID: pointer.String("0"),
-			ID:         pointer.String("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachineScaleSets/myScaleSetName/virtualMachines/156"),
-			Name:       pointer.String("vm0"),
+			InstanceID: ptr.To("0"),
+			ID:         ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachineScaleSets/myScaleSetName/virtualMachines/156"),
+			Name:       ptr.To("vm0"),
 			Zones:      &[]string{"zone0"},
 			VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-				ProvisioningState: pointer.String(string(compute.ProvisioningState1Succeeded)),
+				ProvisioningState: ptr.To(string(compute.ProvisioningState1Succeeded)),
 				OsProfile: &compute.OSProfile{
-					ComputerName: pointer.String("instance-000000"),
+					ComputerName: ptr.To("instance-000000"),
 				},
 			},
 		},
@@ -310,25 +310,25 @@ func fakeVirtualMachineScaleSetVM() []compute.VirtualMachineScaleSetVM {
 
 func fakeVirtualMachineScaleSet() []compute.VirtualMachineScaleSet {
 	tags := map[string]*string{
-		"foo":      pointer.String("bazz"),
-		"poolName": pointer.String("fake-agent-pool-name"),
+		"foo":      ptr.To("bazz"),
+		"poolName": ptr.To("fake-agent-pool-name"),
 	}
 	zones := []string{"zone0", "zone1"}
 	virtualMachineScaleSet := []compute.VirtualMachineScaleSet{
 		{
 			Sku: &compute.Sku{
-				Name:     pointer.String("skuName"),
-				Tier:     pointer.String("skuTier"),
-				Capacity: pointer.Int64(2),
+				Name:     ptr.To("skuName"),
+				Tier:     ptr.To("skuTier"),
+				Capacity: ptr.To[int64](2),
 			},
 			Zones:    &zones,
-			ID:       pointer.String("vmssID"),
-			Name:     pointer.String("vmssName"),
-			Location: pointer.String("westus2"),
+			ID:       ptr.To("vmssID"),
+			Name:     ptr.To("vmssName"),
+			Location: ptr.To("westus2"),
 			Tags:     tags,
 			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-				SinglePlacementGroup: pointer.Bool(false),
-				ProvisioningState:    pointer.String(string(compute.ProvisioningState1Succeeded)),
+				SinglePlacementGroup: ptr.To(false),
+				ProvisioningState:    ptr.To(string(compute.ProvisioningState1Succeeded)),
 			},
 		},
 	}

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	utilfeature "k8s.io/component-base/featuregate/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
 	"sigs.k8s.io/cluster-api-provider-azure/internal/test/mock_log"
@@ -1197,7 +1197,7 @@ func newAzureManagedMachinePool(clusterName, poolName, mode string) *infrav1.Azu
 		Spec: infrav1.AzureManagedMachinePoolSpec{
 			Mode:         mode,
 			SKU:          "Standard_B2s",
-			OSDiskSizeGB: pointer.Int32(512),
+			OSDiskSizeGB: ptr.To[int32](512),
 			KubeletConfig: &infrav1.KubeletConfig{
 				CPUManagerPolicy:      &cpuManagerPolicyStatic,
 				TopologyManagerPolicy: &topologyManagerPolicy,
@@ -1220,7 +1220,7 @@ func newMachinePool(clusterName, poolName string) *expv1.MachinePool {
 			Namespace: "default",
 		},
 		Spec: expv1.MachinePoolSpec{
-			Replicas: pointer.Int32(2),
+			Replicas: ptr.To[int32](2),
 		},
 	}
 }

--- a/exp/api/v1beta1/azuremachinepool_default_test.go
+++ b/exp/api/v1beta1/azuremachinepool_default_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
@@ -278,7 +278,7 @@ func TestAzureMachinePool_SetNetworkInterfacesDefaults(t *testing.T) {
 				Spec: AzureMachinePoolSpec{
 					Template: AzureMachinePoolMachineTemplate{
 						SubnetName:            "test-subnet",
-						AcceleratedNetworking: pointer.Bool(true),
+						AcceleratedNetworking: ptr.To(true),
 					},
 				},
 			},
@@ -291,7 +291,7 @@ func TestAzureMachinePool_SetNetworkInterfacesDefaults(t *testing.T) {
 							{
 								SubnetName:            "test-subnet",
 								PrivateIPConfigs:      1,
-								AcceleratedNetworking: pointer.Bool(true),
+								AcceleratedNetworking: ptr.To(true),
 							},
 						},
 					},

--- a/exp/api/v1beta1/azuremachinepool_test.go
+++ b/exp/api/v1beta1/azuremachinepool_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/onsi/gomega"
 	utilfeature "k8s.io/component-base/featuregate/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
@@ -88,7 +88,7 @@ func TestAzureMachinePool_Validate(t *testing.T) {
 				return &infrav1exp.AzureMachinePool{
 					Spec: infrav1exp.AzureMachinePoolSpec{
 						Template: infrav1exp.AzureMachinePoolMachineTemplate{
-							TerminateNotificationTimeout: pointer.Int(7),
+							TerminateNotificationTimeout: ptr.To(7),
 						},
 					},
 				}
@@ -103,7 +103,7 @@ func TestAzureMachinePool_Validate(t *testing.T) {
 				return &infrav1exp.AzureMachinePool{
 					Spec: infrav1exp.AzureMachinePoolSpec{
 						Template: infrav1exp.AzureMachinePoolMachineTemplate{
-							TerminateNotificationTimeout: pointer.Int(20),
+							TerminateNotificationTimeout: ptr.To(20),
 						},
 					},
 				}
@@ -119,7 +119,7 @@ func TestAzureMachinePool_Validate(t *testing.T) {
 				return &infrav1exp.AzureMachinePool{
 					Spec: infrav1exp.AzureMachinePoolSpec{
 						Template: infrav1exp.AzureMachinePoolMachineTemplate{
-							TerminateNotificationTimeout: pointer.Int(3),
+							TerminateNotificationTimeout: ptr.To(3),
 						},
 					},
 				}

--- a/exp/api/v1beta1/azuremachinepool_webhook_test.go
+++ b/exp/api/v1beta1/azuremachinepool_webhook_test.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	utilfeature "k8s.io/component-base/featuregate/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -92,32 +92,32 @@ func TestAzureMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name:    "azuremachinepool with marketplace image - full",
-			amp:     createMachinePoolWithMarketPlaceImage("PUB1234", "OFFER1234", "SKU1234", "1.0.0", pointer.Int(10)),
+			amp:     createMachinePoolWithMarketPlaceImage("PUB1234", "OFFER1234", "SKU1234", "1.0.0", ptr.To(10)),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachinepool with marketplace image - missing publisher",
-			amp:     createMachinePoolWithMarketPlaceImage("", "OFFER1234", "SKU1234", "1.0.0", pointer.Int(10)),
+			amp:     createMachinePoolWithMarketPlaceImage("", "OFFER1234", "SKU1234", "1.0.0", ptr.To(10)),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachinepool with shared gallery image - full",
-			amp:     createMachinePoolWithSharedImage("SUB123", "RG123", "NAME123", "GALLERY1", "1.0.0", pointer.Int(10)),
+			amp:     createMachinePoolWithSharedImage("SUB123", "RG123", "NAME123", "GALLERY1", "1.0.0", ptr.To(10)),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachinepool with marketplace image - missing subscription",
-			amp:     createMachinePoolWithSharedImage("", "RG123", "NAME123", "GALLERY1", "1.0.0", pointer.Int(10)),
+			amp:     createMachinePoolWithSharedImage("", "RG123", "NAME123", "GALLERY1", "1.0.0", ptr.To(10)),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachinepool with image by - with id",
-			amp:     createMachinePoolWithImageByID("ID123", pointer.Int(10)),
+			amp:     createMachinePoolWithImageByID("ID123", ptr.To(10)),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachinepool with image by - without id",
-			amp:     createMachinePoolWithImageByID("", pointer.Int(10)),
+			amp:     createMachinePoolWithImageByID("", ptr.To(10)),
 			wantErr: true,
 		},
 		{
@@ -132,7 +132,7 @@ func TestAzureMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name:    "azuremachinepool with wrong terminate notification",
-			amp:     createMachinePoolWithSharedImage("SUB123", "RG123", "NAME123", "GALLERY1", "1.0.0", pointer.Int(35)),
+			amp:     createMachinePoolWithSharedImage("SUB123", "RG123", "NAME123", "GALLERY1", "1.0.0", ptr.To(35)),
 			wantErr: true,
 		},
 		{
@@ -684,7 +684,7 @@ func getKnownValidAzureMachinePool() *AzureMachinePool {
 			Template: AzureMachinePoolMachineTemplate{
 				Image:                        &image,
 				SSHPublicKey:                 validSSHPublicKey,
-				TerminateNotificationTimeout: pointer.Int(10),
+				TerminateNotificationTimeout: ptr.To(10),
 			},
 			Identity: infrav1.VMIdentitySystemAssigned,
 			SystemAssignedIdentityRole: &infrav1.SystemAssignedIdentityRole{

--- a/exp/controllers/azuremachinepool_controller_unit_test.go
+++ b/exp/controllers/azuremachinepool_controller_unit_test.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
@@ -94,7 +94,7 @@ func newMachinePool(clusterName, poolName string) *expv1.MachinePool {
 			Namespace: "default",
 		},
 		Spec: expv1.MachinePoolSpec{
-			Replicas: pointer.Int32(2),
+			Replicas: ptr.To[int32](2),
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	k8s.io/component-base v0.26.2
 	k8s.io/klog/v2 v2.90.1
 	k8s.io/kubectl v0.26.1
-	k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/cloud-provider-azure v1.26.7
 	sigs.k8s.io/cluster-api v1.4.5
 	sigs.k8s.io/cluster-api/test v1.4.5

--- a/go.sum
+++ b/go.sum
@@ -1076,8 +1076,8 @@ k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 h1:+70TFaan3hfJzs+7VK2o+O
 k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280/go.mod h1:+Axhij7bCpeqhklhUTe3xmOn6bWxolyZEeyaFpjGtl4=
 k8s.io/kubectl v0.26.1 h1:K8A0Jjlwg8GqrxOXxAbjY5xtmXYeYjLU96cHp2WMQ7s=
 k8s.io/kubectl v0.26.1/go.mod h1:miYFVzldVbdIiXMrHZYmL/EDWwJKM+F0sSsdxsATFPo=
-k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5 h1:kmDqav+P+/5e1i9tFfHq1qcF3sOrDp+YEkVDAHu7Jwk=
-k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/internal/test/env/env.go
+++ b/internal/test/env/env.go
@@ -34,7 +34,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/internal/test/record"
@@ -46,7 +46,7 @@ import (
 )
 
 var (
-	logger                 = record.NewLogger(record.WithThreshold(pointer.Int(1)), record.WithWriter(ginkgo.GinkgoWriter))
+	logger                 = record.NewLogger(record.WithThreshold(ptr.To(1)), record.WithWriter(ginkgo.GinkgoWriter))
 	scheme                 = runtime.NewScheme()
 	env                    *envtest.Environment
 	clusterAPIVersionRegex = regexp.MustCompile(`^(\W)sigs.k8s.io/cluster-api v(.+)`)

--- a/test/e2e/aks_autoscaler.go
+++ b/test/e2e/aks_autoscaler.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -85,8 +85,8 @@ func AKSAutoscaleSpec(ctx context.Context, inputGetter func() AKSAutoscaleSpecIn
 			} else {
 				enabling = "Enabling"
 				ammp.Spec.Scaling = &infrav1.ManagedMachinePoolScaling{
-					MinSize: pointer.Int32(1),
-					MaxSize: pointer.Int32(2),
+					MinSize: ptr.To[int32](1),
+					MaxSize: ptr.To[int32](2),
 				}
 			}
 			By(enabling + " autoscaling")
@@ -114,7 +114,7 @@ func validateAKSAutoscaleDisabled(agentPoolGetter func() (containerservice.Agent
 	Eventually(func(g Gomega) {
 		agentpool, err := agentPoolGetter()
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(pointer.BoolDeref(agentpool.EnableAutoScaling, false)).To(BeFalse())
+		g.Expect(ptr.Deref(agentpool.EnableAutoScaling, false)).To(BeFalse())
 	}, inputGetter().WaitIntervals...).Should(Succeed())
 }
 
@@ -123,6 +123,6 @@ func validateAKSAutoscaleEnabled(agentPoolGetter func() (containerservice.AgentP
 	Eventually(func(g Gomega) {
 		agentpool, err := agentPoolGetter()
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(pointer.BoolDeref(agentpool.EnableAutoScaling, false)).To(BeTrue())
+		g.Expect(ptr.Deref(agentpool.EnableAutoScaling, false)).To(BeTrue())
 	}, inputGetter().WaitIntervals...).Should(Succeed())
 }

--- a/test/e2e/aks_azure_cluster_autoscaler.go
+++ b/test/e2e/aks_azure_cluster_autoscaler.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
@@ -100,7 +100,7 @@ func AKSAzureClusterAutoscalerSettingsSpec(ctx context.Context, inputGetter func
 		}, amcp)
 		g.Expect(err).NotTo(HaveOccurred())
 		amcp.Spec.AutoScalerProfile = &infrav1.AutoScalerProfile{
-			Expander: (*infrav1.Expander)(pointer.String(string(newExpanderValue))),
+			Expander: (*infrav1.Expander)(ptr.To(string(newExpanderValue))),
 		}
 		g.Expect(mgmtClient.Update(ctx, amcp)).To(Succeed())
 	}, input.WaitIntervals...).Should(Succeed())

--- a/test/e2e/aks_machinepools.go
+++ b/test/e2e/aks_machinepools.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
@@ -46,7 +46,7 @@ func AKSMachinePoolSpec(ctx context.Context, inputGetter func() AKSMachinePoolSp
 
 	originalReplicas := map[types.NamespacedName]int32{}
 	for _, mp := range input.MachinePools {
-		originalReplicas[client.ObjectKeyFromObject(mp)] = pointer.Int32Deref(mp.Spec.Replicas, 0)
+		originalReplicas[client.ObjectKeyFromObject(mp)] = ptr.Deref[int32](mp.Spec.Replicas, 0)
 	}
 
 	By("Scaling the machine pools out")
@@ -58,7 +58,7 @@ func AKSMachinePoolSpec(ctx context.Context, inputGetter func() AKSMachinePoolSp
 			framework.ScaleMachinePoolAndWait(ctx, framework.ScaleMachinePoolAndWaitInput{
 				ClusterProxy:              bootstrapClusterProxy,
 				Cluster:                   input.Cluster,
-				Replicas:                  pointer.Int32Deref(mp.Spec.Replicas, 0) + 1,
+				Replicas:                  ptr.Deref[int32](mp.Spec.Replicas, 0) + 1,
 				MachinePools:              []*expv1.MachinePool{mp},
 				WaitForMachinePoolToScale: input.WaitIntervals,
 			})
@@ -75,7 +75,7 @@ func AKSMachinePoolSpec(ctx context.Context, inputGetter func() AKSMachinePoolSp
 			framework.ScaleMachinePoolAndWait(ctx, framework.ScaleMachinePoolAndWaitInput{
 				ClusterProxy:              bootstrapClusterProxy,
 				Cluster:                   input.Cluster,
-				Replicas:                  pointer.Int32Deref(mp.Spec.Replicas, 0) - 1,
+				Replicas:                  ptr.Deref[int32](mp.Spec.Replicas, 0) - 1,
 				MachinePools:              []*expv1.MachinePool{mp},
 				WaitForMachinePoolToScale: input.WaitIntervals,
 			})

--- a/test/e2e/aks_node_labels.go
+++ b/test/e2e/aks_node_labels.go
@@ -28,7 +28,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
@@ -86,7 +86,7 @@ func AKSNodeLabelsSpec(ctx context.Context, inputGetter func() AKSNodeLabelsSpec
 				if agentpool.NodeLabels != nil {
 					actualLabels = make(map[string]string)
 					for k, v := range agentpool.NodeLabels {
-						actualLabels[k] = pointer.StringDeref(v, "")
+						actualLabels[k] = ptr.Deref(v, "")
 					}
 				}
 				if expectedLabels == nil {

--- a/test/e2e/aks_public_ip_prefix.go
+++ b/test/e2e/aks_public_ip_prefix.go
@@ -29,7 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -67,12 +67,12 @@ func AKSPublicIPPrefixSpec(ctx context.Context, inputGetter func() AKSPublicIPPr
 
 	By("Creating public IP prefix with 2 addresses")
 	publicIPPrefixFuture, err := publicIPPrefixClient.CreateOrUpdate(ctx, resourceGroupName, input.Cluster.Name, network.PublicIPPrefix{
-		Location: pointer.String(infraControlPlane.Spec.Location),
+		Location: ptr.To(infraControlPlane.Spec.Location),
 		Sku: &network.PublicIPPrefixSku{
 			Name: network.PublicIPPrefixSkuNameStandard,
 		},
 		PublicIPPrefixPropertiesFormat: &network.PublicIPPrefixPropertiesFormat{
-			PrefixLength: pointer.Int32(31), // In bits. This provides 2 addresses.
+			PrefixLength: ptr.To[int32](31), // In bits. This provides 2 addresses.
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())
@@ -91,8 +91,8 @@ func AKSPublicIPPrefixSpec(ctx context.Context, inputGetter func() AKSPublicIPPr
 		Spec: infrav1.AzureManagedMachinePoolSpec{
 			Mode:                 "User",
 			SKU:                  "Standard_D2s_v3",
-			EnableNodePublicIP:   pointer.Bool(true),
-			NodePublicIPPrefixID: pointer.String("/subscriptions/" + subscriptionID + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.Network/publicipprefixes/" + *publicIPPrefix.Name),
+			EnableNodePublicIP:   ptr.To(true),
+			NodePublicIPPrefixID: ptr.To("/subscriptions/" + subscriptionID + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.Network/publicipprefixes/" + *publicIPPrefix.Name),
 		},
 	}
 	err = mgmtClient.Create(ctx, infraMachinePool)
@@ -105,11 +105,11 @@ func AKSPublicIPPrefixSpec(ctx context.Context, inputGetter func() AKSPublicIPPr
 		},
 		Spec: expv1.MachinePoolSpec{
 			ClusterName: input.Cluster.Name,
-			Replicas:    pointer.Int32(3),
+			Replicas:    ptr.To[int32](3),
 			Template: clusterv1.MachineTemplateSpec{
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
-						DataSecretName: pointer.String(""),
+						DataSecretName: ptr.To(""),
 					},
 					ClusterName: input.Cluster.Name,
 					InfrastructureRef: corev1.ObjectReference{
@@ -117,7 +117,7 @@ func AKSPublicIPPrefixSpec(ctx context.Context, inputGetter func() AKSPublicIPPr
 						Kind:       "AzureManagedMachinePool",
 						Name:       infraMachinePool.Name,
 					},
-					Version: pointer.String(input.KubernetesVersion),
+					Version: ptr.To(input.KubernetesVersion),
 				},
 			},
 		},
@@ -157,7 +157,7 @@ func AKSPublicIPPrefixSpec(ctx context.Context, inputGetter func() AKSPublicIPPr
 	Eventually(func(g Gomega) {
 		err = mgmtClient.Get(ctx, client.ObjectKeyFromObject(machinePool), machinePool)
 		g.Expect(err).NotTo(HaveOccurred())
-		machinePool.Spec.Replicas = pointer.Int32(2)
+		machinePool.Spec.Replicas = ptr.To[int32](2)
 		err = mgmtClient.Update(ctx, machinePool)
 		g.Expect(err).NotTo(HaveOccurred())
 	}, input.WaitIntervals...).Should(Succeed())

--- a/test/e2e/aks_spot.go
+++ b/test/e2e/aks_spot.go
@@ -28,7 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
@@ -53,8 +53,8 @@ func AKSSpotSpec(ctx context.Context, inputGetter func() AKSSpotSpecInput) {
 	Expect(err).NotTo(HaveOccurred())
 
 	scaling := infrav1.ManagedMachinePoolScaling{
-		MaxSize: pointer.Int32(9),
-		MinSize: pointer.Int32(0),
+		MaxSize: ptr.To[int32](9),
+		MinSize: ptr.To[int32](0),
 	}
 	spotMaxPrice := resource.MustParse("123.456789")
 
@@ -67,10 +67,10 @@ func AKSSpotSpec(ctx context.Context, inputGetter func() AKSSpotSpecInput) {
 		Spec: infrav1.AzureManagedMachinePoolSpec{
 			Mode:             "User",
 			SKU:              "Standard_D2s_v3",
-			ScaleSetPriority: pointer.String("Spot"),
+			ScaleSetPriority: ptr.To("Spot"),
 			Scaling:          &scaling,
 			SpotMaxPrice:     &spotMaxPrice,
-			ScaleDownMode:    pointer.String("Deallocate"),
+			ScaleDownMode:    ptr.To("Deallocate"),
 		},
 	}
 	err = mgmtClient.Create(ctx, infraMachinePool)
@@ -83,11 +83,11 @@ func AKSSpotSpec(ctx context.Context, inputGetter func() AKSSpotSpecInput) {
 		},
 		Spec: expv1.MachinePoolSpec{
 			ClusterName: input.Cluster.Name,
-			Replicas:    pointer.Int32(0),
+			Replicas:    ptr.To[int32](0),
 			Template: clusterv1.MachineTemplateSpec{
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
-						DataSecretName: pointer.String(""),
+						DataSecretName: ptr.To(""),
 					},
 					ClusterName: input.Cluster.Name,
 					InfrastructureRef: corev1.ObjectReference{
@@ -95,7 +95,7 @@ func AKSSpotSpec(ctx context.Context, inputGetter func() AKSSpotSpecInput) {
 						Kind:       "AzureManagedMachinePool",
 						Name:       infraMachinePool.Name,
 					},
-					Version: pointer.String(input.KubernetesVersion),
+					Version: ptr.To(input.KubernetesVersion),
 				},
 			},
 		},

--- a/test/e2e/azure_clusterproxy.go
+++ b/test/e2e/azure_clusterproxy.go
@@ -43,7 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubectl/pkg/describe"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
@@ -271,7 +271,7 @@ func (acp *AzureClusterProxy) collectActivityLogs(ctx context.Context, namespace
 			return
 		}
 		event := itr.Value()
-		if pointer.StringDeref(event.Category.Value, "") != "Policy" {
+		if ptr.Deref(event.Category.Value, "") != "Policy" {
 			b, err := json.MarshalIndent(myEventData(event), "", "    ")
 			if err != nil {
 				Logf("Got error converting activity logs data to json: %v", err)

--- a/test/e2e/azure_machinepools.go
+++ b/test/e2e/azure_machinepools.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/util/azure"
@@ -100,7 +100,7 @@ func AzureMachinePoolsSpec(ctx context.Context, inputGetter func() AzureMachineP
 
 	var wg sync.WaitGroup
 	for _, mp := range machinepools {
-		goalReplicas := pointer.Int32Deref(mp.Spec.Replicas, 0) + 1
+		goalReplicas := ptr.Deref[int32](mp.Spec.Replicas, 0) + 1
 		Byf("Scaling machine pool %s out from %d to %d", mp.Name, *mp.Spec.Replicas, goalReplicas)
 		wg.Add(1)
 		go func(mp *expv1.MachinePool) {
@@ -118,7 +118,7 @@ func AzureMachinePoolsSpec(ctx context.Context, inputGetter func() AzureMachineP
 	wg.Wait()
 
 	for _, mp := range machinepools {
-		goalReplicas := pointer.Int32Deref(mp.Spec.Replicas, 0) - 1
+		goalReplicas := ptr.Deref[int32](mp.Spec.Replicas, 0) - 1
 		Byf("Scaling machine pool %s in from %d to %d", mp.Name, *mp.Spec.Replicas, goalReplicas)
 		wg.Add(1)
 		go func(mp *expv1.MachinePool) {

--- a/test/e2e/azure_privatecluster.go
+++ b/test/e2e/azure_privatecluster.go
@@ -37,7 +37,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -229,10 +229,10 @@ func SetupExistingVNet(ctx context.Context, vnetCidr string, cpSubnetCidrs, node
 	By("creating a resource group")
 	groupName := os.Getenv(AzureResourceGroup)
 	_, err = groupClient.CreateOrUpdate(ctx, groupName, resources.Group{
-		Location: pointer.String(os.Getenv(AzureLocation)),
+		Location: ptr.To(os.Getenv(AzureLocation)),
 		Tags: map[string]*string{
-			"jobName":           pointer.String(os.Getenv(JobName)),
-			"creationTimestamp": pointer.String(os.Getenv(Timestamp)),
+			"jobName":           ptr.To(os.Getenv(JobName)),
+			"creationTimestamp": ptr.To(os.Getenv(Timestamp)),
 		},
 	})
 	Expect(err).To(BeNil())
@@ -241,36 +241,36 @@ func SetupExistingVNet(ctx context.Context, vnetCidr string, cpSubnetCidrs, node
 	nsgName := "control-plane-nsg"
 	securityRules := []network.SecurityRule{
 		{
-			Name: pointer.String("allow_ssh"),
+			Name: ptr.To("allow_ssh"),
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-				Description:              pointer.String("Allow SSH"),
-				Priority:                 pointer.Int32(2200),
+				Description:              ptr.To("Allow SSH"),
+				Priority:                 ptr.To[int32](2200),
 				Protocol:                 network.SecurityRuleProtocolTCP,
 				Access:                   network.SecurityRuleAccessAllow,
 				Direction:                network.SecurityRuleDirectionInbound,
-				SourceAddressPrefix:      pointer.String("*"),
-				SourcePortRange:          pointer.String("*"),
-				DestinationAddressPrefix: pointer.String("*"),
-				DestinationPortRange:     pointer.String("22"),
+				SourceAddressPrefix:      ptr.To("*"),
+				SourcePortRange:          ptr.To("*"),
+				DestinationAddressPrefix: ptr.To("*"),
+				DestinationPortRange:     ptr.To("22"),
 			},
 		},
 		{
-			Name: pointer.String("allow_apiserver"),
+			Name: ptr.To("allow_apiserver"),
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-				Description:              pointer.String("Allow API Server"),
-				SourcePortRange:          pointer.String("*"),
-				DestinationPortRange:     pointer.String("6443"),
-				SourceAddressPrefix:      pointer.String("*"),
-				DestinationAddressPrefix: pointer.String("*"),
+				Description:              ptr.To("Allow API Server"),
+				SourcePortRange:          ptr.To("*"),
+				DestinationPortRange:     ptr.To("6443"),
+				SourceAddressPrefix:      ptr.To("*"),
+				DestinationAddressPrefix: ptr.To("*"),
 				Protocol:                 network.SecurityRuleProtocolTCP,
 				Access:                   network.SecurityRuleAccessAllow,
 				Direction:                network.SecurityRuleDirectionInbound,
-				Priority:                 pointer.Int32(2201),
+				Priority:                 ptr.To[int32](2201),
 			},
 		},
 	}
 	nsgFuture, err := nsgClient.CreateOrUpdate(ctx, groupName, nsgName, network.SecurityGroup{
-		Location: pointer.String(os.Getenv(AzureLocation)),
+		Location: ptr.To(os.Getenv(AzureLocation)),
 		SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 			SecurityRules: &securityRules,
 		},
@@ -283,7 +283,7 @@ func SetupExistingVNet(ctx context.Context, vnetCidr string, cpSubnetCidrs, node
 	nsgNodeName := "node-nsg"
 	securityRulesNode := []network.SecurityRule{}
 	nsgNodeFuture, err := nsgClient.CreateOrUpdate(ctx, groupName, nsgNodeName, network.SecurityGroup{
-		Location: pointer.String(os.Getenv(AzureLocation)),
+		Location: ptr.To(os.Getenv(AzureLocation)),
 		SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 			SecurityRules: &securityRulesNode,
 		},
@@ -295,7 +295,7 @@ func SetupExistingVNet(ctx context.Context, vnetCidr string, cpSubnetCidrs, node
 	By("creating a node routetable")
 	routeTableName := "node-routetable"
 	routeTable := network.RouteTable{
-		Location:                   pointer.String(os.Getenv(AzureLocation)),
+		Location:                   ptr.To(os.Getenv(AzureLocation)),
 		RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{},
 	}
 	routetableFuture, err := routetableClient.CreateOrUpdate(ctx, groupName, routeTableName, routeTable)
@@ -308,39 +308,39 @@ func SetupExistingVNet(ctx context.Context, vnetCidr string, cpSubnetCidrs, node
 	for name, cidr := range cpSubnetCidrs {
 		subnets = append(subnets, network.Subnet{
 			SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-				AddressPrefix: pointer.String(cidr),
+				AddressPrefix: ptr.To(cidr),
 				NetworkSecurityGroup: &network.SecurityGroup{
-					ID: pointer.String(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkSecurityGroups/%s", subscriptionID, groupName, nsgName)),
+					ID: ptr.To(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkSecurityGroups/%s", subscriptionID, groupName, nsgName)),
 				},
 			},
-			Name: pointer.String(name),
+			Name: ptr.To(name),
 		})
 	}
 	for name, cidr := range nodeSubnetCidrs {
 		subnets = append(subnets, network.Subnet{
 			SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-				AddressPrefix: pointer.String(cidr),
+				AddressPrefix: ptr.To(cidr),
 				NetworkSecurityGroup: &network.SecurityGroup{
-					ID: pointer.String(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkSecurityGroups/%s", subscriptionID, groupName, nsgNodeName)),
+					ID: ptr.To(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkSecurityGroups/%s", subscriptionID, groupName, nsgNodeName)),
 				},
 				RouteTable: &network.RouteTable{
-					ID: pointer.String(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/routeTables/%s", subscriptionID, groupName, routeTableName)),
+					ID: ptr.To(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/routeTables/%s", subscriptionID, groupName, routeTableName)),
 				},
 			},
-			Name: pointer.String(name),
+			Name: ptr.To(name),
 		})
 	}
 
 	// Create the AzureBastion subnet.
 	subnets = append(subnets, network.Subnet{
 		SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-			AddressPrefix: pointer.String(bastionSubnetCidr),
+			AddressPrefix: ptr.To(bastionSubnetCidr),
 		},
-		Name: pointer.String(bastionSubnetName),
+		Name: ptr.To(bastionSubnetName),
 	})
 
 	vnetFuture, err := vnetClient.CreateOrUpdate(ctx, groupName, os.Getenv(AzureCustomVNetName), network.VirtualNetwork{
-		Location: pointer.String(os.Getenv(AzureLocation)),
+		Location: ptr.To(os.Getenv(AzureLocation)),
 		VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
 			AddressSpace: &network.AddressSpace{
 				AddressPrefixes: &[]string{vnetCidr},
@@ -380,7 +380,7 @@ func SetupExistingVNet(ctx context.Context, vnetCidr string, cpSubnetCidrs, node
 		resClient := resources.NewClient(subscriptionID)
 		resClient.Authorizer = authorizer
 		Eventually(func() ([]resources.GenericResourceExpanded, error) {
-			page, err := resClient.ListByResourceGroup(ctx, groupName, "", "provisioningState", pointer.Int32(10))
+			page, err := resClient.ListByResourceGroup(ctx, groupName, "", "provisioningState", ptr.To[int32](10))
 			if err != nil {
 				return nil, err
 			}

--- a/test/e2e/azure_securitygroups.go
+++ b/test/e2e/azure_securitygroups.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -53,10 +53,10 @@ func AzureSecurityGroupsSpec(ctx context.Context, inputGetter func() AzureSecuri
 			Protocol:         "Tcp",
 			Direction:        "Outbound",
 			Priority:         100,
-			SourcePorts:      pointer.String("*"),
-			DestinationPorts: pointer.String("80"),
-			Source:           pointer.String("*"),
-			Destination:      pointer.String("*"),
+			SourcePorts:      ptr.To("*"),
+			DestinationPorts: ptr.To("80"),
+			Source:           ptr.To("*"),
+			Destination:      ptr.To("*"),
 		}
 		testSecurityRule2 = infrav1.SecurityRule{
 			Name:             "test-security-rule-2",
@@ -64,10 +64,10 @@ func AzureSecurityGroupsSpec(ctx context.Context, inputGetter func() AzureSecuri
 			Protocol:         "Tcp",
 			Direction:        "Inbound",
 			Priority:         110,
-			SourcePorts:      pointer.String("*"),
-			DestinationPorts: pointer.String("80"),
-			Source:           pointer.String("*"),
-			Destination:      pointer.String("*"),
+			SourcePorts:      ptr.To("*"),
+			DestinationPorts: ptr.To("80"),
+			Source:           ptr.To("*"),
+			Destination:      ptr.To("*"),
 		}
 		input AzureSecurityGroupsSpecInput
 	)

--- a/test/e2e/capi_test.go
+++ b/test/e2e/capi_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	e2e_namespace "sigs.k8s.io/cluster-api-provider-azure/test/e2e/kubernetes/namespace"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
@@ -270,8 +270,8 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 				ClusterctlConfigPath:     clusterctlConfigPath,
 				BootstrapClusterProxy:    bootstrapClusterProxy,
 				ArtifactFolder:           artifactFolder,
-				ControlPlaneMachineCount: pointer.Int64(3),
-				WorkerMachineCount:       pointer.Int64(0),
+				ControlPlaneMachineCount: ptr.To[int64](3),
+				WorkerMachineCount:       ptr.To[int64](0),
 				SkipCleanup:              skipCleanup,
 				SkipConformanceTests:     true,
 				ControlPlaneWaiters: clusterctl.ControlPlaneWaiters{
@@ -288,11 +288,11 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 				ClusterctlConfigPath:     clusterctlConfigPath,
 				BootstrapClusterProxy:    bootstrapClusterProxy,
 				ArtifactFolder:           artifactFolder,
-				ControlPlaneMachineCount: pointer.Int64(3),
-				WorkerMachineCount:       pointer.Int64(0),
+				ControlPlaneMachineCount: ptr.To[int64](3),
+				WorkerMachineCount:       ptr.To[int64](0),
 				SkipCleanup:              skipCleanup,
 				SkipConformanceTests:     true,
-				Flavor:                   pointer.String("kcp-scale-in"),
+				Flavor:                   ptr.To("kcp-scale-in"),
 				ControlPlaneWaiters: clusterctl.ControlPlaneWaiters{
 					WaitForControlPlaneInitialized: EnsureControlPlaneInitialized,
 				},

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -38,7 +38,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	e2e_namespace "sigs.k8s.io/cluster-api-provider-azure/test/e2e/kubernetes/namespace"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
@@ -321,8 +321,8 @@ func createApplyClusterTemplateInput(specName string, changes ...func(*clusterct
 			Namespace:                "default",
 			ClusterName:              "cluster",
 			KubernetesVersion:        e2eConfig.GetVariable(capi_e2e.KubernetesVersion),
-			ControlPlaneMachineCount: pointer.Int64(1),
-			WorkerMachineCount:       pointer.Int64(1),
+			ControlPlaneMachineCount: ptr.To[int64](1),
+			WorkerMachineCount:       ptr.To[int64](1),
 		},
 		WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
 		WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
@@ -369,13 +369,13 @@ func withKubernetesVersion(version string) func(*clusterctl.ApplyClusterTemplate
 
 func withControlPlaneMachineCount(count int64) func(*clusterctl.ApplyClusterTemplateAndWaitInput) {
 	return func(input *clusterctl.ApplyClusterTemplateAndWaitInput) {
-		input.ConfigCluster.ControlPlaneMachineCount = pointer.Int64(count)
+		input.ConfigCluster.ControlPlaneMachineCount = ptr.To[int64](count)
 	}
 }
 
 func withWorkerMachineCount(count int64) func(*clusterctl.ApplyClusterTemplateAndWaitInput) {
 	return func(input *clusterctl.ApplyClusterTemplateAndWaitInput) {
-		input.ConfigCluster.WorkerMachineCount = pointer.Int64(count)
+		input.ConfigCluster.WorkerMachineCount = ptr.To[int64](count)
 	}
 }
 

--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	typedappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -63,7 +63,7 @@ func Create(image, name, namespace string) *Builder {
 				Labels:    map[string]string{},
 			},
 			Spec: appsv1.DeploymentSpec{
-				Replicas: pointer.Int32(1),
+				Replicas: ptr.To[int32](1),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"app": name,

--- a/test/e2e/kubernetes/pvc/pvc.go
+++ b/test/e2e/kubernetes/pvc/pvc.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -105,7 +105,7 @@ func (b *Builder) WithAnnotations(annotations map[string]string) *Builder {
 }
 
 func (b *Builder) WithStorageClass(scName string) *Builder {
-	b.pvc.Spec.StorageClassName = pointer.String(scName)
+	b.pvc.Spec.StorageClassName = ptr.To(scName)
 	return b
 }
 

--- a/util/webhook/validator_test.go
+++ b/util/webhook/validator_test.go
@@ -21,7 +21,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestValidateImmutableBoolPtr(t *testing.T) {
@@ -40,25 +40,25 @@ func TestValidateImmutableBoolPtr(t *testing.T) {
 		},
 		{
 			name:   "no change",
-			input1: pointer.Bool(true),
-			input2: pointer.Bool(true),
+			input1: ptr.To(true),
+			input2: ptr.To(true),
 		},
 		{
 			name:           "can't unset",
-			input1:         pointer.Bool(true),
+			input1:         ptr.To(true),
 			input2:         nil,
 			expectedOutput: field.Invalid(testPath, nil, unsetMessage),
 		},
 		{
 			name:           "can't set from empty",
 			input1:         nil,
-			input2:         pointer.Bool(true),
+			input2:         ptr.To(true),
 			expectedOutput: field.Invalid(testPath, nil, setMessage),
 		},
 		{
 			name:           "can't change",
-			input1:         pointer.Bool(true),
-			input2:         pointer.Bool(false),
+			input1:         ptr.To(true),
+			input2:         ptr.To(false),
 			expectedOutput: field.Invalid(testPath, nil, immutableMessage),
 		},
 	}
@@ -148,25 +148,25 @@ func TestValidateImmutableStringPtr(t *testing.T) {
 		},
 		{
 			name:   "no change",
-			input1: pointer.String("foo"),
-			input2: pointer.String("foo"),
+			input1: ptr.To("foo"),
+			input2: ptr.To("foo"),
 		},
 		{
 			name:           "can't unset",
-			input1:         pointer.String("foo"),
+			input1:         ptr.To("foo"),
 			input2:         nil,
 			expectedOutput: field.Invalid(testPath, nil, unsetMessage),
 		},
 		{
 			name:           "can't set from empty",
 			input1:         nil,
-			input2:         pointer.String("foo"),
+			input2:         ptr.To("foo"),
 			expectedOutput: field.Invalid(testPath, nil, setMessage),
 		},
 		{
 			name:           "can't change",
-			input1:         pointer.String("foo"),
-			input2:         pointer.String("bar"),
+			input1:         ptr.To("foo"),
+			input2:         ptr.To("bar"),
 			expectedOutput: field.Invalid(testPath, nil, immutableMessage),
 		},
 	}
@@ -316,24 +316,24 @@ func TestValidateZeroTransitionPtr(t *testing.T) {
 		},
 		{
 			name:   "no change",
-			input1: pointer.Bool(true),
-			input2: pointer.Bool(true),
+			input1: ptr.To(true),
+			input2: ptr.To(true),
 		},
 		{
 			name:   "can unset",
-			input1: pointer.Bool(true),
+			input1: ptr.To(true),
 			input2: nil,
 		},
 		{
 			name:           "can't set from empty",
 			input1:         nil,
-			input2:         pointer.Bool(true),
+			input2:         ptr.To(true),
 			expectedOutput: field.Invalid(testPath, nil, setMessage),
 		},
 		{
 			name:           "can't change",
-			input1:         pointer.Bool(true),
-			input2:         pointer.Bool(false),
+			input1:         ptr.To(true),
+			input2:         ptr.To(false),
 			expectedOutput: field.Invalid(testPath, nil, immutableMessage),
 		},
 	}
@@ -422,24 +422,24 @@ func TestValidateZeroTransitionStringPtr(t *testing.T) {
 		},
 		{
 			name:   "no change",
-			input1: pointer.String("foo"),
-			input2: pointer.String("foo"),
+			input1: ptr.To("foo"),
+			input2: ptr.To("foo"),
 		},
 		{
 			name:   "can unset",
-			input1: pointer.String("foo"),
+			input1: ptr.To("foo"),
 			input2: nil,
 		},
 		{
 			name:           "can't set from empty",
 			input1:         nil,
-			input2:         pointer.String("foo"),
+			input2:         ptr.To("foo"),
 			expectedOutput: field.Invalid(testPath, nil, setMessage),
 		},
 		{
 			name:           "can't change",
-			input1:         pointer.String("foo"),
-			input2:         pointer.String("bar"),
+			input1:         ptr.To("foo"),
+			input2:         ptr.To("bar"),
 			expectedOutput: field.Invalid(testPath, nil, immutableMessage),
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The `k8s.io/utils/pointer` package is [deprecated](https://pkg.go.dev/k8s.io/utils/pointer#pkg-overview) in favor of [`k8s.io/utils/ptr`](https://pkg.go.dev/k8s.io/utils@v0.0.0-20230726121419-3b25d923346b/ptr#section-readme), which uses Go generics.

This is a simpler and more consistent implementation in my opinion, and it also allows for `ptr.To()` of arbitrary structs and string constant types: no need to assign to a temp variable in order to take its address.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

This is gigantic and not particularly urgent. If it would be preferable to do this in pieces, or to defer to the end of a release cycle, please let me know.

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
