### PR TITLE
add pause handling for AzureMachine, AzureManagedMachinePool, AzureMachinePool

### DIFF
--- a/controllers/azuremachine_reconciler_test.go
+++ b/controllers/azuremachine_reconciler_test.go
@@ -104,6 +104,76 @@ func TestAzureMachineServiceReconcile(t *testing.T) {
 	}
 }
 
+func TestAzureMachineServicePause(t *testing.T) {
+	type pausingServiceReconciler struct {
+		*mock_azure.MockServiceReconciler
+		*mock_azure.MockPauser
+	}
+
+	cases := map[string]struct {
+		expectedError string
+		expect        func(one pausingServiceReconciler, two pausingServiceReconciler, three pausingServiceReconciler)
+	}{
+		"all services are paused in order": {
+			expectedError: "",
+			expect: func(one pausingServiceReconciler, two pausingServiceReconciler, three pausingServiceReconciler) {
+				gomock.InOrder(
+					one.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(nil),
+					two.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(nil),
+					three.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(nil))
+			},
+		},
+		"service pause fails": {
+			expectedError: "failed to pause AzureMachine service two: some error happened",
+			expect: func(one pausingServiceReconciler, two pausingServiceReconciler, _ pausingServiceReconciler) {
+				gomock.InOrder(
+					one.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(nil),
+					two.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(errors.New("some error happened")),
+					two.MockServiceReconciler.EXPECT().Name().Return("two"))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			newPausingServiceReconciler := func() pausingServiceReconciler {
+				return pausingServiceReconciler{
+					mock_azure.NewMockServiceReconciler(mockCtrl),
+					mock_azure.NewMockPauser(mockCtrl),
+				}
+			}
+			svcOneMock := newPausingServiceReconciler()
+			svcTwoMock := newPausingServiceReconciler()
+			svcThreeMock := newPausingServiceReconciler()
+
+			tc.expect(svcOneMock, svcTwoMock, svcThreeMock)
+
+			s := &azureMachineService{
+				services: []azure.ServiceReconciler{
+					svcOneMock,
+					svcTwoMock,
+					svcThreeMock,
+				},
+			}
+
+			err := s.pause(context.TODO())
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
 func TestAzureMachineServiceDelete(t *testing.T) {
 	cases := map[string]struct {
 		expectedError string

--- a/controllers/azuremanagedcontrolplane_controller.go
+++ b/controllers/azuremanagedcontrolplane_controller.go
@@ -99,7 +99,7 @@ func (amcpr *AzureManagedControlPlaneReconciler) SetupWithManager(ctx context.Co
 	if err = c.Watch(
 		&source.Kind{Type: &clusterv1.Cluster{}},
 		handler.EnqueueRequestsFromMapFunc(amcpr.ClusterToAzureManagedControlPlane),
-		predicates.Any(log, predicates.ClusterCreateInfraReady(log), predicates.ClusterUpdateInfraReady(log), ClusterUpdatePauseChange(log)),
+		ClusterPauseChangeAndInfrastructureReady(log),
 		predicates.ResourceHasFilterLabel(log, amcpr.WatchFilterValue),
 	); err != nil {
 		return errors.Wrap(err, "failed adding a watch for ready clusters")

--- a/controllers/azuremanagedmachinepool_reconciler.go
+++ b/controllers/azuremanagedmachinepool_reconciler.go
@@ -158,6 +158,22 @@ func (s *azureManagedMachinePoolService) Reconcile(ctx context.Context) error {
 	return nil
 }
 
+// Pause pauses all components making up the machine pool.
+func (s *azureManagedMachinePoolService) Pause(ctx context.Context) error {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureManagedMachinePoolService.Pause")
+	defer done()
+
+	pauser, ok := s.agentPoolsSvc.(azure.Pauser)
+	if !ok {
+		return nil
+	}
+	if err := pauser.Pause(ctx); err != nil {
+		return errors.Wrapf(err, "failed to pause machine pool %s", s.scope.Name())
+	}
+
+	return nil
+}
+
 // Delete reconciles all the services in a predetermined order.
 func (s *azureManagedMachinePoolService) Delete(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureManagedMachinePoolService.Delete")

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -51,6 +51,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -1066,4 +1067,10 @@ func getCertificateFromFile(certificateFilePath string) ([]byte, error) {
 	}
 
 	return os.ReadFile(certificateFilePathTrimmed)
+}
+
+// ClusterPauseChangeAndInfrastructureReady is based on ClusterUnpausedAndInfrastructureReady, but
+// additionally accepts Cluster pause events.
+func ClusterPauseChangeAndInfrastructureReady(log logr.Logger) predicate.Funcs {
+	return predicates.Any(log, predicates.ClusterCreateInfraReady(log), predicates.ClusterUpdateInfraReady(log), ClusterUpdatePauseChange(log))
 }

--- a/exp/controllers/azuremachinepool_controller_test.go
+++ b/exp/controllers/azuremachinepool_controller_test.go
@@ -18,14 +18,23 @@ package controllers
 
 import (
 	"context"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/internal/test"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("AzureMachinePoolReconciler", func() {
@@ -49,3 +58,99 @@ var _ = Describe("AzureMachinePoolReconciler", func() {
 		})
 	})
 })
+
+func TestAzureMachinePoolReconcilePaused(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := context.Background()
+
+	sb := runtime.NewSchemeBuilder(
+		clusterv1.AddToScheme,
+		infrav1.AddToScheme,
+		expv1.AddToScheme,
+		infrav1exp.AddToScheme,
+	)
+	s := runtime.NewScheme()
+	g.Expect(sb.AddToScheme(s)).To(Succeed())
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		Build()
+
+	recorder := record.NewFakeRecorder(1)
+
+	reconciler := NewAzureMachinePoolReconciler(c, recorder, reconciler.DefaultLoopTimeout, "")
+	name := test.RandomName("paused", 10)
+	namespace := "default"
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: clusterv1.ClusterSpec{
+			Paused: true,
+			InfrastructureRef: &corev1.ObjectReference{
+				Name:      name,
+				Namespace: namespace,
+			},
+		},
+	}
+	g.Expect(c.Create(ctx, cluster)).To(Succeed())
+
+	azCluster := &infrav1.AzureCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: infrav1.AzureClusterSpec{
+			AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+				SubscriptionID: "something",
+			},
+		},
+	}
+	g.Expect(c.Create(ctx, azCluster)).To(Succeed())
+
+	mp := &expv1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel: name,
+			},
+		},
+		Spec: expv1.MachinePoolSpec{
+			ClusterName: name,
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					ClusterName: name,
+				},
+			},
+		},
+	}
+	g.Expect(c.Create(ctx, mp)).To(Succeed())
+
+	instance := &infrav1exp.AzureMachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "MachinePool",
+					APIVersion: expv1.GroupVersion.String(),
+					Name:       mp.Name,
+				},
+			},
+		},
+	}
+	g.Expect(c.Create(ctx, instance)).To(Succeed())
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKey{
+			Namespace: instance.Namespace,
+			Name:      instance.Name,
+		},
+	})
+
+	g.Expect(err).To(BeNil())
+	g.Expect(result.RequeueAfter).To(BeZero())
+}

