### PR TITLE
Convert roleassignments service to SDKv2

### DIFF
--- a/azure/services/roleassignments/client.go
+++ b/azure/services/roleassignments/client.go
@@ -19,9 +19,8 @@ package roleassignments
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/2019-03-01/authorization/mgmt/authorization"
-	"github.com/Azure/go-autorest/autorest"
-	azureautorest "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
@@ -29,57 +28,44 @@ import (
 
 // azureClient contains the Azure go-sdk Client.
 type azureClient struct {
-	roleassignments authorization.RoleAssignmentsClient
+	roleassignments armauthorization.RoleAssignmentsClient
 }
 
-// newClient creates a new role assignment client from subscription ID.
-func newClient(auth azure.Authorizer) *azureClient {
-	c := newRoleAssignmentClient(auth.SubscriptionID(), auth.BaseURI(), auth.Authorizer())
-	return &azureClient{c}
+// newClient creates a new role assignments client from an authorizer.
+func newClient(auth azure.Authorizer) (*azureClient, error) {
+	opts, err := azure.ARMClientOptions(auth.CloudEnvironment())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create roleassignments client options")
+	}
+	factory, err := armauthorization.NewClientFactory(auth.SubscriptionID(), auth.Token(), opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create armauthorization client factory")
+	}
+	return &azureClient{*factory.NewRoleAssignmentsClient()}, nil
 }
 
-// newRoleAssignmentClient creates a role assignments client from subscription ID.
-func newRoleAssignmentClient(subscriptionID string, baseURI string, authorizer autorest.Authorizer) authorization.RoleAssignmentsClient {
-	roleClient := authorization.NewRoleAssignmentsClientWithBaseURI(baseURI, subscriptionID)
-	azure.SetAutoRestClientDefaults(&roleClient.Client, authorizer)
-	return roleClient
-}
-
-// Get gets the specified role assignment by the role assignment name.
+// Get gets the specified role assignment.
 func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (interface{}, error) {
-	ctx, span := tele.Tracer().Start(ctx, "roleassignments.AzureClient.Get")
-	defer span.End()
-	return ac.roleassignments.Get(ctx, spec.OwnerResourceName(), spec.ResourceName())
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "roleassignments.azureClient.Get")
+	defer done()
+
+	resp, err := ac.roleassignments.Get(ctx, spec.ResourceGroupName(), spec.ResourceName(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return resp.RoleAssignment, nil
 }
 
 // CreateOrUpdateAsync creates a roleassignment.
-// Creating a roleassignment is not a long running operation, so we don't ever return a future.
-func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, parameters interface{}) (interface{}, azureautorest.FutureAPI, error) {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.AzureClient.CreateOrUpdate")
+// Creating a roleassignment is not a long running operation, so we don't ever return a poller.
+func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armauthorization.RoleAssignmentsClientCreateResponse], err error) {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "roleassignments.azureClient.CreateOrUpdateAsync")
 	defer done()
-	createParams, ok := parameters.(authorization.RoleAssignmentCreateParameters)
+
+	createParams, ok := parameters.(armauthorization.RoleAssignmentCreateParameters)
 	if !ok {
-		return nil, nil, errors.Errorf("%T is not a authorization.RoleAssignmentCreateParameters", parameters)
+		return nil, nil, errors.Errorf("%T is not an armauthorization.RoleAssignmentCreateParameters", parameters)
 	}
-	result, err := ac.roleassignments.Create(ctx, spec.OwnerResourceName(), spec.ResourceName(), createParams)
-	return result, nil, err
-}
-
-// IsDone returns true if the long-running operation has completed.
-func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAPI) (bool, error) {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "roleassignments.AzureClient.IsDone")
-	defer done()
-
-	return future.DoneWithContext(ctx, ac.roleassignments)
-}
-
-// Result fetches the result of a long-running operation future.
-func (ac *azureClient) Result(ctx context.Context, futureData azureautorest.FutureAPI, futureType string) (interface{}, error) {
-	// Result is a no-op for role assignment as only Delete operations return a future.
-	return nil, nil
-}
-
-// DeleteAsync is no-op for role assignments. It gets deleted as part of the VM deletion.
-func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter) (azureautorest.FutureAPI, error) {
-	return nil, nil
+	resp, err := ac.roleassignments.Create(ctx, spec.OwnerResourceName(), spec.ResourceName(), createParams, nil)
+	return resp.RoleAssignment, nil, err
 }

