### PR TITLE
add ux to use workload identity for cloud provider azure

### DIFF
--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -89,6 +89,7 @@ type ClusterDescriber interface {
 	ExtendedLocationType() string
 	AdditionalTags() infrav1.Tags
 	AvailabilitySetEnabled() bool
+	WorkloadIdentityEnabled() bool
 	CloudProviderConfigOverrides() *infrav1.CloudProviderConfigOverrides
 	FailureDomains() []string
 }

--- a/azure/mock_azure/azure_mock.go
+++ b/azure/mock_azure/azure_mock.go
@@ -883,6 +883,20 @@ func (mr *MockClusterDescriberMockRecorder) Token() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockClusterDescriber)(nil).Token))
 }
 
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockClusterDescriber) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockClusterDescriberMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockClusterDescriber)(nil).WorkloadIdentityEnabled))
+}
+
 // MockAsyncStatusUpdater is a mock of AsyncStatusUpdater interface.
 type MockAsyncStatusUpdater struct {
 	ctrl     *gomock.Controller
@@ -1491,6 +1505,20 @@ func (mr *MockClusterScoperMockRecorder) Vnet() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Vnet", reflect.TypeOf((*MockClusterScoper)(nil).Vnet))
 }
 
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockClusterScoper) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockClusterScoperMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockClusterScoper)(nil).WorkloadIdentityEnabled))
+}
+
 // MockManagedClusterScoper is a mock of ManagedClusterScoper interface.
 type MockManagedClusterScoper struct {
 	ctrl     *gomock.Controller
@@ -1792,6 +1820,20 @@ func (m *MockManagedClusterScoper) Token() azcore.TokenCredential {
 func (mr *MockManagedClusterScoperMockRecorder) Token() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockManagedClusterScoper)(nil).Token))
+}
+
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockManagedClusterScoper) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockManagedClusterScoperMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockManagedClusterScoper)(nil).WorkloadIdentityEnabled))
 }
 
 // MockResourceSpecGetter is a mock of ResourceSpecGetter interface.

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -76,7 +76,6 @@ func NewClusterScope(ctx context.Context, params ClusterScopeParams) (*ClusterSc
 		return nil, errors.New("failed to generate new scope from nil AzureCluster")
 	}
 
-	// ToDo: AzureClusterIdentiy is optional now so do not fail.
 	if params.AzureClusterIdentity == nil {
 		return nil, errors.New("failed to generate new scope from nil AzureClusterIdentity")
 	}

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -131,6 +131,12 @@ func (s *ManagedControlPlaneScope) GetClient() client.Client {
 	return s.Client
 }
 
+// WorkloadIdentityEnabled returns true if workload identity is enabled.
+func (s *ManagedControlPlaneScope) WorkloadIdentityEnabled() bool {
+	// ToDo: complete this method
+	return false
+}
+
 // ResourceGroup returns the managed control plane's resource group.
 func (s *ManagedControlPlaneScope) ResourceGroup() string {
 	if s.ControlPlane == nil {

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -133,7 +133,8 @@ func (s *ManagedControlPlaneScope) GetClient() client.Client {
 
 // WorkloadIdentityEnabled returns true if workload identity is enabled.
 func (s *ManagedControlPlaneScope) WorkloadIdentityEnabled() bool {
-	// ToDo: complete this method
+	// this method will be no-op until workload identity UX is added for managed
+	// cluster
 	return false
 }
 

--- a/azure/scope/workload_identity.go
+++ b/azure/scope/workload_identity.go
@@ -56,8 +56,8 @@ const (
 	azureClientIDEnvKey = "AZURE_CLIENT_ID"
 	// azureTenantIDEnvKey is the env key for AZURE_TENANT_ID.
 	azureTenantIDEnvKey = "AZURE_TENANT_ID"
-	// azureTokenFilePath is the path of the projected token.
-	azureTokenFilePath = "/var/run/secrets/azure/tokens/azure-identity-token" // #nosec G101
+	// AzureTokenFilePath is the path of the projected token.
+	AzureTokenFilePath = "/var/run/secrets/azure/tokens/azure-identity-token" // #nosec G101
 	// azureFederatedTokenFileRefreshTime is the time interval after which it should be read again.
 	azureFederatedTokenFileRefreshTime = 5 * time.Minute
 )
@@ -98,7 +98,7 @@ func (w *WorkloadIdentityCredentialOptions) WithTenantID(tenantID string) *Workl
 func getProjectedTokenPath() string {
 	tokenPath := strings.TrimSpace(os.Getenv(azureFederatedTokenFileEnvKey))
 	if tokenPath == "" {
-		return azureTokenFilePath
+		return AzureTokenFilePath
 	}
 	return tokenPath
 }

--- a/azure/services/agentpools/mock_agentpools/agentpools_mock.go
+++ b/azure/services/agentpools/mock_agentpools/agentpools_mock.go
@@ -533,3 +533,17 @@ func (mr *MockAgentPoolScopeMockRecorder) UpdatePutStatus(arg0, arg1, arg2 inter
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePutStatus", reflect.TypeOf((*MockAgentPoolScope)(nil).UpdatePutStatus), arg0, arg1, arg2)
 }
+
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockAgentPoolScope) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockAgentPoolScopeMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockAgentPoolScope)(nil).WorkloadIdentityEnabled))
+}

