### PR TITLE
🚨 Azureutil alias rule added and respective  fixed lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,6 +93,9 @@ linters-settings:
       # ASO
       - pkg: github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601
         alias: asoresourcesv1
+      # Azureutil
+      - pkg: sigs.k8s.io/cluster-api-provider-azure/util/azure
+        alias: azureutil
       # Deprecated
       - pkg: github.com/Azure/go-autorest/autorest/to
         alias: deprecated-use-k8s.io-utils-pointer

--- a/exp/api/v1beta1/azuremachinepool_webhook.go
+++ b/exp/api/v1beta1/azuremachinepool_webhook.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
-	"sigs.k8s.io/cluster-api-provider-azure/util/azure"
+	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	capifeature "sigs.k8s.io/cluster-api/feature"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -298,7 +298,7 @@ func (amp *AzureMachinePool) ValidateOrchestrationMode(c client.Client) func() e
 	return func() error {
 		// Only Flexible orchestration mode requires validation.
 		if amp.Spec.OrchestrationMode == infrav1.OrchestrationModeType(compute.OrchestrationModeFlexible) {
-			parent, err := azure.FindParentMachinePoolWithRetry(amp.Name, c, 5)
+			parent, err := azureutil.FindParentMachinePoolWithRetry(amp.Name, c, 5)
 			if err != nil {
 				return errors.Wrap(err, "failed to find parent MachinePool")
 			}

--- a/test/e2e/azure_machinepools.go
+++ b/test/e2e/azure_machinepools.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-azure/util/azure"
+	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -92,7 +92,7 @@ func AzureMachinePoolsSpec(ctx context.Context, inputGetter func() AzureMachineP
 				Expect(providerID).To(MatchRegexp(regexpUniformInstance))
 			}
 		}
-		mp, err := azure.FindParentMachinePool(amp.Name, bootstrapClusterProxy.GetClient())
+		mp, err := azureutil.FindParentMachinePool(amp.Name, bootstrapClusterProxy.GetClient())
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mp).NotTo(BeNil())
 		machinepools = append(machinepools, mp)


### PR DESCRIPTION
Fix added as per Reference [issue #3823](https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/3823)


**Release note**:

```release-note
NONE
```