### PR TITLE
Convert disks service to SDKv2

### DIFF
--- a/azure/services/disks/client.go
+++ b/azure/services/disks/client.go
@@ -19,40 +19,42 @@ package disks
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
-	"github.com/Azure/go-autorest/autorest"
-	azureautorest "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asyncpoller"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
 // azureClient contains the Azure go-sdk Client.
 type azureClient struct {
-	disks compute.DisksClient
+	disks *armcompute.DisksClient
 }
 
-// newClient creates a new disk Client from subscription ID.
-func newClient(auth azure.Authorizer) *azureClient {
-	c := NewDisksClient(auth.SubscriptionID(), auth.BaseURI(), auth.Authorizer())
-	return &azureClient{c}
+// newClient creates a new disks client from an authorizer.
+func newClient(auth azure.Authorizer) (*azureClient, error) {
+	opts, err := azure.ARMClientOptions(auth.CloudEnvironment())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create disks client options")
+	}
+	factory, err := armcompute.NewClientFactory(auth.SubscriptionID(), auth.Token(), opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create armcompute client factory")
+	}
+	return &azureClient{factory.NewDisksClient()}, nil
 }
 
-// NewDisksClient creates a new disks Client from subscription ID.
-func NewDisksClient(subscriptionID string, baseURI string, authorizer autorest.Authorizer) compute.DisksClient {
-	disksClient := compute.NewDisksClientWithBaseURI(baseURI, subscriptionID)
-	azure.SetAutoRestClientDefaults(&disksClient.Client, authorizer)
-	return disksClient
-}
-
-// DeleteAsync deletes a route table asynchronously. DeleteAsync sends a DELETE
-// request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// DeleteAsync deletes a disk asynchronously. DeleteAsync sends a DELETE
+// request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter) (future azureautorest.FutureAPI, err error) {
+func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string) (poller *runtime.Poller[armcompute.DisksClientDeleteResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "disks.azureClient.DeleteAsync")
 	defer done()
 
-	deleteFuture, err := ac.disks.Delete(ctx, spec.ResourceGroupName(), spec.ResourceName())
+	opts := &armcompute.DisksClientBeginDeleteOptions{ResumeToken: resumeToken}
+	poller, err = ac.disks.BeginDelete(ctx, spec.ResourceGroupName(), spec.ResourceName(), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -60,26 +62,14 @@ func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecG
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
 	defer cancel()
 
-	err = deleteFuture.WaitForCompletionRef(ctx, ac.disks.Client)
+	pollOpts := &runtime.PollUntilDoneOptions{Frequency: asyncpoller.DefaultPollerFrequency}
+	_, err = poller.PollUntilDone(ctx, pollOpts)
 	if err != nil {
-		// if an error occurs, return the future.
+		// if an error occurs, return the Poller.
 		// this means the long-running operation didn't finish in the specified timeout.
-		return &deleteFuture, err
+		return poller, err
 	}
-	_, err = deleteFuture.Result(ac.disks)
-	// if the operation completed, return a nil future.
+
+	// if the operation completed, return a nil poller.
 	return nil, err
-}
-
-// Result fetches the result of a long-running operation future.
-func (ac *azureClient) Result(ctx context.Context, future azureautorest.FutureAPI, futureType string) (result interface{}, err error) {
-	return nil, nil
-}
-
-// IsDone returns true if the long-running operation has completed.
-func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAPI) (isDone bool, err error) {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "disks.azureClient.IsDone")
-	defer done()
-
-	return future.DoneWithContext(ctx, ac.disks)
 }

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -53,6 +53,10 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating a NewCache")
 	}
+	disksSvc, err := disks.New(machineScope)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating a new disks service")
+	}
 	ams := &azureMachineService{
 		scope: machineScope,
 		services: []azure.ServiceReconciler{
@@ -60,7 +64,7 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 			inboundnatrules.New(machineScope),
 			networkinterfaces.New(machineScope, cache),
 			availabilitysets.New(machineScope, cache),
-			disks.New(machineScope),
+			disksSvc,
 			virtualmachines.New(machineScope),
 			roleassignments.New(machineScope),
 			vmextensions.New(machineScope),


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the disks service to azure-sdk-for-go version 2 and the `asyncpoller` framework for long-running operations.

**Which issue(s) this PR fixes**:

Fixes #3913

**Special notes for your reviewer**:

This API doesn't actually implement the standard SDK v2 async methods, so this is a degenerate `asyncpoller` implementation.

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
