### PR TITLE
Make scalesetvms delete async

### DIFF
--- a/azure/scope/machinepoolmachine_test.go
+++ b/azure/scope/machinepoolmachine_test.go
@@ -18,8 +18,10 @@ package scope
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
@@ -27,9 +29,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/mock_azure"
 	mock_scope "sigs.k8s.io/cluster-api-provider-azure/azure/scope/mocks"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/scalesetvms"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
 	gomock2 "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -129,6 +133,124 @@ func TestNewMachinePoolMachineScope(t *testing.T) {
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(s).NotTo(BeNil())
+			}
+		})
+	}
+}
+
+func TestMachinePoolMachineScope_ScaleSetVMSpecs(t *testing.T) {
+	tests := []struct {
+		name                    string
+		machinePoolMachineScope MachinePoolMachineScope
+		want                    azure.ResourceSpecGetter
+	}{
+		{
+			name: "return vmss vm spec for uniform vmss",
+			machinePoolMachineScope: MachinePoolMachineScope{
+				MachinePool: &expv1.MachinePool{},
+				AzureMachinePool: &infrav1exp.AzureMachinePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machinepool-name",
+					},
+					Spec: infrav1exp.AzureMachinePoolSpec{
+						Template: infrav1exp.AzureMachinePoolMachineTemplate{
+							OSDisk: infrav1.OSDisk{
+								OSType: "Linux",
+							},
+						},
+						OrchestrationMode: infrav1.UniformOrchestrationMode,
+					},
+				},
+				AzureMachinePoolMachine: &infrav1exp.AzureMachinePoolMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machinepoolmachine-name",
+					},
+					Spec: infrav1exp.AzureMachinePoolMachineSpec{
+						ProviderID: "azure:///subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachineScaleSets/machinepool-name/virtualMachines/0",
+						InstanceID: "0",
+					},
+				},
+				ClusterScoper: &ClusterScope{
+					AzureCluster: &infrav1.AzureCluster{
+						Spec: infrav1.AzureClusterSpec{
+							ResourceGroup: "my-rg",
+						},
+					},
+				},
+				MachinePoolScope: &MachinePoolScope{
+					AzureMachinePool: &infrav1exp.AzureMachinePool{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "machinepool-name",
+						},
+					},
+				},
+			},
+			want: &scalesetvms.ScaleSetVMSpec{
+				Name:          "machinepoolmachine-name",
+				InstanceID:    "0",
+				ResourceGroup: "my-rg",
+				ScaleSetName:  "machinepool-name",
+				ProviderID:    "azure:///subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachineScaleSets/machinepool-name/virtualMachines/0",
+				IsFlex:        false,
+				ResourceID:    "",
+			},
+		},
+		{
+			name: "return vmss vm spec for vmss flex",
+			machinePoolMachineScope: MachinePoolMachineScope{
+				MachinePool: &expv1.MachinePool{},
+				AzureMachinePool: &infrav1exp.AzureMachinePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machinepool-name",
+					},
+					Spec: infrav1exp.AzureMachinePoolSpec{
+						Template: infrav1exp.AzureMachinePoolMachineTemplate{
+							OSDisk: infrav1.OSDisk{
+								OSType: "Linux",
+							},
+						},
+						OrchestrationMode: infrav1.FlexibleOrchestrationMode,
+					},
+				},
+				AzureMachinePoolMachine: &infrav1exp.AzureMachinePoolMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machinepoolmachine-name",
+					},
+					Spec: infrav1exp.AzureMachinePoolMachineSpec{
+						ProviderID: "azure:///subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachineScaleSets/machinepool-name/virtualMachines/0",
+						InstanceID: "0",
+					},
+				},
+				ClusterScoper: &ClusterScope{
+					AzureCluster: &infrav1.AzureCluster{
+						Spec: infrav1.AzureClusterSpec{
+							ResourceGroup: "my-rg",
+						},
+					},
+				},
+				MachinePoolScope: &MachinePoolScope{
+					AzureMachinePool: &infrav1exp.AzureMachinePool{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "machinepool-name",
+						},
+					},
+				},
+			},
+			want: &scalesetvms.ScaleSetVMSpec{
+				Name:          "machinepoolmachine-name",
+				InstanceID:    "0",
+				ResourceGroup: "my-rg",
+				ScaleSetName:  "machinepool-name",
+				ProviderID:    "azure:///subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachineScaleSets/machinepool-name/virtualMachines/0",
+				IsFlex:        true,
+				ResourceID:    "/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachineScaleSets/machinepool-name/virtualMachines/0",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.machinePoolMachineScope.ScaleSetVMSpec(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Diff between expected result and actual result: %+v", cmp.Diff(tt.want, got))
 			}
 		})
 	}

