### PR TITLE
Update virtualmachineimages service to SDK v2

### DIFF
--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -45,6 +45,7 @@ type ServiceReconciler interface {
 }
 
 // Authorizer is an interface which can get the subscription ID, base URI, and authorizer for an Azure service.
+// The Authorizer field is used by SDKv1 services while the Token is used by SDKv2 services.
 type Authorizer interface {
 	SubscriptionID() string
 	ClientID() string

--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -19,6 +19,7 @@ package azure
 import (
 	"context"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/go-autorest/autorest"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -53,6 +54,7 @@ type Authorizer interface {
 	BaseURI() string
 	Authorizer() autorest.Authorizer
 	HashKey() string
+	Token() azcore.TokenCredential
 }
 
 // NetworkDescriber is an interface which can get common Azure Cluster Networking information.

--- a/azure/mock_azure/azure_mock.go
+++ b/azure/mock_azure/azure_mock.go
@@ -24,6 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	genruntime "github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
@@ -332,6 +333,20 @@ func (m *MockAuthorizer) TenantID() string {
 func (mr *MockAuthorizerMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockAuthorizer)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockAuthorizer) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockAuthorizerMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockAuthorizer)(nil).Token))
 }
 
 // MockNetworkDescriber is a mock of NetworkDescriber interface.
@@ -852,6 +867,20 @@ func (m *MockClusterDescriber) TenantID() string {
 func (mr *MockClusterDescriberMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockClusterDescriber)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockClusterDescriber) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockClusterDescriberMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockClusterDescriber)(nil).Token))
 }
 
 // MockAsyncStatusUpdater is a mock of AsyncStatusUpdater interface.
@@ -1434,6 +1463,20 @@ func (mr *MockClusterScoperMockRecorder) TenantID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockClusterScoper)(nil).TenantID))
 }
 
+// Token mocks base method.
+func (m *MockClusterScoper) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockClusterScoperMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockClusterScoper)(nil).Token))
+}
+
 // Vnet mocks base method.
 func (m *MockClusterScoper) Vnet() *v1beta1.VnetSpec {
 	m.ctrl.T.Helper()
@@ -1735,6 +1778,20 @@ func (m *MockManagedClusterScoper) TenantID() string {
 func (mr *MockManagedClusterScoperMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockManagedClusterScoper)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockManagedClusterScoper) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockManagedClusterScoperMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockManagedClusterScoper)(nil).Token))
 }
 
 // MockResourceSpecGetter is a mock of ResourceSpecGetter interface.

--- a/azure/scope/clients.go
+++ b/azure/scope/clients.go
@@ -67,7 +67,7 @@ func (c *AzureClients) SubscriptionID() string {
 	return c.Values[auth.SubscriptionID]
 }
 
-// Token returns the Azure token credential of the cluster.
+// Token returns the Azure token credential of the cluster used for SDKv2 services.
 func (c *AzureClients) Token() azcore.TokenCredential {
 	return c.TokenCredential
 }

--- a/azure/scope/clients.go
+++ b/azure/scope/clients.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/go-autorest/autorest"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
@@ -35,6 +36,7 @@ type AzureClients struct {
 	auth.EnvironmentSettings
 
 	Authorizer                 autorest.Authorizer
+	TokenCredential            azcore.TokenCredential
 	ResourceManagerEndpoint    string
 	ResourceManagerVMDNSSuffix string
 }
@@ -63,6 +65,11 @@ func (c *AzureClients) ClientSecret() string {
 // either specified or from the environment.
 func (c *AzureClients) SubscriptionID() string {
 	return c.Values[auth.SubscriptionID]
+}
+
+// Token returns the Azure token credential of the cluster.
+func (c *AzureClients) Token() azcore.TokenCredential {
+	return c.TokenCredential
 }
 
 // HashKey returns a base64 url encoded sha256 hash for the Auth scope (Azure TenantID + CloudEnv + SubscriptionID +
@@ -133,7 +140,12 @@ func (c *AzureClients) setCredentialsWithProvider(ctx context.Context, subscript
 	}
 	c.Values[auth.ClientSecret] = strings.TrimSuffix(clientSecret, "\n")
 
-	c.Authorizer, err = credentialsProvider.GetAuthorizer(ctx, c.ResourceManagerEndpoint, c.Environment.ActiveDirectoryEndpoint, c.Environment.TokenAudience)
+	tokenCredential, err := credentialsProvider.GetTokenCredential(ctx, c.ResourceManagerEndpoint, c.Environment.ActiveDirectoryEndpoint, c.Environment.TokenAudience)
+	if err != nil {
+		return err
+	}
+	c.TokenCredential = tokenCredential
+	c.Authorizer, err = credentialsProvider.GetAuthorizer(ctx, tokenCredential, c.Environment.TokenAudience)
 	return err
 }
 

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -131,7 +131,7 @@ func (s *ClusterScope) BaseURI() string {
 	return s.ResourceManagerEndpoint
 }
 
