### PR TITLE
fix unit test failure with Go 1.21

### DIFF
--- a/azure/services/inboundnatrules/spec_test.go
+++ b/azure/services/inboundnatrules/spec_test.go
@@ -50,8 +50,8 @@ func TestParameters(t *testing.T) {
 		{
 			name:     "existing is not an InboundNatRule",
 			spec:     fakeInboundNatSpec(true),
-			existing: context.TODO(),
-			errorMsg: "*context.emptyCtx is not an armnetwork.InboundNatRule",
+			existing: "wrong type",
+			errorMsg: "string is not an armnetwork.InboundNatRule",
 		},
 		{
 			name:     "existing InboundNatRule",


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This fixes a unit test failure when running Go 1.21. The test relies on the unexported name of the underlying type of the return value of `context.TODO()` which changed in Go 1.21. This PR changes the type of the invalid input to `string` to fix this issue and hopefully remain more stable in the future. 

This is the test failure:
```
% go test ./azure/services/inboundnatrules
--- FAIL: TestParameters (0.00s)
    --- FAIL: TestParameters/existing_is_not_an_InboundNatRule (0.00s)
        spec_test.go:72:
            Expected
                <string>: context.todoCtx is not an armnetwork.InboundNatRule
            to contain substring
                <string>: *context.emptyCtx is not an armnetwork.InboundNatRule
FAIL
FAIL    sigs.k8s.io/cluster-api-provider-azure/azure/services/inboundnatrules   0.832s
FAIL
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate <-- Not needed if we don't plan to bump to Go 1.21 on the currently-supported release branches.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
