### PR TITLE
fix spurious ASO secret controller errors

### DIFF
--- a/controllers/asosecret_controller.go
+++ b/controllers/asosecret_controller.go
@@ -170,6 +170,10 @@ func (asos *ASOSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+		if cluster == nil {
+			log.Info("Cluster Controller has not yet set OwnerRef")
+			return reconcile.Result{}, nil
+		}
 
 		// Create the scope.
 		clusterScope, err := scope.NewClusterScope(ctx, scope.ClusterScopeParams{
@@ -190,6 +194,10 @@ func (asos *ASOSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		cluster, err = util.GetOwnerCluster(ctx, asos.Client, ownerType.ObjectMeta)
 		if err != nil {
 			return reconcile.Result{}, err
+		}
+		if cluster == nil {
+			log.Info("Cluster Controller has not yet set OwnerRef")
+			return reconcile.Result{}, nil
 		}
 
 		// Create the scope.

--- a/controllers/asosecret_controller_test.go
+++ b/controllers/asosecret_controller_test.go
@@ -72,6 +72,15 @@ func TestASOSecretReconcile(t *testing.T) {
 				}),
 			},
 		},
+		"should not fail for AzureCluster without ownerRef set yet": {
+			clusterName: defaultAzureCluster.Name,
+			objects: []runtime.Object{
+				getASOAzureCluster(func(c *infrav1.AzureCluster) {
+					c.ObjectMeta.OwnerReferences = nil
+				}),
+				defaultCluster,
+			},
+		},
 		"should reconcile normally for AzureCluster with IdentityRef configured": {
 			clusterName: defaultAzureCluster.Name,
 			objects: []runtime.Object{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This change eliminates these spurious errors that appear in the CAPZ logs around when a Cluster is first created:

```
E0829 19:32:35.027517      14 controller.go:324]  "msg"="Reconciler error" "error"="failed to create scope: failed to generate new scope from nil Cluster" "AzureCluster"={"name":"jon-aks","namespace":"default"} "controller"="ASOSecret" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="AzureCluster" "name"="jon-aks" "namespace"="default" "reconcileID"="0e4b6b9a-9c85-453c-bc7a-02a0b54c9cdd"
```

This aligns with other places on how `util.GetOwnerCluster` is called:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/feded83b21215825e131fdacd5b804d9cc40b789/controllers/azurejson_machinetemplate_controller.go#L116-L123
https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/feded83b21215825e131fdacd5b804d9cc40b789/controllers/azuremanagedcluster_controller.go#L127-L134

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
