### PR TITLE
Convert tags service to SDKv2

### DIFF
--- a/azure/scope/managedcontrolplane_test.go
+++ b/azure/scope/managedcontrolplane_test.go
@@ -467,6 +467,12 @@ func TestManagedControlPlaneScope_OSType(t *testing.T) {
 	}
 }
 
+type fakeVnetDescriber struct{}
+
+func (f fakeVnetDescriber) IsManaged(ctx context.Context) (bool, error) {
+	return false, nil
+}
+
 func TestManagedControlPlaneScope_IsVnetManagedCache(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = expv1.AddToScheme(scheme)
@@ -509,6 +515,7 @@ func TestManagedControlPlaneScope_IsVnetManagedCache(t *testing.T) {
 						InfraMachinePool: getLinuxAzureMachinePool("pool1"),
 					},
 				},
+				VnetDescriber: fakeVnetDescriber{},
 			},
 			Expected: false,
 		},

--- a/azure/services/async/interfaces.go
+++ b/azure/services/async/interfaces.go
@@ -19,7 +19,7 @@ package async
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
@@ -44,7 +44,7 @@ type Getter interface {
 
 // TagsGetter is an interface that can get a tags resource.
 type TagsGetter interface {
-	GetAtScope(ctx context.Context, scope string) (result resources.TagsResource, err error)
+	GetAtScope(ctx context.Context, scope string) (result armresources.TagsResource, err error)
 }
 
 // Creator is a client that can create or update a resource asynchronously.

--- a/azure/services/async/mock_async/async_mock.go
+++ b/azure/services/async/mock_async/async_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	resources "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
+	armresources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	azure "github.com/Azure/go-autorest/autorest/azure"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -244,10 +244,10 @@ func (m *MockTagsGetter) EXPECT() *MockTagsGetterMockRecorder {
 }
 
 // GetAtScope mocks base method.
-func (m *MockTagsGetter) GetAtScope(ctx context.Context, scope string) (resources.TagsResource, error) {
+func (m *MockTagsGetter) GetAtScope(ctx context.Context, scope string) (armresources.TagsResource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAtScope", ctx, scope)
-	ret0, _ := ret[0].(resources.TagsResource)
+	ret0, _ := ret[0].(armresources.TagsResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/azure/services/privatedns/privatedns.go
+++ b/azure/services/privatedns/privatedns.go
@@ -64,7 +64,10 @@ func New(scope Scope) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	tagsClient := tags.NewClient(scope)
+	tagsClient, err := tags.NewClient(scope)
+	if err != nil {
+		return nil, err
+	}
 	return &Service{
 		Scope:      scope,
 		TagsGetter: tagsClient,

--- a/azure/services/privatedns/privatedns_test.go
+++ b/azure/services/privatedns/privatedns_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -80,8 +80,8 @@ var (
 		ResourceGroup: resourceGroup,
 	}
 
-	managedTags = resources.TagsResource{
-		Properties: &resources.Tags{
+	managedTags = armresources.TagsResource{
+		Properties: &armresources.Tags{
 			Tags: map[string]*string{
 				"foo": ptr.To("bar"),
 				"sigs.k8s.io_cluster-api-provider-azure_cluster_" + clusterName: ptr.To("owned"),
@@ -115,13 +115,13 @@ func TestReconcilePrivateDNS(t *testing.T) {
 				s.PrivateDNSSpec().Return(fakeZone, []azure.ResourceSpecGetter{fakeLink1, fakeLink2}, []azure.ResourceSpecGetter{fakeRecord1}).Times(2)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				z.CreateOrUpdateResource(gomockinternal.AContext(), fakeZone, serviceName).Return(nil, nil)
 				l.CreateOrUpdateResource(gomockinternal.AContext(), fakeLink1, serviceName).Return(nil, nil)
@@ -139,7 +139,7 @@ func TestReconcilePrivateDNS(t *testing.T) {
 				s.PrivateDNSSpec().Return(fakeZone, []azure.ResourceSpecGetter{fakeLink1, fakeLink2}, []azure.ResourceSpecGetter{fakeRecord1}).Times(2)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				z.CreateOrUpdateResource(gomockinternal.AContext(), fakeZone, serviceName).Return(nil, notDoneError)
 				s.UpdatePutStatus(infrav1.PrivateDNSZoneReadyCondition, serviceName, notDoneError)
@@ -152,7 +152,7 @@ func TestReconcilePrivateDNS(t *testing.T) {
 				s.PrivateDNSSpec().Return(fakeZone, []azure.ResourceSpecGetter{fakeLink1, fakeLink2}, []azure.ResourceSpecGetter{fakeRecord1}).Times(2)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				z.CreateOrUpdateResource(gomockinternal.AContext(), fakeZone, serviceName).Return(nil, errFake)
 				s.UpdatePutStatus(infrav1.PrivateDNSZoneReadyCondition, serviceName, errFake)
@@ -164,14 +164,14 @@ func TestReconcilePrivateDNS(t *testing.T) {
 				s.PrivateDNSSpec().Return(fakeZone, []azure.ResourceSpecGetter{fakeLink1, fakeLink2}, []azure.ResourceSpecGetter{fakeRecord1}).Times(2)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(resources.TagsResource{}, nil)
+				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(armresources.TagsResource{}, nil)
 				s.ClusterName().Return(clusterName)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				l.CreateOrUpdateResource(gomockinternal.AContext(), fakeLink1, serviceName).Return(nil, nil)
 				l.CreateOrUpdateResource(gomockinternal.AContext(), fakeLink2, serviceName).Return(nil, nil)
@@ -187,13 +187,13 @@ func TestReconcilePrivateDNS(t *testing.T) {
 				s.PrivateDNSSpec().Return(fakeZone, []azure.ResourceSpecGetter{fakeLink1, fakeLink2}, []azure.ResourceSpecGetter{fakeRecord1}).Times(2)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				z.CreateOrUpdateResource(gomockinternal.AContext(), fakeZone, serviceName).Return(nil, nil)
 				l.CreateOrUpdateResource(gomockinternal.AContext(), fakeLink1, serviceName).Return(nil, errFake)
@@ -209,13 +209,13 @@ func TestReconcilePrivateDNS(t *testing.T) {
 				s.PrivateDNSSpec().Return(fakeZone, []azure.ResourceSpecGetter{fakeLink1, fakeLink2}, []azure.ResourceSpecGetter{fakeRecord1}).Times(2)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				z.CreateOrUpdateResource(gomockinternal.AContext(), fakeZone, serviceName).Return(nil, nil)
 				l.CreateOrUpdateResource(gomockinternal.AContext(), fakeLink1, serviceName).Return(nil, nil)
@@ -231,13 +231,13 @@ func TestReconcilePrivateDNS(t *testing.T) {
 				s.PrivateDNSSpec().Return(fakeZone, []azure.ResourceSpecGetter{fakeLink1, fakeLink2}, []azure.ResourceSpecGetter{fakeRecord1}).Times(2)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				z.CreateOrUpdateResource(gomockinternal.AContext(), fakeZone, serviceName).Return(nil, nil)
 				l.CreateOrUpdateResource(gomockinternal.AContext(), fakeLink1, serviceName).Return(nil, notDoneError)
@@ -252,14 +252,14 @@ func TestReconcilePrivateDNS(t *testing.T) {
 				s.PrivateDNSSpec().Return(fakeZone, []azure.ResourceSpecGetter{fakeLink1, fakeLink2}, []azure.ResourceSpecGetter{fakeRecord1}).Times(2)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(resources.TagsResource{}, nil)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(armresources.TagsResource{}, nil)
 				s.ClusterName().Return(clusterName)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(resources.TagsResource{}, nil)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(armresources.TagsResource{}, nil)
 				s.ClusterName().Return(clusterName)
 
 				z.CreateOrUpdateResource(gomockinternal.AContext(), fakeZone, serviceName).Return(nil, nil)
@@ -274,14 +274,14 @@ func TestReconcilePrivateDNS(t *testing.T) {
 				s.PrivateDNSSpec().Return(fakeZone, []azure.ResourceSpecGetter{fakeLink1, fakeLink2}, []azure.ResourceSpecGetter{fakeRecord1}).Times(2)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(resources.TagsResource{}, nil)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(armresources.TagsResource{}, nil)
 				s.ClusterName().Return(clusterName)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				z.CreateOrUpdateResource(gomockinternal.AContext(), fakeZone, serviceName).Return(nil, nil)
 				l.CreateOrUpdateResource(gomockinternal.AContext(), fakeLink2, serviceName).Return(nil, nil)
@@ -298,13 +298,13 @@ func TestReconcilePrivateDNS(t *testing.T) {
 				s.PrivateDNSSpec().Return(fakeZone, []azure.ResourceSpecGetter{fakeLink1, fakeLink2}, []azure.ResourceSpecGetter{fakeRecord1}).Times(2)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(resources.TagsResource{}, notFoundError)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(armresources.TagsResource{}, notFoundError)
 
 				z.CreateOrUpdateResource(gomockinternal.AContext(), fakeZone, serviceName).Return(nil, nil)
 				l.CreateOrUpdateResource(gomockinternal.AContext(), fakeLink1, serviceName).Return(nil, nil)
@@ -400,15 +400,15 @@ func TestDeletePrivateDNS(t *testing.T) {
 				s.PrivateDNSSpec().Return(fakeZone, []azure.ResourceSpecGetter{fakeLink1, fakeLink2}, []azure.ResourceSpecGetter{fakeRecord1}).Times(2)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(resources.TagsResource{}, nil)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(armresources.TagsResource{}, nil)
 				s.ClusterName().Return(clusterName)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(resources.TagsResource{}, nil)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink2.ResourceGroupName(), fakeLink2.OwnerResourceName(), fakeLink2.ResourceName())).Return(armresources.TagsResource{}, nil)
 				s.ClusterName().Return(clusterName)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(resources.TagsResource{}, nil)
+				tg.GetAtScope(gomockinternal.AContext(), azure.PrivateDNSZoneID("123", fakeZone.ResourceGroupName(), fakeZone.ResourceName())).Return(armresources.TagsResource{}, nil)
 				s.ClusterName().Return(clusterName)
 			},
 		},
@@ -419,7 +419,7 @@ func TestDeletePrivateDNS(t *testing.T) {
 				s.PrivateDNSSpec().Return(fakeZone, []azure.ResourceSpecGetter{fakeLink1, fakeLink2}, []azure.ResourceSpecGetter{fakeRecord1}).Times(2)
 
 				s.SubscriptionID().Return("123")
-				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(resources.TagsResource{}, nil)
+				tg.GetAtScope(gomockinternal.AContext(), azure.VirtualNetworkLinkID("123", fakeLink1.ResourceGroupName(), fakeLink1.OwnerResourceName(), fakeLink1.ResourceName())).Return(armresources.TagsResource{}, nil)
 				s.ClusterName().Return(clusterName)
 
 				s.SubscriptionID().Return("123")

--- a/azure/services/publicips/publicips.go
+++ b/azure/services/publicips/publicips.go
@@ -47,15 +47,18 @@ type Service struct {
 }
 
 // New creates a new service.
-func New(scope PublicIPScope) *Service {
+func New(scope PublicIPScope) (*Service, error) {
 	client := NewClient(scope)
-	tagsClient := tags.NewClient(scope)
+	tagsClient, err := tags.NewClient(scope)
+	if err != nil {
+		return nil, err
+	}
 	return &Service{
 		Scope:      scope,
 		Getter:     client,
 		TagsGetter: tagsClient,
 		Reconciler: async.New(scope, client, client),
-	}
+	}, nil
 }
 
 // Name returns the service name.

--- a/azure/services/publicips/publicips_test.go
+++ b/azure/services/publicips/publicips_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -94,8 +94,8 @@ var (
 		},
 	}
 
-	managedTags = resources.TagsResource{
-		Properties: &resources.Tags{
+	managedTags = armresources.TagsResource{
+		Properties: &armresources.Tags{
 			Tags: map[string]*string{
 				"foo": ptr.To("bar"),
 				"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
@@ -103,8 +103,8 @@ var (
 		},
 	}
 
-	unmanagedTags = resources.TagsResource{
-		Properties: &resources.Tags{
+	unmanagedTags = armresources.TagsResource{
+		Properties: &armresources.Tags{
 			Tags: map[string]*string{
 				"foo":       ptr.To("bar"),
 				"something": ptr.To("else"),

--- a/azure/services/tags/mock_tags/client_mock.go
+++ b/azure/services/tags/mock_tags/client_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	resources "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
+	armresources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -52,10 +52,10 @@ func (m *Mockclient) EXPECT() *MockclientMockRecorder {
 }
 
 // GetAtScope mocks base method.
-func (m *Mockclient) GetAtScope(arg0 context.Context, arg1 string) (resources.TagsResource, error) {
+func (m *Mockclient) GetAtScope(arg0 context.Context, arg1 string) (armresources.TagsResource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAtScope", arg0, arg1)
-	ret0, _ := ret[0].(resources.TagsResource)
+	ret0, _ := ret[0].(armresources.TagsResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -67,10 +67,10 @@ func (mr *MockclientMockRecorder) GetAtScope(arg0, arg1 interface{}) *gomock.Cal
 }
 
 // UpdateAtScope mocks base method.
-func (m *Mockclient) UpdateAtScope(arg0 context.Context, arg1 string, arg2 resources.TagsPatchResource) (resources.TagsResource, error) {
+func (m *Mockclient) UpdateAtScope(arg0 context.Context, arg1 string, arg2 armresources.TagsPatchResource) (armresources.TagsResource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAtScope", arg0, arg1, arg2)
-	ret0, _ := ret[0].(resources.TagsResource)
+	ret0, _ := ret[0].(armresources.TagsResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/azure/services/tags/tags_test.go
+++ b/azure/services/tags/tags_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -60,16 +60,16 @@ func TestReconcileTags(t *testing.T) {
 							Annotation: "my-annotation-2",
 						},
 					}),
-					m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(resources.TagsResource{Properties: &resources.Tags{
+					m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(armresources.TagsResource{Properties: &armresources.Tags{
 						Tags: map[string]*string{
 							"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": ptr.To("owned"),
 							"externalSystemTag": ptr.To("randomValue"),
 						},
 					}}, nil),
 					s.AnnotationJSON("my-annotation"),
-					m.UpdateAtScope(gomockinternal.AContext(), "/sub/123/fake/scope", resources.TagsPatchResource{
-						Operation: "Merge",
-						Properties: &resources.Tags{
+					m.UpdateAtScope(gomockinternal.AContext(), "/sub/123/fake/scope", armresources.TagsPatchResource{
+						Operation: ptr.To(armresources.TagsPatchOperationMerge),
+						Properties: &armresources.Tags{
 							Tags: map[string]*string{
 								"foo":   ptr.To("bar"),
 								"thing": ptr.To("stuff"),
@@ -77,16 +77,16 @@ func TestReconcileTags(t *testing.T) {
 						},
 					}),
 					s.UpdateAnnotationJSON("my-annotation", map[string]interface{}{"foo": "bar", "thing": "stuff"}),
-					m.GetAtScope(gomockinternal.AContext(), "/sub/123/other/scope").Return(resources.TagsResource{Properties: &resources.Tags{
+					m.GetAtScope(gomockinternal.AContext(), "/sub/123/other/scope").Return(armresources.TagsResource{Properties: &armresources.Tags{
 						Tags: map[string]*string{
 							"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": ptr.To("owned"),
 							"externalSystem2Tag": ptr.To("randomValue2"),
 						},
 					}}, nil),
 					s.AnnotationJSON("my-annotation-2"),
-					m.UpdateAtScope(gomockinternal.AContext(), "/sub/123/other/scope", resources.TagsPatchResource{
-						Operation: "Merge",
-						Properties: &resources.Tags{
+					m.UpdateAtScope(gomockinternal.AContext(), "/sub/123/other/scope", armresources.TagsPatchResource{
+						Operation: ptr.To(armresources.TagsPatchOperationMerge),
+						Properties: &armresources.Tags{
 							Tags: map[string]*string{
 								"tag1": ptr.To("value1"),
 							},
@@ -111,7 +111,7 @@ func TestReconcileTags(t *testing.T) {
 						Annotation: "my-annotation",
 					},
 				})
-				m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(resources.TagsResource{}, nil)
+				m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(armresources.TagsResource{}, nil)
 			},
 		},
 		{
@@ -131,11 +131,11 @@ func TestReconcileTags(t *testing.T) {
 							Annotation: annotation,
 						},
 					}),
-					m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(resources.TagsResource{}, nil),
+					m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(armresources.TagsResource{}, nil),
 					s.AnnotationJSON(annotation),
-					m.UpdateAtScope(gomockinternal.AContext(), "/sub/123/fake/scope", resources.TagsPatchResource{
-						Operation: "Merge",
-						Properties: &resources.Tags{
+					m.UpdateAtScope(gomockinternal.AContext(), "/sub/123/fake/scope", armresources.TagsPatchResource{
+						Operation: ptr.To(armresources.TagsPatchOperationMerge),
+						Properties: &armresources.Tags{
 							Tags: map[string]*string{
 								"foo":   ptr.To("bar"),
 								"thing": ptr.To("stuff"),
@@ -161,7 +161,7 @@ func TestReconcileTags(t *testing.T) {
 							Annotation: "my-annotation",
 						},
 					}),
-					m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(resources.TagsResource{Properties: &resources.Tags{
+					m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(armresources.TagsResource{Properties: &armresources.Tags{
 						Tags: map[string]*string{
 							"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": ptr.To("owned"),
 							"foo":   ptr.To("bar"),
@@ -169,9 +169,9 @@ func TestReconcileTags(t *testing.T) {
 						},
 					}}, nil),
 					s.AnnotationJSON("my-annotation").Return(map[string]interface{}{"foo": "bar", "thing": "stuff"}, nil),
-					m.UpdateAtScope(gomockinternal.AContext(), "/sub/123/fake/scope", resources.TagsPatchResource{
-						Operation: "Delete",
-						Properties: &resources.Tags{
+					m.UpdateAtScope(gomockinternal.AContext(), "/sub/123/fake/scope", armresources.TagsPatchResource{
+						Operation: ptr.To(armresources.TagsPatchOperationDelete),
+						Properties: &armresources.Tags{
 							Tags: map[string]*string{
 								"thing": ptr.To("stuff"),
 							},
@@ -196,7 +196,7 @@ func TestReconcileTags(t *testing.T) {
 						Annotation: "my-annotation",
 					},
 				})
-				m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(resources.TagsResource{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error"))
+				m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(armresources.TagsResource{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error"))
 			},
 		},
 		{
@@ -213,20 +213,20 @@ func TestReconcileTags(t *testing.T) {
 						Annotation: "my-annotation",
 					},
 				})
-				m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(resources.TagsResource{Properties: &resources.Tags{
+				m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(armresources.TagsResource{Properties: &armresources.Tags{
 					Tags: map[string]*string{
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": ptr.To("owned"),
 					},
 				}}, nil)
 				s.AnnotationJSON("my-annotation")
-				m.UpdateAtScope(gomockinternal.AContext(), "/sub/123/fake/scope", resources.TagsPatchResource{
-					Operation: "Merge",
-					Properties: &resources.Tags{
+				m.UpdateAtScope(gomockinternal.AContext(), "/sub/123/fake/scope", armresources.TagsPatchResource{
+					Operation: ptr.To(armresources.TagsPatchOperationMerge),
+					Properties: &armresources.Tags{
 						Tags: map[string]*string{
 							"key": ptr.To("value"),
 						},
 					},
-				}).Return(resources.TagsResource{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error"))
+				}).Return(armresources.TagsResource{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error"))
 			},
 		},
 		{
@@ -243,7 +243,7 @@ func TestReconcileTags(t *testing.T) {
 						Annotation: "my-annotation",
 					},
 				})
-				m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(resources.TagsResource{Properties: &resources.Tags{
+				m.GetAtScope(gomockinternal.AContext(), "/sub/123/fake/scope").Return(armresources.TagsResource{Properties: &armresources.Tags{
 					Tags: map[string]*string{
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": ptr.To("owned"),
 						"key": ptr.To("value"),

--- a/azure/services/virtualnetworks/virtualnetworks.go
+++ b/azure/services/virtualnetworks/virtualnetworks.go
@@ -59,7 +59,10 @@ func New(scope VNetScope) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	tagsClient := tags.NewClient(scope)
+	tagsClient, err := tags.NewClient(scope)
+	if err != nil {
+		return nil, err
+	}
 	return &Service{
 		Scope:      scope,
 		Getter:     client,

--- a/azure/services/virtualnetworks/virtualnetworks_test.go
+++ b/azure/services/virtualnetworks/virtualnetworks_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -44,8 +44,8 @@ var (
 		AdditionalTags: map[string]string{"foo": "bar"},
 	}
 
-	managedTags = resources.TagsResource{
-		Properties: &resources.Tags{
+	managedTags = armresources.TagsResource{
+		Properties: &armresources.Tags{
 			Tags: map[string]*string{
 				"foo": ptr.To("bar"),
 				"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": ptr.To("owned"),
@@ -53,8 +53,8 @@ var (
 		},
 	}
 
-	unmanagedTags = resources.TagsResource{
-		Properties: &resources.Tags{
+	unmanagedTags = armresources.TagsResource{
+		Properties: &armresources.Tags{
 			Tags: map[string]*string{
 				"foo":       ptr.To("bar"),
 				"something": ptr.To("else"),
@@ -304,7 +304,7 @@ func TestIsVnetManaged(t *testing.T) {
 			expect: func(s *mock_virtualnetworks.MockVNetScopeMockRecorder, m *mock_async.MockTagsGetterMockRecorder) {
 				s.VNetSpec().Return(&fakeVNetSpec)
 				s.SubscriptionID().Return("123")
-				m.GetAtScope(gomockinternal.AContext(), azure.VNetID("123", fakeVNetSpec.ResourceGroupName(), fakeVNetSpec.Name)).Return(resources.TagsResource{}, internalError)
+				m.GetAtScope(gomockinternal.AContext(), azure.VNetID("123", fakeVNetSpec.ResourceGroupName(), fakeVNetSpec.Name)).Return(armresources.TagsResource{}, internalError)
 			},
 		},
 	}

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -80,11 +80,19 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 	if err != nil {
 		return nil, err
 	}
+	publicIPsSvc, err := publicips.New(scope)
+	if err != nil {
+		return nil, err
+	}
 	privateDNSSvc, err := privatedns.New(scope)
 	if err != nil {
 		return nil, err
 	}
 	subnetsSvc, err := subnets.New(scope)
+	if err != nil {
+		return nil, err
+	}
+	tagsSvc, err := tags.New(scope)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +115,7 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 			virtualNetworksSvc,
 			securityGroupsSvc,
 			routeTablesSvc,
-			publicips.New(scope),
+			publicIPsSvc,
 			natGatewaysSvc,
 			subnetsSvc,
 			vnetPeeringsSvc,
@@ -115,7 +123,7 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 			privateDNSSvc,
 			bastionHostsSvc,
 			privateEndpointsSvc,
-			tags.New(scope),
+			tagsSvc,
 		},
 		skuCache: skuCache,
 	}, nil

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -65,9 +65,17 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating inboundnatrules service")
 	}
+	publicIPsSvc, err := publicips.New(machineScope)
+	if err != nil {
+		return nil, err
+	}
 	roleAssignmentsSvc, err := roleassignments.New(machineScope)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed creating a roleassignments service")
+		return nil, errors.Wrap(err, "failed creating roleassignments service")
+	}
+	tagsSvc, err := tags.New(machineScope)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating tags service")
 	}
 	virtualmachinesSvc, err := virtualmachines.New(machineScope)
 	if err != nil {
@@ -84,7 +92,7 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 	ams := &azureMachineService{
 		scope: machineScope,
 		services: []azure.ServiceReconciler{
-			publicips.New(machineScope),
+			publicIPsSvc,
 			inboundnatrulesSvc,
 			networkInterfacesSvc,
 			availabilitySetsSvc,
@@ -92,7 +100,7 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 			virtualmachinesSvc,
 			roleAssignmentsSvc,
 			vmextensionsSvc,
-			tags.New(machineScope),
+			tagsSvc,
 		},
 		skuCache: cache,
 	}

--- a/controllers/azuremanagedcontrolplane_reconciler.go
+++ b/controllers/azuremanagedcontrolplane_reconciler.go
@@ -65,6 +65,10 @@ func newAzureManagedControlPlaneReconciler(scope *scope.ManagedControlPlaneScope
 	if err != nil {
 		return nil, err
 	}
+	tagsSvc, err := tags.New(scope)
+	if err != nil {
+		return nil, err
+	}
 	virtualNetworksSvc, err := virtualnetworks.New(scope)
 	if err != nil {
 		return nil, err
@@ -78,7 +82,7 @@ func newAzureManagedControlPlaneReconciler(scope *scope.ManagedControlPlaneScope
 			subnetsSvc,
 			managedClustersSvc,
 			privateEndpointsSvc,
-			tags.New(scope),
+			tagsSvc,
 			resourceHealthSvc,
 		},
 	}, nil


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the tags service to azure-sdk-for-go version 2 and the `ascynpoller` framework for long-running operations.

**Which issue(s) this PR fixes**:

Fixes #3927

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
