### PR TITLE
[release-1.9] Label kubeconfig with cluster name

### DIFF
--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -591,6 +591,7 @@ func (s *ManagedControlPlaneScope) MakeEmptyKubeConfigSecret() corev1.Secret {
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(s.ControlPlane, infrav1.GroupVersion.WithKind("AzureManagedControlPlane")),
 			},
+			Labels: map[string]string{clusterv1.ClusterNameLabel: s.Cluster.Name},
 		},
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

In #3703 CAPZ added a [kubeconfig label](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3707/files#diff-cfd94adbc2ff767742e457e64836e93e88c6e03c3a64c04619c54b7ed76f284eR616) to comply with changes needed for [CAPI v1.5.0 migration](https://main.cluster-api.sigs.k8s.io/developer/providers/migrations/v1.4-to-v1.5.html#other). But this change is not in an existing release and the lack of this label is causing problems for users trying to combine CAPI 1.5.x with a CAPZ release, so let's backport that change.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
