### PR TITLE
chore(make): ignoring gcloud project name for local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,11 @@ else
 endif
 
 # Define Docker related variables. Releases should modify and double check these vars.
-REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
+ifeq (,$(shell command -v gcloud))
+    REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
+else
+    REGISTRY ?= localhost:5000
+endif
 STAGING_REGISTRY := gcr.io/k8s-staging-cluster-api-azure
 PROD_REGISTRY := registry.k8s.io/cluster-api-azure
 IMAGE_NAME ?= cluster-api-azure-controller


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Allowing streamline local development without requiring undocumented third-party tools which are mandatory for the release process.

**Which issue(s) this PR fixes**:
Fixes #3830

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
