### PR TITLE
fix endless reconciliation on AKS system node labels

### DIFF
--- a/azure/services/agentpools/spec_test.go
+++ b/azure/services/agentpools/spec_test.go
@@ -340,6 +340,24 @@ func TestParameters(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "difference in system node labels with empty labels shouldn't trigger update",
+			spec: fakeAgentPool(
+				func(pool *AgentPoolSpec) {
+					pool.NodeLabels = nil
+				},
+			),
+			existing: sdkFakeAgentPool(
+				func(pool *armcontainerservice.AgentPool) {
+					pool.Properties.NodeLabels = map[string]*string{
+						"kubernetes.azure.com/scalesetpriority": ptr.To("spot"),
+					}
+				},
+				sdkWithProvisioningState("Succeeded"),
+			),
+			expected:      nil,
+			expectedError: nil,
+		},
+		{
 			name: "parameters with an existing agent pool and update needed on node taints",
 			spec: fakeAgentPool(),
 			existing: sdkFakeAgentPool(
@@ -428,6 +446,15 @@ func TestMergeSystemNodeLabels(t *testing.T) {
 				"hello": ptr.To("world"),
 			},
 			expected: map[string]*string{},
+		},
+		{
+			name:       "delete labels from nil",
+			capzLabels: nil,
+			aksLabels: map[string]*string{
+				"foo":   ptr.To("bar"),
+				"hello": ptr.To("world"),
+			},
+			expected: nil,
 		},
 		{
 			name: "delete one label",


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
/area managedclusters

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

When AKS labels agent pool nodes on its own (i.e. not labels specified by the user), e.g. when spot instances are being used, CAPZ has to carefully ignore those AKS labels when calculating whether or not an agent pool should be updated. The existing ignore mechanism only took effect when existing labels were specified on the node by the user. This PR fixes a bug where the combination of no user-specified labels and the presence of any AKS-specified values caused CAPZ to endless reconcile the AzureManagedMachinePool on a diff like this:

```diff
  armcontainerservice.AgentPool{
  	Properties: &armcontainerservice.ManagedClusterAgentPoolProfileProperties{
  		... // 15 identical fields
  		MinCount:             &0,
  		Mode:                 &"User",
- 		NodeLabels:           nil,
+ 		NodeLabels:           map[string]*string{"kubernetes.azure.com/scalesetpriority": &"spot"},
  		NodePublicIPPrefixID: nil,
  		NodeTaints:           {&"kubernetes.azure.com/scalesetpriority=spot:NoSchedule"},
  		... // 21 identical fields
  	},
  	ID:   nil,
  	Name: nil,
  	Type: nil,
  }
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

To repro, apply any AzureManagedMachinePool using Spot instances without any `spec.nodeLabels`, such as something like this:
```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: MachinePool
metadata:
  name: jon-aks-$NAME
  namespace: default
spec:
  clusterName: jon-aks
  replicas: 1
  template:
    metadata: {}
    spec:
      bootstrap:
        dataSecretName: ""
      clusterName: jon-aks
      infrastructureRef:
        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
        kind: AzureManagedMachinePool
        name: jon-aks-$NAME
      version: v1.26.3
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: AzureManagedMachinePool
metadata:
  name: jon-aks-$NAME
  namespace: default
spec:
  mode: User
  name: $NAME
  sku: Standard_B2s
  scaleSetPriority: Spot
```

The "found a diff" messages will appear in the logs and the MachinePool will flip between Provisioned and Scaling or Running every minute or so.


- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug where AzureManagedMachinePools using Spot instances would endlessly reconcile without any user-specified node labels
```
