### PR TITLE
Convert vnetpeerings service to SDKv2

### DIFF
--- a/azure/services/vnetpeerings/client.go
+++ b/azure/services/vnetpeerings/client.go
@@ -18,34 +18,32 @@ package vnetpeerings
 
 import (
 	"context"
-	"encoding/json"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest"
-	azureautorest "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/pkg/errors"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asyncpoller"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
 // AzureClient contains the Azure go-sdk Client.
 type AzureClient struct {
-	peerings network.VirtualNetworkPeeringsClient
+	peerings *armnetwork.VirtualNetworkPeeringsClient
 }
 
-// NewClient creates a new virtual network peerings client from subscription ID.
-func NewClient(auth azure.Authorizer) *AzureClient {
-	c := newPeeringsClient(auth.SubscriptionID(), auth.BaseURI(), auth.Authorizer())
-	return &AzureClient{c}
-}
-
-// newPeeringsClient creates a new virtual network peerings client from subscription ID.
-func newPeeringsClient(subscriptionID string, baseURI string, authorizer autorest.Authorizer) network.VirtualNetworkPeeringsClient {
-	peeringsClient := network.NewVirtualNetworkPeeringsClientWithBaseURI(baseURI, subscriptionID)
-	azure.SetAutoRestClientDefaults(&peeringsClient.Client, authorizer)
-	return peeringsClient
+// NewClient creates a new virtual network peerings client from an authorizer.
+func NewClient(auth azure.Authorizer) (*AzureClient, error) {
+	opts, err := azure.ARMClientOptions(auth.CloudEnvironment())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create vnetpeerings client options")
+	}
+	factory, err := armnetwork.NewClientFactory(auth.SubscriptionID(), auth.Token(), opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create armnetwork client factory")
+	}
+	return &AzureClient{factory.NewVirtualNetworkPeeringsClient()}, nil
 }
 
 // Get gets the specified virtual network peering by the peering name, virtual network, and resource group.
@@ -53,22 +51,27 @@ func (ac *AzureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "vnetpeerings.AzureClient.Get")
 	defer done()
 
-	return ac.peerings.Get(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName())
+	resp, err := ac.peerings.Get(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return resp.VirtualNetworkPeering, nil
 }
 
 // CreateOrUpdateAsync creates or updates a virtual network peering asynchronously.
-// It sends a PUT request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// It sends a PUT request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, parameters interface{}) (result interface{}, future azureautorest.FutureAPI, err error) {
+func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armnetwork.VirtualNetworkPeeringsClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "vnetpeerings.AzureClient.CreateOrUpdateAsync")
 	defer done()
 
-	peering, ok := parameters.(network.VirtualNetworkPeering)
-	if !ok {
-		return nil, nil, errors.Errorf("%T is not a network.VirtualNetworkPeering", parameters)
+	peering, ok := parameters.(armnetwork.VirtualNetworkPeering)
+	if !ok && parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armnetwork.VirtualNetworkPeering", parameters)
 	}
 
-	createFuture, err := ac.peerings.CreateOrUpdate(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), peering, network.SyncRemoteAddressSpaceTrue)
+	opts := &armnetwork.VirtualNetworkPeeringsClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
+	poller, err = ac.peerings.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), peering, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -76,26 +79,27 @@ func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
 	defer cancel()
 
-	err = createFuture.WaitForCompletionRef(ctx, ac.peerings.Client)
+	pollOpts := &runtime.PollUntilDoneOptions{Frequency: asyncpoller.DefaultPollerFrequency}
+	resp, err := poller.PollUntilDone(ctx, pollOpts)
 	if err != nil {
-		// if an error occurs, return the future.
+		// if an error occurs, return the poller.
 		// this means the long-running operation didn't finish in the specified timeout.
-		return nil, &createFuture, err
+		return nil, poller, err
 	}
 
-	result, err = createFuture.Result(ac.peerings)
-	// if the operation completed, return a nil future
-	return result, nil, err
+	// if the operation completed, return a nil poller
+	return resp.VirtualNetworkPeering, nil, err
 }
 
 // DeleteAsync deletes a virtual network peering asynchronously. DeleteAsync sends a DELETE
 // request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
 // progress of the operation.
-func (ac *AzureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter) (future azureautorest.FutureAPI, err error) {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "vnetpeerings.AzureClient.Delete")
+func (ac *AzureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string) (poller *runtime.Poller[armnetwork.VirtualNetworkPeeringsClientDeleteResponse], err error) {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "vnetpeerings.AzureClient.DeleteAsync")
 	defer done()
 