--- a/azure/services/availabilitysets/mock_availabilitysets/availabilitysets_mock.go
+++ b/azure/services/availabilitysets/mock_availabilitysets/availabilitysets_mock.go
@@ -407,3 +407,17 @@ func (mr *MockAvailabilitySetScopeMockRecorder) UpdatePutStatus(arg0, arg1, arg2
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePutStatus", reflect.TypeOf((*MockAvailabilitySetScope)(nil).UpdatePutStatus), arg0, arg1, arg2)
 }
+
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockAvailabilitySetScope) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockAvailabilitySetScopeMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockAvailabilitySetScope)(nil).WorkloadIdentityEnabled))
+}

--- a/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
+++ b/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
@@ -629,3 +629,17 @@ func (mr *MockBastionScopeMockRecorder) Vnet() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Vnet", reflect.TypeOf((*MockBastionScope)(nil).Vnet))
 }
+
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockBastionScope) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockBastionScopeMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockBastionScope)(nil).WorkloadIdentityEnabled))
+}

--- a/azure/services/disks/mock_disks/disks_mock.go
+++ b/azure/services/disks/mock_disks/disks_mock.go
@@ -407,3 +407,17 @@ func (mr *MockDiskScopeMockRecorder) UpdatePutStatus(arg0, arg1, arg2 interface{
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePutStatus", reflect.TypeOf((*MockDiskScope)(nil).UpdatePutStatus), arg0, arg1, arg2)
 }
+
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockDiskScope) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockDiskScopeMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockDiskScope)(nil).WorkloadIdentityEnabled))
+}

--- a/azure/services/inboundnatrules/mock_inboundnatrules/inboundnatrules_mock.go
+++ b/azure/services/inboundnatrules/mock_inboundnatrules/inboundnatrules_mock.go
@@ -421,3 +421,17 @@ func (mr *MockInboundNatScopeMockRecorder) UpdatePutStatus(arg0, arg1, arg2 inte
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePutStatus", reflect.TypeOf((*MockInboundNatScope)(nil).UpdatePutStatus), arg0, arg1, arg2)
 }
+
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockInboundNatScope) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockInboundNatScopeMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockInboundNatScope)(nil).WorkloadIdentityEnabled))
+}

--- a/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
+++ b/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
@@ -629,3 +629,17 @@ func (mr *MockLBScopeMockRecorder) Vnet() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Vnet", reflect.TypeOf((*MockLBScope)(nil).Vnet))
 }
+
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockLBScope) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockLBScopeMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockLBScope)(nil).WorkloadIdentityEnabled))
+}

--- a/azure/services/natgateways/mock_natgateways/natgateways_mock.go
+++ b/azure/services/natgateways/mock_natgateways/natgateways_mock.go
@@ -641,3 +641,17 @@ func (mr *MockNatGatewayScopeMockRecorder) Vnet() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Vnet", reflect.TypeOf((*MockNatGatewayScope)(nil).Vnet))
 }
+
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockNatGatewayScope) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockNatGatewayScopeMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockNatGatewayScope)(nil).WorkloadIdentityEnabled))
+}

--- a/azure/services/networkinterfaces/mock_networkinterfaces/networkinterfaces_mock.go
+++ b/azure/services/networkinterfaces/mock_networkinterfaces/networkinterfaces_mock.go
@@ -407,3 +407,17 @@ func (mr *MockNICScopeMockRecorder) UpdatePutStatus(arg0, arg1, arg2 interface{}
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePutStatus", reflect.TypeOf((*MockNICScope)(nil).UpdatePutStatus), arg0, arg1, arg2)
 }
