### PR TITLE
validate DNS Service IP to be a .10 IP belonging to Service CIDR

### DIFF
--- a/api/v1beta1/azuremachine_default_test.go
+++ b/api/v1beta1/azuremachine_default_test.go
@@ -521,10 +521,17 @@ func (m mockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Ob
 	case *AzureCluster:
 		obj.Spec.SubscriptionID = "test-subscription-id"
 	case *clusterv1.Cluster:
-		obj.Spec.InfrastructureRef = &corev1.ObjectReference{
-			Kind:      "AzureCluster",
-			Name:      "test-cluster",
-			Namespace: "default",
+		obj.Spec = clusterv1.ClusterSpec{
+			InfrastructureRef: &corev1.ObjectReference{
+				Kind:      "AzureCluster",
+				Name:      "test-cluster",
+				Namespace: "default",
+			},
+			ClusterNetwork: &clusterv1.ClusterNetwork{
+				Services: &clusterv1.NetworkRanges{
+					CIDRBlocks: []string{"192.168.0.0/26"},
+				},
+			},
 		}
 	default:
 		return errors.New("unexpected object type")

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -97,8 +97,9 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing valid DNSServiceIP",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.17.8",
 				},
 			},
@@ -107,18 +108,41 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid DNSServiceIP",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0.3"),
+					DNSServiceIP: ptr.To("192.168.0.10.3"),
 					Version:      "v1.17.8",
 				},
 			},
 			expectErr: true,
 		},
 		{
+			name: "Testing invalid DNSServiceIP",
+			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: ptr.To("192.168.0.11"),
+					Version:      "v1.17.8",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "Testing empty DNSServiceIP",
+			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
+				Spec: AzureManagedControlPlaneSpec{
+					Version: "v1.17.8",
+				},
+			},
+			expectErr: false,
+		},
+		{
 			name: "Invalid Version",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "honk",
 				},
 			},
@@ -127,8 +151,9 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "not following the Kubernetes Version pattern",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "1.19.0",
 				},
 			},
@@ -137,8 +162,9 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Version not set",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "",
 				},
 			},
@@ -147,8 +173,9 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Valid Version",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.17.8",
 				},
 			},
