### PR TITLE
make dependabot avoid updating golang in Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,6 +92,10 @@ updates:
   commit-message:
     prefix: "dependabot"
     include: scope
+  ignore:
+  - dependency-name: '*golang*'
+    update-types:
+    - version-update:semver-major
   labels:
     - "ok-to-test"
     - "kind/cleanup"


### PR DESCRIPTION


 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change

/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- This PR will make dependabot avoid updating golang version in the Dockerfile.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Originates out of the comment https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3838#issuecomment-1679434679

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
