### PR TITLE
Convert vmextensions service to SDKv2

### DIFF
--- a/azure/services/vmextensions/spec.go
+++ b/azure/services/vmextensions/spec.go
@@ -19,7 +19,7 @@ package vmextensions
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -50,17 +50,17 @@ func (s *VMExtensionSpec) OwnerResourceName() string {
 // Parameters returns the parameters for the VM extension.
 func (s *VMExtensionSpec) Parameters(ctx context.Context, existing interface{}) (interface{}, error) {
 	if existing != nil {
-		_, ok := existing.(compute.VirtualMachineExtension)
+		_, ok := existing.(armcompute.VirtualMachineExtension)
 		if !ok {
-			return nil, errors.Errorf("%T is not a compute.VirtualMachineExtension", existing)
+			return nil, errors.Errorf("%T is not an armcompute.VirtualMachineExtension", existing)
 		}
 
 		// VM extension already exists, nothing to update.
 		return nil, nil
 	}
 
-	return compute.VirtualMachineExtension{
-		VirtualMachineExtensionProperties: &compute.VirtualMachineExtensionProperties{
+	return armcompute.VirtualMachineExtension{
+		Properties: &armcompute.VirtualMachineExtensionProperties{
 			Publisher:          ptr.To(s.Publisher),
 			Type:               ptr.To(s.Name),
 			TypeHandlerVersion: ptr.To(s.Version),

--- a/azure/services/vmextensions/spec_test.go
+++ b/azure/services/vmextensions/spec_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -40,8 +40,8 @@ var (
 		"my-location",
 	}
 
-	fakeVMExtensionParams = compute.VirtualMachineExtension{
-		VirtualMachineExtensionProperties: &compute.VirtualMachineExtensionProperties{
+	fakeVMExtensionParams = armcompute.VirtualMachineExtension{
+		Properties: &armcompute.VirtualMachineExtensionProperties{
 			Publisher:          ptr.To("my-publisher"),
 			Type:               ptr.To("my-vm-extension"),
 			TypeHandlerVersion: ptr.To("1.0"),

--- a/azure/services/vmextensions/vmextensions.go
+++ b/azure/services/vmextensions/vmextensions.go
@@ -19,10 +19,11 @@ package vmextensions
 import (
 	"context"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/pkg/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
-	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asyncpoller"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
@@ -39,16 +40,20 @@ type VMExtensionScope interface {
 // Service provides operations on Azure resources.
 type Service struct {
 	Scope VMExtensionScope
-	async.Reconciler
+	asyncpoller.Reconciler
 }
 
 // New creates a new vm extension service.
-func New(scope VMExtensionScope) *Service {
-	client := newClient(scope)
-	return &Service{
-		Scope:      scope,
-		Reconciler: async.New(scope, client, client),
+func New(scope VMExtensionScope) (*Service, error) {
+	client, err := newClient(scope)
+	if err != nil {
+		return nil, err
 	}
+	return &Service{
+		Scope: scope,
+		Reconciler: asyncpoller.New[armcompute.VirtualMachineExtensionsClientCreateOrUpdateResponse,
+			armcompute.VirtualMachineExtensionsClientDeleteResponse](scope, client, client),
+	}, nil
 }
 
 // Name returns the service name.

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -55,7 +55,11 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 	}
 	disksSvc, err := disks.New(machineScope)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed creating a new disks service")
+		return nil, errors.Wrap(err, "failed creating disks service")
+	}
+	vmextensionsSvc, err := vmextensions.New(machineScope)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating vmextensions service")
 	}
 	ams := &azureMachineService{
 		scope: machineScope,
@@ -67,7 +71,7 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 			disksSvc,
 			virtualmachines.New(machineScope),
 			roleassignments.New(machineScope),
-			vmextensions.New(machineScope),
+			vmextensionsSvc,
 			tags.New(machineScope),
 		},
 		skuCache: cache,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the vmextensions service to azure-sdk-for-go version 2 and the `asyncpoller` framework for long-running operations.

**Which issue(s) this PR fixes**:

Fixes #3443

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