@@ -157,6 +184,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Valid Managed AADProfile",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.21.2",
 					AADProfile: &AADProfile{
@@ -172,6 +200,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Valid LoadBalancerProfile",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.21.2",
 					LoadBalancerProfile: &LoadBalancerProfile{
@@ -186,6 +215,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Invalid LoadBalancerProfile.ManagedOutboundIPs",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.21.2",
 					LoadBalancerProfile: &LoadBalancerProfile{
@@ -198,6 +228,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Invalid LoadBalancerProfile.AllocatedOutboundPorts",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.21.2",
 					LoadBalancerProfile: &LoadBalancerProfile{
@@ -210,6 +241,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Invalid LoadBalancerProfile.IdleTimeoutInMinutes",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.21.2",
 					LoadBalancerProfile: &LoadBalancerProfile{
@@ -222,6 +254,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "LoadBalancerProfile must specify at most one of ManagedOutboundIPs, OutboundIPPrefixes and OutboundIPs",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.21.2",
 					LoadBalancerProfile: &LoadBalancerProfile{
@@ -237,6 +270,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Invalid CIDR for AuthorizedIPRanges",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.21.2",
 					APIServerAccessProfile: &APIServerAccessProfile{
@@ -249,6 +283,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing valid AutoScalerProfile",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -277,6 +312,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing valid AutoScalerProfile.ExpanderRandom",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -289,6 +325,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing valid AutoScalerProfile.ExpanderLeastWaste",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -301,6 +338,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing valid AutoScalerProfile.ExpanderMostPods",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -313,6 +351,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing valid AutoScalerProfile.ExpanderPriority",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -325,6 +364,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing valid AutoScalerProfile.BalanceSimilarNodeGroupsTrue",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -337,6 +377,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing valid AutoScalerProfile.BalanceSimilarNodeGroupsFalse",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -349,6 +390,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid AutoScalerProfile.MaxEmptyBulkDelete",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -361,6 +403,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid AutoScalerProfile.MaxGracefulTerminationSec",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -373,6 +416,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid AutoScalerProfile.MaxNodeProvisionTime",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -385,6 +429,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid AutoScalerProfile.MaxTotalUnreadyPercentage",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -397,6 +442,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid AutoScalerProfile.NewPodScaleUpDelay",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -409,6 +455,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid AutoScalerProfile.OkTotalUnreadyCount",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -421,6 +468,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid AutoScalerProfile.ScanInterval",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -433,6 +481,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownDelayAfterAdd",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -445,6 +494,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownDelayAfterDelete",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -457,6 +507,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownDelayAfterFailure",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -469,6 +520,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownUnneededTime",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -481,6 +533,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownUnreadyTime",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -493,6 +546,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownUtilizationThreshold",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -505,6 +559,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing valid AutoScalerProfile.SkipNodesWithLocalStorageTrue",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -517,6 +572,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing valid AutoScalerProfile.SkipNodesWithLocalStorageFalse",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -529,6 +585,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing valid AutoScalerProfile.SkipNodesWithSystemPodsTrue",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -541,6 +598,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing valid AutoScalerProfile.SkipNodesWithSystemPodsFalse",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					AutoScalerProfile: &AutoScalerProfile{
@@ -553,6 +611,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing valid Identity: SystemAssigned",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					Identity: &Identity{
@@ -565,6 +624,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing valid Identity: UserAssigned",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					Identity: &Identity{
@@ -578,6 +638,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid Identity: SystemAssigned with UserAssigned values",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					Identity: &Identity{
@@ -591,6 +652,7 @@ func TestValidatingWebhook(t *testing.T) {
 		{
 			name: "Testing invalid Identity: UserAssigned with missing properties",
 			amcp: AzureManagedControlPlane{
+				ObjectMeta: getAMCPMetaData(),
 				Spec: AzureManagedControlPlaneSpec{
 					Version: "v1.24.1",
 					Identity: &Identity{
@@ -604,8 +666,12 @@ func TestValidatingWebhook(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
+		// client is used to fetch the AzureManagedControlPlane, we do not want to return an error on client.Get
+		client := mockClient{ReturnError: false}
 		t.Run(tt.name, func(t *testing.T) {
-			mcpw := &azureManagedControlPlaneWebhook{}
+			mcpw := &azureManagedControlPlaneWebhook{
+				Client: client,
+			}
 			if tt.expectErr {
 				g.Expect(mcpw.ValidateCreate(context.Background(), &tt.amcp)).NotTo(Succeed())
 			} else {
@@ -634,25 +700,31 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name:     "invalid DNSServiceIP",
-			amcp:     createAzureManagedControlPlane("192.168.0.0.3", "v1.18.0", generateSSHPublicKey(true)),
+			amcp:     createAzureManagedControlPlane("192.168.0.10.3", "v1.18.0", generateSSHPublicKey(true)),
+			wantErr:  true,
+			errorLen: 1,
+		},
+		{
+			name:     "invalid DNSServiceIP",
+			amcp:     createAzureManagedControlPlane("192.168.0.11", "v1.18.0", generateSSHPublicKey(true)),
 			wantErr:  true,
 			errorLen: 1,
 		},
 		{
 			name:     "invalid sshKey",
-			amcp:     createAzureManagedControlPlane("192.168.0.0", "v1.18.0", generateSSHPublicKey(false)),
+			amcp:     createAzureManagedControlPlane("192.168.0.10", "v1.18.0", generateSSHPublicKey(false)),
 			wantErr:  true,
 			errorLen: 1,
 		},
 		{
 			name:     "invalid sshKey with a simple text and invalid DNSServiceIP",
-			amcp:     createAzureManagedControlPlane("192.168.0.0.3", "v1.18.0", "invalid_sshkey_honk"),
+			amcp:     createAzureManagedControlPlane("192.168.0.10.3", "v1.18.0", "invalid_sshkey_honk"),
 			wantErr:  true,
 			errorLen: 2,
 		},
 		{
 			name:     "invalid version",
-			amcp:     createAzureManagedControlPlane("192.168.0.0", "honk.version", generateSSHPublicKey(true)),
+			amcp:     createAzureManagedControlPlane("192.168.0.10", "honk.version", generateSSHPublicKey(true)),
 			wantErr:  true,
 			errorLen: 1,
 		},
@@ -664,7 +736,7 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 				},
 				Spec: AzureManagedControlPlaneSpec{
 					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.23.5",
 				},
 			},
@@ -679,7 +751,7 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 				},
 				Spec: AzureManagedControlPlaneSpec{
 					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.23.5",
 				},
 			},
@@ -693,7 +765,7 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 					ControlPlaneEndpoint: clusterv1.APIEndpoint{
 						Host: "my-host",
 					},
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
 					AADProfile: &AADProfile{
@@ -713,7 +785,7 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 					ControlPlaneEndpoint: clusterv1.APIEndpoint{
 						Port: 444,
 					},
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
 					AADProfile: &AADProfile{
@@ -727,9 +799,12 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	client := mockClient{ReturnError: false}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mcpw := &azureManagedControlPlaneWebhook{}
+			mcpw := &azureManagedControlPlaneWebhook{
+				Client: client,
+			}
 			err := mcpw.ValidateCreate(context.Background(), tc.amcp)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -762,10 +837,13 @@ func TestAzureManagedControlPlane_ValidateCreateFailure(t *testing.T) {
 			deferFunc: func() {},
 		},
 	}
+	client := mockClient{ReturnError: false}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			defer tc.deferFunc()
-			mcpw := &azureManagedControlPlaneWebhook{}
+			mcpw := &azureManagedControlPlaneWebhook{
+				Client: client,
+			}
 			err := mcpw.ValidateCreate(context.Background(), tc.amcp)
 			g.Expect(err).To(HaveOccurred())
 		})
@@ -783,40 +861,46 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 	}{
 		{
 			name:    "can't add a SSHPublicKey to an existing AzureManagedControlPlane",
-			oldAMCP: createAzureManagedControlPlane("192.168.0.0", "v1.18.0", ""),
-			amcp:    createAzureManagedControlPlane("192.168.0.0", "v1.18.0", generateSSHPublicKey(true)),
+			oldAMCP: createAzureManagedControlPlane("192.168.0.10", "v1.18.0", ""),
+			amcp:    createAzureManagedControlPlane("192.168.0.10", "v1.18.0", generateSSHPublicKey(true)),
 			wantErr: true,
 		},
 		{
 			name:    "same SSHPublicKey is valid",
-			oldAMCP: createAzureManagedControlPlane("192.168.0.0", "v1.18.0", commonSSHKey),
-			amcp:    createAzureManagedControlPlane("192.168.0.0", "v1.18.0", commonSSHKey),
+			oldAMCP: createAzureManagedControlPlane("192.168.0.10", "v1.18.0", commonSSHKey),
+			amcp:    createAzureManagedControlPlane("192.168.0.10", "v1.18.0", commonSSHKey),
 			wantErr: false,
 		},
 		{
 			name:    "AzureManagedControlPlane with invalid serviceIP",
 			oldAMCP: createAzureManagedControlPlane("", "v1.18.0", ""),
-			amcp:    createAzureManagedControlPlane("192.168.0.0.3", "v1.18.0", generateSSHPublicKey(true)),
+			amcp:    createAzureManagedControlPlane("192.168.0.10.3", "v1.18.0", generateSSHPublicKey(true)),
+			wantErr: true,
+		},
+		{
+			name:    "AzureManagedControlPlane with invalid serviceIP",
+			oldAMCP: createAzureManagedControlPlane("", "v1.18.0", ""),
+			amcp:    createAzureManagedControlPlane("192.168.0.11", "v1.18.0", generateSSHPublicKey(true)),
 			wantErr: true,
 		},
 		{
 			name:    "AzureManagedControlPlane with invalid version",
 			oldAMCP: createAzureManagedControlPlane("", "v1.18.0", ""),
-			amcp:    createAzureManagedControlPlane("192.168.0.0", "1.999.9", generateSSHPublicKey(true)),
+			amcp:    createAzureManagedControlPlane("192.168.0.10", "1.999.9", generateSSHPublicKey(true)),
 			wantErr: true,
 		},
 		{
 			name: "AzureManagedControlPlane SubscriptionID is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:   ptr.To("192.168.0.0"),
+					DNSServiceIP:   ptr.To("192.168.0.10"),
 					SubscriptionID: "212ec1q8",
 					Version:        "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:   ptr.To("192.168.0.0"),
+					DNSServiceIP:   ptr.To("192.168.0.10"),
 					SubscriptionID: "212ec1q9",
 					Version:        "v1.18.0",
 				},
@@ -827,14 +911,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane ResourceGroupName is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:      ptr.To("192.168.0.0"),
+					DNSServiceIP:      ptr.To("192.168.0.10"),
 					ResourceGroupName: "hello-1",
 					Version:           "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:      ptr.To("192.168.0.0"),
+					DNSServiceIP:      ptr.To("192.168.0.10"),
 					ResourceGroupName: "hello-2",
 					Version:           "v1.18.0",
 				},
@@ -845,14 +929,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane NodeResourceGroupName is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:          ptr.To("192.168.0.0"),
+					DNSServiceIP:          ptr.To("192.168.0.10"),
 					NodeResourceGroupName: "hello-1",
 					Version:               "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:          ptr.To("192.168.0.0"),
+					DNSServiceIP:          ptr.To("192.168.0.10"),
 					NodeResourceGroupName: "hello-2",
 					Version:               "v1.18.0",
 				},
@@ -863,14 +947,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane Location is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Location:     "westeurope",
 					Version:      "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Location:     "eastus",
 					Version:      "v1.18.0",
 				},
@@ -881,14 +965,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane SSHPublicKey is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
 					Version:      "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
 					Version:      "v1.18.0",
 				},
@@ -899,13 +983,13 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane DNSServiceIP is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.1"),
+					DNSServiceIP: ptr.To("192.168.1.1"),
 					Version:      "v1.18.0",
 				},
 			},
@@ -915,7 +999,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane DNSServiceIP is immutable, unsetting is not allowed",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 				},
 			},
@@ -930,14 +1014,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane NetworkPlugin is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:  ptr.To("192.168.0.0"),
+					DNSServiceIP:  ptr.To("192.168.0.10"),
 					NetworkPlugin: ptr.To("azure"),
 					Version:       "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:  ptr.To("192.168.0.0"),
+					DNSServiceIP:  ptr.To("192.168.0.10"),
 					NetworkPlugin: ptr.To("kubenet"),
 					Version:       "v1.18.0",
 				},
@@ -948,14 +1032,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane NetworkPlugin is immutable, unsetting is not allowed",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:  ptr.To("192.168.0.0"),
+					DNSServiceIP:  ptr.To("192.168.0.10"),
 					NetworkPlugin: ptr.To("azure"),
 					Version:       "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 				},
 			},
@@ -965,14 +1049,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane NetworkPolicy is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:  ptr.To("192.168.0.0"),
+					DNSServiceIP:  ptr.To("192.168.0.10"),
 					NetworkPolicy: ptr.To("azure"),
 					Version:       "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:  ptr.To("192.168.0.0"),
+					DNSServiceIP:  ptr.To("192.168.0.10"),
 					NetworkPolicy: ptr.To("calico"),
 					Version:       "v1.18.0",
 				},
@@ -983,14 +1067,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane NetworkPolicy is immutable, unsetting is not allowed",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:  ptr.To("192.168.0.0"),
+					DNSServiceIP:  ptr.To("192.168.0.10"),
 					NetworkPolicy: ptr.To("azure"),
 					Version:       "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 				},
 			},
