### PR TITLE
Convert privatedns service to SDKv2

### DIFF
--- a/azure/converters/dns.go
+++ b/azure/converters/dns.go
@@ -17,17 +17,17 @@ limitations under the License.
 package converters
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	"k8s.io/utils/net"
 )
 
 // GetRecordType returns the SDK record type to use based on the type of IP to map.
 // Currently only allows type A (IPv4) and AAAA (IPv6) records.
-func GetRecordType(ip string) privatedns.RecordType {
+func GetRecordType(ip string) armprivatedns.RecordType {
 	switch {
 	case net.IsIPv6String(ip):
-		return privatedns.AAAA
+		return armprivatedns.RecordTypeAAAA
 	default:
-		return privatedns.A
+		return armprivatedns.RecordTypeA
 	}
 }

--- a/azure/converters/dns_test.go
+++ b/azure/converters/dns_test.go
@@ -19,7 +19,7 @@ package converters
 import (
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	"github.com/onsi/gomega"
 )
 
@@ -27,22 +27,22 @@ func Test_GetRecordType(t *testing.T) {
 	cases := []struct {
 		name   string
 		ip     string
-		expect privatedns.RecordType
+		expect armprivatedns.RecordType
 	}{
 		{
 			name:   "ipv4",
 			ip:     "10.0.0.4",
-			expect: privatedns.A,
+			expect: armprivatedns.RecordTypeA,
 		},
 		{
 			name:   "ipv6",
 			ip:     "2603:1030:805:2::b",
-			expect: privatedns.AAAA,
+			expect: armprivatedns.RecordTypeAAAA,
 		},
 		{
 			name:   "default",
 			ip:     "",
-			expect: privatedns.A,
+			expect: armprivatedns.RecordTypeA,
 		},
 	}
 

--- a/azure/services/privatedns/link_client.go
+++ b/azure/services/privatedns/link_client.go
@@ -18,44 +18,60 @@ package privatedns
 
 import (
 	"context"
-	"encoding/json"
 
-	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
-	azureautorest "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	"github.com/pkg/errors"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asyncpoller"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
 // azureVirtualNetworkLinksClient contains the Azure go-sdk Client for virtual network links.
 type azureVirtualNetworkLinksClient struct {
-	vnetlinks privatedns.VirtualNetworkLinksClient
+	vnetlinks *armprivatedns.VirtualNetworkLinksClient
 }
 
-// newVirtualNetworkLinksClient creates a new virtual network link client.
-func newVirtualNetworkLinksClient(auth azure.Authorizer) *azureVirtualNetworkLinksClient {
-	linksClient := privatedns.NewVirtualNetworkLinksClientWithBaseURI(auth.BaseURI(), auth.SubscriptionID())
-	azure.SetAutoRestClientDefaults(&linksClient.Client, auth.Authorizer())
-	return &azureVirtualNetworkLinksClient{
-		vnetlinks: linksClient,
+// newVirtualNetworkLinksClient creates a virtual network links client from an authorizer.
+func newVirtualNetworkLinksClient(auth azure.Authorizer) (*azureVirtualNetworkLinksClient, error) {
+	opts, err := azure.ARMClientOptions(auth.CloudEnvironment())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create virtualnetworkslink client options")
 	}
+	factory, err := armprivatedns.NewClientFactory(auth.SubscriptionID(), auth.Token(), opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create armprivatedns client factory")
+	}
+	return &azureVirtualNetworkLinksClient{factory.NewVirtualNetworkLinksClient()}, nil
+}
+
+// Get gets the specified virtual network link.
+func (avc *azureVirtualNetworkLinksClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (result interface{}, err error) {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.azureVirtualNetworkLinksClient.Get")
+	defer done()
+
+	resp, err := avc.vnetlinks.Get(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return resp.VirtualNetworkLink, nil
 }
 
 // CreateOrUpdateAsync creates or updates a virtual network link asynchronously.
-// It sends a PUT request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// It sends a PUT request to Azure and if accepted without error, the func will return a poller which can be used to track the ongoing
 // progress of the operation.
-func (avc *azureVirtualNetworkLinksClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, parameters interface{}) (result interface{}, future azureautorest.FutureAPI, err error) {
+func (avc *azureVirtualNetworkLinksClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armprivatedns.VirtualNetworkLinksClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.azureVirtualNetworkLinksClient.CreateOrUpdateAsync")
 	defer done()
 
-	link, ok := parameters.(privatedns.VirtualNetworkLink)
-	if !ok {
-		return nil, nil, errors.Errorf("%T is not a privatedns.VirtualNetworkLink", parameters)
+	link, ok := parameters.(armprivatedns.VirtualNetworkLink)
+	if !ok && parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armprivatedns.VirtualNetworkLink", parameters)
 	}
 
-	createFuture, err := avc.vnetlinks.CreateOrUpdate(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), link, "", "")
+	opts := &armprivatedns.VirtualNetworkLinksClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
+	poller, err = avc.vnetlinks.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), link, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -63,36 +79,27 @@ func (avc *azureVirtualNetworkLinksClient) CreateOrUpdateAsync(ctx context.Conte
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
 	defer cancel()
 
-	err = createFuture.WaitForCompletionRef(ctx, avc.vnetlinks.Client)
+	pollOpts := &runtime.PollUntilDoneOptions{Frequency: asyncpoller.DefaultPollerFrequency}
+	resp, err := poller.PollUntilDone(ctx, pollOpts)
 	if err != nil {
-		// if an error occurs, return the future.
+		// if an error occurs, return the poller.
 		// this means the long-running operation didn't finish in the specified timeout.
-		return nil, &createFuture, err
+		return nil, poller, err
 	}
-	result, err = createFuture.Result(avc.vnetlinks)
-	// if the operation completed, return a nil future
-	return result, nil, err
-}
 
-// Get gets the specified virtual network link.
-func (avc *azureVirtualNetworkLinksClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (result interface{}, err error) {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.azureVirtualNetworkLinksClient.Get")
-	defer done()
-	link, err := avc.vnetlinks.Get(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName())
-	if err != nil {
-		return privatedns.VirtualNetworkLink{}, err
-	}
-	return link, nil
+	// if the operation completed, return a nil poller
+	return resp.VirtualNetworkLink, nil, err
 }
 
 // DeleteAsync deletes a virtual network link asynchronously. DeleteAsync sends a DELETE
-// request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// request to Azure and if accepted without error, the func will return a poller which can be used to track the ongoing
 // progress of the operation.
-func (avc *azureVirtualNetworkLinksClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter) (future azureautorest.FutureAPI, err error) {
+func (avc *azureVirtualNetworkLinksClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string) (poller *runtime.Poller[armprivatedns.VirtualNetworkLinksClientDeleteResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.azureVirtualNetworkLinksClient.DeleteAsync")
 	defer done()
 
-	deleteFuture, err := avc.vnetlinks.Delete(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), "")
+	opts := &armprivatedns.VirtualNetworkLinksClientBeginDeleteOptions{ResumeToken: resumeToken}
+	poller, err = avc.vnetlinks.BeginDelete(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -100,54 +107,14 @@ func (avc *azureVirtualNetworkLinksClient) DeleteAsync(ctx context.Context, spec
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
 	defer cancel()
 
-	err = deleteFuture.WaitForCompletionRef(ctx, avc.vnetlinks.Client)
+	pollOpts := &runtime.PollUntilDoneOptions{Frequency: asyncpoller.DefaultPollerFrequency}
+	_, err = poller.PollUntilDone(ctx, pollOpts)
 	if err != nil {
-		// if an error occurs, return the future.
+		// if an error occurs, return the Poller.
 		// this means the long-running operation didn't finish in the specified timeout.
-		return &deleteFuture, err
+		return poller, err
 	}
-	_, err = deleteFuture.Result(avc.vnetlinks)
-	// if the operation completed, return a nil future.
+
+	// if the operation completed, return a nil poller.
 	return nil, err
-}
-
-// IsDone returns true if the long-running operation has completed.
-func (avc *azureVirtualNetworkLinksClient) IsDone(ctx context.Context, future azureautorest.FutureAPI) (isDone bool, err error) {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.azureVirtualNetworkLinksClient.IsDone")
-	defer done()
-
-	return future.DoneWithContext(ctx, avc.vnetlinks)
-}
-
-// Result fetches the result of a long-running operation future.
-func (avc *azureVirtualNetworkLinksClient) Result(ctx context.Context, future azureautorest.FutureAPI, futureType string) (result interface{}, err error) {
-	_, _, done := tele.StartSpanWithLogger(ctx, "privatedns.azureVirtualNetworkLinksClient.Result")
-	defer done()
-
-	if future == nil {
-		return nil, errors.Errorf("cannot get result from nil future")
-	}
-
-	switch futureType {
-	case infrav1.PutFuture:
-		// Marshal and Unmarshal the future to put it into the correct future type so we can access the Result function.
-		// Unfortunately the FutureAPI can't be casted directly to VirtualNetworkLinksCreateOrUpdateFuture because it is a azureautorest.Future, which doesn't implement the Result function. See PR #1686 for discussion on alternatives.
-		// It was converted back to a generic azureautorest.Future from the CAPZ infrav1.Future type stored in Status: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/converters/futures.go#L49.
-		var createFuture *privatedns.VirtualNetworkLinksCreateOrUpdateFuture
-		jsonData, err := future.MarshalJSON()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal future")
-		}
-		if err := json.Unmarshal(jsonData, &createFuture); err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal future data")
-		}
-		return createFuture.Result(avc.vnetlinks)
-
-	case infrav1.DeleteFuture:
-		// Delete does not return a result private dns virtual network link.
-		return nil, nil
-
-	default:
-		return nil, errors.Errorf("unknown future type %q", futureType)
-	}
 }

--- a/azure/services/privatedns/link_spec.go
+++ b/azure/services/privatedns/link_spec.go
@@ -19,7 +19,7 @@ package privatedns
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -57,16 +57,16 @@ func (s LinkSpec) ResourceGroupName() string {
 // Parameters returns the parameters for the virtual network link.
 func (s LinkSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
-		_, ok := existing.(privatedns.VirtualNetworkLink)
+		_, ok := existing.(armprivatedns.VirtualNetworkLink)
 		if !ok {
-			return nil, errors.Errorf("%T is not a privatedns.VirtualNetworkLink", existing)
+			return nil, errors.Errorf("%T is not an armprivatedns.VirtualNetworkLink", existing)
 		}
 		return nil, nil
 	}
 
-	return privatedns.VirtualNetworkLink{
-		VirtualNetworkLinkProperties: &privatedns.VirtualNetworkLinkProperties{
-			VirtualNetwork: &privatedns.SubResource{
+	return armprivatedns.VirtualNetworkLink{
+		Properties: &armprivatedns.VirtualNetworkLinkProperties{
+			VirtualNetwork: &armprivatedns.SubResource{
 				ID: ptr.To(azure.VNetID(s.SubscriptionID, s.VNetResourceGroup, s.VNetName)),
 			},
 			RegistrationEnabled: ptr.To(false),

--- a/azure/services/privatedns/link_spec_test.go
+++ b/azure/services/privatedns/link_spec_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -67,9 +67,9 @@ func TestLinkSpec_Parameters(t *testing.T) {
 			expectedError: "",
 			spec:          linkSpec,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(Equal(privatedns.VirtualNetworkLink{
-					VirtualNetworkLinkProperties: &privatedns.VirtualNetworkLinkProperties{
-						VirtualNetwork: &privatedns.SubResource{
+				g.Expect(result).To(Equal(armprivatedns.VirtualNetworkLink{
+					Properties: &armprivatedns.VirtualNetworkLinkProperties{
+						VirtualNetwork: &armprivatedns.SubResource{
 							ID: ptr.To("/subscriptions/123/resourceGroups/my-vnet-rg/providers/Microsoft.Network/virtualNetworks/my-vnet"),
 						},
 						RegistrationEnabled: ptr.To(false),
@@ -85,7 +85,7 @@ func TestLinkSpec_Parameters(t *testing.T) {
 			name:          "existing managed private virtual network link",
 			expectedError: "",
 			spec:          linkSpec,
-			existing: privatedns.VirtualNetworkLink{Tags: map[string]*string{
+			existing: armprivatedns.VirtualNetworkLink{Tags: map[string]*string{
 				"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 			}},
 			expect: func(g *WithT, result interface{}) {
@@ -96,16 +96,16 @@ func TestLinkSpec_Parameters(t *testing.T) {
 			name:          "existing unmanaged private dns zone",
 			expectedError: "",
 			spec:          linkSpec,
-			existing:      privatedns.VirtualNetworkLink{},
+			existing:      armprivatedns.VirtualNetworkLink{},
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeNil())
 			},
 		},
 		{
 			name:          "type cast error",
-			expectedError: "string is not a privatedns.VirtualNetworkLink",
+			expectedError: "string is not an armprivatedns.VirtualNetworkLink",
 			spec:          linkSpec,
-			existing:      "I'm not privatedns.VirtualNetworkLink",
+			existing:      "I'm not armprivatedns.VirtualNetworkLink",
 		},
 	}
 

--- a/azure/services/privatedns/record_spec.go
+++ b/azure/services/privatedns/record_spec.go
@@ -19,7 +19,7 @@ package privatedns
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -51,24 +51,24 @@ func (s RecordSpec) ResourceGroupName() string {
 // Parameters returns the parameters for a record set.
 func (s RecordSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
-		if _, ok := existing.(privatedns.RecordSet); !ok {
-			return nil, errors.Errorf("%T is not a privatedns.RecordSet", existing)
+		if _, ok := existing.(armprivatedns.RecordSet); !ok {
+			return nil, errors.Errorf("%T is not an armprivatedns.RecordSet", existing)
 		}
 	}
-	set := privatedns.RecordSet{
-		RecordSetProperties: &privatedns.RecordSetProperties{
+	set := armprivatedns.RecordSet{
+		Properties: &armprivatedns.RecordSetProperties{
 			TTL: ptr.To[int64](300),
 		},
 	}
 	recordType := converters.GetRecordType(s.Record.IP)
 	switch recordType {
-	case privatedns.A:
-		set.RecordSetProperties.ARecords = &[]privatedns.ARecord{{
-			Ipv4Address: &s.Record.IP,
+	case armprivatedns.RecordTypeA:
+		set.Properties.ARecords = []*armprivatedns.ARecord{{
+			IPv4Address: &s.Record.IP,
 		}}
-	case privatedns.AAAA:
-		set.RecordSetProperties.AaaaRecords = &[]privatedns.AaaaRecord{{
-			Ipv6Address: &s.Record.IP,
+	case armprivatedns.RecordTypeAAAA:
+		set.Properties.AaaaRecords = []*armprivatedns.AaaaRecord{{
+			IPv6Address: &s.Record.IP,
 		}}
 	default:
 		return nil, errors.Errorf("unknown record type %s", recordType)

--- a/azure/services/privatedns/record_spec_test.go
+++ b/azure/services/privatedns/record_spec_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -68,12 +68,12 @@ func TestRecordSpec_Parameters(t *testing.T) {
 			expectedError: "",
 			spec:          recordSpec,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(Equal(privatedns.RecordSet{
-					RecordSetProperties: &privatedns.RecordSetProperties{
+				g.Expect(result).To(Equal(armprivatedns.RecordSet{
+					Properties: &armprivatedns.RecordSetProperties{
 						TTL: ptr.To[int64](300),
-						ARecords: &[]privatedns.ARecord{
+						ARecords: []*armprivatedns.ARecord{
 							{
-								Ipv4Address: ptr.To("10.0.0.8"),
+								IPv4Address: ptr.To("10.0.0.8"),
 							},
 						},
 					},
@@ -85,12 +85,12 @@ func TestRecordSpec_Parameters(t *testing.T) {
 			expectedError: "",
 			spec:          recordSpecIpv6,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(Equal(privatedns.RecordSet{
-					RecordSetProperties: &privatedns.RecordSetProperties{
+				g.Expect(result).To(Equal(armprivatedns.RecordSet{
+					Properties: &armprivatedns.RecordSetProperties{
 						TTL: ptr.To[int64](300),
-						AaaaRecords: &[]privatedns.AaaaRecord{
+						AaaaRecords: []*armprivatedns.AaaaRecord{
 							{
-								Ipv6Address: ptr.To("2603:1030:805:2::b"),
+								IPv6Address: ptr.To("2603:1030:805:2::b"),
 							},
 						},
 					},

--- a/azure/services/privatedns/zone_spec.go
+++ b/azure/services/privatedns/zone_spec.go
@@ -19,7 +19,7 @@ package privatedns
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -53,14 +53,14 @@ func (s ZoneSpec) ResourceGroupName() string {
 // Parameters returns the parameters for the private dns zone.
 func (s ZoneSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
-		_, ok := existing.(privatedns.PrivateZone)
+		_, ok := existing.(armprivatedns.PrivateZone)
 		if !ok {
-			return nil, errors.Errorf("%T is not a privatedns.PrivateZone", existing)
+			return nil, errors.Errorf("%T is not an armprivatedns.PrivateZone", existing)
 		}
 		return nil, nil
 	}
 
-	return privatedns.PrivateZone{
+	return armprivatedns.PrivateZone{
 		Location: ptr.To(azure.Global),
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
 			ClusterName: s.ClusterName,

--- a/azure/services/privatedns/zone_spec_test.go
+++ b/azure/services/privatedns/zone_spec_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -63,7 +63,7 @@ func TestZoneSpec_Parameters(t *testing.T) {
 			expectedError: "",
 			spec:          zoneSpec,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(Equal(privatedns.PrivateZone{
+				g.Expect(result).To(Equal(armprivatedns.PrivateZone{
 					Location: ptr.To(azure.Global),
 					Tags: map[string]*string{
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
@@ -75,7 +75,7 @@ func TestZoneSpec_Parameters(t *testing.T) {
 			name:          "existing managed private dns zone",
 			expectedError: "",
 			spec:          zoneSpec,
-			existing: privatedns.PrivateZone{Tags: map[string]*string{
+			existing: armprivatedns.PrivateZone{Tags: map[string]*string{
 				"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 			}},
 			expect: func(g *WithT, result interface{}) {
@@ -86,16 +86,16 @@ func TestZoneSpec_Parameters(t *testing.T) {
 			name:          "existing unmanaged private dns zone",
 			expectedError: "",
 			spec:          zoneSpec,
-			existing:      privatedns.PrivateZone{},
+			existing:      armprivatedns.PrivateZone{},
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeNil())
 			},
 		},
 		{
 			name:          "type cast error",
-			expectedError: "string is not a privatedns.PrivateZone",
+			expectedError: "string is not an armprivatedns.PrivateZone",
 			spec:          zoneSpec,
-			existing:      "I'm not privatedns.PrivateZone",
+			existing:      "I'm not armprivatedns.PrivateZone",
 		},
 	}
 

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -76,6 +76,10 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 	if err != nil {
 		return nil, err
 	}
+	privateDNSSvc, err := privatedns.New(scope)
+	if err != nil {
+		return nil, err
+	}
 	subnetsSvc, err := subnets.New(scope)
 	if err != nil {
 		return nil, err
@@ -96,7 +100,7 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 			subnetsSvc,
 			vnetPeeringsSvc,
 			loadbalancers.New(scope),
-			privatedns.New(scope),
+			privateDNSSvc,
 			bastionHostsSvc,
 			privateEndpointsSvc,
 			tags.New(scope),

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1
 	github.com/Azure/azure-service-operator/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.1.0 h1:Q707j
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.1.0/go.mod h1:vjoxsjVnPwhjHZw4PuuhpgYlcxWl5tyNedLHUl0ulFA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.1.0 h1:CNHJpPiOM3FHaF0vXch5U9CY8lgzwQ5T4SBD/e2N03M=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.1.0/go.mod h1:pw/iPLHx25GjvPaTHaU3qH07SnGr4RmXSqR9o1+aCtI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.1.0 h1:rR8ZW79lE/ppfXTfiYSnMFv5EzmVuY4pfZWIkscIJ64=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.1.0/go.mod h1:y2zXtLSMM/X5Mfawq0lOftpWn3f4V6OCsRdINsvWBPI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis v1.0.0 h1:nmpTBgRg1HynngFYICRhceC7s5dmbKN9fJ/XQz/UQ2I=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth v1.2.0 h1:k0xuK+BZsJnm7PulC7r9ZvrFZmeMykssronbLihpfZ8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth v1.2.0/go.mod h1:Jv6QNkkicuT3VJY5nSsAD+mTDxn5fDBE6GFpfma8j+g=


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the privatedns service to azure-sdk-for-go version 2 and the `asyncpoller` framework.

**Which issue(s) this PR fixes**:

Fixes #3929

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
