### PR TITLE
convert securitygroups service to SDK v2

### DIFF
--- a/azure/converters/rules.go
+++ b/azure/converters/rules.go
@@ -17,42 +17,42 @@ limitations under the License.
 package converters
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 // SecurityRuleToSDK converts a CAPZ security rule to an Azure network security rule.
-func SecurityRuleToSDK(rule infrav1.SecurityRule) network.SecurityRule {
-	secRule := network.SecurityRule{
+func SecurityRuleToSDK(rule infrav1.SecurityRule) *armnetwork.SecurityRule {
+	secRule := &armnetwork.SecurityRule{
 		Name: ptr.To(rule.Name),
-		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
 			Description:              ptr.To(rule.Description),
 			SourceAddressPrefix:      rule.Source,
 			SourcePortRange:          rule.SourcePorts,
 			DestinationAddressPrefix: rule.Destination,
 			DestinationPortRange:     rule.DestinationPorts,
-			Access:                   network.SecurityRuleAccess(rule.Action),
+			Access:                   ptr.To(armnetwork.SecurityRuleAccess(rule.Action)),
 			Priority:                 ptr.To[int32](rule.Priority),
 		},
 	}
 
 	switch rule.Protocol {
 	case infrav1.SecurityGroupProtocolAll:
-		secRule.Protocol = network.SecurityRuleProtocolAsterisk
+		secRule.Properties.Protocol = ptr.To(armnetwork.SecurityRuleProtocolAsterisk)
 	case infrav1.SecurityGroupProtocolTCP:
-		secRule.Protocol = network.SecurityRuleProtocolTCP
+		secRule.Properties.Protocol = ptr.To(armnetwork.SecurityRuleProtocolTCP)
 	case infrav1.SecurityGroupProtocolUDP:
-		secRule.Protocol = network.SecurityRuleProtocolUDP
+		secRule.Properties.Protocol = ptr.To(armnetwork.SecurityRuleProtocolUDP)
 	case infrav1.SecurityGroupProtocolICMP:
-		secRule.Protocol = network.SecurityRuleProtocolIcmp
+		secRule.Properties.Protocol = ptr.To(armnetwork.SecurityRuleProtocolIcmp)
 	}
 
 	switch rule.Direction {
 	case infrav1.SecurityRuleDirectionOutbound:
-		secRule.Direction = network.SecurityRuleDirectionOutbound
+		secRule.Properties.Direction = ptr.To(armnetwork.SecurityRuleDirectionOutbound)
 	case infrav1.SecurityRuleDirectionInbound:
-		secRule.Direction = network.SecurityRuleDirectionInbound
+		secRule.Properties.Direction = ptr.To(armnetwork.SecurityRuleDirectionInbound)
 	}
 
 	return secRule

--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -388,17 +388,14 @@ func (p userAgentPolicy) Do(req *policy.Request) (*http.Response, error) {
 // CustomPutPatchHeaderPolicy adds custom headers to a PUT or PATCH request.
 // It implements the policy.Policy interface.
 type CustomPutPatchHeaderPolicy struct {
-	Getter ResourceSpecGetter
+	Headers map[string]string
 }
 
 // Do adds any custom headers to a PUT or PATCH request.
 func (p CustomPutPatchHeaderPolicy) Do(req *policy.Request) (*http.Response, error) {
 	if req.Raw().Method == http.MethodPut || req.Raw().Method == http.MethodPatch {
-		headerSpec, ok := p.Getter.(ResourceSpecGetterWithHeaders)
-		if ok {
-			for key, element := range headerSpec.CustomHeaders() {
-				req.Raw().Header.Set(key, element)
-			}
+		for key, element := range p.Headers {
+			req.Raw().Header.Set(key, element)
 		}
 	}
 

--- a/azure/defaults_test.go
+++ b/azure/defaults_test.go
@@ -187,7 +187,7 @@ func TestCustomPutPatchHeaderPolicy(t *testing.T) {
 			// Create options with a custom PUT/PATCH header per-call policy
 			getterMock := mock_azure.NewMockResourceSpecGetterWithHeaders(mockCtrl)
 			getterMock.EXPECT().CustomHeaders().Return(tc.headers).AnyTimes()
-			opts, err := ARMClientOptions("", CustomPutPatchHeaderPolicy{Getter: getterMock})
+			opts, err := ARMClientOptions("", CustomPutPatchHeaderPolicy{Headers: tc.headers})
 			g.Expect(err).NotTo(HaveOccurred())
 
 			// Create a request

--- a/azure/services/agentpools/client.go
+++ b/azure/services/agentpools/client.go
@@ -35,7 +35,11 @@ type azureClient struct {
 
 // newClient creates a new agentpools client from an authorizer.
 func newClient(scope AgentPoolScope) (*azureClient, error) {
-	opts, err := azure.ARMClientOptions(scope.CloudEnvironment(), azure.CustomPutPatchHeaderPolicy{Getter: scope.AgentPoolSpec()})
+	var headers map[string]string
+	if customHeaders, ok := scope.AgentPoolSpec().(azure.ResourceSpecGetterWithHeaders); ok {
+		headers = customHeaders.CustomHeaders()
+	}
+	opts, err := azure.ARMClientOptions(scope.CloudEnvironment(), azure.CustomPutPatchHeaderPolicy{Headers: headers})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create agentpools client options")
 	}

--- a/azure/services/managedclusters/client.go
+++ b/azure/services/managedclusters/client.go
@@ -40,7 +40,11 @@ type azureClient struct {
 
 // newClient creates a new managedclusters client from an authorizer.
 func newClient(scope ManagedClusterScope) (*azureClient, error) {
-	opts, err := azure.ARMClientOptions(scope.CloudEnvironment(), azure.CustomPutPatchHeaderPolicy{Getter: scope.ManagedClusterSpec()})
+	var headers map[string]string
+	if customHeaders, ok := scope.ManagedClusterSpec().(azure.ResourceSpecGetterWithHeaders); ok {
+		headers = customHeaders.CustomHeaders()
+	}
+	opts, err := azure.ARMClientOptions(scope.CloudEnvironment(), azure.CustomPutPatchHeaderPolicy{Headers: headers})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create managedclusters client options")
 	}

--- a/azure/services/securitygroups/securitygroups.go
+++ b/azure/services/securitygroups/securitygroups.go
@@ -19,10 +19,11 @@ package securitygroups
 import (
 	"context"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/pkg/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
-	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asyncpoller"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
@@ -41,16 +42,20 @@ type NSGScope interface {
 // Service provides operations on Azure resources.
 type Service struct {
 	Scope NSGScope
-	async.Reconciler
+	asyncpoller.Reconciler
 }
 
 // New creates a new service.
-func New(scope NSGScope) *Service {
-	client := newClient(scope)
-	return &Service{
-		Scope:      scope,
-		Reconciler: async.New(scope, client, client),
+func New(scope NSGScope) (*Service, error) {
+	client, err := newClient(scope)
+	if err != nil {
+		return nil, err
 	}
+	return &Service{
+		Scope: scope,
+		Reconciler: asyncpoller.New[armnetwork.SecurityGroupsClientCreateOrUpdateResponse,
+			armnetwork.SecurityGroupsClientDeleteResponse](scope, client, client),
+	}, nil
 }
 
 // Name returns the service name.

--- a/azure/services/securitygroups/securitygroups_test.go
+++ b/azure/services/securitygroups/securitygroups_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
@@ -287,46 +287,46 @@ func TestDeleteSecurityGroups(t *testing.T) {
 }
 
 var (
-	ruleA = network.SecurityRule{
+	ruleA = &armnetwork.SecurityRule{
 		Name: ptr.To("A"),
-		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
 			Description:              ptr.To("this is rule A"),
-			Protocol:                 network.SecurityRuleProtocolTCP,
+			Protocol:                 ptr.To(armnetwork.SecurityRuleProtocolTCP),
 			DestinationPortRange:     ptr.To("*"),
 			SourcePortRange:          ptr.To("*"),
 			DestinationAddressPrefix: ptr.To("*"),
 			SourceAddressPrefix:      ptr.To("*"),
 			Priority:                 ptr.To[int32](100),
-			Direction:                network.SecurityRuleDirectionInbound,
-			Access:                   network.SecurityRuleAccessAllow,
+			Direction:                ptr.To(armnetwork.SecurityRuleDirectionInbound),
+			Access:                   ptr.To(armnetwork.SecurityRuleAccessAllow),
 		},
 	}
-	ruleB = network.SecurityRule{
+	ruleB = &armnetwork.SecurityRule{
 		Name: ptr.To("B"),
-		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
 			Description:              ptr.To("this is rule B"),
-			Protocol:                 network.SecurityRuleProtocolTCP,
+			Protocol:                 ptr.To(armnetwork.SecurityRuleProtocolTCP),
 			DestinationPortRange:     ptr.To("*"),
 			SourcePortRange:          ptr.To("*"),
 			DestinationAddressPrefix: ptr.To("*"),
 			SourceAddressPrefix:      ptr.To("*"),
 			Priority:                 ptr.To[int32](100),
-			Direction:                network.SecurityRuleDirectionOutbound,
-			Access:                   network.SecurityRuleAccessAllow,
+			Direction:                ptr.To(armnetwork.SecurityRuleDirectionOutbound),
+			Access:                   ptr.To(armnetwork.SecurityRuleAccessAllow),
 		},
 	}
-	ruleBModified = network.SecurityRule{
+	ruleBModified = &armnetwork.SecurityRule{
 		Name: ptr.To("B"),
-		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
 			Description:              ptr.To("this is rule B"),
-			Protocol:                 network.SecurityRuleProtocolTCP,
+			Protocol:                 ptr.To(armnetwork.SecurityRuleProtocolTCP),
 			DestinationPortRange:     ptr.To("80"),
 			SourcePortRange:          ptr.To("*"),
 			DestinationAddressPrefix: ptr.To("*"),
 			SourceAddressPrefix:      ptr.To("*"),
 			Priority:                 ptr.To[int32](100),
-			Direction:                network.SecurityRuleDirectionOutbound,
-			Access:                   network.SecurityRuleAccessAllow,
+			Direction:                ptr.To(armnetwork.SecurityRuleDirectionOutbound),
+			Access:                   ptr.To(armnetwork.SecurityRuleAccessAllow),
 		},
 	}
 )

--- a/azure/services/securitygroups/spec_test.go
+++ b/azure/services/securitygroups/spec_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -98,10 +98,10 @@ func TestParameters(t *testing.T) {
 				ResourceGroup: "test-group",
 				ClusterName:   "my-cluster",
 			},
-			existing: network.SecurityGroup{
+			existing: armnetwork.SecurityGroup{
 				Name: ptr.To("test-nsg"),
-				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
-					SecurityRules: &[]network.SecurityRule{
+				Properties: &armnetwork.SecurityGroupPropertiesFormat{
+					SecurityRules: []*armnetwork.SecurityRule{
 						converters.SecurityRuleToSDK(sshRule),
 						converters.SecurityRuleToSDK(otherRule),
 					},
@@ -123,24 +123,24 @@ func TestParameters(t *testing.T) {
 				ResourceGroup: "test-group",
 				ClusterName:   "my-cluster",
 			},
-			existing: network.SecurityGroup{
+			existing: armnetwork.SecurityGroup{
 				Name:     ptr.To("test-nsg"),
 				Location: ptr.To("test-location"),
 				Etag:     ptr.To("fake-etag"),
-				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
-					SecurityRules: &[]network.SecurityRule{
+				Properties: &armnetwork.SecurityGroupPropertiesFormat{
+					SecurityRules: []*armnetwork.SecurityRule{
 						converters.SecurityRuleToSDK(sshRule),
 						converters.SecurityRuleToSDK(customRule),
 					},
 				},
 			},
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.SecurityGroup{}))
-				g.Expect(result).To(Equal(network.SecurityGroup{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.SecurityGroup{}))
+				g.Expect(result).To(Equal(armnetwork.SecurityGroup{
 					Location: ptr.To("test-location"),
 					Etag:     ptr.To("fake-etag"),
-					SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
-						SecurityRules: &[]network.SecurityRule{
+					Properties: &armnetwork.SecurityGroupPropertiesFormat{
+						SecurityRules: []*armnetwork.SecurityRule{
 							converters.SecurityRuleToSDK(otherRule),
 							converters.SecurityRuleToSDK(sshRule),
 							converters.SecurityRuleToSDK(customRule),
@@ -165,24 +165,24 @@ func TestParameters(t *testing.T) {
 				ResourceGroup: "test-group",
 				ClusterName:   "my-cluster",
 			},
-			existing: network.SecurityGroup{
+			existing: armnetwork.SecurityGroup{
 				Name:     ptr.To("test-nsg"),
 				Location: ptr.To("test-location"),
 				Etag:     ptr.To("fake-etag"),
-				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
-					SecurityRules: &[]network.SecurityRule{
+				Properties: &armnetwork.SecurityGroupPropertiesFormat{
+					SecurityRules: []*armnetwork.SecurityRule{
 						converters.SecurityRuleToSDK(sshRule),
 						converters.SecurityRuleToSDK(denyRule),
 					},
 				},
 			},
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.SecurityGroup{}))
-				g.Expect(result).To(Equal(network.SecurityGroup{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.SecurityGroup{}))
+				g.Expect(result).To(Equal(armnetwork.SecurityGroup{
 					Location: ptr.To("test-location"),
 					Etag:     ptr.To("fake-etag"),
-					SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
-						SecurityRules: &[]network.SecurityRule{
+					Properties: &armnetwork.SecurityGroupPropertiesFormat{
+						SecurityRules: []*armnetwork.SecurityRule{
 							converters.SecurityRuleToSDK(otherRule),
 							converters.SecurityRuleToSDK(sshRule),
 							converters.SecurityRuleToSDK(denyRule),
@@ -212,12 +212,12 @@ func TestParameters(t *testing.T) {
 					"other_rule":  otherRule,
 				},
 			},
-			existing: network.SecurityGroup{
+			existing: armnetwork.SecurityGroup{
 				Name:     ptr.To("test-nsg"),
 				Location: ptr.To("test-location"),
 				Etag:     ptr.To("fake-etag"),
-				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
-					SecurityRules: &[]network.SecurityRule{
+				Properties: &armnetwork.SecurityGroupPropertiesFormat{
+					SecurityRules: []*armnetwork.SecurityRule{
 						converters.SecurityRuleToSDK(sshRule),
 						converters.SecurityRuleToSDK(customRule),
 						converters.SecurityRuleToSDK(otherRule),
@@ -225,12 +225,12 @@ func TestParameters(t *testing.T) {
 				},
 			},
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.SecurityGroup{}))
-				g.Expect(result).To(Equal(network.SecurityGroup{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.SecurityGroup{}))
+				g.Expect(result).To(Equal(armnetwork.SecurityGroup{
 					Location: ptr.To("test-location"),
 					Etag:     ptr.To("fake-etag"),
-					SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
-						SecurityRules: &[]network.SecurityRule{
+					Properties: &armnetwork.SecurityGroupPropertiesFormat{
+						SecurityRules: []*armnetwork.SecurityRule{
 							converters.SecurityRuleToSDK(sshRule),
 							converters.SecurityRuleToSDK(customRule),
 						},
@@ -259,12 +259,12 @@ func TestParameters(t *testing.T) {
 					"deny_rule":   denyRule,
 				},
 			},
-			existing: network.SecurityGroup{
+			existing: armnetwork.SecurityGroup{
 				Name:     ptr.To("test-nsg"),
 				Location: ptr.To("test-location"),
 				Etag:     ptr.To("fake-etag"),
-				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
-					SecurityRules: &[]network.SecurityRule{
+				Properties: &armnetwork.SecurityGroupPropertiesFormat{
+					SecurityRules: []*armnetwork.SecurityRule{
 						converters.SecurityRuleToSDK(sshRule),
 						converters.SecurityRuleToSDK(customRule),
 						converters.SecurityRuleToSDK(denyRule),
@@ -272,12 +272,12 @@ func TestParameters(t *testing.T) {
 				},
 			},
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.SecurityGroup{}))
-				g.Expect(result).To(Equal(network.SecurityGroup{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.SecurityGroup{}))
+				g.Expect(result).To(Equal(armnetwork.SecurityGroup{
 					Location: ptr.To("test-location"),
 					Etag:     ptr.To("fake-etag"),
-					SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
-						SecurityRules: &[]network.SecurityRule{
+					Properties: &armnetwork.SecurityGroupPropertiesFormat{
+						SecurityRules: []*armnetwork.SecurityRule{
 							converters.SecurityRuleToSDK(sshRule),
 							converters.SecurityRuleToSDK(customRule),
 						},
@@ -305,12 +305,12 @@ func TestParameters(t *testing.T) {
 					"custom_rule": customRule,
 				},
 			},
-			existing: network.SecurityGroup{
+			existing: armnetwork.SecurityGroup{
 				Name:     ptr.To("test-nsg"),
 				Location: ptr.To("test-location"),
 				Etag:     ptr.To("fake-etag"),
-				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
-					SecurityRules: &[]network.SecurityRule{
+				Properties: &armnetwork.SecurityGroupPropertiesFormat{
+					SecurityRules: []*armnetwork.SecurityRule{
 						converters.SecurityRuleToSDK(sshRule),
 						converters.SecurityRuleToSDK(customRule),
 						converters.SecurityRuleToSDK(otherRule),
@@ -335,10 +335,10 @@ func TestParameters(t *testing.T) {
 			},
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.SecurityGroup{}))
-				g.Expect(result).To(Equal(network.SecurityGroup{
-					SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
-						SecurityRules: &[]network.SecurityRule{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.SecurityGroup{}))
+				g.Expect(result).To(Equal(armnetwork.SecurityGroup{
+					Properties: &armnetwork.SecurityGroupPropertiesFormat{
+						SecurityRules: []*armnetwork.SecurityRule{
 							converters.SecurityRuleToSDK(sshRule),
 							converters.SecurityRuleToSDK(otherRule),
 						},
@@ -374,25 +374,25 @@ func TestParameters(t *testing.T) {
 func TestRuleExists(t *testing.T) {
 	testcases := []struct {
 		name     string
-		rules    []network.SecurityRule
-		rule     network.SecurityRule
+		rules    []*armnetwork.SecurityRule
+		rule     *armnetwork.SecurityRule
 		expected bool
 	}{
 		{
 			name:     "rule doesn't exitst",
-			rules:    []network.SecurityRule{ruleA},
+			rules:    []*armnetwork.SecurityRule{ruleA},
 			rule:     ruleB,
 			expected: false,
 		},
 		{
 			name:     "rule exists",
-			rules:    []network.SecurityRule{ruleA, ruleB},
+			rules:    []*armnetwork.SecurityRule{ruleA, ruleB},
 			rule:     ruleB,
 			expected: true,
 		},
 		{
 			name:     "rule exists but has been modified",
-			rules:    []network.SecurityRule{ruleA, ruleB},
+			rules:    []*armnetwork.SecurityRule{ruleA, ruleB},
 			rule:     ruleBModified,
 			expected: false,
 		},

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -56,6 +56,10 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating a NewCache")
 	}
+	securityGroupsSvc, err := securitygroups.New(scope)
+	if err != nil {
+		return nil, err
+	}
 	routeTablesSvc, err := routetables.New(scope)
 	if err != nil {
 		return nil, err
@@ -93,7 +97,7 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 		services: []azure.ServiceReconciler{
 			groupsSvc,
 			virtualnetworks.New(scope),
-			securitygroups.New(scope),
+			securityGroupsSvc,
 			routeTablesSvc,
 			publicips.New(scope),
 			natGatewaysSvc,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR updates the securitygroups service to use SDK v2 and the new asyncpoller framework.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3923

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

This PR is split into two commits that I intend to squash before merging. The first commit is the "standard" conversion to SDK v2. The second commit adds back some special logic that existed to propagate the Etag from an existing resource to a subsequent PUT by creating a new SDK client that will add a HTTP header with the Etag. This isn't quite what the managedclusters or agentpools services does for custom headers because the Etag isn't known right at the beginning of reconciliation, only after we GET the existing resource.

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
