### PR TITLE
Convert resourceskus service to SDKv2

### DIFF
--- a/azure/services/availabilitysets/availabilitysets_test.go
+++ b/azure/services/availabilitysets/availabilitysets_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -39,7 +38,7 @@ import (
 var (
 	fakeFaultDomainCount = 3
 	fakeSku              = resourceskus.SKU{
-		Capabilities: &[]compute.ResourceSkuCapabilities{
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
 			{
 				Name:  ptr.To(resourceskus.MaximumPlatformFaultDomainCount),
 				Value: ptr.To(strconv.Itoa(fakeFaultDomainCount)),

--- a/azure/services/networkinterfaces/spec_test.go
+++ b/azure/services/networkinterfaces/spec_test.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"k8s.io/utils/ptr"
@@ -45,16 +45,16 @@ var (
 	fakeSku = resourceskus.SKU{
 		Name: ptr.To("Standard_D2v2"),
 		Kind: ptr.To(string(resourceskus.VirtualMachines)),
-		Locations: &[]string{
-			"fake-location",
+		Locations: []*string{
+			ptr.To("fake-location"),
 		},
-		LocationInfo: &[]compute.ResourceSkuLocationInfo{
+		LocationInfo: []*armcompute.ResourceSKULocationInfo{
 			{
 				Location: ptr.To("fake-location"),
-				Zones:    &[]string{"1"},
+				Zones:    []*string{ptr.To("1")},
 			},
 		},
-		Capabilities: &[]compute.ResourceSkuCapabilities{
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
 			{
 				Name:  ptr.To(resourceskus.AcceleratedNetworking),
 				Value: ptr.To(string(resourceskus.CapabilitySupported)),

--- a/azure/services/resourceskus/cache_test.go
+++ b/azure/services/resourceskus/cache_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/utils/ptr"
@@ -31,14 +31,14 @@ func TestCacheGet(t *testing.T) {
 		sku          string
 		location     string
 		resourceType ResourceType
-		have         []compute.ResourceSku
+		have         []armcompute.ResourceSKU
 		err          string
 	}{
 		"should find": {
 			sku:          "foo",
 			location:     "test",
 			resourceType: "bar",
-			have: []compute.ResourceSku{
+			have: []armcompute.ResourceSKU{
 				{
 					Name:         ptr.To("other"),
 					ResourceType: ptr.To("baz"),
@@ -53,7 +53,7 @@ func TestCacheGet(t *testing.T) {
 			sku:          "foo",
 			location:     "test",
 			resourceType: "bar",
-			have: []compute.ResourceSku{
+			have: []armcompute.ResourceSKU{
 				{
 					Name: ptr.To("other"),
 				},
@@ -104,21 +104,21 @@ func TestCacheGet(t *testing.T) {
 
 func TestCacheGetZones(t *testing.T) {
 	cases := map[string]struct {
-		have []compute.ResourceSku
+		have []armcompute.ResourceSKU
 		want []string
 	}{
 		"should find 1 result": {
-			have: []compute.ResourceSku{
+			have: []armcompute.ResourceSKU{
 				{
 					Name:         ptr.To("foo"),
 					ResourceType: ptr.To(string(VirtualMachines)),
-					Locations: &[]string{
-						"baz",
+					Locations: []*string{
+						ptr.To("baz"),
 					},
-					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+					LocationInfo: []*armcompute.ResourceSKULocationInfo{
 						{
 							Location: ptr.To("baz"),
-							Zones:    &[]string{"1"},
+							Zones:    []*string{ptr.To("1")},
 						},
 					},
 				},
@@ -126,30 +126,30 @@ func TestCacheGetZones(t *testing.T) {
 			want: []string{"1"},
 		},
 		"should find 2 results": {
-			have: []compute.ResourceSku{
+			have: []armcompute.ResourceSKU{
 				{
 					Name:         ptr.To("foo"),
 					ResourceType: ptr.To(string(VirtualMachines)),
-					Locations: &[]string{
-						"baz",
+					Locations: []*string{
+						ptr.To("baz"),
 					},
-					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+					LocationInfo: []*armcompute.ResourceSKULocationInfo{
 						{
 							Location: ptr.To("baz"),
-							Zones:    &[]string{"1"},
+							Zones:    []*string{ptr.To("1")},
 						},
 					},
 				},
 				{
 					Name:         ptr.To("foo"),
 					ResourceType: ptr.To(string(VirtualMachines)),
-					Locations: &[]string{
-						"baz",
+					Locations: []*string{
+						ptr.To("baz"),
 					},
-					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+					LocationInfo: []*armcompute.ResourceSKULocationInfo{
 						{
 							Location: ptr.To("baz"),
-							Zones:    &[]string{"2"},
+							Zones:    []*string{ptr.To("2")},
 						},
 					},
 				},
@@ -157,17 +157,17 @@ func TestCacheGetZones(t *testing.T) {
 			want: []string{"1", "2"},
 		},
 		"should not find due to location mismatch": {
-			have: []compute.ResourceSku{
+			have: []armcompute.ResourceSKU{
 				{
 					Name:         ptr.To("foo"),
 					ResourceType: ptr.To(string(VirtualMachines)),
-					Locations: &[]string{
-						"foobar",
+					Locations: []*string{
+						ptr.To("foobar"),
 					},
-					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+					LocationInfo: []*armcompute.ResourceSKULocationInfo{
 						{
 							Location: ptr.To("foobar"),
-							Zones:    &[]string{"1"},
+							Zones:    []*string{ptr.To("1")},
 						},
 					},
 				},
@@ -175,23 +175,23 @@ func TestCacheGetZones(t *testing.T) {
 			want: nil,
 		},
 		"should not find due to location restriction": {
-			have: []compute.ResourceSku{
+			have: []armcompute.ResourceSKU{
 				{
 					Name:         ptr.To("foo"),
 					ResourceType: ptr.To(string(VirtualMachines)),
-					Locations: &[]string{
-						"baz",
+					Locations: []*string{
+						ptr.To("baz"),
 					},
-					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+					LocationInfo: []*armcompute.ResourceSKULocationInfo{
 						{
 							Location: ptr.To("baz"),
-							Zones:    &[]string{"1"},
+							Zones:    []*string{ptr.To("1")},
 						},
 					},
-					Restrictions: &[]compute.ResourceSkuRestrictions{
+					Restrictions: []*armcompute.ResourceSKURestrictions{
 						{
-							Type:   compute.ResourceSkuRestrictionsTypeLocation,
-							Values: &[]string{"baz"},
+							Type:   ptr.To(armcompute.ResourceSKURestrictionsTypeLocation),
+							Values: []*string{ptr.To("baz")},
 						},
 					},
 				},
@@ -199,24 +199,24 @@ func TestCacheGetZones(t *testing.T) {
 			want: nil,
 		},
 		"should not find due to zone restriction": {
-			have: []compute.ResourceSku{
+			have: []armcompute.ResourceSKU{
 				{
 					Name:         ptr.To("foo"),
 					ResourceType: ptr.To(string(VirtualMachines)),
-					Locations: &[]string{
-						"baz",
+					Locations: []*string{
+						ptr.To("baz"),
 					},
-					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+					LocationInfo: []*armcompute.ResourceSKULocationInfo{
 						{
 							Location: ptr.To("baz"),
-							Zones:    &[]string{"1"},
+							Zones:    []*string{ptr.To("1")},
 						},
 					},
-					Restrictions: &[]compute.ResourceSkuRestrictions{
+					Restrictions: []*armcompute.ResourceSKURestrictions{
 						{
-							Type: compute.ResourceSkuRestrictionsTypeZone,
-							RestrictionInfo: &compute.ResourceSkuRestrictionInfo{
-								Zones: &[]string{"1"},
+							Type: ptr.To(armcompute.ResourceSKURestrictionsTypeZone),
+							RestrictionInfo: &armcompute.ResourceSKURestrictionInfo{
+								Zones: []*string{ptr.To("1")},
 							},
 						},
 					},
@@ -248,21 +248,21 @@ func TestCacheGetZones(t *testing.T) {
 
 func TestCacheGetZonesWithVMSize(t *testing.T) {
 	cases := map[string]struct {
-		have []compute.ResourceSku
+		have []armcompute.ResourceSKU
 		want []string
 	}{
 		"should find 1 result": {
-			have: []compute.ResourceSku{
+			have: []armcompute.ResourceSKU{
 				{
 					Name:         ptr.To("foo"),
 					ResourceType: ptr.To(string(VirtualMachines)),
-					Locations: &[]string{
-						"baz",
+					Locations: []*string{
+						ptr.To("baz"),
 					},
-					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+					LocationInfo: []*armcompute.ResourceSKULocationInfo{
 						{
 							Location: ptr.To("baz"),
-							Zones:    &[]string{"1"},
+							Zones:    []*string{ptr.To("1")},
 						},
 					},
 				},
@@ -270,17 +270,17 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 			want: []string{"1"},
 		},
 		"should find 2 results": {
-			have: []compute.ResourceSku{
+			have: []armcompute.ResourceSKU{
 				{
 					Name:         ptr.To("foo"),
 					ResourceType: ptr.To(string(VirtualMachines)),
-					Locations: &[]string{
-						"baz",
+					Locations: []*string{
+						ptr.To("baz"),
 					},
-					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+					LocationInfo: []*armcompute.ResourceSKULocationInfo{
 						{
 							Location: ptr.To("baz"),
-							Zones:    &[]string{"1", "2"},
+							Zones:    []*string{ptr.To("1"), ptr.To("2")},
 						},
 					},
 				},
@@ -288,17 +288,17 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 			want: []string{"1", "2"},
 		},
 		"should not find due to size mismatch": {
-			have: []compute.ResourceSku{
+			have: []armcompute.ResourceSKU{
 				{
 					Name:         ptr.To("foobar"),
 					ResourceType: ptr.To(string(VirtualMachines)),
-					Locations: &[]string{
-						"baz",
+					Locations: []*string{
+						ptr.To("baz"),
 					},
-					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+					LocationInfo: []*armcompute.ResourceSKULocationInfo{
 						{
 							Location: ptr.To("baz"),
-							Zones:    &[]string{"1"},
+							Zones:    []*string{ptr.To("1")},
 						},
 					},
 				},
@@ -306,17 +306,17 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 			want: nil,
 		},
 		"should not find due to location mismatch": {
-			have: []compute.ResourceSku{
+			have: []armcompute.ResourceSKU{
 				{
 					Name:         ptr.To("foo"),
 					ResourceType: ptr.To(string(VirtualMachines)),
-					Locations: &[]string{
-						"foobar",
+					Locations: []*string{
+						ptr.To("foobar"),
 					},
-					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+					LocationInfo: []*armcompute.ResourceSKULocationInfo{
 						{
 							Location: ptr.To("foobar"),
-							Zones:    &[]string{"1"},
+							Zones:    []*string{ptr.To("1")},
 						},
 					},
 				},
@@ -324,23 +324,23 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 			want: nil,
 		},
 		"should not find due to location restriction": {
-			have: []compute.ResourceSku{
+			have: []armcompute.ResourceSKU{
 				{
 					Name:         ptr.To("foo"),
 					ResourceType: ptr.To(string(VirtualMachines)),
-					Locations: &[]string{
-						"baz",
+					Locations: []*string{
+						ptr.To("baz"),
 					},
-					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+					LocationInfo: []*armcompute.ResourceSKULocationInfo{
 						{
 							Location: ptr.To("baz"),
-							Zones:    &[]string{"1"},
+							Zones:    []*string{ptr.To("1")},
 						},
 					},
-					Restrictions: &[]compute.ResourceSkuRestrictions{
+					Restrictions: []*armcompute.ResourceSKURestrictions{
 						{
-							Type:   compute.ResourceSkuRestrictionsTypeLocation,
-							Values: &[]string{"baz"},
+							Type:   ptr.To(armcompute.ResourceSKURestrictionsTypeLocation),
+							Values: []*string{ptr.To("baz")},
 						},
 					},
 				},
@@ -348,24 +348,24 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 			want: nil,
 		},
 		"should not find due to zone restriction": {
-			have: []compute.ResourceSku{
+			have: []armcompute.ResourceSKU{
 				{
 					Name:         ptr.To("foo"),
 					ResourceType: ptr.To(string(VirtualMachines)),
-					Locations: &[]string{
-						"baz",
+					Locations: []*string{
+						ptr.To("baz"),
 					},
-					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+					LocationInfo: []*armcompute.ResourceSKULocationInfo{
 						{
 							Location: ptr.To("baz"),
-							Zones:    &[]string{"1"},
+							Zones:    []*string{ptr.To("1")},
 						},
 					},
-					Restrictions: &[]compute.ResourceSkuRestrictions{
+					Restrictions: []*armcompute.ResourceSKURestrictions{
 						{
-							Type: compute.ResourceSkuRestrictionsTypeZone,
-							RestrictionInfo: &compute.ResourceSkuRestrictionInfo{
-								Zones: &[]string{"1"},
+							Type: ptr.To(armcompute.ResourceSKURestrictionsTypeZone),
+							RestrictionInfo: &armcompute.ResourceSKURestrictionInfo{
+								Zones: []*string{ptr.To("1")},
 							},
 						},
 					},

--- a/azure/services/resourceskus/mock_resourceskus/resourceskus_mock.go
+++ b/azure/services/resourceskus/mock_resourceskus/resourceskus_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -52,10 +52,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // List mocks base method.
-func (m *MockClient) List(arg0 context.Context, arg1 string) ([]compute.ResourceSku, error) {
+func (m *MockClient) List(arg0 context.Context, arg1 string) ([]armcompute.ResourceSKU, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", arg0, arg1)
-	ret0, _ := ret[0].([]compute.ResourceSku)
+	ret0, _ := ret[0].([]armcompute.ResourceSKU)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
@@ -395,33 +396,33 @@ func TestDeleteVMSS(t *testing.T) {
 	}
 }
 
-func getFakeSkus() []compute.ResourceSku {
-	return []compute.ResourceSku{
+func getFakeSkus() []armcompute.ResourceSKU {
+	return []armcompute.ResourceSKU{
 		{
 			Name:         ptr.To("VM_SIZE"),
 			ResourceType: ptr.To(string(resourceskus.VirtualMachines)),
 			Kind:         ptr.To(string(resourceskus.VirtualMachines)),
-			Locations: &[]string{
-				"test-location",
+			Locations: []*string{
+				ptr.To("test-location"),
 			},
-			LocationInfo: &[]compute.ResourceSkuLocationInfo{
+			LocationInfo: []*armcompute.ResourceSKULocationInfo{
 				{
 					Location: ptr.To("test-location"),
-					Zones:    &[]string{"1", "3"},
-					ZoneDetails: &[]compute.ResourceSkuZoneDetails{
+					Zones:    []*string{ptr.To("1"), ptr.To("3")},
+					ZoneDetails: []*armcompute.ResourceSKUZoneDetails{
 						{
-							Capabilities: &[]compute.ResourceSkuCapabilities{
+							Capabilities: []*armcompute.ResourceSKUCapabilities{
 								{
 									Name:  ptr.To("UltraSSDAvailable"),
 									Value: ptr.To("True"),
 								},
 							},
-							Name: &[]string{"1", "3"},
+							Name: []*string{ptr.To("1"), ptr.To("3")},
 						},
 					},
 				},
 			},
-			Capabilities: &[]compute.ResourceSkuCapabilities{
+			Capabilities: []*armcompute.ResourceSKUCapabilities{
 				{
 					Name:  ptr.To(resourceskus.AcceleratedNetworking),
 					Value: ptr.To(string(resourceskus.CapabilityUnsupported)),
@@ -440,16 +441,16 @@ func getFakeSkus() []compute.ResourceSku {
 			Name:         ptr.To("VM_SIZE_AN"),
 			ResourceType: ptr.To(string(resourceskus.VirtualMachines)),
 			Kind:         ptr.To(string(resourceskus.VirtualMachines)),
-			Locations: &[]string{
-				"test-location",
+			Locations: []*string{
+				ptr.To("test-location"),
 			},
-			LocationInfo: &[]compute.ResourceSkuLocationInfo{
+			LocationInfo: []*armcompute.ResourceSKULocationInfo{
 				{
 					Location: ptr.To("test-location"),
-					Zones:    &[]string{"1", "3"},
+					Zones:    []*string{ptr.To("1"), ptr.To("3")},
 				},
 			},
-			Capabilities: &[]compute.ResourceSkuCapabilities{
+			Capabilities: []*armcompute.ResourceSKUCapabilities{
 				{
 					Name:  ptr.To(resourceskus.AcceleratedNetworking),
 					Value: ptr.To(string(resourceskus.CapabilitySupported)),
@@ -468,16 +469,16 @@ func getFakeSkus() []compute.ResourceSku {
 			Name:         ptr.To("VM_SIZE_1_CPU"),
 			ResourceType: ptr.To(string(resourceskus.VirtualMachines)),
 			Kind:         ptr.To(string(resourceskus.VirtualMachines)),
-			Locations: &[]string{
-				"test-location",
+			Locations: []*string{
+				ptr.To("test-location"),
 			},
-			LocationInfo: &[]compute.ResourceSkuLocationInfo{
+			LocationInfo: []*armcompute.ResourceSKULocationInfo{
 				{
 					Location: ptr.To("test-location"),
-					Zones:    &[]string{"1", "3"},
+					Zones:    []*string{ptr.To("1"), ptr.To("3")},
 				},
 			},
-			Capabilities: &[]compute.ResourceSkuCapabilities{
+			Capabilities: []*armcompute.ResourceSKUCapabilities{
 				{
 					Name:  ptr.To(resourceskus.AcceleratedNetworking),
 					Value: ptr.To(string(resourceskus.CapabilityUnsupported)),
@@ -496,16 +497,16 @@ func getFakeSkus() []compute.ResourceSku {
 			Name:         ptr.To("VM_SIZE_1_MEM"),
 			ResourceType: ptr.To(string(resourceskus.VirtualMachines)),
 			Kind:         ptr.To(string(resourceskus.VirtualMachines)),
-			Locations: &[]string{
-				"test-location",
+			Locations: []*string{
+				ptr.To("test-location"),
 			},
-			LocationInfo: &[]compute.ResourceSkuLocationInfo{
+			LocationInfo: []*armcompute.ResourceSKULocationInfo{
 				{
 					Location: ptr.To("test-location"),
-					Zones:    &[]string{"1", "3"},
+					Zones:    []*string{ptr.To("1"), ptr.To("3")},
 				},
 			},
-			Capabilities: &[]compute.ResourceSkuCapabilities{
+			Capabilities: []*armcompute.ResourceSKUCapabilities{
 				{
 					Name:  ptr.To(resourceskus.AcceleratedNetworking),
 					Value: ptr.To(string(resourceskus.CapabilityUnsupported)),
@@ -524,16 +525,16 @@ func getFakeSkus() []compute.ResourceSku {
 			Name:         ptr.To("VM_SIZE_EAH"),
 			ResourceType: ptr.To(string(resourceskus.VirtualMachines)),
 			Kind:         ptr.To(string(resourceskus.VirtualMachines)),
-			Locations: &[]string{
-				"test-location",
+			Locations: []*string{
+				ptr.To("test-location"),
 			},
-			LocationInfo: &[]compute.ResourceSkuLocationInfo{
+			LocationInfo: []*armcompute.ResourceSKULocationInfo{
 				{
 					Location: ptr.To("test-location"),
-					Zones:    &[]string{"1", "3"},
+					Zones:    []*string{ptr.To("1"), ptr.To("3")},
 				},
 			},
-			Capabilities: &[]compute.ResourceSkuCapabilities{
+			Capabilities: []*armcompute.ResourceSKUCapabilities{
 				{
 					Name:  ptr.To(resourceskus.VCPUs),
 					Value: ptr.To("4"),
@@ -552,16 +553,16 @@ func getFakeSkus() []compute.ResourceSku {
 			Name:         ptr.To(vmSizeUSSD),
 			ResourceType: ptr.To(string(resourceskus.VirtualMachines)),
 			Kind:         ptr.To(string(resourceskus.VirtualMachines)),
-			Locations: &[]string{
-				"test-location",
+			Locations: []*string{
+				ptr.To("test-location"),
 			},
-			LocationInfo: &[]compute.ResourceSkuLocationInfo{
+			LocationInfo: []*armcompute.ResourceSKULocationInfo{
 				{
 					Location: ptr.To("test-location"),
-					Zones:    &[]string{"1", "3"},
+					Zones:    []*string{ptr.To("1"), ptr.To("3")},
 				},
 			},
-			Capabilities: &[]compute.ResourceSkuCapabilities{
+			Capabilities: []*armcompute.ResourceSKUCapabilities{
 				{
 					Name:  ptr.To(resourceskus.AcceleratedNetworking),
 					Value: ptr.To(string(resourceskus.CapabilitySupported)),
@@ -580,27 +581,27 @@ func getFakeSkus() []compute.ResourceSku {
 			Name:         ptr.To("VM_SIZE_EPH"),
 			ResourceType: ptr.To(string(resourceskus.VirtualMachines)),
 			Kind:         ptr.To(string(resourceskus.VirtualMachines)),
-			Locations: &[]string{
-				"test-location",
+			Locations: []*string{
+				ptr.To("test-location"),
 			},
-			LocationInfo: &[]compute.ResourceSkuLocationInfo{
+			LocationInfo: []*armcompute.ResourceSKULocationInfo{
 				{
 					Location: ptr.To("test-location"),
-					Zones:    &[]string{"1", "3"},
-					ZoneDetails: &[]compute.ResourceSkuZoneDetails{
+					Zones:    []*string{ptr.To("1"), ptr.To("3")},
+					ZoneDetails: []*armcompute.ResourceSKUZoneDetails{
 						{
-							Capabilities: &[]compute.ResourceSkuCapabilities{
+							Capabilities: []*armcompute.ResourceSKUCapabilities{
 								{
 									Name:  ptr.To("UltraSSDAvailable"),
 									Value: ptr.To("True"),
 								},
 							},
-							Name: &[]string{"1", "3"},
+							Name: []*string{ptr.To("1"), ptr.To("3")},
 						},
 					},
 				},
 			},
-			Capabilities: &[]compute.ResourceSkuCapabilities{
+			Capabilities: []*armcompute.ResourceSKUCapabilities{
 				{
 					Name:  ptr.To(resourceskus.AcceleratedNetworking),
 					Value: ptr.To(string(resourceskus.CapabilityUnsupported)),

--- a/azure/services/scalesets/spec_test.go
+++ b/azure/services/scalesets/spec_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
@@ -211,7 +212,7 @@ func getEPHVMSSS() (ScaleSetSpec, compute.VirtualMachineScaleSet) {
 	spec := newDefaultVMSSSpec()
 	spec.Size = vmSizeEPH
 	spec.SKU = resourceskus.SKU{
-		Capabilities: &[]compute.ResourceSkuCapabilities{
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
 			{
 				Name:  ptr.To(resourceskus.EphemeralOSDisk),
 				Value: ptr.To("True"),
@@ -326,7 +327,7 @@ func getHostEncryptionVMSS() (ScaleSetSpec, compute.VirtualMachineScaleSet) {
 	spec.Size = "VM_SIZE_EAH"
 	spec.SecurityProfile = &infrav1.SecurityProfile{EncryptionAtHost: ptr.To(true)}
 	spec.SKU = resourceskus.SKU{
-		Capabilities: &[]compute.ResourceSkuCapabilities{
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
 			{
 				Name:  ptr.To(resourceskus.EncryptionAtHost),
 				Value: ptr.To("True"),
@@ -356,7 +357,7 @@ func getEphemeralReadOnlyVMSS() (ScaleSetSpec, compute.VirtualMachineScaleSet) {
 	}
 	spec.OSDisk.CachingType = "ReadOnly"
 	spec.SKU = resourceskus.SKU{
-		Capabilities: &[]compute.ResourceSkuCapabilities{
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
 			{
 				Name:  ptr.To(resourceskus.EphemeralOSDisk),
 				Value: ptr.To("True"),

--- a/azure/services/virtualmachines/spec_test.go
+++ b/azure/services/virtualmachines/spec_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/google/go-cmp/cmp"
@@ -35,10 +36,10 @@ var (
 	validSKU = resourceskus.SKU{
 		Name: ptr.To("Standard_D2v3"),
 		Kind: ptr.To(string(resourceskus.VirtualMachines)),
-		Locations: &[]string{
-			"test-location",
+		Locations: []*string{
+			ptr.To("test-location"),
 		},
-		Capabilities: &[]compute.ResourceSkuCapabilities{
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
 			{
 				Name:  ptr.To(resourceskus.VCPUs),
 				Value: ptr.To("2"),
@@ -53,10 +54,10 @@ var (
 	validSKUWithEncryptionAtHost = resourceskus.SKU{
 		Name: ptr.To("Standard_D2v3"),
 		Kind: ptr.To(string(resourceskus.VirtualMachines)),
-		Locations: &[]string{
-			"test-location",
+		Locations: []*string{
+			ptr.To("test-location"),
 		},
-		Capabilities: &[]compute.ResourceSkuCapabilities{
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
 			{
 				Name:  ptr.To(resourceskus.VCPUs),
 				Value: ptr.To("2"),
@@ -75,10 +76,10 @@ var (
 	validSKUWithTrustedLaunchDisabled = resourceskus.SKU{
 		Name: ptr.To("Standard_D2v3"),
 		Kind: ptr.To(string(resourceskus.VirtualMachines)),
-		Locations: &[]string{
-			"test-location",
+		Locations: []*string{
+			ptr.To("test-location"),
 		},
-		Capabilities: &[]compute.ResourceSkuCapabilities{
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
 			{
 				Name:  ptr.To(resourceskus.VCPUs),
 				Value: ptr.To("2"),
@@ -97,10 +98,10 @@ var (
 	validSKUWithConfidentialComputingType = resourceskus.SKU{
 		Name: ptr.To("Standard_D2v3"),
 		Kind: ptr.To(string(resourceskus.VirtualMachines)),
-		Locations: &[]string{
-			"test-location",
+		Locations: []*string{
+			ptr.To("test-location"),
 		},
-		Capabilities: &[]compute.ResourceSkuCapabilities{
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
 			{
 				Name:  ptr.To(resourceskus.VCPUs),
 				Value: ptr.To("2"),
@@ -119,10 +120,10 @@ var (
 	validSKUWithEphemeralOS = resourceskus.SKU{
 		Name: ptr.To("Standard_D2v3"),
 		Kind: ptr.To(string(resourceskus.VirtualMachines)),
-		Locations: &[]string{
-			"test-location",
+		Locations: []*string{
+			ptr.To("test-location"),
 		},
-		Capabilities: &[]compute.ResourceSkuCapabilities{
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
 			{
 				Name:  ptr.To(resourceskus.VCPUs),
 				Value: ptr.To("2"),
@@ -141,27 +142,27 @@ var (
 	validSKUWithUltraSSD = resourceskus.SKU{
 		Name: ptr.To("Standard_D2v3"),
 		Kind: ptr.To(string(resourceskus.VirtualMachines)),
-		Locations: &[]string{
-			"test-location",
+		Locations: []*string{
+			ptr.To("test-location"),
 		},
-		LocationInfo: &[]compute.ResourceSkuLocationInfo{
+		LocationInfo: []*armcompute.ResourceSKULocationInfo{
 			{
 				Location: ptr.To("test-location"),
-				Zones:    &[]string{"1"},
-				ZoneDetails: &[]compute.ResourceSkuZoneDetails{
+				Zones:    []*string{ptr.To("1")},
+				ZoneDetails: []*armcompute.ResourceSKUZoneDetails{
 					{
-						Capabilities: &[]compute.ResourceSkuCapabilities{
+						Capabilities: []*armcompute.ResourceSKUCapabilities{
 							{
 								Name:  ptr.To("UltraSSDAvailable"),
 								Value: ptr.To("True"),
 							},
 						},
-						Name: &[]string{"1"},
+						Name: []*string{ptr.To("1")},
 					},
 				},
 			},
 		},
-		Capabilities: &[]compute.ResourceSkuCapabilities{
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
 			{
 				Name:  ptr.To(resourceskus.VCPUs),
 				Value: ptr.To("2"),
@@ -176,10 +177,10 @@ var (
 	invalidCPUSKU = resourceskus.SKU{
 		Name: ptr.To("Standard_D2v3"),
 		Kind: ptr.To(string(resourceskus.VirtualMachines)),
-		Locations: &[]string{
-			"test-location",
+		Locations: []*string{
+			ptr.To("test-location"),
 		},
-		Capabilities: &[]compute.ResourceSkuCapabilities{
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
 			{
 				Name:  ptr.To(resourceskus.VCPUs),
 				Value: ptr.To("1"),
@@ -194,10 +195,10 @@ var (
 	invalidMemSKU = resourceskus.SKU{
 		Name: ptr.To("Standard_D2v3"),
 		Kind: ptr.To(string(resourceskus.VirtualMachines)),
-		Locations: &[]string{
-			"test-location",
+		Locations: []*string{
+			ptr.To("test-location"),
 		},
-		Capabilities: &[]compute.ResourceSkuCapabilities{
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
 			{
 				Name:  ptr.To(resourceskus.VCPUs),
 				Value: ptr.To("2"),

--- a/controllers/azurecluster_reconciler_test.go
+++ b/controllers/azurecluster_reconciler_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	asoresourcesv1 "github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -91,7 +91,7 @@ func TestAzureClusterServiceReconcile(t *testing.T) {
 					svcTwoMock,
 					svcThreeMock,
 				},
-				skuCache: resourceskus.NewStaticCache([]compute.ResourceSku{}, ""),
+				skuCache: resourceskus.NewStaticCache([]armcompute.ResourceSKU{}, ""),
 			}
 
 			err := s.Reconcile(context.TODO())
@@ -359,7 +359,7 @@ func TestAzureClusterServiceDelete(t *testing.T) {
 					svcTwoMock,
 					svcThreeMock,
 				},
-				skuCache: resourceskus.NewStaticCache([]compute.ResourceSku{}, ""),
+				skuCache: resourceskus.NewStaticCache([]armcompute.ResourceSKU{}, ""),
 			}
 
 			err := s.Delete(context.TODO())

--- a/controllers/azuremachine_reconciler_test.go
+++ b/controllers/azuremachine_reconciler_test.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -90,7 +90,7 @@ func TestAzureMachineServiceReconcile(t *testing.T) {
 					svcTwoMock,
 					svcThreeMock,
 				},
-				skuCache: resourceskus.NewStaticCache([]compute.ResourceSku{}, ""),
+				skuCache: resourceskus.NewStaticCache([]armcompute.ResourceSKU{}, ""),
 			}
 
 			err := s.reconcile(context.TODO())
@@ -227,7 +227,7 @@ func TestAzureMachineServiceDelete(t *testing.T) {
 					svcTwoMock,
 					svcThreeMock,
 				},
-				skuCache: resourceskus.NewStaticCache([]compute.ResourceSku{}, ""),
+				skuCache: resourceskus.NewStaticCache([]armcompute.ResourceSKU{}, ""),
 			}
 
 			err := s.delete(context.TODO())

--- a/exp/controllers/azuremachinepool_controller_unit_test.go
+++ b/exp/controllers/azuremachinepool_controller_unit_test.go
@@ -54,6 +54,8 @@ func Test_newAzureMachinePoolService(t *testing.T) {
 	clusterMock.EXPECT().Token().AnyTimes()
 	clusterMock.EXPECT().Location().Return(cluster.Spec.Location)
 	clusterMock.EXPECT().HashKey().Return("fakeCluster")
+	clusterMock.EXPECT().CloudEnvironment().AnyTimes()
+	clusterMock.EXPECT().Token().AnyTimes()
 
 	mps := &scope.MachinePoolScope{
 		ClusterScoper: clusterMock,

--- a/exp/controllers/azuremachinepool_reconciler_test.go
+++ b/exp/controllers/azuremachinepool_reconciler_test.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -94,7 +94,7 @@ func TestAzureMachinePoolServiceReconcile(t *testing.T) {
 					svcTwoMock,
 					svcThreeMock,
 				},
-				skuCache: resourceskus.NewStaticCache([]compute.ResourceSku{}, ""),
+				skuCache: resourceskus.NewStaticCache([]armcompute.ResourceSKU{}, ""),
 			}
 
 			err := s.Reconcile(context.TODO())
@@ -231,7 +231,7 @@ func TestAzureMachinePoolServiceDelete(t *testing.T) {
 					svcTwoMock,
 					svcThreeMock,
 				},
-				skuCache: resourceskus.NewStaticCache([]compute.ResourceSku{}, ""),
+				skuCache: resourceskus.NewStaticCache([]armcompute.ResourceSKU{}, ""),
 			}
 
 			err := s.Delete(context.TODO())


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the resource skus service to azure-sdk-for-go version 2.

**Which issue(s) this PR fixes**:

Fixes #3920

**Special notes for your reviewer**:

This service doesn't provide "Create" or "Delete" functionality, it just lists and gets existing SKUs.

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
