### PR TITLE
Convert scalesetvms service to SDKv2

### DIFF
--- a/azure/converters/vmss.go
+++ b/azure/converters/vmss.go
@@ -20,7 +20,6 @@ import (
 	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"k8s.io/utils/ptr"
 	azprovider "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -35,7 +34,7 @@ const (
 )
 
 // SDKToVMSS converts an Azure SDK VirtualMachineScaleSet to the AzureMachinePool type.
-func SDKToVMSS(sdkvmss armcompute.VirtualMachineScaleSet, sdkinstances []compute.VirtualMachineScaleSetVM) azure.VMSS {
+func SDKToVMSS(sdkvmss armcompute.VirtualMachineScaleSet, sdkinstances []armcompute.VirtualMachineScaleSetVM) azure.VMSS {
 	vmss := azure.VMSS{
 		ID:    ptr.Deref(sdkvmss.ID, ""),
 		Name:  ptr.Deref(sdkvmss.Name, ""),
@@ -68,39 +67,39 @@ func SDKToVMSS(sdkvmss armcompute.VirtualMachineScaleSet, sdkinstances []compute
 		sdkvmss.Properties.VirtualMachineProfile.StorageProfile != nil &&
 		sdkvmss.Properties.VirtualMachineProfile.StorageProfile.ImageReference != nil {
 		imageRef := sdkvmss.Properties.VirtualMachineProfile.StorageProfile.ImageReference
-		vmss.Image = SDKImageToImageV2(imageRef, sdkvmss.Plan != nil)
+		vmss.Image = SDKImageToImage(imageRef, sdkvmss.Plan != nil)
 	}
 
 	return vmss
 }
 
 // SDKVMToVMSSVM converts an Azure SDK VM to a VMSS VM.
-func SDKVMToVMSSVM(sdkInstance compute.VirtualMachine, mode infrav1.OrchestrationModeType) *azure.VMSSVM {
+func SDKVMToVMSSVM(sdkInstance armcompute.VirtualMachine, mode infrav1.OrchestrationModeType) *azure.VMSSVM {
 	instance := azure.VMSSVM{
 		ID: ptr.Deref(sdkInstance.ID, ""),
 	}
 
-	if sdkInstance.VirtualMachineProperties == nil {
+	if sdkInstance.Properties == nil {
 		return &instance
 	}
 
 	instance.State = infrav1.Creating
-	if sdkInstance.ProvisioningState != nil {
-		instance.State = infrav1.ProvisioningState(ptr.Deref(sdkInstance.ProvisioningState, ""))
+	if sdkInstance.Properties.ProvisioningState != nil {
+		instance.State = infrav1.ProvisioningState(ptr.Deref(sdkInstance.Properties.ProvisioningState, ""))
 	}
 
-	if sdkInstance.OsProfile != nil && sdkInstance.OsProfile.ComputerName != nil {
-		instance.Name = *sdkInstance.OsProfile.ComputerName
+	if sdkInstance.Properties.OSProfile != nil && sdkInstance.Properties.OSProfile.ComputerName != nil {
+		instance.Name = *sdkInstance.Properties.OSProfile.ComputerName
 	}
 
-	if sdkInstance.StorageProfile != nil && sdkInstance.StorageProfile.ImageReference != nil {
-		imageRef := sdkInstance.StorageProfile.ImageReference
+	if sdkInstance.Properties.StorageProfile != nil && sdkInstance.Properties.StorageProfile.ImageReference != nil {
+		imageRef := sdkInstance.Properties.StorageProfile.ImageReference
 		instance.Image = SDKImageToImage(imageRef, sdkInstance.Plan != nil)
 	}
 
-	if sdkInstance.Zones != nil && len(*sdkInstance.Zones) > 0 {
+	if len(sdkInstance.Zones) > 0 {
 		// An instance should have only 1 zone, so use the first item of the slice.
-		instance.AvailabilityZone = azure.StringSlice(sdkInstance.Zones)[0]
+		instance.AvailabilityZone = *sdkInstance.Zones[0]
 	}
 
 	instance.OrchestrationMode = mode
@@ -109,7 +108,7 @@ func SDKVMToVMSSVM(sdkInstance compute.VirtualMachine, mode infrav1.Orchestratio
 }
 
 // SDKToVMSSVM converts an Azure SDK VirtualMachineScaleSetVM into an infrav1exp.VMSSVM.
-func SDKToVMSSVM(sdkInstance compute.VirtualMachineScaleSetVM) *azure.VMSSVM {
+func SDKToVMSSVM(sdkInstance armcompute.VirtualMachineScaleSetVM) *azure.VMSSVM {
 	// Convert resourceGroup Name ID ( ProviderID in capz objects )
 	var convertedID string
 	convertedID, err := azprovider.ConvertResourceGroupNameToLower(ptr.Deref(sdkInstance.ID, ""))
@@ -122,61 +121,44 @@ func SDKToVMSSVM(sdkInstance compute.VirtualMachineScaleSetVM) *azure.VMSSVM {
 		InstanceID: ptr.Deref(sdkInstance.InstanceID, ""),
 	}
 
-	if sdkInstance.VirtualMachineScaleSetVMProperties == nil {
+	if sdkInstance.Properties == nil {
 		return &instance
 	}
 
 	instance.State = infrav1.Creating
-	if sdkInstance.ProvisioningState != nil {
-		instance.State = infrav1.ProvisioningState(ptr.Deref(sdkInstance.ProvisioningState, ""))
+	if sdkInstance.Properties.ProvisioningState != nil {
+		instance.State = infrav1.ProvisioningState(ptr.Deref(sdkInstance.Properties.ProvisioningState, ""))
 	}
 
-	if sdkInstance.OsProfile != nil && sdkInstance.OsProfile.ComputerName != nil {
-		instance.Name = *sdkInstance.OsProfile.ComputerName
+	if sdkInstance.Properties.OSProfile != nil && sdkInstance.Properties.OSProfile.ComputerName != nil {
+		instance.Name = *sdkInstance.Properties.OSProfile.ComputerName
 	}
 
 	if sdkInstance.Resources != nil {
-		for _, r := range *sdkInstance.Resources {
-			if r.ProvisioningState != nil && r.Name != nil &&
+		for _, r := range sdkInstance.Resources {
+			if r.Properties.ProvisioningState != nil && r.Name != nil &&
 				(*r.Name == azure.BootstrappingExtensionLinux || *r.Name == azure.BootstrappingExtensionWindows) {
-				instance.BootstrappingState = infrav1.ProvisioningState(ptr.Deref(r.ProvisioningState, ""))
+				instance.BootstrappingState = infrav1.ProvisioningState(ptr.Deref(r.Properties.ProvisioningState, ""))
 				break
 			}
 		}
 	}
 
-	if sdkInstance.StorageProfile != nil && sdkInstance.StorageProfile.ImageReference != nil {
-		imageRef := sdkInstance.StorageProfile.ImageReference
+	if sdkInstance.Properties.StorageProfile != nil && sdkInstance.Properties.StorageProfile.ImageReference != nil {
+		imageRef := sdkInstance.Properties.StorageProfile.ImageReference
 		instance.Image = SDKImageToImage(imageRef, sdkInstance.Plan != nil)
 	}
 
-	if sdkInstance.Zones != nil && len(*sdkInstance.Zones) > 0 {
+	if len(sdkInstance.Zones) > 0 {
 		// an instance should only have 1 zone, so we select the first item of the slice
-		instance.AvailabilityZone = azure.StringSlice(sdkInstance.Zones)[0]
+		instance.AvailabilityZone = *sdkInstance.Zones[0]
 	}
 
 	return &instance
 }
 
-// SDKImageToImageV2 converts a SDK image reference to infrav1.Image.
-func SDKImageToImageV2(sdkImageRef *armcompute.ImageReference, isThirdPartyImage bool) infrav1.Image {
-	if sdkImageRef.ID != nil {
-		return IDImageRefToImage(*sdkImageRef.ID)
-	}
-	// community gallery image
-	if sdkImageRef.CommunityGalleryImageID != nil {
-		return cgImageRefToImage(*sdkImageRef.CommunityGalleryImageID)
-	}
-	// shared gallery image
-	if sdkImageRef.SharedGalleryImageID != nil {
-		return sgImageRefToImage(*sdkImageRef.SharedGalleryImageID)
-	}
-	// marketplace image
-	return mpImageRefToImageV2(sdkImageRef, isThirdPartyImage)
-}
-
 // SDKImageToImage converts a SDK image reference to infrav1.Image.
-func SDKImageToImage(sdkImageRef *compute.ImageReference, isThirdPartyImage bool) infrav1.Image {
+func SDKImageToImage(sdkImageRef *armcompute.ImageReference, isThirdPartyImage bool) infrav1.Image {
 	if sdkImageRef.ID != nil {
 		return IDImageRefToImage(*sdkImageRef.ID)
 	}
@@ -221,29 +203,14 @@ func IDImageRefToImage(id string) infrav1.Image {
 	}
 }
 
-// mpImageRefToImageV2 converts a marketplace gallery ImageReference to an infrav1.Image.
-func mpImageRefToImageV2(sdkImageRef *armcompute.ImageReference, isThirdPartyImage bool) infrav1.Image {
+// mpImageRefToImage converts a marketplace gallery ImageReference to an infrav1.Image.
+func mpImageRefToImage(sdkImageRef *armcompute.ImageReference, isThirdPartyImage bool) infrav1.Image {
 	return infrav1.Image{
 		Marketplace: &infrav1.AzureMarketplaceImage{
 			ImagePlan: infrav1.ImagePlan{
 				Publisher: ptr.Deref(sdkImageRef.Publisher, ""),
 				Offer:     ptr.Deref(sdkImageRef.Offer, ""),
 				SKU:       ptr.Deref(sdkImageRef.SKU, ""),
-			},
-			Version:         ptr.Deref(sdkImageRef.Version, ""),
-			ThirdPartyImage: isThirdPartyImage,
-		},
-	}
-}
-
-// mpImageRefToImage converts a marketplace gallery ImageReference to an infrav1.Image.
-func mpImageRefToImage(sdkImageRef *compute.ImageReference, isThirdPartyImage bool) infrav1.Image {
-	return infrav1.Image{
-		Marketplace: &infrav1.AzureMarketplaceImage{
-			ImagePlan: infrav1.ImagePlan{
-				Publisher: ptr.Deref(sdkImageRef.Publisher, ""),
-				Offer:     ptr.Deref(sdkImageRef.Offer, ""),
-				SKU:       ptr.Deref(sdkImageRef.Sku, ""),
 			},
 			Version:         ptr.Deref(sdkImageRef.Version, ""),
 			ThirdPartyImage: isThirdPartyImage,

--- a/azure/services/scalesets/client.go
+++ b/azure/services/scalesets/client.go
@@ -18,12 +18,9 @@ package scalesets
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asyncpoller"
@@ -35,7 +32,7 @@ import (
 type Client interface {
 	Get(context.Context, azure.ResourceSpecGetter) (interface{}, error)
 	List(context.Context, string) ([]armcompute.VirtualMachineScaleSet, error)
-	ListInstances(context.Context, string, string) ([]compute.VirtualMachineScaleSetVM, error)
+	ListInstances(context.Context, string, string) ([]armcompute.VirtualMachineScaleSetVM, error)
 
 	CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], err error)
 	DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string) (poller *runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeleteResponse], err error)
@@ -43,7 +40,7 @@ type Client interface {
 
 // AzureClient contains the Azure go-sdk Client.
 type AzureClient struct {
-	scalesetvms compute.VirtualMachineScaleSetVMsClient
+	scalesetvms *armcompute.VirtualMachineScaleSetVMsClient
 	scalesets   *armcompute.VirtualMachineScaleSetsClient
 }
 
@@ -51,21 +48,31 @@ var _ Client = &AzureClient{}
 
 // NewClient creates a new VMSS client from an authorizer.
 func NewClient(auth azure.Authorizer) (*AzureClient, error) {
+	scaleSetVMsClient, err := newVirtualMachineScaleSetVMsClient(auth)
+	if err != nil {
+		return nil, err
+	}
 	scaleSetsClient, err := newVirtualMachineScaleSetsClient(auth)
 	if err != nil {
 		return nil, err
 	}
 	return &AzureClient{
-		scalesetvms: newVirtualMachineScaleSetVMsClient(auth.SubscriptionID(), auth.BaseURI(), auth.Authorizer()),
+		scalesetvms: scaleSetVMsClient,
 		scalesets:   scaleSetsClient,
 	}, nil
 }
 
-// newVirtualMachineScaleSetVMsClient creates a new vmss VM client from subscription ID.
-func newVirtualMachineScaleSetVMsClient(subscriptionID string, baseURI string, authorizer autorest.Authorizer) compute.VirtualMachineScaleSetVMsClient {
-	c := compute.NewVirtualMachineScaleSetVMsClientWithBaseURI(baseURI, subscriptionID)
-	azure.SetAutoRestClientDefaults(&c.Client, authorizer)
-	return c
+// newVirtualMachineScaleSetVMsClient creates a vmss VM client from an authorizer.
+func newVirtualMachineScaleSetVMsClient(auth azure.Authorizer) (*armcompute.VirtualMachineScaleSetVMsClient, error) {
+	opts, err := azure.ARMClientOptions(auth.CloudEnvironment())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create scalesetvms client options")
+	}
+	factory, err := armcompute.NewClientFactory(auth.SubscriptionID(), auth.Token(), opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create armcompute client factory")
+	}
+	return factory.NewVirtualMachineScaleSetVMsClient(), nil
 }
 
 // newVirtualMachineScaleSetsClient creates a vmss client from an authorizer.
@@ -82,23 +89,22 @@ func newVirtualMachineScaleSetsClient(auth azure.Authorizer) (*armcompute.Virtua
 }
 
 // ListInstances retrieves information about the model views of a virtual machine scale set.
-func (ac *AzureClient) ListInstances(ctx context.Context, resourceGroupName string, resourceName string) ([]compute.VirtualMachineScaleSetVM, error) {
+func (ac *AzureClient) ListInstances(ctx context.Context, resourceGroupName string, resourceName string) ([]armcompute.VirtualMachineScaleSetVM, error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.AzureClient.ListInstances")
 	defer done()
 
-	itr, err := ac.scalesetvms.ListComplete(ctx, resourceGroupName, resourceName, "", "", "")
-	if err != nil {
-		return nil, err
+	var instances []armcompute.VirtualMachineScaleSetVM
+	pager := ac.scalesetvms.NewListPager(resourceGroupName, resourceName, nil)
+	for pager.More() {
+		nextResult, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not iterate scalesetvms")
+		}
+		for _, scaleSetVM := range nextResult.Value {
+			instances = append(instances, *scaleSetVM)
+		}
 	}
 
-	var instances []compute.VirtualMachineScaleSetVM
-	for ; itr.NotDone(); err = itr.NextWithContext(ctx) {
-		if err != nil {
-			return nil, fmt.Errorf("failed to iterate vm scale set vms [%w]", err)
-		}
-		vm := itr.Value()
-		instances = append(instances, vm)
-	}
 	return instances, nil
 }
 

--- a/azure/services/scalesets/mock_scalesets/client_mock.go
+++ b/azure/services/scalesets/mock_scalesets/client_mock.go
@@ -26,7 +26,6 @@ import (
 
 	runtime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	gomock "go.uber.org/mock/gomock"
 	azure "sigs.k8s.io/cluster-api-provider-azure/azure"
 )
@@ -116,10 +115,10 @@ func (mr *MockClientMockRecorder) List(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // ListInstances mocks base method.
-func (m *MockClient) ListInstances(arg0 context.Context, arg1, arg2 string) ([]compute.VirtualMachineScaleSetVM, error) {
+func (m *MockClient) ListInstances(arg0 context.Context, arg1, arg2 string) ([]armcompute.VirtualMachineScaleSetVM, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInstances", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]compute.VirtualMachineScaleSetVM)
+	ret0, _ := ret[0].([]armcompute.VirtualMachineScaleSetVM)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -921,22 +920,22 @@ func fetchDataDiskBasedOnSize(vmSize string) []*armcompute.VirtualMachineScaleSe
 	return dataDisk
 }
 
-func newDefaultInstances() []compute.VirtualMachineScaleSetVM {
-	return []compute.VirtualMachineScaleSetVM{
+func newDefaultInstances() []armcompute.VirtualMachineScaleSetVM {
+	return []armcompute.VirtualMachineScaleSetVM{
 		{
 			ID:         ptr.To("my-vm-id"),
 			InstanceID: ptr.To("my-vm-1"),
 			Name:       ptr.To("my-vm"),
-			VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+			Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 				ProvisioningState: ptr.To("Succeeded"),
-				OsProfile: &compute.OSProfile{
+				OSProfile: &armcompute.OSProfile{
 					ComputerName: ptr.To("instance-000001"),
 				},
-				StorageProfile: &compute.StorageProfile{
-					ImageReference: &compute.ImageReference{
+				StorageProfile: &armcompute.StorageProfile{
+					ImageReference: &armcompute.ImageReference{
 						Publisher: ptr.To("fake-publisher"),
 						Offer:     ptr.To("my-offer"),
-						Sku:       ptr.To("sku-id"),
+						SKU:       ptr.To("sku-id"),
 						Version:   ptr.To("1.0"),
 					},
 				},
@@ -946,16 +945,16 @@ func newDefaultInstances() []compute.VirtualMachineScaleSetVM {
 			ID:         ptr.To("my-vm-id"),
 			InstanceID: ptr.To("my-vm-2"),
 			Name:       ptr.To("my-vm"),
-			VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+			Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 				ProvisioningState: ptr.To("Succeeded"),
-				OsProfile: &compute.OSProfile{
+				OSProfile: &armcompute.OSProfile{
 					ComputerName: ptr.To("instance-000002"),
 				},
-				StorageProfile: &compute.StorageProfile{
-					ImageReference: &compute.ImageReference{
+				StorageProfile: &armcompute.StorageProfile{
+					ImageReference: &armcompute.ImageReference{
 						Publisher: ptr.To("fake-publisher"),
 						Offer:     ptr.To("my-offer"),
-						Sku:       ptr.To("sku-id"),
+						SKU:       ptr.To("sku-id"),
 						Version:   ptr.To("1.0"),
 					},
 				},

--- a/azure/services/scalesets/spec.go
+++ b/azure/services/scalesets/spec.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -67,7 +66,7 @@ type ScaleSetSpec struct {
 	VMSSExtensionSpecs           []azure.ResourceSpecGetter
 	VMImage                      *infrav1.Image
 	BootstrapData                string
-	VMSSInstances                []compute.VirtualMachineScaleSetVM
+	VMSSInstances                []armcompute.VirtualMachineScaleSetVM
 	MaxSurge                     int
 	ClusterName                  string
 	ShouldPatchCustomData        bool
@@ -275,7 +274,7 @@ func (s *ScaleSetSpec) Parameters(ctx context.Context, existing interface{}) (pa
 }
 
 func hasModelModifyingDifferences(infraVMSS *azure.VMSS, vmss armcompute.VirtualMachineScaleSet) bool {
-	other := converters.SDKToVMSS(vmss, []compute.VirtualMachineScaleSetVM{})
+	other := converters.SDKToVMSS(vmss, []armcompute.VirtualMachineScaleSetVM{})
 	return infraVMSS.HasModelChanges(other)
 }
 

--- a/azure/services/scalesetvms/client.go
+++ b/azure/services/scalesetvms/client.go
@@ -19,11 +19,11 @@ package scalesetvms
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
-	"github.com/Azure/go-autorest/autorest"
-	azureautorest "github.com/Azure/go-autorest/autorest/azure"
-	"k8s.io/utils/ptr"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asyncpoller"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
@@ -31,31 +31,28 @@ import (
 // client wraps go-sdk.
 type client interface {
 	Get(context.Context, azure.ResourceSpecGetter) (interface{}, error)
-	DeleteAsync(context.Context, azure.ResourceSpecGetter) (azureautorest.FutureAPI, error)
-	IsDone(ctx context.Context, future azureautorest.FutureAPI) (isDone bool, err error)
+	CreateOrUpdateAsync(context.Context, azure.ResourceSpecGetter, string, interface{}) (interface{}, *runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error)
+	DeleteAsync(context.Context, azure.ResourceSpecGetter, string) (*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientDeleteResponse], error)
 }
 
 // azureClient contains the Azure go-sdk Client.
 type azureClient struct {
-	scalesetvms compute.VirtualMachineScaleSetVMsClient
+	scalesetvms *armcompute.VirtualMachineScaleSetVMsClient
 }
 
 var _ client = &azureClient{}
 
-// newClient creates a new VMSS client from subscription ID.
-func newClient(auth azure.Authorizer) *azureClient {
-	return &azureClient{
-		scalesetvms: newVirtualMachineScaleSetVMsClient(auth.SubscriptionID(), auth.BaseURI(), auth.Authorizer()),
+// newClient creates a VMSS client from an authorizer.
+func newClient(auth azure.Authorizer) (*azureClient, error) {
+	opts, err := azure.ARMClientOptions(auth.CloudEnvironment())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create scalesetvms client options")
 	}
-}
-
-// newVirtualMachineScaleSetVMsClient creates a new vmss VM client from subscription ID.
-func newVirtualMachineScaleSetVMsClient(subscriptionID string, baseURI string, authorizer autorest.Authorizer) compute.VirtualMachineScaleSetVMsClient {
-	c := compute.NewVirtualMachineScaleSetVMsClientWithBaseURI(baseURI, subscriptionID)
-	c.Authorizer = authorizer
-	c.RetryAttempts = 1
-	_ = c.AddToUserAgent(azure.UserAgent()) // intentionally ignore error as it doesn't matter
-	return c
+	factory, err := armcompute.NewClientFactory(auth.SubscriptionID(), auth.Token(), opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create armcompute client factory")
+	}
+	return &azureClient{factory.NewVirtualMachineScaleSetVMsClient()}, nil
 }
 
 // Get retrieves the Virtual Machine Scale Set Virtual Machine.
@@ -63,11 +60,15 @@ func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesetvms.azureClient.Get")
 	defer done()
 
-	return ac.scalesetvms.Get(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), "")
+	resp, err := ac.scalesetvms.Get(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return resp.VirtualMachineScaleSetVM, nil
 }
 
-// CreateOrUpdateAsync is a dummy implementation to fulfill the async.Reconciler interface.
-func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, parameters interface{}) (result interface{}, future azureautorest.FutureAPI, err error) {
+// CreateOrUpdateAsync is a dummy implementation to fulfill the asyncpoller.Reconciler interface.
+func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], err error) {
 	_, _, done := tele.StartSpanWithLogger(ctx, "scalesets.AzureClient.CreateOrUpdateAsync")
 	defer done()
 
@@ -75,13 +76,14 @@ func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 }
 
 // DeleteAsync deletes a virtual machine scale set instance asynchronously. DeleteAsync sends a DELETE
-// request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter) (future azureautorest.FutureAPI, err error) {
+func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string) (poller *runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientDeleteResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesetvms.AzureClient.DeleteAsync")
 	defer done()
 
-	deleteFuture, err := ac.scalesetvms.Delete(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), ptr.To(false))
+	opts := &armcompute.VirtualMachineScaleSetVMsClientBeginDeleteOptions{ResumeToken: resumeToken}
+	poller, err = ac.scalesetvms.BeginDelete(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -89,26 +91,14 @@ func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecG
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
 	defer cancel()
 
-	err = deleteFuture.WaitForCompletionRef(ctx, ac.scalesetvms.Client)
+	pollOpts := &runtime.PollUntilDoneOptions{Frequency: asyncpoller.DefaultPollerFrequency}
+	_, err = poller.PollUntilDone(ctx, pollOpts)
 	if err != nil {
-		// if an error occurs, return the future.
+		// if an error occurs, return the Poller.
 		// this means the long-running operation didn't finish in the specified timeout.
-		return &deleteFuture, err
+		return poller, err
 	}
-	_, err = deleteFuture.Result(ac.scalesetvms)
-	// if the operation completed, return a nil future.
+
+	// if the operation completed, return a nil poller.
 	return nil, err
-}
-
-// Result fetches the result of a long-running operation future.
-func (ac *azureClient) Result(ctx context.Context, future azureautorest.FutureAPI, futureType string) (result interface{}, err error) {
-	return nil, nil
-}
-
-// IsDone returns true if the long-running operation has completed.
-func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAPI) (bool, error) {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesetvms.AzureClient.IsDone")
-	defer done()
-
-	return future.DoneWithContext(ctx, ac.scalesetvms)
 }

--- a/azure/services/scalesetvms/mock_scalesetvms/client_mock.go
+++ b/azure/services/scalesetvms/mock_scalesetvms/client_mock.go
@@ -24,9 +24,10 @@ import (
 	context "context"
 	reflect "reflect"
 
-	azure "github.com/Azure/go-autorest/autorest/azure"
+	runtime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	gomock "go.uber.org/mock/gomock"
-	azure0 "sigs.k8s.io/cluster-api-provider-azure/azure"
+	azure "sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
 // Mockclient is a mock of client interface.
@@ -52,23 +53,39 @@ func (m *Mockclient) EXPECT() *MockclientMockRecorder {
 	return m.recorder
 }
 
-// DeleteAsync mocks base method.
-func (m *Mockclient) DeleteAsync(arg0 context.Context, arg1 azure0.ResourceSpecGetter) (azure.FutureAPI, error) {
+// CreateOrUpdateAsync mocks base method.
+func (m *Mockclient) CreateOrUpdateAsync(arg0 context.Context, arg1 azure.ResourceSpecGetter, arg2 string, arg3 interface{}) (interface{}, *runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAsync", arg0, arg1)
-	ret0, _ := ret[0].(azure.FutureAPI)
+	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse])
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreateOrUpdateAsync indicates an expected call of CreateOrUpdateAsync.
+func (mr *MockclientMockRecorder) CreateOrUpdateAsync(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*Mockclient)(nil).CreateOrUpdateAsync), arg0, arg1, arg2, arg3)
+}
+
+// DeleteAsync mocks base method.
+func (m *Mockclient) DeleteAsync(arg0 context.Context, arg1 azure.ResourceSpecGetter, arg2 string) (*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientDeleteResponse], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAsync", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientDeleteResponse])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DeleteAsync indicates an expected call of DeleteAsync.
-func (mr *MockclientMockRecorder) DeleteAsync(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) DeleteAsync(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAsync", reflect.TypeOf((*Mockclient)(nil).DeleteAsync), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAsync", reflect.TypeOf((*Mockclient)(nil).DeleteAsync), arg0, arg1, arg2)
 }
 
 // Get mocks base method.
-func (m *Mockclient) Get(arg0 context.Context, arg1 azure0.ResourceSpecGetter) (interface{}, error) {
+func (m *Mockclient) Get(arg0 context.Context, arg1 azure.ResourceSpecGetter) (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(interface{})
@@ -80,19 +97,4 @@ func (m *Mockclient) Get(arg0 context.Context, arg1 azure0.ResourceSpecGetter) (
 func (mr *MockclientMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockclient)(nil).Get), arg0, arg1)
-}
-
-// IsDone mocks base method.
-func (m *Mockclient) IsDone(ctx context.Context, future azure.FutureAPI) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsDone", ctx, future)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsDone indicates an expected call of IsDone.
-func (mr *MockclientMockRecorder) IsDone(ctx, future interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDone", reflect.TypeOf((*Mockclient)(nil).IsDone), ctx, future)
 }

--- a/azure/services/scalesetvms/scalesetvms_test.go
+++ b/azure/services/scalesetvms/scalesetvms_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -42,7 +42,7 @@ var (
 		ResourceID:    "/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachineScaleSets/my-vmss/virtualMachines/0",
 		IsFlex:        false,
 	}
-	uniformScaleSetVM = compute.VirtualMachineScaleSetVM{
+	uniformScaleSetVM = armcompute.VirtualMachineScaleSetVM{
 		ID: &uniformScaleSetVMSpec.ResourceID,
 	}
 
@@ -59,7 +59,7 @@ var (
 		Name:          flexScaleSetVMSpec.Name,
 		ResourceGroup: flexScaleSetVMSpec.ResourceGroup,
 	}
-	flexScaleSetVM = compute.VirtualMachine{
+	flexScaleSetVM = armcompute.VirtualMachine{
 		Name: &uniformScaleSetVMSpec.Name,
 	}
 

--- a/controllers/azuremanagedmachinepool_controller_test.go
+++ b/controllers/azuremanagedmachinepool_controller_test.go
@@ -319,16 +319,16 @@ func fakeAgentPool(changes ...func(*agentpools.AgentPoolSpec)) agentpools.AgentP
 	return pool
 }
 
-func fakeVirtualMachineScaleSetVM() []compute.VirtualMachineScaleSetVM {
-	virtualMachineScaleSetVM := []compute.VirtualMachineScaleSetVM{
+func fakeVirtualMachineScaleSetVM() []armcompute.VirtualMachineScaleSetVM {
+	virtualMachineScaleSetVM := []armcompute.VirtualMachineScaleSetVM{
 		{
 			InstanceID: ptr.To("0"),
 			ID:         ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachineScaleSets/myScaleSetName/virtualMachines/156"),
 			Name:       ptr.To("vm0"),
-			Zones:      &[]string{"zone0"},
-			VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-				ProvisioningState: ptr.To(string(compute.ProvisioningState1Succeeded)),
-				OsProfile: &compute.OSProfile{
+			Zones:      []*string{ptr.To("zone0")},
+			Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+				ProvisioningState: ptr.To("Succeeded"),
+				OSProfile: &armcompute.OSProfile{
 					ComputerName: ptr.To("instance-000000"),
 				},
 			},

--- a/controllers/azuremanagedmachinepool_reconciler.go
+++ b/controllers/azuremanagedmachinepool_reconciler.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/pkg/errors"
 	azprovider "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -49,7 +48,7 @@ type (
 
 	// NodeLister is a service interface for returning generic lists.
 	NodeLister interface {
-		ListInstances(context.Context, string, string) ([]compute.VirtualMachineScaleSetVM, error)
+		ListInstances(context.Context, string, string) ([]armcompute.VirtualMachineScaleSetVM, error)
 		List(context.Context, string) ([]armcompute.VirtualMachineScaleSet, error)
 	}
 )

--- a/controllers/nodelister_mock.go
+++ b/controllers/nodelister_mock.go
@@ -25,7 +25,6 @@ import (
 	reflect "reflect"
 
 	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -68,10 +67,10 @@ func (mr *MockNodeListerMockRecorder) List(arg0, arg1 interface{}) *gomock.Call 
 }
 
 // ListInstances mocks base method.
-func (m *MockNodeLister) ListInstances(arg0 context.Context, arg1, arg2 string) ([]compute.VirtualMachineScaleSetVM, error) {
+func (m *MockNodeLister) ListInstances(arg0 context.Context, arg1, arg2 string) ([]armcompute.VirtualMachineScaleSetVM, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInstances", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]compute.VirtualMachineScaleSetVM)
+	ret0, _ := ret[0].([]armcompute.VirtualMachineScaleSetVM)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/exp/controllers/azuremachinepoolmachine_controller_test.go
+++ b/exp/controllers/azuremachinepoolmachine_controller_test.go
@@ -104,8 +104,8 @@ func TestAzureMachinePoolMachineReconciler_Reconcile(t *testing.T) {
 
 			c.Setup(cb, reconciler.EXPECT())
 			controller := NewAzureMachinePoolMachineController(cb.Build(), nil, 30*time.Second, "foo")
-			controller.reconcilerFactory = func(_ *scope.MachinePoolMachineScope) azure.Reconciler {
-				return reconciler
+			controller.reconcilerFactory = func(_ *scope.MachinePoolMachineScope) (azure.Reconciler, error) {
+				return reconciler, nil
 			}
 			res, err := controller.Reconcile(context.TODO(), ctrl.Request{
 				NamespacedName: types.NamespacedName{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the scalesetvms service to azure-sdk-for-go version 2 and the `asyncpoller` framework.

**Which issue(s) this PR fixes**:

Fixes #3891

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