--- a/azure/services/roleassignments/spec.go
+++ b/azure/services/roleassignments/spec.go
@@ -19,7 +19,7 @@ package roleassignments
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/2019-03-01/authorization/mgmt/authorization"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 )
@@ -54,14 +54,14 @@ func (s *RoleAssignmentSpec) OwnerResourceName() string {
 // Parameters returns the parameters for the RoleAssignmentSpec.
 func (s *RoleAssignmentSpec) Parameters(ctx context.Context, existing interface{}) (interface{}, error) {
 	if existing != nil {
-		if _, ok := existing.(authorization.RoleAssignment); !ok {
-			return nil, errors.Errorf("%T is not a authorization.RoleAssignment", existing)
+		if _, ok := existing.(armauthorization.RoleAssignment); !ok {
+			return nil, errors.Errorf("%T is not an armauthorization.RoleAssignment", existing)
 		}
 		// RoleAssignmentSpec already exists
 		return nil, nil
 	}
-	return authorization.RoleAssignmentCreateParameters{
-		Properties: &authorization.RoleAssignmentProperties{
+	return armauthorization.RoleAssignmentCreateParameters{
+		Properties: &armauthorization.RoleAssignmentProperties{
 			PrincipalID:      s.PrincipalID,
 			RoleDefinitionID: ptr.To(s.RoleDefinitionID),
 		},

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -65,6 +65,10 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating inboundnatrules service")
 	}
+	roleAssignmentsSvc, err := roleassignments.New(machineScope)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating a roleassignments service")
+	}
 	vmextensionsSvc, err := vmextensions.New(machineScope)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating vmextensions service")
@@ -78,7 +82,7 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 			availabilitySetsSvc,
 			disksSvc,
 			virtualmachines.New(machineScope),
-			roleassignments.New(machineScope),
+			roleAssignmentsSvc,
 			vmextensionsSvc,
 			tags.New(machineScope),
 		},

--- a/exp/controllers/azuremachinepool_controller_unit_test.go
+++ b/exp/controllers/azuremachinepool_controller_unit_test.go
@@ -50,6 +50,8 @@ func Test_newAzureMachinePoolService(t *testing.T) {
 	clusterMock.EXPECT().SubscriptionID().AnyTimes()
 	clusterMock.EXPECT().BaseURI().AnyTimes()
 	clusterMock.EXPECT().Authorizer().AnyTimes()
+	clusterMock.EXPECT().CloudEnvironment().AnyTimes()
+	clusterMock.EXPECT().Token().AnyTimes()
 	clusterMock.EXPECT().Location().Return(cluster.Spec.Location)
 	clusterMock.EXPECT().HashKey().Return("fakeCluster")
 

--- a/exp/controllers/azuremachinepool_reconciler.go
+++ b/exp/controllers/azuremachinepool_reconciler.go
@@ -41,12 +41,16 @@ func newAzureMachinePoolService(machinePoolScope *scope.MachinePoolScope) (*azur
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create a NewCache")
 	}
+	roleAssignmentsSvc, err := roleassignments.New(machinePoolScope)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create a roleassignments service")
+	}
 
 	return &azureMachinePoolService{
 		scope: machinePoolScope,
 		services: []azure.ServiceReconciler{
 			scalesets.New(machinePoolScope, cache),
-			roleassignments.New(machinePoolScope),
+			roleAssignmentsSvc,
 		},
 		skuCache: cache,
 	}, nil

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.1
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.1.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.1.0

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.1/go.mod h1:uE9zaUfEQT/nbQ
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appconfiguration/armappconfiguration v1.0.0 h1:5reBX+9pzc5xp9VrjSUoPrE8Wl/3y7wjfHzGjXzJbNk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.1.1 h1:6A4M8smF+y8nM/DYsLNQz9n7n2ZGaEVqfz8ZWQirQkI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.1.1/go.mod h1:WqyxV5S0VtXD2+2d6oPqOvyhGubCvzLCKSAKgQ004Uk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.1.0 h1:Sg/D8VuUQ+bw+FOYJF+xRKcwizCOP13HL0Se8pWNBzE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.1.0/go.mod h1:Kyqzdqq0XDoCm+o9aZ25wZBmBUBzPBzPAj1R5rYsT6I=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice v1.0.0 h1:figxyQZXzZQIcP3njhC68bYUiTw45J8/SsHaLW8Ax0M=


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the roleassignments service to azure-sdk-for-go version 2 and the `asyncpoller` framework for long-running operations.

**Which issue(s) this PR fixes**:

Fixes #3921

**Special notes for your reviewer**:

This API doesn't actually implement the standard SDK v2 async methods, so this is a degenerate `asyncpoller` implementation.

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
