### PR TITLE
Convert identities service to SDKv2

### DIFF
--- a/azure/services/identities/mock_identities/client_mock.go
+++ b/azure/services/identities/mock_identities/client_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	msi "github.com/Azure/azure-sdk-for-go/services/msi/mgmt/2018-11-30/msi"
+	armmsi "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -52,10 +52,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Get mocks base method.
-func (m *MockClient) Get(ctx context.Context, resourceGroupName, name string) (msi.Identity, error) {
+func (m *MockClient) Get(ctx context.Context, resourceGroupName, name string) (armmsi.Identity, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", ctx, resourceGroupName, name)
-	ret0, _ := ret[0].(msi.Identity)
+	ret0, _ := ret[0].(armmsi.Identity)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -63,15 +63,19 @@ type Service struct {
 }
 
 // New creates a new service.
-func New(scope VMScope) *Service {
+func New(scope VMScope) (*Service, error) {
 	Client := NewClient(scope)
+	identitiesSvc, err := identities.NewClient(scope)
+	if err != nil {
+		return nil, err
+	}
 	return &Service{
 		Scope:            scope,
 		interfacesGetter: networkinterfaces.NewClient(scope),
 		publicIPsGetter:  publicips.NewClient(scope),
-		identitiesGetter: identities.NewClient(scope),
+		identitiesGetter: identitiesSvc,
 		Reconciler:       async.New(scope, Client, Client),
-	}
+	}, nil
 }
 
 // Name returns the service name.

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -69,6 +69,10 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating a roleassignments service")
 	}
+	virtualmachinesSvc, err := virtualmachines.New(machineScope)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating virtualmachines service")
+	}
 	vmextensionsSvc, err := vmextensions.New(machineScope)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating vmextensions service")
@@ -81,7 +85,7 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 			networkinterfaces.New(machineScope, cache),
 			availabilitySetsSvc,
 			disksSvc,
-			virtualmachines.New(machineScope),
+			virtualmachinesSvc,
 			roleAssignmentsSvc,
 			vmextensionsSvc,
 			tags.New(machineScope),

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.1.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.3.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1
 	github.com/Azure/azure-service-operator/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNL
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iothub/armiothub v1.1.1 h1:Dh8SxVXcSyQN76LI4IseKyrnqyTUsx336Axg8zDYSMs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning v1.0.0 h1:KWvCVjnOTKCZAlqED5KPNoN9AfcK2BhUeveLdiwy33Q=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0 h1:pPvTJ1dY0sA35JOeFq6TsY2xj6Z85Yo23Pj4wCCvu4o=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.1.0 h1:Q707jfTFqfunSnh73YkCBDXR3GQJKno3chPRxXw//ho=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.1.0/go.mod h1:vjoxsjVnPwhjHZw4PuuhpgYlcxWl5tyNedLHUl0ulFA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.1.0 h1:CNHJpPiOM3FHaF0vXch5U9CY8lgzwQ5T4SBD/e2N03M=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.1.0/go.mod h1:pw/iPLHx25GjvPaTHaU3qH07SnGr4RmXSqR9o1+aCtI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis v1.0.0 h1:nmpTBgRg1HynngFYICRhceC7s5dmbKN9fJ/XQz/UQ2I=


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the identities service to azure-sdk-for-go version 2.

**Which issue(s) this PR fixes**:

Fixes #3930

**Special notes for your reviewer**:

This is a simple, non-async service that only supports `Get` and `GetClientID`.

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