-	deleteFuture, err := ac.peerings.Delete(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName())
+	opts := &armnetwork.VirtualNetworkPeeringsClientBeginDeleteOptions{ResumeToken: resumeToken}
+	poller, err = ac.peerings.BeginDelete(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -103,54 +107,14 @@ func (ac *AzureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecG
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
 	defer cancel()
 
-	err = deleteFuture.WaitForCompletionRef(ctx, ac.peerings.Client)
+	pollOpts := &runtime.PollUntilDoneOptions{Frequency: asyncpoller.DefaultPollerFrequency}
+	_, err = poller.PollUntilDone(ctx, pollOpts)
 	if err != nil {
-		// if an error occurs, return the future.
+		// if an error occurs, return the poller.
 		// this means the long-running operation didn't finish in the specified timeout.
-		return &deleteFuture, err
+		return poller, err
 	}
-	_, err = deleteFuture.Result(ac.peerings)
-	// if the operation completed, return a nil future.
+
+	// if the operation completed, return a nil poller.
 	return nil, err
-}
-
-// IsDone returns true if the long-running operation has completed.
-func (ac *AzureClient) IsDone(ctx context.Context, future azureautorest.FutureAPI) (isDone bool, err error) {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "vnetpeerings.AzureClient.IsDone")
-	defer done()
-
-	return future.DoneWithContext(ctx, ac.peerings)
-}
-
-// Result fetches the result of a long-running operation future.
-func (ac *AzureClient) Result(ctx context.Context, future azureautorest.FutureAPI, futureType string) (result interface{}, err error) {
-	_, _, done := tele.StartSpanWithLogger(ctx, "vnetpeerings.AzureClient.Result")
-	defer done()
-
-	if future == nil {
-		return nil, errors.Errorf("cannot get result from nil future")
-	}
-
-	switch futureType {
-	case infrav1.PutFuture:
-		// Marshal and Unmarshal the future to put it into the correct future type so we can access the Result function.
-		// Unfortunately the FutureAPI can't be casted directly to VirtualNetworkPeeringsCreateOrUpdateFuture because it is a azureautorest.Future, which doesn't implement the Result function. See PR #1686 for discussion on alternatives.
-		// It was converted back to a generic azureautorest.Future from the CAPZ infrav1.Future type stored in Status: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/converters/futures.go#L49.
-		var createFuture *network.VirtualNetworkPeeringsCreateOrUpdateFuture
-		jsonData, err := future.MarshalJSON()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal future")
-		}
-		if err := json.Unmarshal(jsonData, &createFuture); err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal future data")
-		}
-		return createFuture.Result(ac.peerings)
-
-	case infrav1.DeleteFuture:
-		// Delete does not return a result virtual network peering
-		return nil, nil
-
-	default:
-		return nil, errors.Errorf("unknown future type %q", futureType)
-	}
 }

--- a/azure/services/vnetpeerings/spec.go
+++ b/azure/services/vnetpeerings/spec.go
@@ -19,7 +19,7 @@ package vnetpeerings
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -57,15 +57,15 @@ func (s *VnetPeeringSpec) OwnerResourceName() string {
 // Parameters returns the parameters for the virtual network peering.
 func (s *VnetPeeringSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
-		if _, ok := existing.(network.VirtualNetworkPeering); !ok {
-			return nil, errors.Errorf("%T is not a network.VnetPeering", existing)
+		if _, ok := existing.(armnetwork.VirtualNetworkPeering); !ok {
+			return nil, errors.Errorf("%T is not an armnetwork.VnetPeering", existing)
 		}
 		// virtual network peering already exists
 		return nil, nil
 	}
 	vnetID := azure.VNetID(s.SubscriptionID, s.RemoteResourceGroup, s.RemoteVnetName)
-	peeringProperties := network.VirtualNetworkPeeringPropertiesFormat{
-		RemoteVirtualNetwork: &network.SubResource{
+	peeringProperties := armnetwork.VirtualNetworkPeeringPropertiesFormat{
+		RemoteVirtualNetwork: &armnetwork.SubResource{
 			ID: ptr.To(vnetID),
 		},
 		AllowForwardedTraffic:     s.AllowForwardedTraffic,
@@ -73,8 +73,8 @@ func (s *VnetPeeringSpec) Parameters(ctx context.Context, existing interface{}) 
 		AllowVirtualNetworkAccess: s.AllowVirtualNetworkAccess,
 		UseRemoteGateways:         s.UseRemoteGateways,
 	}
-	return network.VirtualNetworkPeering{
-		Name:                                  ptr.To(s.PeeringName),
-		VirtualNetworkPeeringPropertiesFormat: &peeringProperties,
+	return armnetwork.VirtualNetworkPeering{
+		Name:       ptr.To(s.PeeringName),
+		Properties: &peeringProperties,
 	}, nil
 }

--- a/azure/services/vnetpeerings/vnetpeerings.go
+++ b/azure/services/vnetpeerings/vnetpeerings.go
@@ -19,9 +19,10 @@ package vnetpeerings
 import (
 	"context"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
-	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asyncpoller"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
@@ -39,16 +40,20 @@ type VnetPeeringScope interface {
 // Service provides operations on Azure resources.
 type Service struct {
 	Scope VnetPeeringScope
-	async.Reconciler
+	asyncpoller.Reconciler
 }
 
 // New creates a new service.
-func New(scope VnetPeeringScope) *Service {
-	Client := NewClient(scope)
-	return &Service{
-		Scope:      scope,
-		Reconciler: async.New(scope, Client, Client),
+func New(scope VnetPeeringScope) (*Service, error) {
+	Client, err := NewClient(scope)
+	if err != nil {
+		return nil, err
 	}
+	return &Service{
+		Scope: scope,
+		Reconciler: asyncpoller.New[armnetwork.VirtualNetworkPeeringsClientCreateOrUpdateResponse,
+			armnetwork.VirtualNetworkPeeringsClientDeleteResponse](scope, Client, Client),
+	}, nil
 }
 
 // Name returns the service name.

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -68,6 +68,10 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 	if err != nil {
 		return nil, err
 	}
+	vnetPeeringsSvc, err := vnetpeerings.New(scope)
+	if err != nil {
+		return nil, err
+	}
 	return &azureClusterService{
 		scope: scope,
 		services: []azure.ServiceReconciler{
@@ -78,7 +82,7 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 			publicips.New(scope),
 			natGatewaysSvc,
 			subnets.New(scope),
-			vnetpeerings.New(scope),
+			vnetPeeringsSvc,
 			loadbalancers.New(scope),
 			privatedns.New(scope),
 			bastionHostsSvc,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the vnetpeerings service to azure-sdk-for-go version 2 and the `ascynpoller` framework for long-running operations.

**Which issue(s) this PR fixes**:

Fixes #3926

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
