### PR TITLE
update routetables service to SDK v2

### DIFF
--- a/azure/services/routetables/client.go
+++ b/azure/services/routetables/client.go
@@ -18,34 +18,32 @@ package routetables
 
 import (
 	"context"
-	"encoding/json"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest"
-	azureautorest "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/pkg/errors"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asyncpoller"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
 // azureClient contains the Azure go-sdk Client.
 type azureClient struct {
-	routetables network.RouteTablesClient
+	routetables *armnetwork.RouteTablesClient
 }
 
-// newClient creates a new route tables client from subscription ID.
-func newClient(auth azure.Authorizer) *azureClient {
-	c := newRouteTablesClient(auth.SubscriptionID(), auth.BaseURI(), auth.Authorizer())
-	return &azureClient{c}
-}
-
-// newRouteTablesClient creates a new route tables client from subscription ID.
-func newRouteTablesClient(subscriptionID string, baseURI string, authorizer autorest.Authorizer) network.RouteTablesClient {
-	routeTablesClient := network.NewRouteTablesClientWithBaseURI(baseURI, subscriptionID)
-	azure.SetAutoRestClientDefaults(&routeTablesClient.Client, authorizer)
-	return routeTablesClient
+// newClient creates a new route tables client from an authorizer.
+func newClient(auth azure.Authorizer) (*azureClient, error) {
+	opts, err := azure.ARMClientOptions(auth.CloudEnvironment())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create routetables client options")
+	}
+	factory, err := armnetwork.NewClientFactory(auth.SubscriptionID(), auth.Token(), opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create armnetwork client factory")
+	}
+	return &azureClient{factory.NewRouteTablesClient()}, nil
 }
 
 // Get gets the specified route table.
@@ -53,22 +51,27 @@ func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "routetables.azureClient.Get")
 	defer done()
 
-	return ac.routetables.Get(ctx, spec.ResourceGroupName(), spec.ResourceName(), "")
+	resp, err := ac.routetables.Get(ctx, spec.ResourceGroupName(), spec.ResourceName(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return resp.RouteTable, nil
 }
 
 // CreateOrUpdateAsync creates or updates a route table asynchronously.
-// It sends a PUT request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// It sends a PUT request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, parameters interface{}) (result interface{}, future azureautorest.FutureAPI, err error) {
+func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armnetwork.RouteTablesClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "routetables.azureClient.CreateOrUpdateAsync")
 	defer done()
 
-	rt, ok := parameters.(network.RouteTable)
-	if !ok {
-		return nil, nil, errors.Errorf("%T is not a network.RouteTable", parameters)
+	rt, ok := parameters.(armnetwork.RouteTable)
+	if !ok && parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armnetwork.RouteTable", parameters)
 	}
 
-	createFuture, err := ac.routetables.CreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), rt)
+	opts := &armnetwork.RouteTablesClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
+	poller, err = ac.routetables.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), rt, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -76,25 +79,27 @@ func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
 	defer cancel()
 
-	err = createFuture.WaitForCompletionRef(ctx, ac.routetables.Client)
+	pollOpts := &runtime.PollUntilDoneOptions{Frequency: asyncpoller.DefaultPollerFrequency}
+	resp, err := poller.PollUntilDone(ctx, pollOpts)
 	if err != nil {
-		// if an error occurs, return the future.
-		// this means the long-running operation didn't finish in the specified timeout.
-		return nil, &createFuture, err
+		// If an error occurs, return the poller.
+		// This means the long-running operation didn't finish in the specified timeout.
+		return nil, poller, err
 	}
-	result, err = createFuture.Result(ac.routetables)
-	// if the operation completed, return a nil future
-	return result, nil, err
+
+	// if the operation completed, return a nil poller
+	return resp.RouteTable, nil, err
 }
 
 // DeleteAsync deletes a route table asynchronously. DeleteAsync sends a DELETE
