### PR TITLE
fix tilt for non-kind clusters

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -35,8 +35,6 @@ settings.update(read_yaml(
     default = {},
 ))
 
-os_arch = str(local("go env GOARCH")).rstrip("\n")
-
 if settings.get("trigger_mode") == "manual":
     trigger_mode(TRIGGER_MODE_MANUAL)
 
@@ -45,6 +43,8 @@ if "allowed_contexts" in settings:
 
 if "default_registry" in settings:
     default_registry(settings.get("default_registry"))
+
+os_arch = str(local("go env GOARCH")).rstrip("\n")
 
 # deploy CAPI
 def deploy_capi():


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR moves the `local()` invocation in the Tiltfile below where `allowed_k8s_contexts()` is called to work around this error:
```
Error in local: Refusing to run 'local' because aso-auth-test might be a production kube context.
If you're sure you want to continue add:
	allow_k8s_contexts('aso-auth-test')
before this function call in your Tiltfile. Otherwise, switch k8s contexts and restart Tilt.
```

I have `aso-auth-test` in the `allowed_contexts` in my tilt-settings.yaml, but those contexts need to be set before calling `local()`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate <-- Could be, but probably not worth it.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
