### PR TITLE
Convert virtualnetworks service to SDKv2

### DIFF
--- a/azure/converters/extendedlocation.go
+++ b/azure/converters/extendedlocation.go
@@ -17,11 +17,23 @@ limitations under the License.
 package converters
 
 import (
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
+
+// ExtendedLocationToNetworkSDKv2 converts an infrav1.ExtendedLocationSpec to an armnetwork.ExtendedLocation.
+func ExtendedLocationToNetworkSDKv2(src *infrav1.ExtendedLocationSpec) *armnetwork.ExtendedLocation {
+	if src == nil {
+		return nil
+	}
+	return &armnetwork.ExtendedLocation{
+		Name: ptr.To(src.Name),
+		Type: ptr.To(armnetwork.ExtendedLocationTypes(src.Type)),
+	}
+}
 
 // ExtendedLocationToNetworkSDK converts infrav1.ExtendedLocationSpec to network.ExtendedLocation.
 func ExtendedLocationToNetworkSDK(src *infrav1.ExtendedLocationSpec) *network.ExtendedLocation {

--- a/azure/converters/extendedlocation_test.go
+++ b/azure/converters/extendedlocation_test.go
@@ -20,11 +20,44 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
+
+func TestExtendedLocationToNetworkSDKv2(t *testing.T) {
+	tests := []struct {
+		name string
+		args *infrav1.ExtendedLocationSpec
+		want *armnetwork.ExtendedLocation
+	}{
+		{
+			name: "normal extendedLocation instance",
+			args: &infrav1.ExtendedLocationSpec{
+				Name: "value",
+				Type: "EdgeZone",
+			},
+			want: &armnetwork.ExtendedLocation{
+				Name: ptr.To("value"),
+				Type: ptr.To(armnetwork.ExtendedLocationTypesEdgeZone),
+			},
+		},
+		{
+			name: "nil extendedLocation properties",
+			args: nil,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtendedLocationToNetworkSDKv2(tt.args); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtendedLocationToNetworkSDKv2() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestExtendedLocationToNetworkSDK(t *testing.T) {
 	tests := []struct {

--- a/azure/converters/subnets.go
+++ b/azure/converters/subnets.go
@@ -35,13 +35,15 @@ func GetSubnetAddresses(subnet network.Subnet) []string {
 }
 
 // GetSubnetAddressesV2 returns the address prefixes contained in an SDK v2 subnet.
-func GetSubnetAddressesV2(subnet armnetwork.Subnet) []string {
+func GetSubnetAddressesV2(subnet *armnetwork.Subnet) []string {
 	var addresses []string
 	if subnet.Properties != nil && subnet.Properties.AddressPrefix != nil {
 		addresses = []string{ptr.Deref(subnet.Properties.AddressPrefix, "")}
 	} else if subnet.Properties != nil && subnet.Properties.AddressPrefixes != nil {
 		for _, address := range subnet.Properties.AddressPrefixes {
-			addresses = append(addresses, ptr.Deref(address, ""))
+			if address != nil {
+				addresses = append(addresses, *address)
+			}
 		}
 	}
 	return addresses

--- a/azure/converters/subnets_test.go
+++ b/azure/converters/subnets_test.go
@@ -100,7 +100,7 @@ func TestGetSubnetAddressesV2(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
-			got := GetSubnetAddressesV2(tt.subnet)
+			got := GetSubnetAddressesV2(&tt.subnet)
 			g.Expect(got).To(Equal(tt.want), fmt.Sprintf("got: %v, want: %v", got, tt.want))
 		})
 	}

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -402,7 +402,12 @@ func (s *ManagedControlPlaneScope) IsVnetManaged() bool {
 	ctx := context.Background()
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "scope.ManagedControlPlaneScope.IsVnetManaged")
 	defer done()
-	isManaged, err := virtualnetworks.New(s).IsManaged(ctx)
+	virtualNetworksSvc, err := virtualnetworks.New(s)
+	if err != nil {
+		log.Error(err, "failed to create virtualnetworks service")
+		return false
+	}
+	isManaged, err := virtualNetworksSvc.IsManaged(ctx)
 	if err != nil {
 		log.Error(err, "Unable to determine if ManagedControlPlaneScope VNET is managed by capz", "AzureManagedCluster", s.ClusterName())
 	}

--- a/azure/services/subnets/subnets.go
+++ b/azure/services/subnets/subnets.go
@@ -95,7 +95,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 				return errors.Errorf("%T is not an armnetwork.Subnet", result)
 			}
 			s.Scope.UpdateSubnetID(subnetSpec.ResourceName(), ptr.Deref(subnet.ID, ""))
-			s.Scope.UpdateSubnetCIDRs(subnetSpec.ResourceName(), converters.GetSubnetAddressesV2(subnet))
+			s.Scope.UpdateSubnetCIDRs(subnetSpec.ResourceName(), converters.GetSubnetAddressesV2(&subnet))
 		}
 	}
 

--- a/azure/services/virtualnetworks/spec.go
+++ b/azure/services/virtualnetworks/spec.go
@@ -19,9 +19,10 @@ package virtualnetworks
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 )
 
@@ -57,7 +58,7 @@ func (s *VNetSpec) Parameters(ctx context.Context, existing interface{}) (interf
 		// vnet already exists, nothing to update.
 		return nil, nil
 	}
-	return network.VirtualNetwork{
+	return armnetwork.VirtualNetwork{
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
@@ -66,10 +67,10 @@ func (s *VNetSpec) Parameters(ctx context.Context, existing interface{}) (interf
 			Additional:  s.AdditionalTags,
 		})),
 		Location:         ptr.To(s.Location),
-		ExtendedLocation: converters.ExtendedLocationToNetworkSDK(s.ExtendedLocation),
-		VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
-			AddressSpace: &network.AddressSpace{
-				AddressPrefixes: &s.CIDRs,
+		ExtendedLocation: converters.ExtendedLocationToNetworkSDKv2(s.ExtendedLocation),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{
+				AddressPrefixes: azure.PtrSlice(&s.CIDRs),
 			},
 		},
 	}, nil

--- a/azure/services/virtualnetworks/virtualnetworks_test.go
+++ b/azure/services/virtualnetworks/virtualnetworks_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
@@ -62,30 +62,30 @@ var (
 		},
 	}
 
-	customVnet = network.VirtualNetwork{
+	customVnet = armnetwork.VirtualNetwork{
 		ID:   ptr.To("/subscriptions/subscription/resourceGroups/test-group/providers/Microsoft.Network/virtualNetworks/test-vnet"),
 		Name: ptr.To("test-vnet"),
 		Tags: map[string]*string{
 			"foo":       ptr.To("bar"),
 			"something": ptr.To("else"),
 		},
-		VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
-			AddressSpace: &network.AddressSpace{
-				AddressPrefixes: &[]string{"fake-cidr"},
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{
+				AddressPrefixes: []*string{ptr.To("fake-cidr")},
 			},
-			Subnets: &[]network.Subnet{
+			Subnets: []*armnetwork.Subnet{
 				{
 					Name: ptr.To("test-subnet"),
-					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+					Properties: &armnetwork.SubnetPropertiesFormat{
 						AddressPrefix: ptr.To("subnet-cidr"),
 					},
 				},
 				{
 					Name: ptr.To("test-subnet-2"),
-					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-						AddressPrefixes: &[]string{
-							"subnet-cidr-1",
-							"subnet-cidr-2",
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						AddressPrefixes: []*string{
+							ptr.To("subnet-cidr-1"),
+							ptr.To("subnet-cidr-2"),
 						},
 					},
 				},

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -88,6 +88,10 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 	if err != nil {
 		return nil, err
 	}
+	virtualNetworksSvc, err := virtualnetworks.New(scope)
+	if err != nil {
+		return nil, err
+	}
 	vnetPeeringsSvc, err := vnetpeerings.New(scope)
 	if err != nil {
 		return nil, err
@@ -96,7 +100,7 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 		scope: scope,
 		services: []azure.ServiceReconciler{
 			groupsSvc,
-			virtualnetworks.New(scope),
+			virtualNetworksSvc,
 			securityGroupsSvc,
 			routeTablesSvc,
 			publicips.New(scope),

--- a/controllers/azuremanagedcontrolplane_reconciler.go
+++ b/controllers/azuremanagedcontrolplane_reconciler.go
@@ -65,12 +65,16 @@ func newAzureManagedControlPlaneReconciler(scope *scope.ManagedControlPlaneScope
 	if err != nil {
 		return nil, err
 	}
+	virtualNetworksSvc, err := virtualnetworks.New(scope)
+	if err != nil {
+		return nil, err
+	}
 	return &azureManagedControlPlaneService{
 		kubeclient: scope.Client,
 		scope:      scope,
 		services: []azure.ServiceReconciler{
 			groupsService,
-			virtualnetworks.New(scope),
+			virtualNetworksSvc,
 			subnetsSvc,
 			managedClustersSvc,
 			privateEndpointsSvc,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the virtualnetworks service to azure-sdk-for-go version 2 and the `asyncpoller` framework.

**Which issue(s) this PR fixes**:

Fixes #3925

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
