### PR TITLE
Convert bastionhosts service to SDKv2

### DIFF
--- a/azure/services/bastionhosts/spec.go
+++ b/azure/services/bastionhosts/spec.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -65,8 +65,8 @@ func (s *AzureBastionSpec) OwnerResourceName() string {
 // Parameters returns the parameters for the bastion host.
 func (s *AzureBastionSpec) Parameters(ctx context.Context, existing interface{}) (parameters interface{}, err error) {
 	if existing != nil {
-		if _, ok := existing.(network.BastionHost); !ok {
-			return nil, errors.Errorf("%T is not a network.BastionHost", existing)
+		if _, ok := existing.(armnetwork.BastionHost); !ok {
+			return nil, errors.Errorf("%T is not an armnetwork.BastionHost", existing)
 		}
 		// bastion host already exists
 		return nil, nil
@@ -74,7 +74,7 @@ func (s *AzureBastionSpec) Parameters(ctx context.Context, existing interface{})
 
 	bastionHostIPConfigName := fmt.Sprintf("%s-%s", s.Name, "bastionIP")
 
-	return network.BastionHost{
+	return armnetwork.BastionHost{
 		Name:     ptr.To(s.Name),
 		Location: ptr.To(s.Location),
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
@@ -83,23 +83,23 @@ func (s *AzureBastionSpec) Parameters(ctx context.Context, existing interface{})
 			Name:        ptr.To(s.Name),
 			Role:        ptr.To("Bastion"),
 		})),
-		Sku: &network.Sku{
-			Name: network.BastionHostSkuName(s.Sku),
+		SKU: &armnetwork.SKU{
+			Name: ptr.To(armnetwork.BastionHostSKUName(s.Sku)),
 		},
-		BastionHostPropertiesFormat: &network.BastionHostPropertiesFormat{
+		Properties: &armnetwork.BastionHostPropertiesFormat{
 			EnableTunneling: ptr.To(s.EnableTunneling),
 			DNSName:         ptr.To(fmt.Sprintf("%s-bastion", strings.ToLower(s.Name))),
-			IPConfigurations: &[]network.BastionHostIPConfiguration{
+			IPConfigurations: []*armnetwork.BastionHostIPConfiguration{
 				{
 					Name: ptr.To(bastionHostIPConfigName),
-					BastionHostIPConfigurationPropertiesFormat: &network.BastionHostIPConfigurationPropertiesFormat{
-						Subnet: &network.SubResource{
+					Properties: &armnetwork.BastionHostIPConfigurationPropertiesFormat{
+						Subnet: &armnetwork.SubResource{
 							ID: &s.SubnetID,
 						},
-						PublicIPAddress: &network.SubResource{
+						PublicIPAddress: &armnetwork.SubResource{
 							ID: &s.PublicIPID,
 						},
-						PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
+						PrivateIPAllocationMethod: ptr.To(armnetwork.IPAllocationMethodDynamic),
 					},
 				},
 			},

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -56,6 +56,10 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating a NewCache")
 	}
+	bastionHostsSvc, err := bastionhosts.New(scope)
+	if err != nil {
+		return nil, err
+	}
 	var groupsSvc azure.ServiceReconciler = asogroups.New(scope)
 	if scope.UseLegacyGroups {
 		groupsSvc = groups.New(scope)
@@ -77,7 +81,7 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 			vnetpeerings.New(scope),
 			loadbalancers.New(scope),
 			privatedns.New(scope),
-			bastionhosts.New(scope),
+			bastionHostsSvc,
 			privateendpoints.New(scope),
 			tags.New(scope),
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the bastionhosts service to azure-sdk-for-go version 2 and the `asyncpoller` framework for long-running operations.

**Which issue(s) this PR fixes**:

Fixes #3890

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
