### PR TITLE
ignore AKS user-assigned ClientID/PrincipalID in diff

### DIFF
--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -681,6 +681,14 @@ func computeDiffOfNormalizedClusters(managedCluster armcontainerservice.ManagedC
 			Type:                   existingMC.Identity.Type,
 			UserAssignedIdentities: existingMC.Identity.UserAssignedIdentities,
 		}
+
+		// ClientID and PrincipalID are read-only and should not trigger a diff.
+		for _, id := range existingMCClusterNormalized.Identity.UserAssignedIdentities {
+			if id != nil {
+				id.ClientID = nil
+				id.PrincipalID = nil
+			}
+		}
 	}
 
 	if managedCluster.SKU != nil {

--- a/azure/services/managedclusters/spec_test.go
+++ b/azure/services/managedclusters/spec_test.go
@@ -358,6 +358,27 @@ func TestParameters(t *testing.T) {
 				g.Expect(result).To(BeNil())
 			},
 		},
+		{
+			name:     "managedcluster exists with UserAssigned identity, no update needed",
+			existing: getExistingClusterWithUserAssignedIdentity(),
+			spec: &ManagedClusterSpec{
+				Name:          "test-managedcluster",
+				ResourceGroup: "test-rg",
+				Location:      "test-location",
+				Tags: map[string]string{
+					"test-tag": "test-value",
+				},
+				Version:         "v1.22.0",
+				LoadBalancerSKU: "standard",
+				Identity: &infrav1.Identity{
+					Type:                           infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
+					UserAssignedIdentityResourceID: "some id",
+				},
+			},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+		},
 	}
 	for _, tc := range testcases {
 		tc := tc
@@ -439,6 +460,22 @@ func getExistingCluster() armcontainerservice.ManagedCluster {
 	mc := getSampleManagedCluster()
 	mc.Properties.ProvisioningState = ptr.To("Succeeded")
 	mc.ID = ptr.To("test-id")
+	return mc
+}
+
+func getExistingClusterWithUserAssignedIdentity() armcontainerservice.ManagedCluster {
+	mc := getSampleManagedCluster()
+	mc.Properties.ProvisioningState = ptr.To("Succeeded")
+	mc.ID = ptr.To("test-id")
+	mc.Identity = &armcontainerservice.ManagedClusterIdentity{
+		Type: ptr.To(armcontainerservice.ResourceIdentityTypeUserAssigned),
+		UserAssignedIdentities: map[string]*armcontainerservice.ManagedServiceIdentityUserAssignedIdentitiesValue{
+			"some id": {
+				ClientID:    ptr.To("some client id"),
+				PrincipalID: ptr.To("some principal id"),
+			},
+		},
+	}
 	return mc
 }
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This fixes a bug causing an endless reconciliation of AzureManagedControlPlane with `spec.identity.type` set to `UserAssigned` because of a continuous diff like this:
```diff
&armcontainerservice.ManagedCluster{
  	Location:         nil,
  	ExtendedLocation: nil,
  	Identity: &armcontainerservice.ManagedClusterIdentity{
  		DelegatedResources: nil,
  		Type:               &"UserAssigned",
  		UserAssignedIdentities: map[string]*armcontainerservice.ManagedServiceIdentityUserAssignedIdentitiesValue{
  			"/subscriptions/<sub>/resourcegroups/<group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<name>": &{
- 				ClientID:    nil,
+ 				ClientID:    &"00000000-0000-0000-00000-00000000000",
- 				PrincipalID: nil,
+ 				PrincipalID: &"00000000-0000-0000-00000-00000000000",
  			},
  		},
  		PrincipalID: nil,
  		TenantID:    nil,
  	},
  	Properties: &{AutoScalerProfile: &{}, IdentityProfile: {"kubeletidentity": &{ResourceID: &"/subscriptions/<sub>/resourcegrou"...}}, KubernetesVersion: &"1.26.3", NetworkProfile: &{}, ...},
  	SKU:        &{Name: &"Base", Tier: &"Free"},
  	... // 5 identical fields
  }
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate <-- I'm guessing the SDK v1 implementation on the release branches has the same bug.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug causing AzureManagedControlPlanes with `spec.identity.type` set to `UserAssigned` to needlessly reconcile constantly.
```