@@ -1000,14 +1084,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane LoadBalancerSKU is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:    ptr.To("192.168.0.0"),
+					DNSServiceIP:    ptr.To("192.168.0.10"),
 					LoadBalancerSKU: ptr.To("Standard"),
 					Version:         "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:    ptr.To("192.168.0.0"),
+					DNSServiceIP:    ptr.To("192.168.0.10"),
 					LoadBalancerSKU: ptr.To("Basic"),
 					Version:         "v1.18.0",
 				},
@@ -1018,14 +1102,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane LoadBalancerSKU is immutable, unsetting is not allowed",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP:    ptr.To("192.168.0.0"),
+					DNSServiceIP:    ptr.To("192.168.0.10"),
 					LoadBalancerSKU: ptr.To("Standard"),
 					Version:         "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 				},
 			},
@@ -1146,13 +1230,13 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane EnablePrivateCluster is immutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 					APIServerAccessProfile: &APIServerAccessProfile{
 						EnablePrivateCluster: ptr.To(true),
@@ -1165,13 +1249,13 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name: "AzureManagedControlPlane AuthorizedIPRanges is mutable",
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 					APIServerAccessProfile: &APIServerAccessProfile{
 						AuthorizedIPRanges: []string{"192.168.0.1/32"},
@@ -1187,7 +1271,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 					VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 						Name:          "test-network",
@@ -1205,7 +1289,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 				},
 			},