--- a/azure/services/scalesetvms/mock_scalesetvms/client_mock.go
+++ b/azure/services/scalesetvms/mock_scalesetvms/client_mock.go
@@ -24,10 +24,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
-	autorest "github.com/Azure/go-autorest/autorest"
+	azure "github.com/Azure/go-autorest/autorest/azure"
 	gomock "go.uber.org/mock/gomock"
-	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	azure0 "sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
 // Mockclient is a mock of client interface.
@@ -54,99 +53,46 @@ func (m *Mockclient) EXPECT() *MockclientMockRecorder {
 }
 
 // DeleteAsync mocks base method.
-func (m *Mockclient) DeleteAsync(arg0 context.Context, arg1, arg2, arg3 string) (*v1beta1.Future, error) {
+func (m *Mockclient) DeleteAsync(arg0 context.Context, arg1 azure0.ResourceSpecGetter) (azure.FutureAPI, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAsync", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(*v1beta1.Future)
+	ret := m.ctrl.Call(m, "DeleteAsync", arg0, arg1)
+	ret0, _ := ret[0].(azure.FutureAPI)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DeleteAsync indicates an expected call of DeleteAsync.
-func (mr *MockclientMockRecorder) DeleteAsync(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) DeleteAsync(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAsync", reflect.TypeOf((*Mockclient)(nil).DeleteAsync), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAsync", reflect.TypeOf((*Mockclient)(nil).DeleteAsync), arg0, arg1)
 }
 
 // Get mocks base method.
-func (m *Mockclient) Get(arg0 context.Context, arg1, arg2, arg3 string) (compute.VirtualMachineScaleSetVM, error) {
+func (m *Mockclient) Get(arg0 context.Context, arg1 azure0.ResourceSpecGetter) (interface{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(compute.VirtualMachineScaleSetVM)
+	ret := m.ctrl.Call(m, "Get", arg0, arg1)
+	ret0, _ := ret[0].(interface{})
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockclientMockRecorder) Get(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockclient)(nil).Get), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockclient)(nil).Get), arg0, arg1)
 }
 
