### PR TITLE
Convert subnets service to SDKv2

### DIFF
--- a/azure/converters/subnets.go
+++ b/azure/converters/subnets.go
@@ -17,6 +17,7 @@ limitations under the License.
 package converters
 
 import (
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -29,6 +30,19 @@ func GetSubnetAddresses(subnet network.Subnet) []string {
 		addresses = []string{ptr.Deref(subnet.SubnetPropertiesFormat.AddressPrefix, "")}
 	} else if subnet.SubnetPropertiesFormat != nil && subnet.SubnetPropertiesFormat.AddressPrefixes != nil {
 		addresses = azure.StringSlice(subnet.SubnetPropertiesFormat.AddressPrefixes)
+	}
+	return addresses
+}
+
+// GetSubnetAddressesV2 returns the address prefixes contained in an SDK v2 subnet.
+func GetSubnetAddressesV2(subnet armnetwork.Subnet) []string {
+	var addresses []string
+	if subnet.Properties != nil && subnet.Properties.AddressPrefix != nil {
+		addresses = []string{ptr.Deref(subnet.Properties.AddressPrefix, "")}
+	} else if subnet.Properties != nil && subnet.Properties.AddressPrefixes != nil {
+		for _, address := range subnet.Properties.AddressPrefixes {
+			addresses = append(addresses, ptr.Deref(address, ""))
+		}
 	}
 	return addresses
 }

--- a/azure/converters/subnets_test.go
+++ b/azure/converters/subnets_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
@@ -60,6 +61,46 @@ func TestGetSubnetAddresses(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 			got := GetSubnetAddresses(tt.subnet)
+			g.Expect(got).To(Equal(tt.want), fmt.Sprintf("got: %v, want: %v", got, tt.want))
+		})
+	}
+}
+
+func TestGetSubnetAddressesV2(t *testing.T) {
+	tests := []struct {
+		name   string
+		subnet armnetwork.Subnet
+		want   []string
+	}{
+		{
+			name:   "nil properties subnet",
+			subnet: armnetwork.Subnet{},
+		},
+		{
+			name: "subnet with single address prefix",
+			subnet: armnetwork.Subnet{
+				Properties: &armnetwork.SubnetPropertiesFormat{
+					AddressPrefix: ptr.To("test-address-prefix"),
+				},
+			},
+			want: []string{"test-address-prefix"},
+		},
+		{
+			name: "subnet with multiple address prefixes",
+			subnet: armnetwork.Subnet{
+				Properties: &armnetwork.SubnetPropertiesFormat{
+					AddressPrefixes: []*string{ptr.To("test-address-prefix-1"), ptr.To("test-address-prefix-2")},
+				},
+			},
+			want: []string{"test-address-prefix-1", "test-address-prefix-2"},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+			got := GetSubnetAddressesV2(tt.subnet)
 			g.Expect(got).To(Equal(tt.want), fmt.Sprintf("got: %v, want: %v", got, tt.want))
 		})
 	}

--- a/azure/services/subnets/spec_test.go
+++ b/azure/services/subnets/spec_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -41,13 +41,12 @@ var (
 		Role:              infrav1.SubnetNode,
 	}
 