@@ -1218,7 +1302,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 				},
 			},
@@ -1227,7 +1311,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 					VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 						Name:          "test-network",
@@ -1249,7 +1333,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 					VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 						Name:          "test-network",
@@ -1267,7 +1351,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: ptr.To("192.168.0.0"),
+					DNSServiceIP: ptr.To("192.168.0.10"),
 					Version:      "v1.18.0",
 					VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 						Name:          "test-network",
@@ -1303,9 +1387,12 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	client := mockClient{ReturnError: false}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mcpw := &azureManagedControlPlaneWebhook{}
+			mcpw := &azureManagedControlPlaneWebhook{
+				Client: client,
+			}
 			err := mcpw.ValidateUpdate(context.Background(), tc.oldAMCP, tc.amcp)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -1318,6 +1405,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 
 func createAzureManagedControlPlane(serviceIP, version, sshKey string) *AzureManagedControlPlane {
 	return &AzureManagedControlPlane{
+		ObjectMeta: getAMCPMetaData(),
 		Spec: AzureManagedControlPlaneSpec{
 			SSHPublicKey: &sshKey,
 			DNSServiceIP: ptr.To(serviceIP),
@@ -1328,8 +1416,9 @@ func createAzureManagedControlPlane(serviceIP, version, sshKey string) *AzureMan
 
 func getKnownValidAzureManagedControlPlane() *AzureManagedControlPlane {
 	return &AzureManagedControlPlane{
+		ObjectMeta: getAMCPMetaData(),
 		Spec: AzureManagedControlPlaneSpec{
-			DNSServiceIP: ptr.To("192.168.0.0"),
+			DNSServiceIP: ptr.To("192.168.0.10"),
 			Version:      "v1.18.0",
 			SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
 			AADProfile: &AADProfile{
@@ -1339,5 +1428,15 @@ func getKnownValidAzureManagedControlPlane() *AzureManagedControlPlane {
 				},
 			},
 		},
+	}
+}
+
+func getAMCPMetaData() metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name: "test-AMCP",
+		Labels: map[string]string{
+			"cluster.x-k8s.io/cluster-name": "test-cluster",
+		},
+		Namespace: "default",
 	}
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- This PR updates `azuremanagedcontrolplane_webhook` to validate DNS Service IP is a `.10` IP address.
- Refer to the second point of https://learn.microsoft.com/en-us/azure/aks/configure-kubenet#create-an-aks-cluster-with-system-assigned-managed-identities 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3824 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
validate DNS Service IP to be a .10 IP belonging to Service CIDR
```