-// GetResultIfDone mocks base method.
-func (m *Mockclient) GetResultIfDone(ctx context.Context, future *v1beta1.Future) (compute.VirtualMachineScaleSetVM, error) {
+// IsDone mocks base method.
+func (m *Mockclient) IsDone(ctx context.Context, future azure.FutureAPI) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResultIfDone", ctx, future)
-	ret0, _ := ret[0].(compute.VirtualMachineScaleSetVM)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetResultIfDone indicates an expected call of GetResultIfDone.
-func (mr *MockclientMockRecorder) GetResultIfDone(ctx, future interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResultIfDone", reflect.TypeOf((*Mockclient)(nil).GetResultIfDone), ctx, future)
-}
-
-// MockgenericScaleSetVMFuture is a mock of genericScaleSetVMFuture interface.
-type MockgenericScaleSetVMFuture struct {
-	ctrl     *gomock.Controller
-	recorder *MockgenericScaleSetVMFutureMockRecorder
-}
-
-// MockgenericScaleSetVMFutureMockRecorder is the mock recorder for MockgenericScaleSetVMFuture.
-type MockgenericScaleSetVMFutureMockRecorder struct {
-	mock *MockgenericScaleSetVMFuture
-}
-
-// NewMockgenericScaleSetVMFuture creates a new mock instance.
-func NewMockgenericScaleSetVMFuture(ctrl *gomock.Controller) *MockgenericScaleSetVMFuture {
-	mock := &MockgenericScaleSetVMFuture{ctrl: ctrl}
-	mock.recorder = &MockgenericScaleSetVMFutureMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockgenericScaleSetVMFuture) EXPECT() *MockgenericScaleSetVMFutureMockRecorder {
-	return m.recorder
-}
-
-// DoneWithContext mocks base method.
-func (m *MockgenericScaleSetVMFuture) DoneWithContext(ctx context.Context, sender autorest.Sender) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DoneWithContext", ctx, sender)
+	ret := m.ctrl.Call(m, "IsDone", ctx, future)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DoneWithContext indicates an expected call of DoneWithContext.
-func (mr *MockgenericScaleSetVMFutureMockRecorder) DoneWithContext(ctx, sender interface{}) *gomock.Call {
+// IsDone indicates an expected call of IsDone.
+func (mr *MockclientMockRecorder) IsDone(ctx, future interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoneWithContext", reflect.TypeOf((*MockgenericScaleSetVMFuture)(nil).DoneWithContext), ctx, sender)
-}
-
-// Result mocks base method.
-func (m *MockgenericScaleSetVMFuture) Result(client compute.VirtualMachineScaleSetVMsClient) (compute.VirtualMachineScaleSetVM, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Result", client)
-	ret0, _ := ret[0].(compute.VirtualMachineScaleSetVM)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Result indicates an expected call of Result.
-func (mr *MockgenericScaleSetVMFutureMockRecorder) Result(client interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Result", reflect.TypeOf((*MockgenericScaleSetVMFuture)(nil).Result), client)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDone", reflect.TypeOf((*Mockclient)(nil).IsDone), ctx, future)
 }

--- a/azure/services/scalesetvms/mock_scalesetvms/scalesetvms_mock.go
+++ b/azure/services/scalesetvms/mock_scalesetvms/scalesetvms_mock.go
@@ -275,20 +275,6 @@ func (mr *MockScaleSetVMScopeMockRecorder) HashKey() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HashKey", reflect.TypeOf((*MockScaleSetVMScope)(nil).HashKey))
 }
 
-// InstanceID mocks base method.
-func (m *MockScaleSetVMScope) InstanceID() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstanceID")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// InstanceID indicates an expected call of InstanceID.
-func (mr *MockScaleSetVMScopeMockRecorder) InstanceID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceID", reflect.TypeOf((*MockScaleSetVMScope)(nil).InstanceID))
-}
-
 // Location mocks base method.
 func (m *MockScaleSetVMScope) Location() string {
 	m.ctrl.T.Helper()
@@ -301,34 +287,6 @@ func (m *MockScaleSetVMScope) Location() string {
 func (mr *MockScaleSetVMScopeMockRecorder) Location() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Location", reflect.TypeOf((*MockScaleSetVMScope)(nil).Location))
-}
-
-// OrchestrationMode mocks base method.
-func (m *MockScaleSetVMScope) OrchestrationMode() v1beta1.OrchestrationModeType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OrchestrationMode")
-	ret0, _ := ret[0].(v1beta1.OrchestrationModeType)
-	return ret0
-}
-
-// OrchestrationMode indicates an expected call of OrchestrationMode.
-func (mr *MockScaleSetVMScopeMockRecorder) OrchestrationMode() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OrchestrationMode", reflect.TypeOf((*MockScaleSetVMScope)(nil).OrchestrationMode))
-}
-
-// ProviderID mocks base method.
-func (m *MockScaleSetVMScope) ProviderID() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProviderID")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ProviderID indicates an expected call of ProviderID.
-func (mr *MockScaleSetVMScopeMockRecorder) ProviderID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderID", reflect.TypeOf((*MockScaleSetVMScope)(nil).ProviderID))
 }
 
 // ResourceGroup mocks base method.