-// request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter) (future azureautorest.FutureAPI, err error) {
+func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string) (poller *runtime.Poller[armnetwork.RouteTablesClientDeleteResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "routetables.azureClient.DeleteAsync")
 	defer done()
 
-	deleteFuture, err := ac.routetables.Delete(ctx, spec.ResourceGroupName(), spec.ResourceName())
+	opts := &armnetwork.RouteTablesClientBeginDeleteOptions{ResumeToken: resumeToken}
+	poller, err = ac.routetables.BeginDelete(ctx, spec.ResourceGroupName(), spec.ResourceName(), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -102,54 +107,14 @@ func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecG
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
 	defer cancel()
 
-	err = deleteFuture.WaitForCompletionRef(ctx, ac.routetables.Client)
+	pollOpts := &runtime.PollUntilDoneOptions{Frequency: asyncpoller.DefaultPollerFrequency}
+	_, err = poller.PollUntilDone(ctx, pollOpts)
 	if err != nil {
-		// if an error occurs, return the future.
+		// if an error occurs, return the poller.
 		// this means the long-running operation didn't finish in the specified timeout.
-		return &deleteFuture, err
+		return poller, err
 	}
-	_, err = deleteFuture.Result(ac.routetables)
-	// if the operation completed, return a nil future.
+
+	// if the operation completed, return a nil poller.
 	return nil, err
-}
-
-// IsDone returns true if the long-running operation has completed.
-func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAPI) (isDone bool, err error) {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "routetables.azureClient.IsDone")
-	defer done()
-
-	return future.DoneWithContext(ctx, ac.routetables)
-}
-
-// Result fetches the result of a long-running operation future.
-func (ac *azureClient) Result(ctx context.Context, future azureautorest.FutureAPI, futureType string) (result interface{}, err error) {
-	_, _, done := tele.StartSpanWithLogger(ctx, "routetables.azureClient.Result")
-	defer done()
-
-	if future == nil {
-		return nil, errors.Errorf("cannot get result from nil future")
-	}
-
-	switch futureType {
-	case infrav1.PutFuture:
-		// Marshal and Unmarshal the future to put it into the correct future type so we can access the Result function.
-		// Unfortunately the FutureAPI can't be casted directly to RouteTablesCreateOrUpdateFuture because it is a azureautorest.Future, which doesn't implement the Result function. See PR #1686 for discussion on alternatives.
-		// It was converted back to a generic azureautorest.Future from the CAPZ infrav1.Future type stored in Status: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/converters/futures.go#L49.
-		var createFuture *network.RouteTablesCreateOrUpdateFuture
-		jsonData, err := future.MarshalJSON()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal future")
-		}
-		if err := json.Unmarshal(jsonData, &createFuture); err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal future data")
-		}
-		return createFuture.Result(ac.routetables)
-
-	case infrav1.DeleteFuture:
-		// Delete does not return a result route table.
-		return nil, nil
-
-	default:
-		return nil, errors.Errorf("unknown future type %q", futureType)
-	}
 }

--- a/azure/services/routetables/spec.go
+++ b/azure/services/routetables/spec.go
@@ -19,7 +19,7 @@ package routetables
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -53,16 +53,16 @@ func (s *RouteTableSpec) OwnerResourceName() string {
 // Parameters returns the parameters for the route table.
 func (s *RouteTableSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
-		if _, ok := existing.(network.RouteTable); !ok {
-			return nil, errors.Errorf("%T is not a network.RouteTable", existing)
+		if _, ok := existing.(armnetwork.RouteTable); !ok {
+			return nil, errors.Errorf("%T is not an armnetwork.RouteTable", existing)
 		}
 		// route table already exists
 		// currently don't support specifying your own routes via spec.
 		return nil, nil
 	}
-	return network.RouteTable{
-		Location:                   ptr.To(s.Location),
-		RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{},
+	return armnetwork.RouteTable{
+		Location:   ptr.To(s.Location),
+		Properties: &armnetwork.RouteTablePropertiesFormat{},
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,
 			Lifecycle:   infrav1.ResourceLifecycleOwned,

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -56,6 +56,10 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating a NewCache")
 	}
+	routeTablesSvc, err := routetables.New(scope)
+	if err != nil {
+		return nil, err
+	}
 	bastionHostsSvc, err := bastionhosts.New(scope)
 	if err != nil {
 		return nil, err
@@ -74,7 +78,7 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 			groupsSvc,
 			virtualnetworks.New(scope),
 			securitygroups.New(scope),
-			routetables.New(scope),
+			routeTablesSvc,
 			publicips.New(scope),
 			natGatewaysSvc,
 			subnets.New(scope),


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Updates the routetables service to use SDK v2 and the asyncpoller framework.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3922

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
