### PR TITLE
Set cloud provider config to have shorter cache ttl

### DIFF
--- a/hack/create-custom-cloud-provider-config.sh
+++ b/hack/create-custom-cloud-provider-config.sh
@@ -25,12 +25,16 @@ source "${REPO_ROOT}/hack/common-vars.sh"
 
 make --directory="${REPO_ROOT}" "${KUBECTL##*/}"
 
+# Test cloud provider config with shorter cache ttl
+CLOUD_PROVIDER_CONFIG="https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-short-cache-ttl.json"
 if [[ -n "${CUSTOM_CLOUD_PROVIDER_CONFIG:-}" ]]; then
-  curl --retry 3 -sL -o tmp_azure_json "${CUSTOM_CLOUD_PROVIDER_CONFIG}"
-  envsubst < tmp_azure_json > azure_json
-  "${KUBECTL}" delete secret "${CLUSTER_NAME}-control-plane-azure-json" || true
-  "${KUBECTL}" create secret generic "${CLUSTER_NAME}-control-plane-azure-json" \
-    --from-file=control-plane-azure.json=azure_json \
-    --from-file=worker-node-azure.json=azure_json
-  rm tmp_azure_json azure_json
+  CLOUD_PROVIDER_CONFIG="${CUSTOM_CLOUD_PROVIDER_CONFIG:-}"
 fi
+
+curl --retry 3 -sL -o tmp_azure_json "${CLOUD_PROVIDER_CONFIG}"
+envsubst < tmp_azure_json > azure_json
+"${KUBECTL}" delete secret "${CLUSTER_NAME}-control-plane-azure-json" || true
+"${KUBECTL}" create secret generic "${CLUSTER_NAME}-control-plane-azure-json" \
+  --from-file=control-plane-azure.json=azure_json \
+  --from-file=worker-node-azure.json=azure_json
+rm tmp_azure_json azure_json


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind testing
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Set cloud provider config to have shorter cache ttl
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Related: https://github.com/kubernetes-sigs/cloud-provider-azure/issues/4594

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
