### PR TITLE
fix asyncpoller long running op state cleanup

### DIFF
--- a/azure/services/asyncpoller/asyncpoller_test.go
+++ b/azure/services/asyncpoller/asyncpoller_test.go
@@ -70,8 +70,6 @@ func TestServiceCreateOrUpdateResource(t *testing.T) {
 					r.ResourceName().Return(resourceName),
 					r.ResourceGroupName().Return(resourceGroupName),
 					s.GetLongRunningOperationState(resourceName, serviceName, infrav1.PutFuture).Return(validPutFuture),
-					c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(azureResourceGetterType)).Return(fakeResource, nil),
-					r.Parameters(gomockinternal.AContext(), fakeResource).Return(fakeParameters, nil),
 					c.CreateOrUpdateAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(azureResourceGetterType), resumeToken, gomock.Any()).Return(fakeResource, nil, nil),
 					s.DeleteLongRunningOperationState(resourceName, serviceName, infrav1.PutFuture),
 				)
@@ -86,8 +84,6 @@ func TestServiceCreateOrUpdateResource(t *testing.T) {
 					r.ResourceName().Return(resourceName),
 					r.ResourceGroupName().Return(resourceGroupName),
 					s.GetLongRunningOperationState(resourceName, serviceName, infrav1.PutFuture).Return(validPutFuture),
-					c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(azureResourceGetterType)).Return(fakeResource, nil),
-					r.Parameters(gomockinternal.AContext(), fakeResource).Return(fakeParameters, nil),
 					c.CreateOrUpdateAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(azureResourceGetterType), resumeToken, gomock.Any()).Return(nil, fakePoller[MockCreator](g, http.StatusAccepted), nil),
 					s.SetLongRunningOperationState(gomock.AssignableToTypeOf(&infrav1.Future{})),
 				)
@@ -101,10 +97,10 @@ func TestServiceCreateOrUpdateResource(t *testing.T) {
 				gomock.InOrder(
 					r.ResourceName().Return(resourceName),
 					r.ResourceGroupName().Return(resourceGroupName),
-					s.GetLongRunningOperationState(resourceName, serviceName, infrav1.PutFuture).Return(validPutFuture),
+					s.GetLongRunningOperationState(resourceName, serviceName, infrav1.PutFuture).Return(nil),
 					c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(azureResourceGetterType)).Return(nil, &azcore.ResponseError{StatusCode: http.StatusNotFound}),
 					r.Parameters(gomockinternal.AContext(), nil).Return(fakeParameters, nil),
-					c.CreateOrUpdateAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(azureResourceGetterType), resumeToken, gomock.Any()).Return(nil, fakePoller[MockCreator](g, http.StatusAccepted), nil),
+					c.CreateOrUpdateAsync(gomockinternal.AContext(), gomock.AssignableToTypeOf(azureResourceGetterType), "", gomock.Any()).Return(nil, fakePoller[MockCreator](g, http.StatusAccepted), nil),
 					s.SetLongRunningOperationState(gomock.AssignableToTypeOf(&infrav1.Future{})),
 				)
 			},
@@ -117,7 +113,7 @@ func TestServiceCreateOrUpdateResource(t *testing.T) {
 				gomock.InOrder(
 					r.ResourceName().Return(resourceName),
 					r.ResourceGroupName().Return(resourceGroupName),
-					s.GetLongRunningOperationState(resourceName, serviceName, infrav1.PutFuture).Return(validPutFuture),
+					s.GetLongRunningOperationState(resourceName, serviceName, infrav1.PutFuture).Return(nil),
 					c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(azureResourceGetterType)).Return(nil, errors.New("foo")),
 				)
 			},
@@ -131,7 +127,7 @@ func TestServiceCreateOrUpdateResource(t *testing.T) {
 				gomock.InOrder(
 					r.ResourceName().Return(resourceName),
 					r.ResourceGroupName().Return(resourceGroupName),
-					s.GetLongRunningOperationState(resourceName, serviceName, infrav1.PutFuture).Return(validPutFuture),
+					s.GetLongRunningOperationState(resourceName, serviceName, infrav1.PutFuture).Return(nil),
 					c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(azureResourceGetterType)).Return(fakeResource, nil),
 					r.Parameters(gomockinternal.AContext(), fakeResource).Return(nil, nil),
 				)
@@ -146,7 +142,7 @@ func TestServiceCreateOrUpdateResource(t *testing.T) {
 				gomock.InOrder(
 					r.ResourceName().Return(resourceName),
 					r.ResourceGroupName().Return(resourceGroupName),
-					s.GetLongRunningOperationState(resourceName, serviceName, infrav1.PutFuture).Return(validPutFuture),
+					s.GetLongRunningOperationState(resourceName, serviceName, infrav1.PutFuture).Return(nil),
 					c.Get(gomockinternal.AContext(), gomock.AssignableToTypeOf(azureResourceGetterType)).Return(fakeResource, nil),
 					r.Parameters(gomockinternal.AContext(), fakeResource).Return(nil, errors.New("foo")),
 				)

--- a/azure/services/availabilitysets/client.go
+++ b/azure/services/availabilitysets/client.go
@@ -64,7 +64,7 @@ func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 	defer done()
 
 	availabilitySet, ok := parameters.(armcompute.AvailabilitySet)
-	if !ok {
+	if !ok && parameters != nil {
 		return nil, nil, errors.Errorf("%T is not an armcompute.AvailabilitySet", parameters)
 	}
 

--- a/azure/services/bastionhosts/client.go
+++ b/azure/services/bastionhosts/client.go
@@ -66,7 +66,7 @@ func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 	defer done()
 
 	host, ok := parameters.(armnetwork.BastionHost)
-	if !ok {
+	if !ok && parameters != nil {
 		return nil, nil, errors.Errorf("%T is not an armnetwork.BastionHost", parameters)
 	}
 

--- a/azure/services/inboundnatrules/client.go
+++ b/azure/services/inboundnatrules/client.go
@@ -93,7 +93,7 @@ func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 	defer done()
 
 	natRule, ok := parameters.(armnetwork.InboundNatRule)
-	if !ok {
+	if !ok && parameters != nil {
 		return nil, nil, errors.Errorf("%T is not an armnetwork.InboundNatRule", parameters)
 	}
 

--- a/azure/services/natgateways/client.go
+++ b/azure/services/natgateways/client.go
@@ -66,7 +66,7 @@ func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 	defer done()
 
 	natGateway, ok := parameters.(armnetwork.NatGateway)
-	if !ok {
+	if !ok && parameters != nil {
 		return nil, nil, errors.Errorf("%T is not an armnetwork.NatGateway", parameters)
 	}
 

--- a/azure/services/vmextensions/client.go
+++ b/azure/services/vmextensions/client.go
@@ -66,7 +66,7 @@ func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 	defer done()
 
 	vmextension, ok := parameters.(armcompute.VirtualMachineExtension)
-	if !ok {
+	if !ok && parameters != nil {
 		return nil, nil, errors.Errorf("%T is not an armcompute.VirtualMachineExtension", parameters)
 	}
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR fixes a bug where the asyncpoller framework would not properly clean up the `status.longRunningOperationStates` when the operations completed. The main change is to skip calling `Parameters()` when a resource already has a long-running operation in progress. This allows reconciliation of resources with in-progress operations to reach the `CreateOrUpdateAsync()` call instead of erroneously short-circuiting in the case where the result of `Parameters()` is nil and therefore never reaching `DeleteLongRunningOperationState()`. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
