### PR TITLE
fix AuthorizedIPRanges disable -> enable bug

### DIFF
--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -261,6 +261,9 @@ func buildAutoScalerProfile(autoScalerProfile *AutoScalerProfile) *containerserv
 }
 
 // Parameters returns the parameters for the managed clusters.
+// TODO: remove nolint after refactoring this function
+//
+//nolint:gocyclo
 func (s *ManagedClusterSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "managedclusters.Service.Parameters")
 	defer done()

--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net"
+	"reflect"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2022-03-01/containerservice"
@@ -387,7 +388,7 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existing interface{
 			EnablePrivateClusterPublicFQDN: s.APIServerAccessProfile.EnablePrivateClusterPublicFQDN,
 		}
 
-		if len(s.APIServerAccessProfile.AuthorizedIPRanges) > 0 {
+		if s.APIServerAccessProfile.AuthorizedIPRanges != nil {
 			managedCluster.APIServerAccessProfile.AuthorizedIPRanges = &s.APIServerAccessProfile.AuthorizedIPRanges
 		}
 	}
@@ -421,6 +422,16 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existing interface{
 		// Avoid changing agent pool profiles through AMCP and just use the existing agent pool profiles
 		// AgentPool changes are managed through AMMP.
 		managedCluster.AgentPoolProfiles = existingMC.AgentPoolProfiles
+
+		// if the AuthorizedIPRanges is nil in the user-updated spec, but not nil in the existing spec, then
+		// we need to set the AuthorizedIPRanges to empty array (&[]string{}) once so that the Azure API will
+		// update the existing authorized IP ranges to nil.
+		if !isAuthIPRangesNilOrEmpty(existingMC) && isAuthIPRangesNilOrEmpty(managedCluster) {
+			log.V(4).Info("managed cluster spec has nil AuthorizedIPRanges, updating existing authorized IP ranges to an empty list")
+			managedCluster.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
+				AuthorizedIPRanges: &[]string{},
+			}
+		}
 
 		diff := computeDiffOfNormalizedClusters(managedCluster, existingMC)
 		if diff == "" {
@@ -583,4 +594,32 @@ func computeDiffOfNormalizedClusters(managedCluster containerservice.ManagedClus
 
 	diff := cmp.Diff(clusterNormalized, existingMCClusterNormalized)
 	return diff
+}
+
+func getIdentity(identity *infrav1.Identity) (managedClusterIdentity *containerservice.ManagedClusterIdentity, err error) {
+	if identity.Type == "" {
+		return
+	}
+
+	managedClusterIdentity = &containerservice.ManagedClusterIdentity{
+		Type: containerservice.ResourceIdentityType(identity.Type),
+	}
+	if managedClusterIdentity.Type == containerservice.ResourceIdentityTypeUserAssigned {
+		if identity.UserAssignedIdentityResourceID == "" {
+			err = errors.Errorf("Identity is set to \"UserAssigned\" but no UserAssignedIdentityResourceID is present")
+			return
+		}
+		managedClusterIdentity.UserAssignedIdentities = map[string]*containerservice.ManagedClusterIdentityUserAssignedIdentitiesValue{
+			identity.UserAssignedIdentityResourceID: {},
+		}
+	}
+	return
+}
+
+// isAuthIPRangesNilOrEmpty returns true if the managed cluster's APIServerAccessProfile or AuthorizedIPRanges is nil or if AuthorizedIPRanges is empty.
+func isAuthIPRangesNilOrEmpty(managedCluster containerservice.ManagedCluster) bool {
+	if managedCluster.APIServerAccessProfile == nil || managedCluster.APIServerAccessProfile.AuthorizedIPRanges == nil || reflect.DeepEqual(managedCluster.APIServerAccessProfile.AuthorizedIPRanges, &[]string{}) {
+		return true
+	}
+	return false
 }

--- a/azure/services/managedclusters/spec_test.go
+++ b/azure/services/managedclusters/spec_test.go
@@ -177,6 +177,67 @@ func TestParameters(t *testing.T) {
 				g.Expect(result).To(BeNil())
 			},
 		},
