### PR TITLE
restore capz-system namespace labels

### DIFF
--- a/config/aso/kustomization.yaml
+++ b/config/aso/kustomization.yaml
@@ -12,7 +12,7 @@ patches:
       apiVersion: v1
       kind: Namespace
       metadata:
-        name: capz-system
+        name: azureserviceoperator-system
   - patch: |- # CAPZ will manage ASO's CRDs
       - op: test
         path: /spec/template/spec/containers/0/args/4


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: #3450 introduced a bug surfaced once #3723 merged which involved some labels on the `capz-system` Namespace object generated by kustomize being removed. This change restores those labels.

This is the diff of the entire `./hack/tools/bin/kustomize build ./config/default/` output from before/after this PR:
```
4,6d3
<   labels:
<     cluster.x-k8s.io/provider: infrastructure-azure
<     pod-security.kubernetes.io/enforce: privileged
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
