### PR TITLE
test: fix delete test subnet logic

### DIFF
--- a/test/e2e/azure_securitygroups.go
+++ b/test/e2e/azure_securitygroups.go
@@ -110,6 +110,7 @@ func AzureSecurityGroupsSpec(ctx context.Context, inputGetter func() AzureSecuri
 		Name:      input.Cluster.Spec.InfrastructureRef.Name,
 	}, azureCluster)
 	Expect(err).NotTo(HaveOccurred())
+	originalSubnets := azureCluster.Spec.NetworkSpec.Subnets
 
 	var expectedSubnets infrav1.Subnets
 	checkSubnets := func(g Gomega) {
@@ -146,8 +147,11 @@ func AzureSecurityGroupsSpec(ctx context.Context, inputGetter func() AzureSecuri
 			},
 		},
 	}
-	originalSubnets := azureCluster.Spec.NetworkSpec.Subnets
-	expectedSubnets = originalSubnets
+
+	expectedSubnets = infrav1.Subnets{}
+	for _, subnet := range originalSubnets {
+		expectedSubnets = append(expectedSubnets, subnet)
+	}
 	expectedSubnets = append(expectedSubnets, testSubnet)
 	Eventually(func(g Gomega) {
 		g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(azureCluster), azureCluster)).To(Succeed())
@@ -159,7 +163,10 @@ func AzureSecurityGroupsSpec(ctx context.Context, inputGetter func() AzureSecuri
 	By("Creating new security rule for the subnet")
 	Expect(len(expectedSubnets)).To(Not(Equal(0)))
 	testSubnet.SecurityGroup.SecurityRules = infrav1.SecurityRules{testSecurityRule, testSecurityRule2}
-	expectedSubnets = originalSubnets
+	expectedSubnets = infrav1.Subnets{}
+	for _, subnet := range originalSubnets {
+		expectedSubnets = append(expectedSubnets, subnet)
+	}
 	expectedSubnets = append(expectedSubnets, testSubnet)
 	Eventually(func(g Gomega) {
 		g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(azureCluster), azureCluster)).To(Succeed())
@@ -171,7 +178,10 @@ func AzureSecurityGroupsSpec(ctx context.Context, inputGetter func() AzureSecuri
 	By("Deleting security rule from the subnet")
 	Expect(len(expectedSubnets)).To(Not(Equal(0)))
 	testSubnet.SecurityGroup.SecurityRules = infrav1.SecurityRules{testSecurityRule2}
-	expectedSubnets = originalSubnets
+	expectedSubnets = infrav1.Subnets{}
+	for _, subnet := range originalSubnets {
+		expectedSubnets = append(expectedSubnets, subnet)
+	}
 	expectedSubnets = append(expectedSubnets, testSubnet)
 	Eventually(func(g Gomega) {
 		g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(azureCluster), azureCluster)).To(Succeed())


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR updates the way we re-use and mutate test subnets in the test flow so that we can revert to the original properly to implement a cleanup at the end.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
