### PR TITLE
Add proper validation for nodepool name

### DIFF
--- a/api/v1beta1/azuremanagedmachinepool_webhook_test.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook_test.go
@@ -39,7 +39,7 @@ func TestAzureManagedMachinePoolDefaultingWebhook(t *testing.T) {
 	t.Logf("Testing ammp defaulting webhook with mode system")
 	ammp := &AzureManagedMachinePool{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "fooName",
+			Name: "fooname",
 		},
 		Spec: AzureManagedMachinePoolSpec{
 			Mode:         "System",
@@ -57,7 +57,7 @@ func TestAzureManagedMachinePoolDefaultingWebhook(t *testing.T) {
 	val, ok := ammp.Labels[LabelAgentPoolMode]
 	g.Expect(ok).To(BeTrue())
 	g.Expect(val).To(Equal("System"))
-	g.Expect(*ammp.Spec.Name).To(Equal("fooName"))
+	g.Expect(*ammp.Spec.Name).To(Equal("fooname"))
 	g.Expect(*ammp.Spec.OSType).To(Equal(LinuxOS))
 
 	t.Logf("Testing ammp defaulting webhook with empty string name specified in Spec")
@@ -65,14 +65,14 @@ func TestAzureManagedMachinePoolDefaultingWebhook(t *testing.T) {
 	ammp.Spec.Name = &emptyName
 	err = mw.Default(context.Background(), ammp)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(*ammp.Spec.Name).To(Equal("fooName"))
+	g.Expect(*ammp.Spec.Name).To(Equal("fooname"))
 
 	t.Logf("Testing ammp defaulting webhook with normal name specified in Spec")
-	normalName := "barName"
+	normalName := "barname"
 	ammp.Spec.Name = &normalName
 	err = mw.Default(context.Background(), ammp)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(*ammp.Spec.Name).To(Equal("barName"))
+	g.Expect(*ammp.Spec.Name).To(Equal("barname"))
 
 	t.Logf("Testing ammp defaulting webhook with normal OsDiskType specified in Spec")
 	normalOsDiskType := "Ephemeral"


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

1. According to [Azure Docs](https://learn.microsoft.com/en-us/azure/aks/create-node-pools#limitations), these are the nodepool naming restrictions:
    - The name of a node pool may only contain lowercase alphanumeric characters and must begin with a lowercase letter.
    - For Linux node pools, the length must be between 1-12 characters.

But the nodepool name is not validated properly (according to these restrictions). Proper validation following these restrictions in the [`azuremanagedmachinepool_webhook.go`](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/api/v1beta1/azuremanagedmachinepool_webhook.go#L365) is added.

2. If the name of the nodepool i.e. `spec.name` field is `not specified` in the YAML of `AzureManagedMachinePool`, then the default name is set to the `metadata.name`. Take a look [here](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/api/v1beta1/azuremanagedmachinepool_webhook.go#L74-L75C3). So `metadata.name` is validated when `spec.name` is not set. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3968 





**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [X] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add proper validation for nodepool name
```