### PR TITLE
Convert resourcehealth service to SDKv2

### DIFF
--- a/azure/converters/resourcehealth.go
+++ b/azure/converters/resourcehealth.go
@@ -19,21 +19,22 @@ package converters
 import (
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/resourcehealth/mgmt/2020-05-01/resourcehealth"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 )
 
 // SDKAvailabilityStatusToCondition converts an Azure Resource Health availability status to a status condition.
-func SDKAvailabilityStatusToCondition(availStatus resourcehealth.AvailabilityStatus) *clusterv1.Condition {
+func SDKAvailabilityStatusToCondition(availStatus armresourcehealth.AvailabilityStatus) *clusterv1.Condition {
 	if availStatus.Properties == nil {
 		return conditions.FalseCondition(infrav1.AzureResourceAvailableCondition, "", "", "")
 	}
 
 	state := availStatus.Properties.AvailabilityState
 
-	if state == resourcehealth.AvailabilityStateValuesAvailable {
+	if ptr.Deref(state, "") == armresourcehealth.AvailabilityStateValuesAvailable {
 		return conditions.TrueCondition(infrav1.AzureResourceAvailableCondition)
 	}
 
@@ -53,10 +54,10 @@ func SDKAvailabilityStatusToCondition(availStatus resourcehealth.AvailabilitySta
 	}
 
 	var severity clusterv1.ConditionSeverity
-	switch availStatus.Properties.AvailabilityState {
-	case resourcehealth.AvailabilityStateValuesUnavailable:
+	switch ptr.Deref(availStatus.Properties.AvailabilityState, "") {
+	case armresourcehealth.AvailabilityStateValuesUnavailable:
 		severity = clusterv1.ConditionSeverityError
-	case resourcehealth.AvailabilityStateValuesDegraded, resourcehealth.AvailabilityStateValuesUnknown:
+	case armresourcehealth.AvailabilityStateValuesDegraded, armresourcehealth.AvailabilityStateValuesUnknown:
 		severity = clusterv1.ConditionSeverityWarning
 	}
 

--- a/azure/converters/resourcehealth_test.go
+++ b/azure/converters/resourcehealth_test.go
@@ -19,7 +19,7 @@ package converters
 import (
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/resourcehealth/mgmt/2020-05-01/resourcehealth"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
@@ -29,21 +29,21 @@ import (
 func TestAzureAvailabilityStatusToCondition(t *testing.T) {
 	tests := []struct {
 		name     string
-		avail    resourcehealth.AvailabilityStatus
+		avail    armresourcehealth.AvailabilityStatus
 		expected *clusterv1.Condition
 	}{
 		{
 			name:  "empty",
-			avail: resourcehealth.AvailabilityStatus{},
+			avail: armresourcehealth.AvailabilityStatus{},
 			expected: &clusterv1.Condition{
 				Status: corev1.ConditionFalse,
 			},
 		},
 		{
 			name: "available",
-			avail: resourcehealth.AvailabilityStatus{
-				Properties: &resourcehealth.AvailabilityStatusProperties{
-					AvailabilityState: resourcehealth.AvailabilityStateValuesAvailable,
+			avail: armresourcehealth.AvailabilityStatus{
+				Properties: &armresourcehealth.AvailabilityStatusProperties{
+					AvailabilityState: ptr.To(armresourcehealth.AvailabilityStateValuesAvailable),
 				},
 			},
 			expected: &clusterv1.Condition{
@@ -52,9 +52,9 @@ func TestAzureAvailabilityStatusToCondition(t *testing.T) {
 		},
 		{
 			name: "unavailable",
-			avail: resourcehealth.AvailabilityStatus{
-				Properties: &resourcehealth.AvailabilityStatusProperties{
-					AvailabilityState: resourcehealth.AvailabilityStateValuesUnavailable,
+			avail: armresourcehealth.AvailabilityStatus{
+				Properties: &armresourcehealth.AvailabilityStatusProperties{
+					AvailabilityState: ptr.To(armresourcehealth.AvailabilityStateValuesUnavailable),
 					ReasonType:        ptr.To("this Is  a reason "),
 					Summary:           ptr.To("The Summary"),
 				},
@@ -68,9 +68,9 @@ func TestAzureAvailabilityStatusToCondition(t *testing.T) {
 		},
 		{
 			name: "degraded",
-			avail: resourcehealth.AvailabilityStatus{
-				Properties: &resourcehealth.AvailabilityStatusProperties{
-					AvailabilityState: resourcehealth.AvailabilityStateValuesDegraded,
+			avail: armresourcehealth.AvailabilityStatus{
+				Properties: &armresourcehealth.AvailabilityStatusProperties{
+					AvailabilityState: ptr.To(armresourcehealth.AvailabilityStateValuesDegraded),
 					ReasonType:        ptr.To("TheReason"),
 					Summary:           ptr.To("The Summary"),
 				},

--- a/azure/services/resourcehealth/mock_resourcehealth/client_mock.go
+++ b/azure/services/resourcehealth/mock_resourcehealth/client_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	resourcehealth "github.com/Azure/azure-sdk-for-go/services/resourcehealth/mgmt/2020-05-01/resourcehealth"
+	armresourcehealth "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -52,10 +52,10 @@ func (m *Mockclient) EXPECT() *MockclientMockRecorder {
 }
 
 // GetByResource mocks base method.
-func (m *Mockclient) GetByResource(arg0 context.Context, arg1 string) (resourcehealth.AvailabilityStatus, error) {
+func (m *Mockclient) GetByResource(arg0 context.Context, arg1 string) (armresourcehealth.AvailabilityStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetByResource", arg0, arg1)
-	ret0, _ := ret[0].(resourcehealth.AvailabilityStatus)
+	ret0, _ := ret[0].(armresourcehealth.AvailabilityStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/azure/services/resourcehealth/resourcehealth.go
+++ b/azure/services/resourcehealth/resourcehealth.go
@@ -53,11 +53,15 @@ type Service struct {
 }
 
 // New creates a new service.
-func New(scope ResourceHealthScope) *Service {
+func New(scope ResourceHealthScope) (*Service, error) {
+	cli, err := newClient(scope)
+	if err != nil {
+		return nil, err
+	}
 	return &Service{
 		Scope:  scope,
-		client: newClient(scope),
-	}
+		client: cli,
+	}, nil
 }
 
 // Name returns the service name.

--- a/azure/services/resourcehealth/resourcehealth_test.go
+++ b/azure/services/resourcehealth/resourcehealth_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/resourcehealth/mgmt/2020-05-01/resourcehealth"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
@@ -46,9 +46,9 @@ func TestReconcileResourceHealth(t *testing.T) {
 			expect: func(s *mock_resourcehealth.MockResourceHealthScopeMockRecorder, m *mock_resourcehealth.MockclientMockRecorder, _ *mock_resourcehealth.MockAvailabilityStatusFiltererMockRecorder) {
 				s.AvailabilityStatusResource().Times(1)
 				s.AvailabilityStatusResourceURI().Times(1)
-				m.GetByResource(gomockinternal.AContext(), gomock.Any()).Times(1).Return(resourcehealth.AvailabilityStatus{
-					Properties: &resourcehealth.AvailabilityStatusProperties{
-						AvailabilityState: resourcehealth.AvailabilityStateValuesAvailable,
+				m.GetByResource(gomockinternal.AContext(), gomock.Any()).Times(1).Return(armresourcehealth.AvailabilityStatus{
+					Properties: &armresourcehealth.AvailabilityStatusProperties{
+						AvailabilityState: ptr.To(armresourcehealth.AvailabilityStateValuesAvailable),
 					},
 				}, nil)
 			},
@@ -59,9 +59,9 @@ func TestReconcileResourceHealth(t *testing.T) {
 			expect: func(s *mock_resourcehealth.MockResourceHealthScopeMockRecorder, m *mock_resourcehealth.MockclientMockRecorder, _ *mock_resourcehealth.MockAvailabilityStatusFiltererMockRecorder) {
 				s.AvailabilityStatusResource().Times(1)
 				s.AvailabilityStatusResourceURI().Times(1)
-				m.GetByResource(gomockinternal.AContext(), gomock.Any()).Times(1).Return(resourcehealth.AvailabilityStatus{
-					Properties: &resourcehealth.AvailabilityStatusProperties{
-						AvailabilityState: resourcehealth.AvailabilityStateValuesUnavailable,
+				m.GetByResource(gomockinternal.AContext(), gomock.Any()).Times(1).Return(armresourcehealth.AvailabilityStatus{
+					Properties: &armresourcehealth.AvailabilityStatusProperties{
+						AvailabilityState: ptr.To(armresourcehealth.AvailabilityStateValuesUnavailable),
 						Summary:           ptr.To("summary"),
 					},
 				}, nil)
@@ -72,7 +72,7 @@ func TestReconcileResourceHealth(t *testing.T) {
 			name: "API error",
 			expect: func(s *mock_resourcehealth.MockResourceHealthScopeMockRecorder, m *mock_resourcehealth.MockclientMockRecorder, _ *mock_resourcehealth.MockAvailabilityStatusFiltererMockRecorder) {
 				s.AvailabilityStatusResourceURI().Times(1).Return("myURI")
-				m.GetByResource(gomockinternal.AContext(), gomock.Any()).Times(1).Return(resourcehealth.AvailabilityStatus{}, errors.New("some API error"))
+				m.GetByResource(gomockinternal.AContext(), gomock.Any()).Times(1).Return(armresourcehealth.AvailabilityStatus{}, errors.New("some API error"))
 			},
 			expectedError: "failed to get availability status for resource myURI: some API error",
 		},
@@ -82,9 +82,9 @@ func TestReconcileResourceHealth(t *testing.T) {
 			expect: func(s *mock_resourcehealth.MockResourceHealthScopeMockRecorder, m *mock_resourcehealth.MockclientMockRecorder, f *mock_resourcehealth.MockAvailabilityStatusFiltererMockRecorder) {
 				s.AvailabilityStatusResource().Times(1)
 				s.AvailabilityStatusResourceURI().Times(1)
-				m.GetByResource(gomockinternal.AContext(), gomock.Any()).Times(1).Return(resourcehealth.AvailabilityStatus{
-					Properties: &resourcehealth.AvailabilityStatusProperties{
-						AvailabilityState: resourcehealth.AvailabilityStateValuesUnavailable,
+				m.GetByResource(gomockinternal.AContext(), gomock.Any()).Times(1).Return(armresourcehealth.AvailabilityStatus{
+					Properties: &armresourcehealth.AvailabilityStatusProperties{
+						AvailabilityState: ptr.To(armresourcehealth.AvailabilityStateValuesUnavailable),
 						Summary:           ptr.To("summary"),
 					},
 				}, nil)

--- a/controllers/azuremanagedcontrolplane_reconciler.go
+++ b/controllers/azuremanagedcontrolplane_reconciler.go
@@ -57,6 +57,10 @@ func newAzureManagedControlPlaneReconciler(scope *scope.ManagedControlPlaneScope
 	if err != nil {
 		return nil, err
 	}
+	resourceHealthSvc, err := resourcehealth.New(scope)
+	if err != nil {
+		return nil, err
+	}
 	return &azureManagedControlPlaneService{
 		kubeclient: scope.Client,
 		scope:      scope,
@@ -67,7 +71,7 @@ func newAzureManagedControlPlaneReconciler(scope *scope.ManagedControlPlaneScope
 			managedClustersService,
 			privateEndpointsSvc,
 			tags.New(scope),
-			resourcehealth.New(scope),
+			resourceHealthSvc,
 		},
 	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1
 	github.com/Azure/azure-service-operator/v2 v2.2.0
 	github.com/Azure/go-autorest/autorest v0.11.29

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanage
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.1.0 h1:CNHJpPiOM3FHaF0vXch5U9CY8lgzwQ5T4SBD/e2N03M=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.1.0/go.mod h1:pw/iPLHx25GjvPaTHaU3qH07SnGr4RmXSqR9o1+aCtI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis v1.0.0 h1:nmpTBgRg1HynngFYICRhceC7s5dmbKN9fJ/XQz/UQ2I=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth v1.2.0 h1:k0xuK+BZsJnm7PulC7r9ZvrFZmeMykssronbLihpfZ8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth v1.2.0/go.mod h1:Jv6QNkkicuT3VJY5nSsAD+mTDxn5fDBE6GFpfma8j+g=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1 h1:7CBQ+Ei8SP2c6ydQTGCCrS35bDxgTMfoP2miAwK++OU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1/go.mod h1:c/wcGeGx5FUPbM/JltUYHZcKmigwyVLJlDq+4HdtXaw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch v1.1.0 h1:SCO2mlFZrUMU8MmA5Y6EszSm2OGumuPBXFQXEvkESvk=


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the resourcehealth service to azure-sdk-for-go version 2.

**Which issue(s) this PR fixes**:

Fixes #3941

**Special notes for your reviewer**:

This is a simple, non-async service that doesn't support create or delete, only `GetByResource`.

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