-	fakeSubnetOneCidrParams = network.Subnet{
-		SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+	fakeSubnetOneCidrParams = armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{
 			AddressPrefix:        ptr.To("10.0.0.0/16"),
-			RouteTable:           &network.RouteTable{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
-			NetworkSecurityGroup: &network.SecurityGroup{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
-			NatGateway:           &network.SubResource{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/natGateways/my-nat-gateway")},
-			ServiceEndpoints:     &[]network.ServiceEndpointPropertiesFormat{},
+			RouteTable:           &armnetwork.RouteTable{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
+			NetworkSecurityGroup: &armnetwork.SecurityGroup{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
+			NatGateway:           &armnetwork.SubResource{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/natGateways/my-nat-gateway")},
 		},
 	}
 
@@ -65,17 +64,16 @@ var (
 		Role:              infrav1.SubnetNode,
 	}
 
-	fakeSubnetMultipleCidrParams = network.Subnet{
-		SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-			AddressPrefixes: &[]string{
-				"10.0.0.0/16",
-				"10.1.0.0/16",
-				"10.2.0.0/16",
+	fakeSubnetMultipleCidrParams = armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefixes: []*string{
+				ptr.To("10.0.0.0/16"),
+				ptr.To("10.1.0.0/16"),
+				ptr.To("10.2.0.0/16"),
 			},
-			RouteTable:           &network.RouteTable{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
-			NetworkSecurityGroup: &network.SecurityGroup{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
-			NatGateway:           &network.SubResource{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/natGateways/my-nat-gateway")},
-			ServiceEndpoints:     &[]network.ServiceEndpointPropertiesFormat{},
+			RouteTable:           &armnetwork.RouteTable{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
+			NetworkSecurityGroup: &armnetwork.SecurityGroup{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
+			NatGateway:           &armnetwork.SubResource{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/natGateways/my-nat-gateway")},
 		},
 	}
 
@@ -92,16 +90,16 @@ var (
 		Role:              infrav1.SubnetNode,
 	}
 
-	fakeIpv6SubnetNotManaged = network.Subnet{
+	fakeIpv6SubnetNotManaged = armnetwork.Subnet{
 		ID:   ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-ipv6-subnet"),
 		Name: ptr.To("my-ipv6-subnet"),
-		SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-			AddressPrefixes: &[]string{
-				"10.0.0.0/16",
-				"2001:1234:5678:9abd::/64",
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefixes: []*string{
+				ptr.To("10.0.0.0/16"),
+				ptr.To("2001:1234:5678:9abd::/64"),
 			},
-			RouteTable:           &network.RouteTable{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
-			NetworkSecurityGroup: &network.SecurityGroup{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
+			RouteTable:           &armnetwork.RouteTable{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/routeTables/my-subnet_route_table")},
+			NetworkSecurityGroup: &armnetwork.SecurityGroup{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/my-sg")},
 		},
 	}
 )
@@ -203,7 +201,7 @@ func TestSubnetSpec_shouldUpdate(t *testing.T) {
 		ServiceEndpoints  infrav1.ServiceEndpoints
 	}
 	type args struct {
-		existingSubnet network.Subnet
+		existingSubnet armnetwork.Subnet
 	}
 	tests := []struct {
 		name   string
@@ -220,7 +218,7 @@ func TestSubnetSpec_shouldUpdate(t *testing.T) {
 				IsVNetManaged:  false,
 			},
 			args: args{
-				existingSubnet: network.Subnet{
+				existingSubnet: armnetwork.Subnet{
 					Name: ptr.To("my-subnet"),
 				},
 			},
@@ -236,9 +234,9 @@ func TestSubnetSpec_shouldUpdate(t *testing.T) {
 				NatGatewayName: "my-nat-gateway",
 			},
 			args: args{
-				existingSubnet: network.Subnet{
+				existingSubnet: armnetwork.Subnet{
 					Name: ptr.To("my-subnet"),
-					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+					Properties: &armnetwork.SubnetPropertiesFormat{
 						NatGateway: nil,
 					},
 				},
@@ -259,9 +257,9 @@ func TestSubnetSpec_shouldUpdate(t *testing.T) {
 				},
 			},
 			args: args{
-				existingSubnet: network.Subnet{
+				existingSubnet: armnetwork.Subnet{
 					Name: ptr.To("my-subnet"),
-					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+					Properties: &armnetwork.SubnetPropertiesFormat{
 						ServiceEndpoints: nil,
 					},
 				},
@@ -278,10 +276,10 @@ func TestSubnetSpec_shouldUpdate(t *testing.T) {
 				CIDRs:          []string{"10.1.0.0/16"},
 			},
 			args: args{
-				existingSubnet: network.Subnet{
+				existingSubnet: armnetwork.Subnet{
 					Name: ptr.To("my-subnet"),
-					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-						AddressPrefixes: &[]string{"10.1.0.0/8"},
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						AddressPrefixes: []*string{ptr.To("10.1.0.0/8")},
 					},
 				},
 			},

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -76,6 +76,10 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 	if err != nil {
 		return nil, err
 	}
+	subnetsSvc, err := subnets.New(scope)
+	if err != nil {
+		return nil, err
+	}
 	vnetPeeringsSvc, err := vnetpeerings.New(scope)
 	if err != nil {
 		return nil, err
@@ -89,7 +93,7 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 			routeTablesSvc,
 			publicips.New(scope),
 			natGatewaysSvc,
-			subnets.New(scope),
+			subnetsSvc,
 			vnetPeeringsSvc,
 			loadbalancers.New(scope),
 			privatedns.New(scope),

--- a/controllers/azuremanagedcontrolplane_reconciler.go
+++ b/controllers/azuremanagedcontrolplane_reconciler.go
@@ -49,7 +49,7 @@ func newAzureManagedControlPlaneReconciler(scope *scope.ManagedControlPlaneScope
 	if scope.UseLegacyGroups {
 		groupsService = groups.New(scope)
 	}
-	managedClustersService, err := managedclusters.New(scope)
+	managedClustersSvc, err := managedclusters.New(scope)
 	if err != nil {
 		return nil, err
 	}
@@ -61,14 +61,18 @@ func newAzureManagedControlPlaneReconciler(scope *scope.ManagedControlPlaneScope
 	if err != nil {
 		return nil, err
 	}
+	subnetsSvc, err := subnets.New(scope)
+	if err != nil {
+		return nil, err
+	}
 	return &azureManagedControlPlaneService{
 		kubeclient: scope.Client,
 		scope:      scope,
 		services: []azure.ServiceReconciler{
 			groupsService,
 			virtualnetworks.New(scope),
-			subnets.New(scope),
-			managedClustersService,
+			subnetsSvc,
+			managedClustersSvc,
 			privateEndpointsSvc,
 			tags.New(scope),
 			resourceHealthSvc,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the subnets service to azure-sdk-for-go version 2 and the `asyncpoller` framework.

**Which issue(s) this PR fixes**:

Fixes #3924

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