--- a/exp/controllers/azuremachinepool_reconciler.go
+++ b/exp/controllers/azuremachinepool_reconciler.go
@@ -73,6 +73,24 @@ func (s *azureMachinePoolService) Reconcile(ctx context.Context) error {
 	return nil
 }
 
+// Pause pauses all the services.
+func (s *azureMachinePoolService) Pause(ctx context.Context) error {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureMachinePoolService.Pause")
+	defer done()
+
+	for _, service := range s.services {
+		pauser, ok := service.(azure.Pauser)
+		if !ok {
+			continue
+		}
+		if err := pauser.Pause(ctx); err != nil {
+			return errors.Wrapf(err, "failed to pause AzureMachinePool service %s", service.Name())
+		}
+	}
+
+	return nil
+}
+
 // Delete reconciles all the services in pre determined order.
 func (s *azureMachinePoolService) Delete(ctx context.Context) error {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureMachinePoolService.Delete")

--- a/exp/controllers/azuremachinepool_reconciler_test.go
+++ b/exp/controllers/azuremachinepool_reconciler_test.go
@@ -108,6 +108,76 @@ func TestAzureMachinePoolServiceReconcile(t *testing.T) {
 	}
 }
 
+func TestAzureMachinePoolServicePause(t *testing.T) {
+	type pausingServiceReconciler struct {
+		*mock_azure.MockServiceReconciler
+		*mock_azure.MockPauser
+	}
+
+	cases := map[string]struct {
+		expectedError string
+		expect        func(one pausingServiceReconciler, two pausingServiceReconciler, three pausingServiceReconciler)
+	}{
+		"all services are paused in order": {
+			expectedError: "",
+			expect: func(one pausingServiceReconciler, two pausingServiceReconciler, three pausingServiceReconciler) {
+				gomock.InOrder(
+					one.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(nil),
+					two.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(nil),
+					three.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(nil))
+			},
+		},
+		"service pause fails": {
+			expectedError: "failed to pause AzureMachinePool service two: some error happened",
+			expect: func(one pausingServiceReconciler, two pausingServiceReconciler, _ pausingServiceReconciler) {
+				gomock.InOrder(
+					one.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(nil),
+					two.MockPauser.EXPECT().Pause(gomockinternal.AContext()).Return(errors.New("some error happened")),
+					two.MockServiceReconciler.EXPECT().Name().Return("two"))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			newPausingServiceReconciler := func() pausingServiceReconciler {
+				return pausingServiceReconciler{
+					mock_azure.NewMockServiceReconciler(mockCtrl),
+					mock_azure.NewMockPauser(mockCtrl),
+				}
+			}
+			svcOneMock := newPausingServiceReconciler()
+			svcTwoMock := newPausingServiceReconciler()
+			svcThreeMock := newPausingServiceReconciler()
+
+			tc.expect(svcOneMock, svcTwoMock, svcThreeMock)
+
+			s := &azureMachinePoolService{
+				services: []azure.ServiceReconciler{
+					svcOneMock,
+					svcTwoMock,
+					svcThreeMock,
+				},
+			}
+
+			err := s.Pause(context.TODO())
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
 func TestAzureMachinePoolServiceDelete(t *testing.T) {
 	cases := map[string]struct {
 		expectedError string


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR follows up from #3735 and #3783 to set up the remaining controllers to handle pausing ASO resources when the parent Cluster is paused. These changes aren't strictly necessary until more services are re-implemented to use ASO, but I figured it would be worth merging ahead of time so we don't have to remember to do that later.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3525

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
