### PR TITLE
enable users to `allow` or `deny` the security rules

### DIFF
--- a/api/v1beta1/azurecluster_default_test.go
+++ b/api/v1beta1/azurecluster_default_test.go
@@ -696,6 +696,7 @@ func TestSubnetDefaults(t *testing.T) {
 												DestinationPorts: ptr.To("*"),
 												Source:           ptr.To("*"),
 												Destination:      ptr.To("*"),
+												Action:           SecurityRuleActionAllow,
 											},
 										},
 									},
@@ -732,6 +733,99 @@ func TestSubnetDefaults(t *testing.T) {
 												Source:           ptr.To("*"),
 												Destination:      ptr.To("*"),
 												Direction:        SecurityRuleDirectionInbound,
+												Action:           SecurityRuleActionAllow,
+											},
+										},
+									},
+									Name: "my-custom-sg",
+								},
+							},
+							{
+								SubnetClassSpec: SubnetClassSpec{
+									Role:       SubnetNode,
+									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
+									Name:       "cluster-test-node-subnet",
+								},
+								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
+								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
+								NatGateway: NatGateway{
+									NatGatewayIP: PublicIPSpec{
+										Name: "",
+									},
+									NatGatewayClassSpec: NatGatewayClassSpec{
+										Name: "cluster-test-node-natgw",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "subnets with custom security group to deny port 49999",
+			cluster: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-test",
+				},
+				Spec: AzureClusterSpec{
+					NetworkSpec: NetworkSpec{
+						Subnets: Subnets{
+							{
+								SubnetClassSpec: SubnetClassSpec{
+									Role: "control-plane",
+									Name: "cluster-test-controlplane-subnet",
+								},
+								SecurityGroup: SecurityGroup{
+									SecurityGroupClass: SecurityGroupClass{
+										SecurityRules: []SecurityRule{
+											{
+												Name:             "deny_port_49999",
+												Description:      "deny port 49999",
+												Protocol:         "*",
+												Priority:         2201,
+												SourcePorts:      ptr.To("*"),
+												DestinationPorts: ptr.To("*"),
+												Source:           ptr.To("*"),
+												Destination:      ptr.To("*"),
+												Action:           SecurityRuleActionDeny,
+											},
+										},
+									},
+									Name: "my-custom-sg",
+								},
+							},
+						},
+					},
+				},
+			},
+			output: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-test",
+				},
+				Spec: AzureClusterSpec{
+					NetworkSpec: NetworkSpec{
+						Subnets: Subnets{
+							{
+								SubnetClassSpec: SubnetClassSpec{
+									Role:       "control-plane",
+									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
+									Name:       "cluster-test-controlplane-subnet",
+								},
+								SecurityGroup: SecurityGroup{
+									SecurityGroupClass: SecurityGroupClass{
+										SecurityRules: []SecurityRule{
+											{
+												Name:             "deny_port_49999",
+												Description:      "deny port 49999",
+												Protocol:         "*",
+												Priority:         2201,
+												SourcePorts:      ptr.To("*"),
+												DestinationPorts: ptr.To("*"),
+												Source:           ptr.To("*"),
+												Destination:      ptr.To("*"),
+												Direction:        SecurityRuleDirectionInbound,
+												Action:           SecurityRuleActionDeny,
 											},
 										},
 									},

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -270,6 +270,17 @@ const (
 	SecurityRuleDirectionOutbound = SecurityRuleDirection("Outbound")
 )
 
+// SecurityRuleAccess defines the action type for a security group rule.
+type SecurityRuleAccess string
+
+const (
+	// SecurityRuleActionAllow allows traffic defined in the rule.
+	SecurityRuleActionAllow SecurityRuleAccess = "Allow"
+
+	// SecurityRuleActionDeny denies traffic defined in the rule.
+	SecurityRuleActionDeny SecurityRuleAccess = "Deny"
+)
+
 // SecurityRule defines an Azure security rule for security groups.
 type SecurityRule struct {
 	// Name is a unique name within the network security group.
@@ -297,6 +308,11 @@ type SecurityRule struct {
 	// Destination is the destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.
 	// +optional
 	Destination *string `json:"destination,omitempty"`
+	// Action specifies whether network traffic is allowed or denied. Can either be "Allow" or "Deny". Defaults to "Allow".
+	// +kubebuilder:default=Allow
+	// +kubebuilder:validation:Enum=Allow;Deny
+	//+optional
+	Action SecurityRuleAccess `json:"action"`
 }
 
 // SecurityRules is a slice of Azure security rules for security groups.

--- a/azure/converters/rules.go
+++ b/azure/converters/rules.go
@@ -32,7 +32,7 @@ func SecurityRuleToSDK(rule infrav1.SecurityRule) network.SecurityRule {
 			SourcePortRange:          rule.SourcePorts,
 			DestinationAddressPrefix: rule.Destination,
 			DestinationPortRange:     rule.DestinationPorts,
-			Access:                   network.SecurityRuleAccessAllow,
+			Access:                   network.SecurityRuleAccess(rule.Action),
 			Priority:                 ptr.To[int32](rule.Priority),
 		},
 	}

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -932,6 +932,7 @@ func (s *ClusterScope) SetControlPlaneSecurityRules() {
 				SourcePorts:      ptr.To("*"),
 				Destination:      ptr.To("*"),
 				DestinationPorts: ptr.To("22"),
+				Action:           infrav1.SecurityRuleActionAllow,
 			},
 			infrav1.SecurityRule{
 				Name:             "allow_apiserver",
@@ -943,6 +944,7 @@ func (s *ClusterScope) SetControlPlaneSecurityRules() {
 				SourcePorts:      ptr.To("*"),
 				Destination:      ptr.To("*"),
 				DestinationPorts: ptr.To(strconv.Itoa(int(s.APIServerPort()))),
+				Action:           infrav1.SecurityRuleActionAllow,
 			},
 		}
 		s.AzureCluster.Spec.NetworkSpec.UpdateControlPlaneSubnet(subnet)

--- a/azure/services/securitygroups/securitygroups_test.go
+++ b/azure/services/securitygroups/securitygroups_test.go
@@ -70,6 +70,7 @@ var (
 		SourcePorts:      ptr.To("*"),
 		Destination:      ptr.To("*"),
 		DestinationPorts: ptr.To("22"),
+		Action:           infrav1.SecurityRuleActionAllow,
 	}
 	securityRule2 = infrav1.SecurityRule{
 		Name:             "other_rule",
@@ -81,6 +82,7 @@ var (
 		SourcePorts:      ptr.To("*"),
 		Destination:      ptr.To("*"),
 		DestinationPorts: ptr.To("80"),
+		Action:           infrav1.SecurityRuleActionAllow,
 	}
 	errFake      = errors.New("this is an error")
 	notDoneError = azure.NewOperationNotDoneError(&infrav1.Future{})
@@ -296,6 +298,7 @@ var (
 			SourceAddressPrefix:      ptr.To("*"),
 			Priority:                 ptr.To[int32](100),
 			Direction:                network.SecurityRuleDirectionInbound,
+			Access:                   network.SecurityRuleAccessAllow,
 		},
 	}
 	ruleB = network.SecurityRule{
@@ -309,6 +312,7 @@ var (
 			SourceAddressPrefix:      ptr.To("*"),
 			Priority:                 ptr.To[int32](100),
 			Direction:                network.SecurityRuleDirectionOutbound,
+			Access:                   network.SecurityRuleAccessAllow,
 		},
 	}
 	ruleBModified = network.SecurityRule{
@@ -322,6 +326,7 @@ var (
 			SourceAddressPrefix:      ptr.To("*"),
 			Priority:                 ptr.To[int32](100),
 			Direction:                network.SecurityRuleDirectionOutbound,
+			Access:                   network.SecurityRuleAccessAllow,
 		},
 	}
 )

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -317,6 +317,15 @@ spec:
                                   description: SecurityRule defines an Azure security
                                     rule for security groups.
                                   properties:
+                                    action:
+                                      default: Allow
+                                      description: Action specifies whether network
+                                        traffic is allowed or denied. Can either be
+                                        "Allow" or "Deny". Defaults to "Allow".
+                                      enum:
+                                      - Allow
+                                      - Deny
+                                      type: string
                                     description:
                                       description: A description for this rule. Restricted
                                         to 140 chars.
@@ -1022,6 +1031,15 @@ spec:
                                 description: SecurityRule defines an Azure security
                                   rule for security groups.
                                 properties:
+                                  action:
+                                    default: Allow
+                                    description: Action specifies whether network
+                                      traffic is allowed or denied. Can either be
+                                      "Allow" or "Deny". Defaults to "Allow".
+                                    enum:
+                                    - Allow
+                                    - Deny
+                                    type: string
                                   description:
                                     description: A description for this rule. Restricted
                                       to 140 chars.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
@@ -200,6 +200,16 @@ spec:
                                           description: SecurityRule defines an Azure
                                             security rule for security groups.
                                           properties:
+                                            action:
+                                              default: Allow
+                                              description: Action specifies whether
+                                                network traffic is allowed or denied.
+                                                Can either be "Allow" or "Deny". Defaults
+                                                to "Allow".
+                                              enum:
+                                              - Allow
+                                              - Deny
+                                              type: string
                                             description:
                                               description: A description for this
                                                 rule. Restricted to 140 chars.
@@ -658,6 +668,16 @@ spec:
                                         description: SecurityRule defines an Azure
                                           security rule for security groups.
                                         properties:
+                                          action:
+                                            default: Allow
+                                            description: Action specifies whether
+                                              network traffic is allowed or denied.
+                                              Can either be "Allow" or "Deny". Defaults
+                                              to "Allow".
+                                            enum:
+                                            - Allow
+                                            - Deny
+                                            type: string
                                           description:
                                             description: A description for this rule.
                                               Restricted to 140 chars.

--- a/docs/book/src/topics/custom-vnet.md
+++ b/docs/book/src/topics/custom-vnet.md
@@ -149,6 +149,7 @@ spec:
               destinationPorts: "22"
               source: "*"
               sourcePorts: "*"
+              action: "Allow"
             - name: "allow_apiserver"
               description: "Allow K8s API Server"
               direction: "Inbound"
@@ -158,6 +159,7 @@ spec:
               destinationPorts: "6443"
               source: "*"
               sourcePorts: "*"
+              action: "Allow"
             - name: "allow_port_50000"
               description: "allow port 50000"
               direction: "Outbound"
@@ -167,6 +169,7 @@ spec:
               destinationPorts: "50000"
               source: "*"
               sourcePorts: "*"
+              action: "Allow"
       - name: my-subnet-node
         role: node
         cidrBlocks:
@@ -213,10 +216,10 @@ spec:
 
 ### Private Endpoints
 
-A [Private Endpoint](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview) is a network interface that uses 
-a private IP address from your virtual network. This network interface connects you privately and securely to a service that's powered 
-by [Azure Private Link](https://learn.microsoft.com/en-us/azure/private-link/private-link-overview). Azure Private Link enables you 
-to access Azure PaaS Services (for example, Azure Storage and SQL Database) and Azure hosted customer-owned/partner services over a 
+A [Private Endpoint](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview) is a network interface that uses
+a private IP address from your virtual network. This network interface connects you privately and securely to a service that's powered
+by [Azure Private Link](https://learn.microsoft.com/en-us/azure/private-link/private-link-overview). Azure Private Link enables you
+to access Azure PaaS Services (for example, Azure Storage and SQL Database) and Azure hosted customer-owned/partner services over a
 private endpoint in your virtual network.
 
  Private Endpoints are configured on a per-subnet basis. Vnets managed by either
@@ -279,10 +282,10 @@ spec:
       privateEndpoints:
       - name: my-pe
         customNetworkInterfaceName: nic-my-pe # optional
-        applicationSecurityGroups: # optional 
+        applicationSecurityGroups: # optional
         - <ASG ID>
-        privateIPAddresses: # optional 
-        - 10.0.2.10 
+        privateIPAddresses: # optional
+        - 10.0.2.10
         location: eastus2 # optional
         privateLinkServiceConnections:
         - name: my-pls # optional

--- a/test/e2e/azure_securitygroups.go
+++ b/test/e2e/azure_securitygroups.go
@@ -57,6 +57,7 @@ func AzureSecurityGroupsSpec(ctx context.Context, inputGetter func() AzureSecuri
 			DestinationPorts: ptr.To("80"),
 			Source:           ptr.To("*"),
 			Destination:      ptr.To("*"),
+			Action:           "Allow",
 		}
 		testSecurityRule2 = infrav1.SecurityRule{
 			Name:             "test-security-rule-2",
@@ -68,6 +69,7 @@ func AzureSecurityGroupsSpec(ctx context.Context, inputGetter func() AzureSecuri
 			DestinationPorts: ptr.To("80"),
 			Source:           ptr.To("*"),
 			Destination:      ptr.To("*"),
+			Action:           "Allow",
 		}
 		input AzureSecurityGroupsSpecInput
 	)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- This PR will let users specify `action` on the securityRules.
  - Users can specify `"Allow"` or `"Deny"` values to the security rule.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3877 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Users can add `Deny` security rules. Security Rules are defaulted to "Allow" if unspecified.
```