+		{
+			name:     "update authorized IP ranges with empty struct if spec does not have authorized IP ranges but existing cluster has authorized IP ranges",
+			existing: getExistingClusterWithAuthorizedIPRanges(),
+			spec: &ManagedClusterSpec{
+				Name:          "test-managedcluster",
+				ResourceGroup: "test-rg",
+				Location:      "test-location",
+				Tags: map[string]string{
+					"test-tag": "test-value",
+				},
+				Version:         "v1.22.0",
+				LoadBalancerSKU: "Standard",
+			},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(containerservice.ManagedCluster{}))
+				g.Expect(result.(containerservice.ManagedCluster).APIServerAccessProfile).To(Not(BeNil()))
+				g.Expect(result.(containerservice.ManagedCluster).APIServerAccessProfile.AuthorizedIPRanges).To(Equal(&[]string{}))
+			},
+		},
+		{
+			name:     "update authorized IP ranges with authorized IPs spec has authorized IP ranges but existing cluster does not have authorized IP ranges",
+			existing: getExistingCluster(),
+			spec: &ManagedClusterSpec{
+				Name:          "test-managedcluster",
+				ResourceGroup: "test-rg",
+				Location:      "test-location",
+				Tags: map[string]string{
+					"test-tag": "test-value",
+				},
+				Version:         "v1.22.0",
+				LoadBalancerSKU: "Standard",
+				APIServerAccessProfile: &APIServerAccessProfile{
+					AuthorizedIPRanges: []string{"192.168.0.1/32, 192.168.0.2/32, 192.168.0.3/32"},
+				},
+			},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(containerservice.ManagedCluster{}))
+				g.Expect(result.(containerservice.ManagedCluster).APIServerAccessProfile).To(Not(BeNil()))
+				g.Expect(result.(containerservice.ManagedCluster).APIServerAccessProfile.AuthorizedIPRanges).To(Equal(&[]string{"192.168.0.1/32, 192.168.0.2/32, 192.168.0.3/32"}))
+			},
+		},
+		{
+			name:     "no update needed when authorized IP ranges when both clusters have the same authorized IP ranges",
+			existing: getExistingClusterWithAuthorizedIPRanges(),
+			spec: &ManagedClusterSpec{
+				Name:          "test-managedcluster",
+				ResourceGroup: "test-rg",
+				Location:      "test-location",
+				Tags: map[string]string{
+					"test-tag": "test-value",
+				},
+				Version:         "v1.22.0",
+				LoadBalancerSKU: "Standard",
+				APIServerAccessProfile: &APIServerAccessProfile{
+					AuthorizedIPRanges: []string{"192.168.0.1/32, 192.168.0.2/32, 192.168.0.3/32"},
+				},
+			},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+		},
 	}
 	for _, tc := range testcases {
 		tc := tc
@@ -276,4 +337,12 @@ func getSampleManagedCluster() containerservice.ManagedCluster {
 			},
 		})),
 	}
+}
+
+func getExistingClusterWithAuthorizedIPRanges() containerservice.ManagedCluster {
+	mc := getExistingCluster()
+	mc.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
+		AuthorizedIPRanges: &[]string{"192.168.0.1/32, 192.168.0.2/32, 192.168.0.3/32"},
+	}
+	return mc
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature

/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- Cherrypick of 7d988059d2572326ed8366eceb733c491320f64a
- Had to manually create this PR since the cherry-pick bot complained about merge conflicts. (strange)
- Also copies over `//nolint:gocyclo` to the `Parameters()` function from [main](https://github.com/pluralsh/cluster-api-provider-azure/blob/64a02e09172a512c0f8630907be15f55ca49e0da/azure/services/managedclusters/spec.go#L270) since https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3800 was erroring out on go-cyclomexic complexity (A lot of nil checks). 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
authorized IP ranges will be set to []string then to nil upon deletion
```