-// Authorizer returns the Azure client Authorizer.
+// Authorizer returns the Azure client Authorizer which is used for SDKv1 services.
 func (s *ClusterScope) Authorizer() autorest.Authorizer {
 	return s.AzureClients.Authorizer
 }

--- a/azure/scope/identity.go
+++ b/azure/scope/identity.go
@@ -47,10 +47,11 @@ const AzureSecretKey = "clientSecret"
 
 // CredentialsProvider defines the behavior for azure identity based credential providers.
 type CredentialsProvider interface {
-	GetAuthorizer(ctx context.Context, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience string) (autorest.Authorizer, error)
+	GetAuthorizer(ctx context.Context, tokenCredential azcore.TokenCredential, tokenAudience string) (autorest.Authorizer, error)
 	GetClientID() string
 	GetClientSecret(ctx context.Context) (string, error)
 	GetTenantID() string
+	GetTokenCredential(ctx context.Context, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience string) (azcore.TokenCredential, error)
 }
 
 // AzureCredentialsProvider represents a credential provider with azure cluster identity.
@@ -102,8 +103,13 @@ func NewAzureClusterCredentialsProvider(ctx context.Context, kubeClient client.C
 }
 
 // GetAuthorizer returns an Azure authorizer based on the provided azure identity. It delegates to AzureCredentialsProvider with AzureCluster metadata.