+
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockNICScope) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockNICScopeMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockNICScope)(nil).WorkloadIdentityEnabled))
+}

--- a/azure/services/privatedns/mock_privatedns/privatedns_mock.go
+++ b/azure/services/privatedns/mock_privatedns/privatedns_mock.go
@@ -409,3 +409,17 @@ func (mr *MockScopeMockRecorder) UpdatePutStatus(arg0, arg1, arg2 interface{}) *
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePutStatus", reflect.TypeOf((*MockScope)(nil).UpdatePutStatus), arg0, arg1, arg2)
 }
+
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockScope) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockScopeMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockScope)(nil).WorkloadIdentityEnabled))
+}

--- a/azure/services/publicips/mock_publicips/publicips_mock.go
+++ b/azure/services/publicips/mock_publicips/publicips_mock.go
@@ -407,3 +407,17 @@ func (mr *MockPublicIPScopeMockRecorder) UpdatePutStatus(arg0, arg1, arg2 interf
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePutStatus", reflect.TypeOf((*MockPublicIPScope)(nil).UpdatePutStatus), arg0, arg1, arg2)
 }
+
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockPublicIPScope) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockPublicIPScopeMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockPublicIPScope)(nil).WorkloadIdentityEnabled))
+}

--- a/azure/services/scalesets/mock_scalesets/scalesets_mock.go
+++ b/azure/services/scalesets/mock_scalesets/scalesets_mock.go
@@ -472,3 +472,17 @@ func (mr *MockScaleSetScopeMockRecorder) VMSSExtensionSpecs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VMSSExtensionSpecs", reflect.TypeOf((*MockScaleSetScope)(nil).VMSSExtensionSpecs))
 }
+
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockScaleSetScope) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockScaleSetScopeMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockScaleSetScope)(nil).WorkloadIdentityEnabled))
+}

--- a/azure/services/scalesetvms/mock_scalesetvms/scalesetvms_mock.go
+++ b/azure/services/scalesetvms/mock_scalesetvms/scalesetvms_mock.go
@@ -461,3 +461,17 @@ func (mr *MockScaleSetVMScopeMockRecorder) UpdatePutStatus(arg0, arg1, arg2 inte
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePutStatus", reflect.TypeOf((*MockScaleSetVMScope)(nil).UpdatePutStatus), arg0, arg1, arg2)
 }
+
+// WorkloadIdentityEnabled mocks base method.
+func (m *MockScaleSetVMScope) WorkloadIdentityEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadIdentityEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WorkloadIdentityEnabled indicates an expected call of WorkloadIdentityEnabled.
+func (mr *MockScaleSetVMScopeMockRecorder) WorkloadIdentityEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadIdentityEnabled", reflect.TypeOf((*MockScaleSetVMScope)(nil).WorkloadIdentityEnabled))
+}

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -198,7 +198,7 @@ func (amr *AzureMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 	if err := amr.Client.Get(ctx, azureClusterIdentityName, azureClusterIdentity); err != nil {
 		amr.Recorder.Eventf(azureMachine, corev1.EventTypeNormal, "AzureClusterIdentity unavailable", "AzureClusterIdentity is not available yet")
-		log.Info("AzureCluster is not available yet")
+		log.Info("AzureClusterIdentity is not available yet")
 		return reconcile.Result{}, nil
 	}
 	// Create the cluster scope

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -265,12 +265,11 @@ func userAssignedIdentityCloudProviderConfig(d azure.ClusterScoper, identityID s
 
 func workloadIdentityCloudProviderConfig(d azure.ClusterScoper) (cpConfig *CloudProviderConfig, wkConfig *CloudProviderConfig) {
 	controlPlaneConfig, workerConfig := newCloudProviderConfig(d)
-	// secret is not needed ins workload identity.
+	// secret is not needed in workload identity.
 	controlPlaneConfig.AadClientSecret = ""
 	controlPlaneConfig.UseFederatedWorkloadIdentityExtension = true
 	workerConfig.AadClientSecret = ""
-	// ToDo: set the path
-	controlPlaneConfig.AADFederatedTokenFile = ""
+	controlPlaneConfig.AADFederatedTokenFile = scope.AzureTokenFilePath
 	return controlPlaneConfig, workerConfig
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds capability to specify to use workload identity for cloud provider azure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3589 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add UX to use wrokload identity for cloud provider azure
```
