### PR TITLE
convert networkinterfaces service to SDK v2

### DIFF
--- a/azure/services/networkinterfaces/client.go
+++ b/azure/services/networkinterfaces/client.go
@@ -18,57 +18,60 @@ package networkinterfaces
 
 import (
 	"context"
-	"encoding/json"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest"
-	azureautorest "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/pkg/errors"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asyncpoller"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// AzureClient contains the Azure go-sdk Client.
-type AzureClient struct {
-	interfaces network.InterfacesClient
+// azureClient contains the Azure go-sdk Client.
+type azureClient struct {
+	interfaces *armnetwork.InterfacesClient
 }
 
-// NewClient creates a new VM client from subscription ID.
-func NewClient(auth azure.Authorizer) *AzureClient {
-	c := newInterfacesClient(auth.SubscriptionID(), auth.BaseURI(), auth.Authorizer())
-	return &AzureClient{c}
-}
-
-// newInterfacesClient creates a new network interfaces client from subscription ID.
-func newInterfacesClient(subscriptionID string, baseURI string, authorizer autorest.Authorizer) network.InterfacesClient {
-	nicClient := network.NewInterfacesClientWithBaseURI(baseURI, subscriptionID)
-	azure.SetAutoRestClientDefaults(&nicClient.Client, authorizer)
-	return nicClient
+// NewClient creates a new network interfaces client from an authorizer.
+func NewClient(auth azure.Authorizer) (*azureClient, error) {
+	opts, err := azure.ARMClientOptions(auth.CloudEnvironment())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create networkinterfaces client options")
+	}
+	factory, err := armnetwork.NewClientFactory(auth.SubscriptionID(), auth.Token(), opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create armnetwork client factory")
+	}
+	return &azureClient{factory.NewInterfacesClient()}, nil
 }
 
 // Get gets the specified network interface.
-func (ac *AzureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (result interface{}, err error) {
+func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (result interface{}, err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.Get")
 	defer done()
 
-	return ac.interfaces.Get(ctx, spec.ResourceGroupName(), spec.ResourceName(), "")
+	resp, err := ac.interfaces.Get(ctx, spec.ResourceGroupName(), spec.ResourceName(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Interface, nil
 }
 
 // CreateOrUpdateAsync creates or updates a network interface asynchronously.
-// It sends a PUT request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// It sends a PUT request to Azure and if accepted without error, the func will return a poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, parameters interface{}) (result interface{}, future azureautorest.FutureAPI, err error) {
+func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armnetwork.InterfacesClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.CreateOrUpdateAsync")
 	defer done()
 
-	networkInterface, ok := parameters.(network.Interface)
-	if !ok {
-		return nil, nil, errors.Errorf("%T is not a network.Interface", parameters)
+	networkInterface, ok := parameters.(armnetwork.Interface)
+	if !ok && parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armnetwork.Interface", parameters)
 	}
 
-	createFuture, err := ac.interfaces.CreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), networkInterface)
+	opts := &armnetwork.InterfacesClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
+	poller, err = ac.interfaces.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), networkInterface, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -76,26 +79,27 @@ func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
 	defer cancel()
 
-	err = createFuture.WaitForCompletionRef(ctx, ac.interfaces.Client)
+	pollOpts := &runtime.PollUntilDoneOptions{Frequency: asyncpoller.DefaultPollerFrequency}
+	resp, err := poller.PollUntilDone(ctx, pollOpts)
 	if err != nil {
-		// if an error occurs, return the future.
+		// if an error occurs, return the poller.
 		// this means the long-running operation didn't finish in the specified timeout.
-		return nil, &createFuture, err
+		return nil, poller, err
 	}
 
-	result, err = createFuture.Result(ac.interfaces)
-	// if the operation completed, return a nil future
-	return result, nil, err
+	// if the operation completed, return a nil poller
+	return resp.Interface, nil, err
 }
 
 // DeleteAsync deletes a network interface asynchronously. DeleteAsync sends a DELETE
-// request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// request to Azure and if accepted without error, the func will return a poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *AzureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter) (future azureautorest.FutureAPI, err error) {
+func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string) (poller *runtime.Poller[armnetwork.InterfacesClientDeleteResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.DeleteAsync")
 	defer done()
 
-	deleteFuture, err := ac.interfaces.Delete(ctx, spec.ResourceGroupName(), spec.ResourceName())
+	opts := &armnetwork.InterfacesClientBeginDeleteOptions{ResumeToken: resumeToken}
+	poller, err = ac.interfaces.BeginDelete(ctx, spec.ResourceGroupName(), spec.ResourceName(), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -103,54 +107,14 @@ func (ac *AzureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecG
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
 	defer cancel()
 
-	err = deleteFuture.WaitForCompletionRef(ctx, ac.interfaces.Client)
+	pollOpts := &runtime.PollUntilDoneOptions{Frequency: asyncpoller.DefaultPollerFrequency}
+	_, err = poller.PollUntilDone(ctx, pollOpts)
 	if err != nil {
-		// if an error occurs, return the future.
+		// if an error occurs, return the Poller.
 		// this means the long-running operation didn't finish in the specified timeout.
-		return &deleteFuture, err
+		return poller, err
 	}
-	_, err = deleteFuture.Result(ac.interfaces)
-	// if the operation completed, return a nil future.
+
+	// if the operation completed, return a nil poller.
 	return nil, err
-}
-
-// IsDone returns true if the long-running operation has completed.
-func (ac *AzureClient) IsDone(ctx context.Context, future azureautorest.FutureAPI) (isDone bool, err error) {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.IsDone")
-	defer done()
-
-	return future.DoneWithContext(ctx, ac.interfaces)
-}
-
-// Result fetches the result of a long-running operation future.
-func (ac *AzureClient) Result(ctx context.Context, future azureautorest.FutureAPI, futureType string) (result interface{}, err error) {
-	_, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.Result")
-	defer done()
-
-	if future == nil {
-		return nil, errors.Errorf("cannot get result from nil future")
-	}
-
-	switch futureType {
-	case infrav1.PutFuture:
-		// Marshal and Unmarshal the future to put it into the correct future type so we can access the Result function.
-		// Unfortunately the FutureAPI can't be casted directly to InterfacesCreateOrUpdateFuture because it is a azureautorest.Future, which doesn't implement the Result function. See PR #1686 for discussion on alternatives.
-		// It was converted back to a generic azureautorest.Future from the CAPZ infrav1.Future type stored in Status: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/converters/futures.go#L49.
-		var createFuture *network.InterfacesCreateOrUpdateFuture
-		jsonData, err := future.MarshalJSON()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal future")
-		}
-		if err := json.Unmarshal(jsonData, &createFuture); err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal future data")
-		}
-		return createFuture.Result(ac.interfaces)
-
-	case infrav1.DeleteFuture:
-		// Delete does not return a result network interface
-		return nil, nil
-
-	default:
-		return nil, errors.Errorf("unknown future type %q", futureType)
-	}
 }

--- a/azure/services/networkinterfaces/networkinterfaces.go
+++ b/azure/services/networkinterfaces/networkinterfaces.go
@@ -19,9 +19,11 @@ package networkinterfaces
 import (
 	"context"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asyncpoller"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
@@ -44,13 +46,17 @@ type Service struct {
 }
 
 // New creates a new service.
-func New(scope NICScope, skuCache *resourceskus.Cache) *Service {
-	Client := NewClient(scope)
-	return &Service{
-		Scope:            scope,
-		Reconciler:       async.New(scope, Client, Client),
-		resourceSKUCache: skuCache,
+func New(scope NICScope, skuCache *resourceskus.Cache) (*Service, error) {
+	client, err := NewClient(scope)
+	if err != nil {
+		return nil, err
 	}
+	return &Service{
+		Scope: scope,
+		Reconciler: asyncpoller.New[armnetwork.InterfacesClientCreateOrUpdateResponse,
+			armnetwork.InterfacesClientDeleteResponse](scope, client, client),
+		resourceSKUCache: skuCache,
+	}, nil
 }
 
 // Name returns the service name.

--- a/azure/services/networkinterfaces/spec.go
+++ b/azure/services/networkinterfaces/spec.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -81,38 +81,38 @@ func (s *NICSpec) OwnerResourceName() string {
 // Parameters returns the parameters for the network interface.
 func (s *NICSpec) Parameters(ctx context.Context, existing interface{}) (parameters interface{}, err error) {
 	if existing != nil {
-		if _, ok := existing.(network.Interface); !ok {
-			return nil, errors.Errorf("%T is not a network.Interface", existing)
+		if _, ok := existing.(armnetwork.Interface); !ok {
+			return nil, errors.Errorf("%T is not an armnetwork.Interface", existing)
 		}
 		// network interface already exists
 		return nil, nil
 	}
 
-	primaryIPConfig := &network.InterfaceIPConfigurationPropertiesFormat{
+	primaryIPConfig := &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 		Primary: ptr.To(true),
 	}
 
-	subnet := &network.Subnet{
+	subnet := &armnetwork.Subnet{
 		ID: ptr.To(azure.SubnetID(s.SubscriptionID, s.VNetResourceGroup, s.VNetName, s.SubnetName)),
 	}
 	primaryIPConfig.Subnet = subnet
 
-	primaryIPConfig.PrivateIPAllocationMethod = network.IPAllocationMethodDynamic
+	primaryIPConfig.PrivateIPAllocationMethod = ptr.To(armnetwork.IPAllocationMethodDynamic)
 	if s.StaticIPAddress != "" {
-		primaryIPConfig.PrivateIPAllocationMethod = network.IPAllocationMethodStatic
+		primaryIPConfig.PrivateIPAllocationMethod = ptr.To(armnetwork.IPAllocationMethodStatic)
 		primaryIPConfig.PrivateIPAddress = ptr.To(s.StaticIPAddress)
 	}
 
-	backendAddressPools := []network.BackendAddressPool{}
+	backendAddressPools := []*armnetwork.BackendAddressPool{}
 	if s.PublicLBName != "" {
 		if s.PublicLBAddressPoolName != "" {
 			backendAddressPools = append(backendAddressPools,
-				network.BackendAddressPool{
+				&armnetwork.BackendAddressPool{
 					ID: ptr.To(azure.AddressPoolID(s.SubscriptionID, s.ResourceGroup, s.PublicLBName, s.PublicLBAddressPoolName)),
 				})
 		}
 		if s.PublicLBNATRuleName != "" {
-			primaryIPConfig.LoadBalancerInboundNatRules = &[]network.InboundNatRule{
+			primaryIPConfig.LoadBalancerInboundNatRules = []*armnetwork.InboundNatRule{
 				{
 					ID: ptr.To(azure.NATRuleID(s.SubscriptionID, s.ResourceGroup, s.PublicLBName, s.PublicLBNATRuleName)),
 				},
@@ -121,14 +121,14 @@ func (s *NICSpec) Parameters(ctx context.Context, existing interface{}) (paramet
 	}
 	if s.InternalLBName != "" && s.InternalLBAddressPoolName != "" {
 		backendAddressPools = append(backendAddressPools,
-			network.BackendAddressPool{
+			&armnetwork.BackendAddressPool{
 				ID: ptr.To(azure.AddressPoolID(s.SubscriptionID, s.ResourceGroup, s.InternalLBName, s.InternalLBAddressPoolName)),
 			})
 	}
-	primaryIPConfig.LoadBalancerBackendAddressPools = &backendAddressPools
+	primaryIPConfig.LoadBalancerBackendAddressPools = backendAddressPools
 
 	if s.PublicIPName != "" {
-		primaryIPConfig.PublicIPAddress = &network.PublicIPAddress{
+		primaryIPConfig.PublicIPAddress = &armnetwork.PublicIPAddress{
 			ID: ptr.To(azure.PublicIPID(s.SubscriptionID, s.ResourceGroup, s.PublicIPName)),
 		}
 	}
@@ -143,70 +143,70 @@ func (s *NICSpec) Parameters(ctx context.Context, existing interface{}) (paramet
 		s.AcceleratedNetworking = &accelNet
 	}
 
-	dnsSettings := network.InterfaceDNSSettings{}
+	dnsSettings := armnetwork.InterfaceDNSSettings{}
 	if len(s.DNSServers) > 0 {
-		dnsSettings.DNSServers = &s.DNSServers
+		dnsSettings.DNSServers = azure.PtrSlice(&s.DNSServers)
 	}
 
-	ipConfigurations := []network.InterfaceIPConfiguration{
+	ipConfigurations := []*armnetwork.InterfaceIPConfiguration{
 		{
-			Name:                                     ptr.To("pipConfig"),
-			InterfaceIPConfigurationPropertiesFormat: primaryIPConfig,
+			Name:       ptr.To("pipConfig"),
+			Properties: primaryIPConfig,
 		},
 	}
 
 	// Build additional IPConfigs if more than 1 is specified
 	for i := 1; i < len(s.IPConfigs); i++ {
 		c := s.IPConfigs[i]
-		newIPConfigPropertiesFormat := &network.InterfaceIPConfigurationPropertiesFormat{}
+		newIPConfigPropertiesFormat := &armnetwork.InterfaceIPConfigurationPropertiesFormat{}
 		newIPConfigPropertiesFormat.Subnet = subnet
-		config := network.InterfaceIPConfiguration{
-			Name:                                     ptr.To(s.Name + "-" + strconv.Itoa(i)),
-			InterfaceIPConfigurationPropertiesFormat: newIPConfigPropertiesFormat,
+		config := &armnetwork.InterfaceIPConfiguration{
+			Name:       ptr.To(s.Name + "-" + strconv.Itoa(i)),
+			Properties: newIPConfigPropertiesFormat,
 		}
 		if c.PrivateIP != nil && *c.PrivateIP != "" {
-			config.InterfaceIPConfigurationPropertiesFormat.PrivateIPAllocationMethod = network.IPAllocationMethodStatic
-			config.InterfaceIPConfigurationPropertiesFormat.PrivateIPAddress = c.PrivateIP
+			config.Properties.PrivateIPAllocationMethod = ptr.To(armnetwork.IPAllocationMethodStatic)
+			config.Properties.PrivateIPAddress = c.PrivateIP
 		} else {
-			config.InterfaceIPConfigurationPropertiesFormat.PrivateIPAllocationMethod = network.IPAllocationMethodDynamic
+			config.Properties.PrivateIPAllocationMethod = ptr.To(armnetwork.IPAllocationMethodDynamic)
 		}
 
 		if c.PublicIPAddress != nil && *c.PublicIPAddress != "" {
-			config.InterfaceIPConfigurationPropertiesFormat.PublicIPAddress = &network.PublicIPAddress{
-				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					PublicIPAllocationMethod: network.IPAllocationMethodStatic,
+			config.Properties.PublicIPAddress = &armnetwork.PublicIPAddress{
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					PublicIPAllocationMethod: ptr.To(armnetwork.IPAllocationMethodStatic),
 					IPAddress:                c.PublicIPAddress,
 				},
 			}
 		} else if c.PublicIPAddress != nil {
-			config.InterfaceIPConfigurationPropertiesFormat.PublicIPAddress = &network.PublicIPAddress{
-				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					PublicIPAllocationMethod: network.IPAllocationMethodDynamic,
+			config.Properties.PublicIPAddress = &armnetwork.PublicIPAddress{
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					PublicIPAllocationMethod: ptr.To(armnetwork.IPAllocationMethodDynamic),
 				},
 			}
 		}
-		config.InterfaceIPConfigurationPropertiesFormat.Primary = ptr.To(false)
+		config.Properties.Primary = ptr.To(false)
 		ipConfigurations = append(ipConfigurations, config)
 	}
 	if s.IPv6Enabled {
-		ipv6Config := network.InterfaceIPConfiguration{
+		ipv6Config := &armnetwork.InterfaceIPConfiguration{
 			Name: ptr.To("ipConfigv6"),
-			InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-				PrivateIPAddressVersion: "IPv6",
+			Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+				PrivateIPAddressVersion: ptr.To(armnetwork.IPVersionIPv6),
 				Primary:                 ptr.To(false),
-				Subnet:                  &network.Subnet{ID: subnet.ID},
+				Subnet:                  &armnetwork.Subnet{ID: subnet.ID},
 			},
 		}
 
 		ipConfigurations = append(ipConfigurations, ipv6Config)
 	}
 
-	return network.Interface{
+	return armnetwork.Interface{
 		Location:         ptr.To(s.Location),
-		ExtendedLocation: converters.ExtendedLocationToNetworkSDK(s.ExtendedLocation),
-		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+		ExtendedLocation: converters.ExtendedLocationToNetworkSDKv2(s.ExtendedLocation),
+		Properties: &armnetwork.InterfacePropertiesFormat{
 			EnableAcceleratedNetworking: s.AcceleratedNetworking,
-			IPConfigurations:            &ipConfigurations,
+			IPConfigurations:            ipConfigurations,
 			DNSSettings:                 &dnsSettings,
 			EnableIPForwarding:          ptr.To(s.EnableIPForwarding),
 		},

--- a/azure/services/networkinterfaces/spec_test.go
+++ b/azure/services/networkinterfaces/spec_test.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"k8s.io/utils/ptr"
@@ -273,27 +273,27 @@ func TestParameters(t *testing.T) {
 			spec:     &fakeStaticPrivateIPNICSpec,
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
-				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.Interface{}))
+				g.Expect(result.(armnetwork.Interface)).To(Equal(armnetwork.Interface{
 					Tags: map[string]*string{
 						"Name": ptr.To("my-net-interface"),
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
 					Location: ptr.To("fake-location"),
-					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+					Properties: &armnetwork.InterfacePropertiesFormat{
 						Primary:                     nil,
 						EnableAcceleratedNetworking: ptr.To(true),
 						EnableIPForwarding:          ptr.To(false),
-						DNSSettings:                 &network.InterfaceDNSSettings{},
-						IPConfigurations: &[]network.InterfaceIPConfiguration{
+						DNSSettings:                 &armnetwork.InterfaceDNSSettings{},
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
 							{
 								Name: ptr.To("pipConfig"),
-								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 									Primary:                         ptr.To(true),
-									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/cluster-name-outboundBackendPool")}},
-									PrivateIPAllocationMethod:       network.IPAllocationMethodStatic,
+									LoadBalancerBackendAddressPools: []*armnetwork.BackendAddressPool{{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/cluster-name-outboundBackendPool")}},
+									PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodStatic),
 									PrivateIPAddress:                ptr.To("fake.static.ip"),
-									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Subnet:                          &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 								},
 							},
 						},
@@ -307,26 +307,26 @@ func TestParameters(t *testing.T) {
 			spec:     &fakeDynamicPrivateIPNICSpec,
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
-				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.Interface{}))
+				g.Expect(result.(armnetwork.Interface)).To(Equal(armnetwork.Interface{
 					Tags: map[string]*string{
 						"Name": ptr.To("my-net-interface"),
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
 					Location: ptr.To("fake-location"),
-					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+					Properties: &armnetwork.InterfacePropertiesFormat{
 						EnableAcceleratedNetworking: ptr.To(true),
 						EnableIPForwarding:          ptr.To(false),
-						DNSSettings:                 &network.InterfaceDNSSettings{},
+						DNSSettings:                 &armnetwork.InterfaceDNSSettings{},
 						Primary:                     nil,
-						IPConfigurations: &[]network.InterfaceIPConfiguration{
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
 							{
 								Name: ptr.To("pipConfig"),
-								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 									Primary:                         ptr.To(true),
-									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/cluster-name-outboundBackendPool")}},
-									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
-									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									LoadBalancerBackendAddressPools: []*armnetwork.BackendAddressPool{{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/cluster-name-outboundBackendPool")}},
+									PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodDynamic),
+									Subnet:                          &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 								},
 							},
 						},
@@ -340,27 +340,27 @@ func TestParameters(t *testing.T) {
 			spec:     &fakeControlPlaneNICSpec,
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
-				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.Interface{}))
+				g.Expect(result.(armnetwork.Interface)).To(Equal(armnetwork.Interface{
 					Tags: map[string]*string{
 						"Name": ptr.To("my-net-interface"),
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
 					Location: ptr.To("fake-location"),
-					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+					Properties: &armnetwork.InterfacePropertiesFormat{
 						EnableAcceleratedNetworking: ptr.To(true),
 						EnableIPForwarding:          ptr.To(false),
-						DNSSettings:                 &network.InterfaceDNSSettings{},
+						DNSSettings:                 &armnetwork.InterfaceDNSSettings{},
 						Primary:                     nil,
-						IPConfigurations: &[]network.InterfaceIPConfiguration{
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
 							{
 								Name: ptr.To("pipConfig"),
-								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 									Primary:                     ptr.To(true),
-									Subnet:                      &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
-									PrivateIPAllocationMethod:   network.IPAllocationMethodDynamic,
-									LoadBalancerInboundNatRules: &[]network.InboundNatRule{{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/inboundNatRules/azure-test1")}},
-									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{
+									Subnet:                      &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:   ptr.To(armnetwork.IPAllocationMethodDynamic),
+									LoadBalancerInboundNatRules: []*armnetwork.InboundNatRule{{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/inboundNatRules/azure-test1")}},
+									LoadBalancerBackendAddressPools: []*armnetwork.BackendAddressPool{
 										{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/my-public-lb-backendPool")},
 										{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-internal-lb/backendAddressPools/my-internal-lb-backendPool")}},
 								},
@@ -376,26 +376,26 @@ func TestParameters(t *testing.T) {
 			spec:     &fakeAcceleratedNetworkingNICSpec,
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
-				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.Interface{}))
+				g.Expect(result.(armnetwork.Interface)).To(Equal(armnetwork.Interface{
 					Tags: map[string]*string{
 						"Name": ptr.To("my-net-interface"),
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
 					Location: ptr.To("fake-location"),
-					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+					Properties: &armnetwork.InterfacePropertiesFormat{
 						Primary:                     nil,
 						EnableAcceleratedNetworking: ptr.To(true),
 						EnableIPForwarding:          ptr.To(false),
-						DNSSettings:                 &network.InterfaceDNSSettings{},
-						IPConfigurations: &[]network.InterfaceIPConfiguration{
+						DNSSettings:                 &armnetwork.InterfaceDNSSettings{},
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
 							{
 								Name: ptr.To("pipConfig"),
-								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 									Primary:                         ptr.To(true),
-									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
-									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
-									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
+									Subnet:                          &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodDynamic),
+									LoadBalancerBackendAddressPools: []*armnetwork.BackendAddressPool{},
 								},
 							},
 						},
@@ -409,26 +409,26 @@ func TestParameters(t *testing.T) {
 			spec:     &fakeNonAcceleratedNetworkingNICSpec,
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
-				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.Interface{}))
+				g.Expect(result.(armnetwork.Interface)).To(Equal(armnetwork.Interface{
 					Tags: map[string]*string{
 						"Name": ptr.To("my-net-interface"),
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
 					Location: ptr.To("fake-location"),
-					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+					Properties: &armnetwork.InterfacePropertiesFormat{
 						Primary:                     nil,
 						EnableAcceleratedNetworking: ptr.To(false),
 						EnableIPForwarding:          ptr.To(false),
-						DNSSettings:                 &network.InterfaceDNSSettings{},
-						IPConfigurations: &[]network.InterfaceIPConfiguration{
+						DNSSettings:                 &armnetwork.InterfaceDNSSettings{},
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
 							{
 								Name: ptr.To("pipConfig"),
-								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 									Primary:                         ptr.To(true),
-									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
-									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
-									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
+									Subnet:                          &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodDynamic),
+									LoadBalancerBackendAddressPools: []*armnetwork.BackendAddressPool{},
 								},
 							},
 						},
@@ -442,34 +442,34 @@ func TestParameters(t *testing.T) {
 			spec:     &fakeIpv6NICSpec,
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
-				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.Interface{}))
+				g.Expect(result.(armnetwork.Interface)).To(Equal(armnetwork.Interface{
 					Tags: map[string]*string{
 						"Name": ptr.To("my-net-interface"),
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
 					Location: ptr.To("fake-location"),
-					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+					Properties: &armnetwork.InterfacePropertiesFormat{
 						Primary:                     nil,
 						EnableAcceleratedNetworking: ptr.To(true),
 						EnableIPForwarding:          ptr.To(true),
-						DNSSettings:                 &network.InterfaceDNSSettings{},
-						IPConfigurations: &[]network.InterfaceIPConfiguration{
+						DNSSettings:                 &armnetwork.InterfaceDNSSettings{},
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
 							{
 								Name: ptr.To("pipConfig"),
-								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 									Primary:                         ptr.To(true),
-									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
-									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
-									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
+									Subnet:                          &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodDynamic),
+									LoadBalancerBackendAddressPools: []*armnetwork.BackendAddressPool{},
 								},
 							},
 							{
 								Name: ptr.To("ipConfigv6"),
-								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Subnet:                  &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+									Subnet:                  &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 									Primary:                 ptr.To(false),
-									PrivateIPAddressVersion: "IPv6",
+									PrivateIPAddressVersion: ptr.To(armnetwork.IPVersionIPv6),
 								},
 							},
 						},
@@ -483,26 +483,26 @@ func TestParameters(t *testing.T) {
 			spec:     &fakeDefaultIPconfigNICSpec,
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
-				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.Interface{}))
+				g.Expect(result.(armnetwork.Interface)).To(Equal(armnetwork.Interface{
 					Tags: map[string]*string{
 						"Name": ptr.To("my-net-interface"),
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
 					Location: ptr.To("fake-location"),
-					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+					Properties: &armnetwork.InterfacePropertiesFormat{
 						Primary:                     nil,
 						EnableAcceleratedNetworking: ptr.To(true),
 						EnableIPForwarding:          ptr.To(true),
-						DNSSettings:                 &network.InterfaceDNSSettings{},
-						IPConfigurations: &[]network.InterfaceIPConfiguration{
+						DNSSettings:                 &armnetwork.InterfaceDNSSettings{},
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
 							{
 								Name: ptr.To("pipConfig"),
-								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 									Primary:                         ptr.To(true),
-									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
-									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
-									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
+									Subnet:                          &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodDynamic),
+									LoadBalancerBackendAddressPools: []*armnetwork.BackendAddressPool{},
 								},
 							},
 						},
@@ -516,26 +516,26 @@ func TestParameters(t *testing.T) {
 			spec:     &fakeOneIPconfigNICSpec,
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
-				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.Interface{}))
+				g.Expect(result.(armnetwork.Interface)).To(Equal(armnetwork.Interface{
 					Tags: map[string]*string{
 						"Name": ptr.To("my-net-interface"),
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
 					Location: ptr.To("fake-location"),
-					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+					Properties: &armnetwork.InterfacePropertiesFormat{
 						Primary:                     nil,
 						EnableAcceleratedNetworking: ptr.To(true),
 						EnableIPForwarding:          ptr.To(true),
-						DNSSettings:                 &network.InterfaceDNSSettings{},
-						IPConfigurations: &[]network.InterfaceIPConfiguration{
+						DNSSettings:                 &armnetwork.InterfaceDNSSettings{},
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
 							{
 								Name: ptr.To("pipConfig"),
-								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 									Primary:                         ptr.To(true),
-									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
-									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
-									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
+									Subnet:                          &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodDynamic),
+									LoadBalancerBackendAddressPools: []*armnetwork.BackendAddressPool{},
 								},
 							},
 						},
@@ -549,34 +549,34 @@ func TestParameters(t *testing.T) {
 			spec:     &fakeTwoIPconfigNICSpec,
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
-				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.Interface{}))
+				g.Expect(result.(armnetwork.Interface)).To(Equal(armnetwork.Interface{
 					Tags: map[string]*string{
 						"Name": ptr.To("my-net-interface"),
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
 					Location: ptr.To("fake-location"),
-					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+					Properties: &armnetwork.InterfacePropertiesFormat{
 						Primary:                     nil,
 						EnableAcceleratedNetworking: ptr.To(true),
 						EnableIPForwarding:          ptr.To(true),
-						DNSSettings:                 &network.InterfaceDNSSettings{},
-						IPConfigurations: &[]network.InterfaceIPConfiguration{
+						DNSSettings:                 &armnetwork.InterfaceDNSSettings{},
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
 							{
 								Name: ptr.To("pipConfig"),
-								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 									Primary:                         ptr.To(true),
-									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
-									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
-									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
+									Subnet:                          &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodDynamic),
+									LoadBalancerBackendAddressPools: []*armnetwork.BackendAddressPool{},
 								},
 							},
 							{
 								Name: ptr.To("my-net-interface-1"),
-								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 									Primary:                         ptr.To(false),
-									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
-									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
+									Subnet:                          &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodDynamic),
 									LoadBalancerBackendAddressPools: nil,
 								},
 							},
@@ -591,37 +591,37 @@ func TestParameters(t *testing.T) {
 			spec:     &fakeTwoIPconfigWithPublicNICSpec,
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
-				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.Interface{}))
+				g.Expect(result.(armnetwork.Interface)).To(Equal(armnetwork.Interface{
 					Tags: map[string]*string{
 						"Name": ptr.To("my-net-interface"),
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
 					Location: ptr.To("fake-location"),
-					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+					Properties: &armnetwork.InterfacePropertiesFormat{
 						Primary:                     nil,
 						EnableAcceleratedNetworking: ptr.To(true),
 						EnableIPForwarding:          ptr.To(true),
-						DNSSettings:                 &network.InterfaceDNSSettings{},
-						IPConfigurations: &[]network.InterfaceIPConfiguration{
+						DNSSettings:                 &armnetwork.InterfaceDNSSettings{},
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
 							{
 								Name: ptr.To("pipConfig"),
-								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 									Primary:                   ptr.To(true),
-									Subnet:                    &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
-									PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-									PublicIPAddress: &network.PublicIPAddress{
+									Subnet:                    &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod: ptr.To(armnetwork.IPAllocationMethodDynamic),
+									PublicIPAddress: &armnetwork.PublicIPAddress{
 										ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/pip-azure-test1"),
 									},
-									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
+									LoadBalancerBackendAddressPools: []*armnetwork.BackendAddressPool{},
 								},
 							},
 							{
 								Name: ptr.To("my-net-interface-1"),
-								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 									Primary:                         ptr.To(false),
-									Subnet:                          &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
-									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
+									Subnet:                          &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodDynamic),
 									LoadBalancerBackendAddressPools: nil,
 								},
 							},
@@ -636,28 +636,28 @@ func TestParameters(t *testing.T) {
 			spec:     &fakeControlPlaneCustomDNSSettingsNICSpec,
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
-				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
-				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.Interface{}))
+				g.Expect(result.(armnetwork.Interface)).To(Equal(armnetwork.Interface{
 					Tags: map[string]*string{
 						"Name": ptr.To("my-net-interface"),
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 					},
 					Location: ptr.To("fake-location"),
-					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+					Properties: &armnetwork.InterfacePropertiesFormat{
 						EnableAcceleratedNetworking: ptr.To(true),
 						EnableIPForwarding:          ptr.To(false),
-						DNSSettings: &network.InterfaceDNSSettings{
-							DNSServers: &[]string{"123.123.123.123", "124.124.124.124"},
+						DNSSettings: &armnetwork.InterfaceDNSSettings{
+							DNSServers: []*string{ptr.To("123.123.123.123"), ptr.To("124.124.124.124")},
 						},
-						IPConfigurations: &[]network.InterfaceIPConfiguration{
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
 							{
 								Name: ptr.To("pipConfig"),
-								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-									Subnet:                      &network.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+									Subnet:                      &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 									Primary:                     ptr.To(true),
-									PrivateIPAllocationMethod:   network.IPAllocationMethodDynamic,
-									LoadBalancerInboundNatRules: &[]network.InboundNatRule{{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/inboundNatRules/azure-test1")}},
-									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{
+									PrivateIPAllocationMethod:   ptr.To(armnetwork.IPAllocationMethodDynamic),
+									LoadBalancerInboundNatRules: []*armnetwork.InboundNatRule{{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/inboundNatRules/azure-test1")}},
+									LoadBalancerBackendAddressPools: []*armnetwork.BackendAddressPool{
 										{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/my-public-lb-backendPool")},
 										{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-internal-lb/backendAddressPools/my-internal-lb-backendPool")}},
 								},

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
@@ -73,13 +74,13 @@ var (
 		Name:          "nic-1",
 		ResourceGroup: "test-group",
 	}
-	fakeNetworkInterface = network.Interface{
-		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
-			IPConfigurations: &[]network.InterfaceIPConfiguration{
+	fakeNetworkInterface = armnetwork.Interface{
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
 				{
-					InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+					Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 						PrivateIPAddress: ptr.To("10.0.0.5"),
-						PublicIPAddress: &network.PublicIPAddress{
+						PublicIPAddress: &armnetwork.PublicIPAddress{
 							ID: ptr.To("/subscriptions/123/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/pip-1"),
 						},
 					},
@@ -168,7 +169,7 @@ func TestReconcileVM(t *testing.T) {
 				s.UpdatePutStatus(infrav1.DisksReadyCondition, serviceName, nil)
 				s.SetProviderID("azure://subscriptions/123/resourceGroups/my_resource_group/providers/Microsoft.Compute/virtualMachines/my-vm")
 				s.SetAnnotation("cluster-api-provider-azure", "true")
-				mnic.Get(gomockinternal.AContext(), &fakeNetworkInterfaceGetterSpec).Return(network.Interface{}, internalError)
+				mnic.Get(gomockinternal.AContext(), &fakeNetworkInterfaceGetterSpec).Return(armnetwork.Interface{}, internalError)
 			},
 		},
 		{

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -77,12 +77,16 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating vmextensions service")
 	}
+	networkInterfacesSvc, err := networkinterfaces.New(machineScope, cache)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating networkinterfaces service")
+	}
 	ams := &azureMachineService{
 		scope: machineScope,
 		services: []azure.ServiceReconciler{
 			publicips.New(machineScope),
 			inboundnatrulesSvc,
-			networkinterfaces.New(machineScope, cache),
+			networkInterfacesSvc,
 			availabilitySetsSvc,
 			disksSvc,
 			virtualmachinesSvc,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR converts the networkinterfaces service to use SDK v2 and the new asyncpoller framework.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3940

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
