### PR TITLE
fix: added regex cluster name validation upon create

### DIFF
--- a/api/v1beta1/azuremanagedcluster_webhook_test.go
+++ b/api/v1beta1/azuremanagedcluster_webhook_test.go
@@ -197,6 +197,9 @@ func TestAzureManagedCluster_ValidateCreate(t *testing.T) {
 						Host: "my-host",
 					},
 				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
 			},
 			wantErr: false,
 		},
@@ -208,8 +211,29 @@ func TestAzureManagedCluster_ValidateCreate(t *testing.T) {
 						Port: 4443,
 					},
 				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "clusterName is valid",
+			amc: &AzureManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-clustername",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "clusterName is invalid",
+			amc: &AzureManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-name-1.0",
+				},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
When creating a cluster with a `.` character in the cluster name, no warning is generated that it is an invalid regex character. This leads to the cluster stuck in a failed provisioning state when creating, and is unable to delete with the following error in the capz logs:

`Invalid input: autorest/validation: validation failed: parameter=resourceName constraint=Pattern value="test.cluster.name" details: value doesn't match pattern ^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$`

This PR adds validation for the cluster name in `ValidateCreate()` and extends existing unit tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3874

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