@@ -345,18 +303,18 @@ func (mr *MockScaleSetVMScopeMockRecorder) ResourceGroup() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockScaleSetVMScope)(nil).ResourceGroup))
 }
 
-// ScaleSetName mocks base method.
-func (m *MockScaleSetVMScope) ScaleSetName() string {
+// ScaleSetVMSpec mocks base method.
+func (m *MockScaleSetVMScope) ScaleSetVMSpec() azure.ResourceSpecGetter {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ScaleSetName")
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "ScaleSetVMSpec")
+	ret0, _ := ret[0].(azure.ResourceSpecGetter)
 	return ret0
 }
 
-// ScaleSetName indicates an expected call of ScaleSetName.
-func (mr *MockScaleSetVMScopeMockRecorder) ScaleSetName() *gomock.Call {
+// ScaleSetVMSpec indicates an expected call of ScaleSetVMSpec.
+func (mr *MockScaleSetVMScopeMockRecorder) ScaleSetVMSpec() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScaleSetName", reflect.TypeOf((*MockScaleSetVMScope)(nil).ScaleSetName))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScaleSetVMSpec", reflect.TypeOf((*MockScaleSetVMScope)(nil).ScaleSetVMSpec))
 }
 
 // SetLongRunningOperationState mocks base method.
@@ -381,6 +339,18 @@ func (m *MockScaleSetVMScope) SetVMSSVM(vmssvm *azure.VMSSVM) {
 func (mr *MockScaleSetVMScopeMockRecorder) SetVMSSVM(vmssvm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVMSSVM", reflect.TypeOf((*MockScaleSetVMScope)(nil).SetVMSSVM), vmssvm)
+}
+
+// SetVMSSVMState mocks base method.
+func (m *MockScaleSetVMScope) SetVMSSVMState(state v1beta1.ProvisioningState) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetVMSSVMState", state)
+}
+
+// SetVMSSVMState indicates an expected call of SetVMSSVMState.
+func (mr *MockScaleSetVMScopeMockRecorder) SetVMSSVMState(state interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVMSSVMState", reflect.TypeOf((*MockScaleSetVMScope)(nil).SetVMSSVMState), state)
 }
 
 // SubscriptionID mocks base method.

--- a/azure/services/scalesetvms/scalesetvms.go
+++ b/azure/services/scalesetvms/scalesetvms.go
@@ -19,14 +19,14 @@ package scalesetvms
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/pkg/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/virtualmachines"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
@@ -39,27 +39,27 @@ type (
 	ScaleSetVMScope interface {
 		azure.ClusterDescriber
 		azure.AsyncStatusUpdater
-		InstanceID() string
-		ProviderID() string
-		ScaleSetName() string
-		OrchestrationMode() infrav1.OrchestrationModeType
+		ScaleSetVMSpec() azure.ResourceSpecGetter
 		SetVMSSVM(vmssvm *azure.VMSSVM)
+		SetVMSSVMState(state infrav1.ProvisioningState)
 	}
 
 	// Service provides operations on Azure resources.
 	Service struct {
-		Client   client
-		VMClient virtualmachines.Client
-		Scope    ScaleSetVMScope
+		Scope ScaleSetVMScope
+		async.Reconciler
+		VMReconciler async.Reconciler
 	}
 )
 
 // NewService creates a new service.
 func NewService(scope ScaleSetVMScope) *Service {
+	client := newClient(scope)
+	vmClient := virtualmachines.NewClient(scope)
 	return &Service{
-		Client:   newClient(scope),
-		VMClient: virtualmachines.NewClient(scope),
-		Scope:    scope,
+		Reconciler:   async.New(scope, client, client),
+		VMReconciler: async.New(scope, vmClient, vmClient),
+		Scope:        scope,
 	}
 }
 