-func (p *AzureClusterCredentialsProvider) GetAuthorizer(ctx context.Context, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience string) (autorest.Authorizer, error) {
-	return p.AzureCredentialsProvider.GetAuthorizer(ctx, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience, p.AzureCluster.ObjectMeta)
+func (p *AzureClusterCredentialsProvider) GetAuthorizer(ctx context.Context, tokenCredential azcore.TokenCredential, tokenAudience string) (autorest.Authorizer, error) {
+	return p.AzureCredentialsProvider.GetAuthorizer(ctx, tokenCredential, tokenAudience)
+}
+
+// GetTokenCredential returns an Azure TokenCredential based on the provided azure identity.
+func (p *AzureClusterCredentialsProvider) GetTokenCredential(ctx context.Context, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience string) (azcore.TokenCredential, error) {
+	return p.AzureCredentialsProvider.GetTokenCredential(ctx, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience, p.AzureCluster.ObjectMeta)
 }
 
 // NewManagedControlPlaneCredentialsProvider creates a new ManagedControlPlaneCredentialsProvider from the supplied inputs.
@@ -134,14 +140,20 @@ func NewManagedControlPlaneCredentialsProvider(ctx context.Context, kubeClient c
 }
 
 // GetAuthorizer returns an Azure authorizer based on the provided azure identity. It delegates to AzureCredentialsProvider with AzureManagedControlPlane metadata.
-func (p *ManagedControlPlaneCredentialsProvider) GetAuthorizer(ctx context.Context, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience string) (autorest.Authorizer, error) {
-	return p.AzureCredentialsProvider.GetAuthorizer(ctx, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience, p.AzureManagedControlPlane.ObjectMeta)
+func (p *ManagedControlPlaneCredentialsProvider) GetAuthorizer(ctx context.Context, tokenCredential azcore.TokenCredential, tokenAudience string) (autorest.Authorizer, error) {
+	return p.AzureCredentialsProvider.GetAuthorizer(ctx, tokenCredential, tokenAudience)
 }
 
-// GetAuthorizer returns an Azure authorizer based on the provided azure identity and cluster metadata.
-func (p *AzureCredentialsProvider) GetAuthorizer(ctx context.Context, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience string, clusterMeta metav1.ObjectMeta) (autorest.Authorizer, error) {
+// GetTokenCredential returns an Azure TokenCredential based on the provided azure identity.
+func (p *ManagedControlPlaneCredentialsProvider) GetTokenCredential(ctx context.Context, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience string) (azcore.TokenCredential, error) {
+	return p.AzureCredentialsProvider.GetTokenCredential(ctx, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience, p.AzureManagedControlPlane.ObjectMeta)
+}
+
+// GetTokenCredential returns an Azure TokenCredential based on the provided azure identity.
+func (p *AzureCredentialsProvider) GetTokenCredential(ctx context.Context, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience string, clusterMeta metav1.ObjectMeta) (azcore.TokenCredential, error) {
 	var authErr error
 	var cred azcore.TokenCredential
+
 	switch p.Identity.Spec.Type {
 	case infrav1.WorkloadIdentity:
 		azwiCredOptions, err := NewWorkloadIdentityCredentialOptions().
@@ -191,6 +203,12 @@ func (p *AzureCredentialsProvider) GetAuthorizer(ctx context.Context, resourceMa
 	if authErr != nil {
 		return nil, errors.Errorf("failed to get token from service principal identity: %v", authErr)
 	}
+
+	return cred, nil
+}
+
+// GetAuthorizer returns an Azure authorizer based on the provided azure identity, cluster metadata, and tokenCredential.
+func (p *AzureCredentialsProvider) GetAuthorizer(ctx context.Context, cred azcore.TokenCredential, tokenAudience string) (autorest.Authorizer, error) {
 	// We must use TokenAudience for StackCloud, otherwise we get an
 	// AADSTS500011 error from the API
 	scope := tokenAudience

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -689,7 +689,10 @@ func (m *MachineScope) GetVMImage(ctx context.Context) (*infrav1.Image, error) {
 		return m.AzureMachine.Spec.Image, nil
 	}
 
-	svc := virtualmachineimages.New(m)
+	svc, err := virtualmachineimages.New(m)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create virtualmachineimages service")
+	}
 
 	if m.AzureMachine.Spec.OSDisk.OSType == azure.WindowsOS {
 		runtime := m.AzureMachine.Annotations["runtime"]

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/google/go-cmp/cmp"
@@ -1398,9 +1399,10 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 
 	clusterMock := mock_azure.NewMockClusterScoper(mockCtrl)
 	clusterMock.EXPECT().Authorizer().AnyTimes()
-	clusterMock.EXPECT().BaseURI().AnyTimes()
 	clusterMock.EXPECT().Location().AnyTimes()
 	clusterMock.EXPECT().SubscriptionID().AnyTimes()
+	clusterMock.EXPECT().CloudEnvironment().AnyTimes()
+	clusterMock.EXPECT().Token().Return(&azidentity.DefaultAzureCredential{}).AnyTimes()
 	svc := virtualmachineimages.Service{Client: mock_virtualmachineimages.NewMockClient(mockCtrl)}
 
 	tests := []struct {

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -656,12 +656,16 @@ func (m *MachinePoolScope) GetVMImage(ctx context.Context) (*infrav1.Image, erro
 		return m.AzureMachinePool.Spec.Template.Image, nil
 	}
 
-	svc := virtualmachineimages.New(m)
-
 	var (
 		err          error
 		defaultImage *infrav1.Image
 	)
+
+	svc, err := virtualmachineimages.New(m)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create virtualmachineimages service")
+	}
+
 	if m.AzureMachinePool.Spec.Template.OSDisk.OSType == azure.WindowsOS {
 		runtime := m.AzureMachinePool.Annotations["runtime"]
 		windowsServerVersion := m.AzureMachinePool.Annotations["windowsServerVersion"]

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	. "github.com/onsi/gomega"
@@ -401,9 +402,10 @@ func TestMachinePoolScope_GetVMImage(t *testing.T) {
 
 	clusterMock := mock_azure.NewMockClusterScoper(mockCtrl)
 	clusterMock.EXPECT().Authorizer().AnyTimes()
-	clusterMock.EXPECT().BaseURI().AnyTimes()
 	clusterMock.EXPECT().Location().AnyTimes()
 	clusterMock.EXPECT().SubscriptionID().AnyTimes()
+	clusterMock.EXPECT().CloudEnvironment().AnyTimes()
+	clusterMock.EXPECT().Token().Return(&azidentity.DefaultAzureCredential{}).AnyTimes()
 	cases := []struct {
 		Name   string
 		Setup  func(mp *expv1.MachinePool, amp *infrav1exp.AzureMachinePool)

--- a/azure/services/agentpools/mock_agentpools/agentpools_mock.go
+++ b/azure/services/agentpools/mock_agentpools/agentpools_mock.go
@@ -23,6 +23,7 @@ package mock_agentpools
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -481,6 +482,20 @@ func (m *MockAgentPoolScope) TenantID() string {
 func (mr *MockAgentPoolScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockAgentPoolScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockAgentPoolScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockAgentPoolScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockAgentPoolScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/availabilitysets/mock_availabilitysets/availabilitysets_mock.go
+++ b/azure/services/availabilitysets/mock_availabilitysets/availabilitysets_mock.go
@@ -23,6 +23,7 @@ package mock_availabilitysets
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -355,6 +356,20 @@ func (m *MockAvailabilitySetScope) TenantID() string {
 func (mr *MockAvailabilitySetScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockAvailabilitySetScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockAvailabilitySetScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockAvailabilitySetScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockAvailabilitySetScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
+++ b/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
@@ -23,6 +23,7 @@ package mock_bastionhosts
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -563,6 +564,20 @@ func (m *MockBastionScope) TenantID() string {
 func (mr *MockBastionScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockBastionScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockBastionScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockBastionScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockBastionScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/disks/mock_disks/disks_mock.go
+++ b/azure/services/disks/mock_disks/disks_mock.go
@@ -23,6 +23,7 @@ package mock_disks
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -355,6 +356,20 @@ func (m *MockDiskScope) TenantID() string {
 func (mr *MockDiskScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockDiskScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockDiskScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockDiskScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockDiskScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/groups/mock_groups/groups_mock.go
+++ b/azure/services/groups/mock_groups/groups_mock.go
@@ -23,6 +23,7 @@ package mock_groups
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -229,6 +230,20 @@ func (m *MockGroupScope) TenantID() string {
 func (mr *MockGroupScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockGroupScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockGroupScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockGroupScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockGroupScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/inboundnatrules/mock_inboundnatrules/inboundnatrules_mock.go
+++ b/azure/services/inboundnatrules/mock_inboundnatrules/inboundnatrules_mock.go
@@ -23,6 +23,7 @@ package mock_inboundnatrules
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -369,6 +370,20 @@ func (m *MockInboundNatScope) TenantID() string {
 func (mr *MockInboundNatScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockInboundNatScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockInboundNatScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockInboundNatScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockInboundNatScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
+++ b/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
@@ -23,6 +23,7 @@ package mock_loadbalancers
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -563,6 +564,20 @@ func (m *MockLBScope) TenantID() string {
 func (mr *MockLBScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockLBScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockLBScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockLBScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockLBScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
+++ b/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
@@ -23,6 +23,7 @@ package mock_managedclusters
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
@@ -280,6 +281,20 @@ func (m *MockManagedClusterScope) TenantID() string {
 func (mr *MockManagedClusterScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockManagedClusterScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockManagedClusterScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockManagedClusterScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockManagedClusterScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/natgateways/mock_natgateways/natgateways_mock.go
+++ b/azure/services/natgateways/mock_natgateways/natgateways_mock.go
@@ -23,6 +23,7 @@ package mock_natgateways
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -575,6 +576,20 @@ func (m *MockNatGatewayScope) TenantID() string {
 func (mr *MockNatGatewayScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockNatGatewayScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockNatGatewayScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockNatGatewayScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockNatGatewayScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/networkinterfaces/mock_networkinterfaces/networkinterfaces_mock.go
+++ b/azure/services/networkinterfaces/mock_networkinterfaces/networkinterfaces_mock.go
@@ -23,6 +23,7 @@ package mock_networkinterfaces
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -355,6 +356,20 @@ func (m *MockNICScope) TenantID() string {
 func (mr *MockNICScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockNICScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockNICScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockNICScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockNICScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/privatedns/mock_privatedns/privatedns_mock.go
+++ b/azure/services/privatedns/mock_privatedns/privatedns_mock.go
@@ -23,6 +23,7 @@ package mock_privatedns
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -357,6 +358,20 @@ func (m *MockScope) TenantID() string {
 func (mr *MockScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/privateendpoints/mock_privateendpoints/privateendpoints_mock.go
+++ b/azure/services/privateendpoints/mock_privateendpoints/privateendpoints_mock.go
@@ -23,6 +23,7 @@ package mock_privateendpoints
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -215,6 +216,20 @@ func (m *MockPrivateEndpointScope) TenantID() string {
 func (mr *MockPrivateEndpointScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockPrivateEndpointScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockPrivateEndpointScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockPrivateEndpointScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockPrivateEndpointScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/publicips/mock_publicips/publicips_mock.go
+++ b/azure/services/publicips/mock_publicips/publicips_mock.go
@@ -23,6 +23,7 @@ package mock_publicips
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -355,6 +356,20 @@ func (m *MockPublicIPScope) TenantID() string {
 func (mr *MockPublicIPScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockPublicIPScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockPublicIPScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockPublicIPScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockPublicIPScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/resourcehealth/mock_resourcehealth/resourcehealth_mock.go
+++ b/azure/services/resourcehealth/mock_resourcehealth/resourcehealth_mock.go
@@ -23,6 +23,7 @@ package mock_resourcehealth
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -190,6 +191,20 @@ func (m *MockResourceHealthScope) TenantID() string {
 func (mr *MockResourceHealthScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockResourceHealthScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockResourceHealthScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockResourceHealthScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockResourceHealthScope)(nil).Token))
 }
 
 // MockAvailabilityStatusFilterer is a mock of AvailabilityStatusFilterer interface.

--- a/azure/services/roleassignments/mock_roleassignments/roleassignments_mock.go
+++ b/azure/services/roleassignments/mock_roleassignments/roleassignments_mock.go
@@ -23,6 +23,7 @@ package mock_roleassignments
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -271,6 +272,20 @@ func (m *MockRoleAssignmentScope) TenantID() string {
 func (mr *MockRoleAssignmentScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockRoleAssignmentScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockRoleAssignmentScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockRoleAssignmentScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockRoleAssignmentScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/routetables/mock_routetables/routetables_mock.go
+++ b/azure/services/routetables/mock_routetables/routetables_mock.go
@@ -23,6 +23,7 @@ package mock_routetables
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -229,6 +230,20 @@ func (m *MockRouteTableScope) TenantID() string {
 func (mr *MockRouteTableScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockRouteTableScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockRouteTableScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockRouteTableScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockRouteTableScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/scalesets/mock_scalesets/scalesets_mock.go
+++ b/azure/services/scalesets/mock_scalesets/scalesets_mock.go
@@ -24,6 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -492,6 +493,20 @@ func (m *MockScaleSetScope) TenantID() string {
 func (mr *MockScaleSetScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockScaleSetScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockScaleSetScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockScaleSetScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockScaleSetScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/scalesetvms/mock_scalesetvms/scalesetvms_mock.go
+++ b/azure/services/scalesetvms/mock_scalesetvms/scalesetvms_mock.go
@@ -23,6 +23,7 @@ package mock_scalesetvms
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -409,6 +410,20 @@ func (m *MockScaleSetVMScope) TenantID() string {
 func (mr *MockScaleSetVMScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockScaleSetVMScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockScaleSetVMScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockScaleSetVMScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockScaleSetVMScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/securitygroups/mock_securitygroups/securitygroups_mock.go
+++ b/azure/services/securitygroups/mock_securitygroups/securitygroups_mock.go
@@ -23,6 +23,7 @@ package mock_securitygroups
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -229,6 +230,20 @@ func (m *MockNSGScope) TenantID() string {
 func (mr *MockNSGScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockNSGScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockNSGScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockNSGScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockNSGScope)(nil).Token))
 }
 
 // UpdateAnnotationJSON mocks base method.

--- a/azure/services/subnets/mock_subnets/subnets_mock.go
+++ b/azure/services/subnets/mock_subnets/subnets_mock.go
@@ -23,6 +23,7 @@ package mock_subnets
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -229,6 +230,20 @@ func (m *MockSubnetScope) TenantID() string {
 func (mr *MockSubnetScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockSubnetScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockSubnetScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockSubnetScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockSubnetScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/tags/mock_tags/tags_mock.go
+++ b/azure/services/tags/mock_tags/tags_mock.go
@@ -23,6 +23,7 @@ package mock_tags
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	azure "sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -204,6 +205,20 @@ func (m *MockTagScope) TenantID() string {
 func (mr *MockTagScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockTagScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockTagScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockTagScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockTagScope)(nil).Token))
 }
 
 // UpdateAnnotationJSON mocks base method.

--- a/azure/services/virtualmachineimages/cache_test.go
+++ b/azure/services/virtualmachineimages/cache_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
@@ -34,13 +34,13 @@ func TestCacheGet(t *testing.T) {
 		publisher     string
 		offer         string
 		sku           string
-		have          compute.ListVirtualMachineImageResource
+		have          armcompute.VirtualMachineImagesClientListResponse
 		expectedError error
 	}{
 		"should find": {
 			location: "test", publisher: "foo", offer: "bar", sku: "baz",
-			have: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			have: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("foo")},
 				},
 			},
@@ -48,8 +48,8 @@ func TestCacheGet(t *testing.T) {
 		},
 		"should not find": {
 			location: "test", publisher: "foo", offer: "bar", sku: "baz",
-			have: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{},
+			have: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{},
 			},
 			expectedError: errors.New("failed to refresh VM images cache"),
 		},

--- a/azure/services/virtualmachineimages/client.go
+++ b/azure/services/virtualmachineimages/client.go
@@ -19,45 +19,55 @@ package virtualmachineimages
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
-	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
 // Client is an interface for listing VM images.
 type Client interface {
-	List(ctx context.Context, location, publisher, offer, sku string) (compute.ListVirtualMachineImageResource, error)
+	List(ctx context.Context, location, publisher, offer, sku string) (armcompute.VirtualMachineImagesClientListResponse, error)
 }
 
 // AzureClient contains the Azure go-sdk Client.
 type AzureClient struct {
-	images compute.VirtualMachineImagesClient
+	images armcompute.VirtualMachineImagesClient
 }
 
 var _ Client = (*AzureClient)(nil)
 
-// NewClient creates a new VM images client from auth info.
-func NewClient(auth azure.Authorizer) *AzureClient {
-	return &AzureClient{
-		images: newVirtualMachineImagesClient(auth.SubscriptionID(), auth.BaseURI(), auth.Authorizer()),
+// NewClient creates an AzureClient from an Authorizer.
+func NewClient(auth azure.Authorizer) (*AzureClient, error) {
+	c, err := newVirtualMachineImagesClient(auth)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create VM images client")
 	}
+	return &AzureClient{c}, nil
 }
 
-// newVirtualMachineImagesClient creates a new VM images client from subscription ID, base URI and authorizer.
-func newVirtualMachineImagesClient(subscriptionID, baseURI string, authorizer autorest.Authorizer) compute.VirtualMachineImagesClient {
-	c := compute.NewVirtualMachineImagesClientWithBaseURI(baseURI, subscriptionID)
-	azure.SetAutoRestClientDefaults(&c.Client, authorizer)
-	return c
+// newVirtualMachineImagesClient creates a new VM images client from subscription ID and base URI.
+func newVirtualMachineImagesClient(auth azure.Authorizer) (armcompute.VirtualMachineImagesClient, error) {
+	credential := auth.Token()
+	if credential == nil {
+		return armcompute.VirtualMachineImagesClient{}, errors.New("azure auth is nil")
+	}
+	opts, err := azure.ARMClientOptions(auth.CloudEnvironment())
+	if err != nil {
+		return armcompute.VirtualMachineImagesClient{}, errors.Wrap(err, "failed to create ARM client options")
+	}
+	computeClientFactory, err := armcompute.NewClientFactory(auth.SubscriptionID(), credential, opts)
+	if err != nil {
+		return armcompute.VirtualMachineImagesClient{}, errors.Wrap(err, "failed to create ARM compute client factory")
+	}
+	return *computeClientFactory.NewVirtualMachineImagesClient(), nil
 }
 
-// List returns a VM image list resource.
-func (ac *AzureClient) List(ctx context.Context, location, publisher, offer, sku string) (compute.ListVirtualMachineImageResource, error) {
+// List returns a VM image list response.
+func (ac *AzureClient) List(ctx context.Context, location, publisher, offer, sku string) (armcompute.VirtualMachineImagesClientListResponse, error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachineimages.AzureClient.List")
 	defer done()
 
-	// See https://learn.microsoft.com/odata/concepts/queryoptions-overview for how to use these query options.
-	expand, orderby := "", ""
-	var top *int32
-	return ac.images.List(ctx, location, publisher, offer, sku, expand, top, orderby)
+	opts := &armcompute.VirtualMachineImagesClientListOptions{}
+	return ac.images.List(ctx, location, publisher, offer, sku, opts)
 }

--- a/azure/services/virtualmachineimages/images_test.go
+++ b/azure/services/virtualmachineimages/images_test.go
@@ -21,7 +21,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	"k8s.io/utils/ptr"
@@ -35,7 +36,7 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 		k8sVersion      string
 		expectedSKU     string
 		expectedVersion string
-		versions        compute.ListVirtualMachineImageResource
+		versions        armcompute.VirtualMachineImagesClientListResponse
 	}{
 		{
 			k8sVersion:      "v1.15.6",
@@ -86,8 +87,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.21.13",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "121.13.20220613",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("121.13.20220526")},
 					{Name: ptr.To("121.13.20220613")},
 					{Name: ptr.To("121.13.20220524")},
@@ -108,8 +109,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.22.10",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "122.10.20220613",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("122.10.20220524")},
 					{Name: ptr.To("122.10.20220613")},
 				},
@@ -119,8 +120,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.22.16",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "122.16.20221117",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("122.16.20221117")},
 				},
 			},
@@ -134,8 +135,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.23.7",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "123.7.20231231",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("123.7.20221124")},
 					{Name: ptr.To("123.7.20220524")},
 					{Name: ptr.To("123.7.20231231")},
@@ -147,8 +148,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.24.0",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "124.0.20220512",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("124.0.20220512")},
 				},
 			},
@@ -157,8 +158,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.23.12",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "123.12.20220921",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("123.12.20220921")},
 				},
 			},
@@ -167,8 +168,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.23.13",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "123.13.20221014",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("123.13.20221014")},
 				},
 			},
@@ -177,8 +178,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.24.6",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "124.6.20220921",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("124.6.20220921")},
 				},
 			},
@@ -187,8 +188,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.24.7",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "124.7.20221014",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("124.7.20221014")},
 				},
 			},
@@ -197,8 +198,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.25.2",
 			expectedSKU:     "ubuntu-2004-gen1",
 			expectedVersion: "125.2.20220921",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("125.2.20220921")},
 				},
 			},
@@ -207,8 +208,8 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			k8sVersion:      "v1.25.3",
 			expectedSKU:     "ubuntu-2204-gen1",
 			expectedVersion: "125.3.20221014",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("125.3.20221014")},
 				},
 			},
@@ -226,12 +227,13 @@ func TestGetDefaultUbuntuImage(t *testing.T) {
 			mockAuth := mock_azure.NewMockAuthorizer(mockCtrl)
 			mockAuth.EXPECT().HashKey().Return(t.Name()).AnyTimes()
 			mockAuth.EXPECT().Authorizer().AnyTimes()
-			mockAuth.EXPECT().BaseURI().AnyTimes()
 			mockAuth.EXPECT().SubscriptionID().AnyTimes()
+			mockAuth.EXPECT().CloudEnvironment().AnyTimes()
+			mockAuth.EXPECT().Token().Return(&azidentity.DefaultAzureCredential{}).AnyTimes()
 			mockClient := mock_virtualmachineimages.NewMockClient(mockCtrl)
 			svc := Service{Client: mockClient, Authorizer: mockAuth}
 
-			if test.versions.Value != nil {
+			if test.versions.VirtualMachineImageResourceArray != nil {
 				mockClient.EXPECT().
 					List(gomock.Any(), location, azure.DefaultImagePublisherID, azure.DefaultImageOfferID, gomock.Any()).
 					Return(test.versions, nil)
@@ -349,7 +351,7 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 		expectedSKU     string
 		expectedVersion string
 		expectedError   bool
-		versions        compute.ListVirtualMachineImageResource
+		versions        armcompute.VirtualMachineImagesClientListResponse
 	}{
 		{
 			k8sVersion:      "v1.14.9",
@@ -432,8 +434,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "121.13.20300524",
 			expectedError:   false,
 			osAndVersion:    "windows-2022",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("121.13.20220524")},
 					{Name: ptr.To("124.0.20220512")},
 					{Name: ptr.To("121.13.20220524")},
@@ -482,8 +484,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "123.12.20220921",
 			expectedError:   false,
 			osAndVersion:    "ubuntu-2004",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("123.12.20220921")},
 				},
 			},
@@ -494,8 +496,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "123.13.20220524",
 			expectedError:   false,
 			osAndVersion:    "ubuntu-2204",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("123.13.20220524")},
 				},
 			},
@@ -504,8 +506,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			k8sVersion:    "v1.23.13",
 			expectedError: true,
 			osAndVersion:  "ubuntu-2004",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{},
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{},
 			},
 		},
 		{
@@ -514,8 +516,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "124.0.20220512",
 			expectedError:   false,
 			osAndVersion:    "ubuntu-2004",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("124.0.20220512")},
 				},
 			},
@@ -526,8 +528,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "124.0.20220606",
 			expectedError:   false,
 			osAndVersion:    "windows-2022-containerd",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("124.0.20220606")},
 				},
 			},
@@ -536,8 +538,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			k8sVersion:    "v1.24.1",
 			expectedError: true,
 			osAndVersion:  "windows-2022-containerd",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("124.0.20220606")},
 				},
 			},
@@ -548,8 +550,8 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			expectedVersion: "125.4.20221011",
 			expectedError:   false,
 			osAndVersion:    "ubuntu-2204",
-			versions: compute.ListVirtualMachineImageResource{
-				Value: &[]compute.VirtualMachineImageResource{
+			versions: armcompute.VirtualMachineImagesClientListResponse{
+				VirtualMachineImageResourceArray: []*armcompute.VirtualMachineImageResource{
 					{Name: ptr.To("125.4.20221011")},
 				},
 			},
@@ -567,8 +569,9 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			mockAuth := mock_azure.NewMockAuthorizer(mockCtrl)
 			mockAuth.EXPECT().HashKey().Return(t.Name()).AnyTimes()
 			mockAuth.EXPECT().Authorizer().AnyTimes()
-			mockAuth.EXPECT().BaseURI().AnyTimes()
 			mockAuth.EXPECT().SubscriptionID().AnyTimes()
+			mockAuth.EXPECT().CloudEnvironment().AnyTimes()
+			mockAuth.EXPECT().Token().Return(&azidentity.DefaultAzureCredential{}).AnyTimes()
 			mockClient := mock_virtualmachineimages.NewMockClient(mockCtrl)
 			svc := Service{Client: mockClient, Authorizer: mockAuth}
 
@@ -576,7 +579,7 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 			if strings.HasPrefix(test.osAndVersion, "windows") {
 				offer = azure.DefaultWindowsImageOfferID
 			}
-			if test.versions.Value != nil {
+			if test.versions.VirtualMachineImageResourceArray != nil {
 				mockClient.EXPECT().
 					List(gomock.Any(), location, azure.DefaultImagePublisherID, offer, gomock.Any()).
 					Return(test.versions, nil)

--- a/azure/services/virtualmachineimages/mock_virtualmachineimages/client_mock.go
+++ b/azure/services/virtualmachineimages/mock_virtualmachineimages/client_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -52,10 +52,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // List mocks base method.
-func (m *MockClient) List(ctx context.Context, location, publisher, offer, sku string) (compute.ListVirtualMachineImageResource, error) {
+func (m *MockClient) List(ctx context.Context, location, publisher, offer, sku string) (armcompute.VirtualMachineImagesClientListResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, location, publisher, offer, sku)
-	ret0, _ := ret[0].(compute.ListVirtualMachineImageResource)
+	ret0, _ := ret[0].(armcompute.VirtualMachineImagesClientListResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/azure/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
+++ b/azure/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
@@ -23,6 +23,7 @@ package mock_virtualmachines
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
@@ -262,6 +263,20 @@ func (m *MockVMScope) TenantID() string {
 func (mr *MockVMScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockVMScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockVMScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockVMScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockVMScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/virtualnetworks/mock_virtualnetworks/virtualnetworks_mock.go
+++ b/azure/services/virtualnetworks/mock_virtualnetworks/virtualnetworks_mock.go
@@ -23,6 +23,7 @@ package mock_virtualnetworks
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -229,6 +230,20 @@ func (m *MockVNetScope) TenantID() string {
 func (mr *MockVNetScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockVNetScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockVNetScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockVNetScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockVNetScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/vmextensions/mock_vmextensions/vmextensions_mock.go
+++ b/azure/services/vmextensions/mock_vmextensions/vmextensions_mock.go
@@ -23,6 +23,7 @@ package mock_vmextensions
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -201,6 +202,20 @@ func (m *MockVMExtensionScope) TenantID() string {
 func (mr *MockVMExtensionScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockVMExtensionScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockVMExtensionScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockVMExtensionScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockVMExtensionScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/vnetpeerings/mock_vnetpeerings/vnetpeerings_mock.go
+++ b/azure/services/vnetpeerings/mock_vnetpeerings/vnetpeerings_mock.go
@@ -23,6 +23,7 @@ package mock_vnetpeerings
 import (
 	reflect "reflect"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -201,6 +202,20 @@ func (m *MockVnetPeeringScope) TenantID() string {
 func (mr *MockVnetPeeringScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockVnetPeeringScope)(nil).TenantID))
+}
+
+// Token mocks base method.
+func (m *MockVnetPeeringScope) Token() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Token")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// Token indicates an expected call of Token.
+func (mr *MockVnetPeeringScopeMockRecorder) Token() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockVnetPeeringScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.0.0
 	github.com/Azure/azure-service-operator/v2 v2.2.0
 	github.com/Azure/go-autorest/autorest v0.11.29
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.12

--- a/go.sum
+++ b/go.sum
@@ -48,11 +48,15 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0/go.mod h1:OQeznEEkTZ9Orh
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appconfiguration/armappconfiguration v1.0.0 h1:5reBX+9pzc5xp9VrjSUoPrE8Wl/3y7wjfHzGjXzJbNk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.0.0 h1:zpMyM8MoI8ZR/KNcfTothBjV5oTm6QVpuPwz/9TXQ1Q=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.0.0/go.mod h1:mXdzU0jht34j8BVO6q+sns1M1CYmHdq1AA9mRHeFvv0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice v1.0.0 h1:figxyQZXzZQIcP3njhC68bYUiTw45J8/SsHaLW8Ax0M=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos v1.0.0 h1:Fv8iibGn1eSw0lt2V3cTsuokBEnOP+M//n8OiMcCgTM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNLjCUeKhgnAJWAKhEUQM+RJQo2H1fuGSw1Ky1E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iothub/armiothub v1.1.1 h1:Dh8SxVXcSyQN76LI4IseKyrnqyTUsx336Axg8zDYSMs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning v1.0.0 h1:KWvCVjnOTKCZAlqED5KPNoN9AfcK2BhUeveLdiwy33Q=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis v1.0.0 h1:nmpTBgRg1HynngFYICRhceC7s5dmbKN9fJ/XQz/UQ2I=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1 h1:7CBQ+Ei8SP2c6ydQTGCCrS35bDxgTMfoP2miAwK++OU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch v1.1.0 h1:SCO2mlFZrUMU8MmA5Y6EszSm2OGumuPBXFQXEvkESvk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus v1.1.1 h1:h+ZMdUM0/8oVqHjY9+1rupIvT0craBLapKhuzWui9lo=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.0.0 h1:TMEyRFKh1zaSPmoQh3kxK+xRAYVq8guCI/7SMO0F3KY=


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Updates the virtualmachineimages service to use SDK v2.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3569
Fixes #3473

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update virtualmachineimages service to SDK v2
```
