### PR TITLE
Add future conversion funcs for SDKv2

### DIFF
--- a/azure/converters/futures.go
+++ b/azure/converters/futures.go
@@ -19,6 +19,7 @@ package converters
 import (
 	"encoding/base64"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/pkg/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -51,4 +52,31 @@ func FutureToSDK(future infrav1.Future) (azureautorest.FutureAPI, error) {
 		return nil, errors.Wrap(err, "failed to unmarshal future data")
 	}
 	return &genericFuture, nil
+}
+
+// PollerToFuture converts an SDK poller to an infrav1.Future.
+func PollerToFuture[T any](poller *runtime.Poller[T], futureType, service, resourceName, rgName string) (*infrav1.Future, error) {
+	token, err := poller.ResumeToken()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get resume token")
+	}
+	return &infrav1.Future{
+		Type:          futureType,
+		ResourceGroup: rgName,
+		ServiceName:   service,
+		Name:          resourceName,
+		Data:          base64.URLEncoding.EncodeToString([]byte(token)),
+	}, nil
+}
+
+// FutureToResumeToken converts an infrav1.Future to an Azure SDK resume token.
+func FutureToResumeToken(future infrav1.Future) (string, error) {
+	if future.Data == "" {
+		return "", errors.New("failed to unmarshal future data: data is empty")
+	}
+	token, err := base64.URLEncoding.DecodeString(future.Data)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to decode future data")
+	}
+	return string(token), nil
 }

--- a/azure/converters/futures_test.go
+++ b/azure/converters/futures_test.go
@@ -17,9 +17,14 @@ limitations under the License.
 package converters
 
 import (
+	"encoding/base64"
+	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	. "github.com/onsi/gomega"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -154,4 +159,133 @@ func Test_FutureToSDK(t *testing.T) {
 			c.expect(g, result, err)
 		})
 	}
+}
+
+func TestPollerToFuture(t *testing.T) {
+	cases := []struct {
+		name        string
+		futureType  string
+		statusCode  int
+		expectedErr string
+	}{
+		{
+			name:       "valid DELETE poller",
+			futureType: infrav1.DeleteFuture,
+			statusCode: http.StatusAccepted,
+		},
+		{
+			name:        "invalid DELETE poller",
+			futureType:  infrav1.DeleteFuture,
+			statusCode:  http.StatusNoContent,
+			expectedErr: "failed to get resume token",
+		},
+		{
+			name:       "valid PUT poller",
+			futureType: infrav1.PutFuture,
+			statusCode: http.StatusAccepted,
+		},
+		{
+			name:        "invalid PUT poller",
+			futureType:  infrav1.PutFuture,
+			statusCode:  http.StatusNoContent,
+			expectedErr: "failed to get resume token",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+			poller := fakePoller[MockPolled](g, c.statusCode)
+			future, err := PollerToFuture(poller, c.futureType, "test-service", "test-resource", "test-group")
+			if c.expectedErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(c.expectedErr))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(future).NotTo(BeNil())
+				g.Expect(future.Data).NotTo(BeNil())
+				token, err := base64.URLEncoding.DecodeString(future.Data)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(token)).NotTo(BeEmpty())
+				// The following assertion should pass, but the token's format could change.
+				// g.Expect(string(token)).To(MatchJSON(`{"type":"MockPolled","token":{"type":"body","pollURL":"/","state":"InProgress"}}`))
+			}
+		})
+	}
+}
+
+func TestFutureToResumeToken(t *testing.T) {
+	cases := []struct {
+		name   string
+		future infrav1.Future
+		expect func(*GomegaWithT, string, error)
+	}{
+		{
+			name:   "data is empty",
+			future: emptyDataFuture,
+			expect: func(g *GomegaWithT, token string, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).Should(ContainSubstring("failed to unmarshal future data"))
+			},
+		},
+		{
+			name:   "data is not base64-encoded",
+			future: decodedDataFuture,
+			expect: func(g *GomegaWithT, token string, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).Should(ContainSubstring("failed to decode future data"))
+			},
+		},
+		{
+			name:   "data does not contain a valid resume token",
+			future: invalidFuture,
+			expect: func(g *GomegaWithT, token string, err error) {
+				// "The token's format should be considered opaque and is subject to change."
+				// This validates decoding the unit test data, but actual SDKv2 tokens won't look like this.
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(token).To(ContainSubstring("fake b64 future data"))
+			},
+		},
+		{
+			name:   "data contains a valid resume token",
+			future: validFuture,
+			expect: func(g *GomegaWithT, token string, err error) {
+				// "The token's format should be considered opaque and is subject to change."
+				// This validates decoding the unit test data, but actual SDKv2 tokens won't look like this.
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(token).To(MatchJSON(`{"method":"DELETE","pollingMethod":"Location","lroState":"InProgress"}`))
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+			token, err := FutureToResumeToken(c.future)
+			c.expect(g, token, err)
+		})
+	}
+}
+
+type MockPolled struct{}
+
+func (m *MockPolled) Done() bool { return true }
+
+func fakePoller[T any](g *GomegaWithT, statusCode int) *runtime.Poller[T] {
+	response := &http.Response{
+		Body: io.NopCloser(strings.NewReader("")),
+		Request: &http.Request{
+			Method: http.MethodPut,
+			URL:    &url.URL{Path: "/"},
+		},
+		StatusCode: statusCode,
+	}
+	pipeline := runtime.NewPipeline("testmodule", "v0.1.0", runtime.PipelineOptions{}, nil)
+	poller, err := runtime.NewPoller[T](response, pipeline, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+	return poller
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds the `PollerToFuture()` and `FutureToResumeToken()` funcs with tests. These are parallel to the existing `SDKToFuture()` and `FutureToSDK()` funcs, but work with the `Poller` construct from Azure SDK for Go v2.

**Which issue(s) this PR fixes**:

Refs #2974

**Special notes for your reviewer**:

These will be used by the "asyncpoller" framework. I'm trying to trickle out the changes to keep them easier to review, but that means this code isn't actually being used yet...so let me know if I've gone too far in this direction, happy to repackage.

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