@@ -73,211 +73,96 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "scalesetvms.Service.Reconcile")
 	defer done()
 
-	var (
-		resourceGroup = s.Scope.ResourceGroup()
-		vmssName      = s.Scope.ScaleSetName()
-		instanceID    = s.Scope.InstanceID()
-		providerID    = s.Scope.ProviderID()
-		isFlex        = s.Scope.OrchestrationMode() == infrav1.FlexibleOrchestrationMode
-	)
+	spec := s.Scope.ScaleSetVMSpec()
+	scaleSetVMSpec, ok := spec.(*ScaleSetVMSpec)
+	if !ok {
+		return errors.Errorf("%T is not of type ScaleSetVMSpec", spec)
+	}
 
+	reconciler := s.Reconciler
+	var getter azure.ResourceSpecGetter = scaleSetVMSpec
+	var result interface{}
+	var err error
 	// Fetch the latest instance or VM data. AzureMachinePoolReconciler handles model mutations.
-	if isFlex {
-		resourceID := strings.TrimPrefix(providerID, azureutil.ProviderIDPrefix)
-		log.V(4).Info("VMSS is flex", "vmssName", vmssName, "providerID", providerID, "resourceID", resourceID)
-		// Using VMSS Flex, so fetch by resource ID.
-		vm, err := s.VMClient.GetByID(ctx, resourceID)
+	if scaleSetVMSpec.IsFlex {
+		log.V(4).Info("VMSS is flex", "vmssName", scaleSetVMSpec.Name, "providerID", scaleSetVMSpec.ProviderID, "resourceID", scaleSetVMSpec.ResourceID)
+		getter, err = scaleSetVMSpecToVMSpec(*scaleSetVMSpec)
 		if err != nil {
-			if azure.ResourceNotFound(err) {
-				return azure.WithTransientError(errors.New("vm does not exist yet"), 30*time.Second)
-			}
-			return errors.Wrap(err, "failed getting vm")
+			return errors.Wrap(err, "failed to convert scaleSetVMSpec to vmSpec")
+		}
+		reconciler = s.VMReconciler
+	} else {
+		log.V(4).Info("VMSS is uniform", "vmssName", scaleSetVMSpec.Name, "providerID", scaleSetVMSpec.ProviderID, "instanceID", scaleSetVMSpec.InstanceID)
+	}
+
+	// We only want to get the resource if it exists and handle the not found error.
+	// We're using CreateOrUpdateResource() to do so but it doesn't actually create or update anything since getter.Parameters() always returns nil.
+	result, err = reconciler.CreateOrUpdateResource(ctx, getter, serviceName)
+	if err != nil {
+		return err
+	} else if result == nil {
+		return azure.WithTransientError(fmt.Errorf("instance does not exist yet"), time.Second*30)
+	}
+
+	if scaleSetVMSpec.IsFlex {
+		vm, ok := result.(compute.VirtualMachine)
+		if !ok {
+			return errors.Errorf("%T is not of type compute.VirtualMachine", result)
 		}
 		s.Scope.SetVMSSVM(converters.SDKVMToVMSSVM(vm, infrav1.FlexibleOrchestrationMode))
-		return nil
-	}
-
-	log.V(4).Info("VMSS is uniform", "vmssName", vmssName, "providerID", providerID, "instanceID", instanceID)
-	// Using VMSS Uniform, so fetch by instance ID.
-	instance, err := s.Client.Get(ctx, resourceGroup, vmssName, instanceID)
-	if err != nil {
-		if azure.ResourceNotFound(err) {
-			return azure.WithTransientError(errors.New("instance does not exist yet"), 30*time.Second)
+	} else {
+		instance, ok := result.(compute.VirtualMachineScaleSetVM)
+		if !ok {
+			return errors.Errorf("%T is not of type compute.VirtualMachineScaleSetVM", result)
 		}
-		return errors.Wrap(err, "failed getting instance")
+		s.Scope.SetVMSSVM(converters.SDKToVMSSVM(instance))
 	}
 
-	s.Scope.SetVMSSVM(converters.SDKToVMSSVM(instance))
 	return nil
 }
 
 // Delete deletes a scaleset instance asynchronously returning a future which encapsulates the long-running operation.
 func (s *Service) Delete(ctx context.Context) error {
-	var (
-		resourceGroup = s.Scope.ResourceGroup()
-		vmssName      = s.Scope.ScaleSetName()
-		instanceID    = s.Scope.InstanceID()
-		providerID    = s.Scope.ProviderID()
-		isFlex        = s.Scope.OrchestrationMode() == infrav1.FlexibleOrchestrationMode
-	)
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesetvms.Service.Delete")
 
-	ctx, log, done := tele.StartSpanWithLogger(
-		ctx,
-		"scalesetvms.Service.Delete",
-		tele.KVP("resourceGroup", resourceGroup),
-		tele.KVP("scaleset", vmssName),
-		tele.KVP("instanceID", instanceID),
-	)
 	defer done()
 
-	if isFlex {
-		return s.deleteVMSSFlexVM(ctx, strings.TrimPrefix(providerID, azureutil.ProviderIDPrefix))
+	spec := s.Scope.ScaleSetVMSpec()
+	scaleSetVMSpec, ok := spec.(*ScaleSetVMSpec)
+	if !ok {
+		return errors.Errorf("%T is not of type ScaleSetVMSpec", spec)
 	}
-	return s.deleteVMSSUniformInstance(ctx, resourceGroup, vmssName, instanceID, log)
+
+	reconciler := s.Reconciler
+	var getter azure.ResourceSpecGetter = scaleSetVMSpec
+	var err error
+	if scaleSetVMSpec.IsFlex {
+		getter, err = scaleSetVMSpecToVMSpec(*scaleSetVMSpec)
+		if err != nil {
+			return errors.Wrap(err, "failed to convert scaleSetVMSpec to vmSpec")
+		}
+		reconciler = s.VMReconciler
+	}
+
+	err = reconciler.DeleteResource(ctx, getter, serviceName)
+	if err != nil {
+		s.Scope.SetVMSSVMState(infrav1.Deleting)
+	} else {
+		s.Scope.SetVMSSVMState(infrav1.Deleted)
+	}
+
+	return err
 }
 
-func (s *Service) deleteVMSSFlexVM(ctx context.Context, resourceID string) error {
-	ctx, log, done := tele.StartSpanWithLogger(ctx, "scalesetvms.Service.deleteVMSSFlexVM")
-	defer done()
-
-	defer func() {
-		if vm, err := s.VMClient.GetByID(ctx, resourceID); err == nil && vm.VirtualMachineProperties != nil {
-			log.V(4).Info("vmss vm delete in progress", "state", vm.ProvisioningState)
-			s.Scope.SetVMSSVM(converters.SDKVMToVMSSVM(vm, s.Scope.OrchestrationMode()))
-		}
-	}()
-
-	parsed, err := azureutil.ParseResourceID(resourceID)
+func scaleSetVMSpecToVMSpec(scaleSetVMSpec ScaleSetVMSpec) (*VMSSFlexGetter, error) {
+	parsed, err := azureutil.ParseResourceID(scaleSetVMSpec.ResourceID)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to parse resource id %q", resourceID))
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to parse resource id %q", scaleSetVMSpec.ResourceID))
 	}
 	resourceGroup, resourceName := parsed.ResourceGroupName, parsed.Name
 
-	log.V(4).Info("entering delete")
-	future := s.Scope.GetLongRunningOperationState(resourceName, serviceName, infrav1.DeleteFuture)
-	if future != nil {
-		if future.Type != infrav1.DeleteFuture {
-			return azure.WithTransientError(errors.New("attempting to delete, non-delete operation in progress"), 30*time.Second)
-		}
-
-		log.V(4).Info("checking if the vm is done deleting")
-		if _, err := s.VMClient.GetResultIfDone(ctx, future); err != nil {
-			// fetch vm to update status
-			return errors.Wrap(err, "failed to get result of long running operation")
-		}
-
-		// there was no error in fetching the result, the future has been completed
-		log.V(4).Info("successfully deleted the vm")
-		s.Scope.DeleteLongRunningOperationState(resourceName, serviceName, infrav1.DeleteFuture)
-		return nil
-	}
-	// since the future was nil, there is no ongoing activity; start deleting the vm
-	log.V(4).Info("vmss delete vm future is nil") // This is always true
-
-	vmGetter := &VMSSFlexVMGetter{
+	return &VMSSFlexGetter{
 		Name:          resourceName,
 		ResourceGroup: resourceGroup,
-	}
-
-	sdkFuture, err := s.VMClient.DeleteAsync(ctx, vmGetter)
-	if err != nil {
-		if azure.ResourceNotFound(err) {
-			// already deleted
-			return nil
-		}
-		return errors.Wrapf(err, "failed to delete vm %s/%s", resourceGroup, resourceName)
-	}
-
-	if sdkFuture != nil {
-		future, err = converters.SDKToFuture(sdkFuture, infrav1.DeleteFuture, serviceName, vmGetter.ResourceName(), vmGetter.ResourceGroupName())
-		if err != nil {
-			return errors.Wrapf(err, "failed to convert SDK to Future %s/%s", resourceGroup, resourceName)
-		}
-		s.Scope.SetLongRunningOperationState(future)
-		return nil
-	}
-
-	s.Scope.DeleteLongRunningOperationState(resourceName, serviceName, infrav1.DeleteFuture)
-	return nil
-}
-
-func (s *Service) deleteVMSSUniformInstance(ctx context.Context, resourceGroup string, vmssName string, instanceID string, log logr.Logger) error {
-	ctx, log, done := tele.StartSpanWithLogger(ctx, "scalesetvms.Service.deleteVMSSUniformInstance")
-	defer done()
-
-	defer func() {
-		if instance, err := s.Client.Get(ctx, resourceGroup, vmssName, instanceID); err == nil && instance.VirtualMachineScaleSetVMProperties != nil {
-			log.V(4).Info("updating vmss vm state", "state", instance.ProvisioningState)
-			s.Scope.SetVMSSVM(converters.SDKToVMSSVM(instance))
-		}
-	}()
-
-	log.V(4).Info("entering delete")
-	future := s.Scope.GetLongRunningOperationState(instanceID, serviceName, infrav1.DeleteFuture)
-	if future != nil {
-		if future.Type != infrav1.DeleteFuture {
-			return azure.WithTransientError(errors.New("attempting to delete, non-delete operation in progress"), 30*time.Second)
-		}
-
-		log.V(4).Info("checking if the instance is done deleting")
-		if _, err := s.Client.GetResultIfDone(ctx, future); err != nil {
-			// fetch instance to update status
-			return errors.Wrap(err, "failed to get result of long running operation")
-		}
-
-		// there was no error in fetching the result, the future has been completed
-		log.V(4).Info("successfully deleted the instance")
-		s.Scope.DeleteLongRunningOperationState(instanceID, serviceName, infrav1.DeleteFuture)
-		return nil
-	}
-
-	// since the future was nil, there is no ongoing activity; start deleting the instance
-	future, err := s.Client.DeleteAsync(ctx, resourceGroup, vmssName, instanceID)
-	if err != nil {
-		if azure.ResourceNotFound(err) {
-			// already deleted
-			return nil
-		}
-		return errors.Wrapf(err, "failed to delete instance %s/%s", vmssName, instanceID)
-	}
-
-	s.Scope.SetLongRunningOperationState(future)
-
-	log.V(4).Info("checking if the instance is done deleting")
-	if _, err := s.Client.GetResultIfDone(ctx, future); err != nil {
-		// fetch instance to update status
-		return errors.Wrap(err, "failed to get result of long running operation")
-	}
-
-	s.Scope.DeleteLongRunningOperationState(instanceID, serviceName, infrav1.DeleteFuture)
-	return nil
-}
-
-// VMSSFlexVMGetter gets the information required to create, update, or delete an Azure resource.
-type VMSSFlexVMGetter struct {
-	Name          string
-	ResourceGroup string
-}
-
-// ResourceName returns the name of the resource.
-func (vm *VMSSFlexVMGetter) ResourceName() string {
-	return vm.Name
-}
-
-// OwnerResourceName returns the name of the resource that owns this Azure subresource.
-func (vm *VMSSFlexVMGetter) OwnerResourceName() string {
-	return ""
-}
-
-// ResourceGroupName returns the name of the resource group the resource is in.
-func (vm *VMSSFlexVMGetter) ResourceGroupName() string {
-	return vm.ResourceGroup
-}
-
-// Parameters takes the existing resource and returns the desired parameters of the resource.
-// If the resource does not exist, or we do not care about existing parameters to update the resource, existing should be `nil`.
-// If no update is needed on the resource, Parameters should return `nil`.
-// NOTE: Not yet implemented, see kubernetes-sigs/cluster-api-provider-azure#2720.
-func (vm *VMSSFlexVMGetter) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
-	return nil, nil
+	}, nil
 }

--- a/azure/services/scalesetvms/spec.go
+++ b/azure/services/scalesetvms/spec.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scalesetvms
+
+import (
+	"context"
+)
+
+// ScaleSetVMSpec defines the specification for a VMSS VM.
+type ScaleSetVMSpec struct {
+	Name          string
+	InstanceID    string
+	ResourceGroup string
+	ScaleSetName  string
+	ProviderID    string
+	ResourceID    string
+	IsFlex        bool
+}
+
+// ResourceName returns the instance ID of the VMSS VM. This is because the it is identified by the instance ID in Azure instead of the name.
+func (s *ScaleSetVMSpec) ResourceName() string {
+	return s.InstanceID
+}
+
+// ResourceGroupName returns the name of the resource group the VMSS that owns this VM.
+func (s *ScaleSetVMSpec) ResourceGroupName() string {
+	return s.ResourceGroup
+}
+
+// OwnerResourceName returns the name of the VMSS that owns this VM.
+func (s *ScaleSetVMSpec) OwnerResourceName() string {
+	return s.ScaleSetName
+}
+
+// Parameters is a no-op for VMSS VMs as this spec is only used to Get().
+func (s *ScaleSetVMSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
+	return nil, nil
+}
+
+// VMSSFlexGetter defines the specification for a VMSS flex VM.
+type VMSSFlexGetter struct {
+	Name          string
+	ResourceGroup string
+}
+
+// ResourceName returns the name of the flex VM.
+func (s *VMSSFlexGetter) ResourceName() string {
+	return s.Name
+}
+
+// ResourceGroupName returns the name of the flex VM.
+func (s *VMSSFlexGetter) ResourceGroupName() string {
+	return s.ResourceGroup
+}
+
+// OwnerResourceName is a no-op for flex VMs.
+func (s *VMSSFlexGetter) OwnerResourceName() string {
+	return ""
+}
+
+// Parameters is a no-op for flex VMs as this spec is only used to Get().
+func (s *VMSSFlexGetter) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
+	return nil, nil
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Implementation of an async service for managed agent pools as part of an effort to make all services async. See #1610 and #1541.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2720

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make scalesetvms delete async
```
