### PR TITLE
Convert /api references to SDKv2

### DIFF
--- a/api/v1beta1/azuremachine_default.go
+++ b/api/v1beta1/azuremachine_default.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -78,10 +78,10 @@ func (s *AzureMachineSpec) SetDataDisksDefaults() {
 		}
 		if disk.CachingType == "" {
 			if s.DataDisks[i].ManagedDisk != nil &&
-				s.DataDisks[i].ManagedDisk.StorageAccountType == string(compute.StorageAccountTypesUltraSSDLRS) {
-				s.DataDisks[i].CachingType = string(compute.CachingTypesNone)
+				s.DataDisks[i].ManagedDisk.StorageAccountType == string(armcompute.StorageAccountTypesUltraSSDLRS) {
+				s.DataDisks[i].CachingType = string(armcompute.CachingTypesNone)
 			} else {
-				s.DataDisks[i].CachingType = string(compute.CachingTypesReadWrite)
+				s.DataDisks[i].CachingType = string(armcompute.CachingTypesReadWrite)
 			}
 		}
 	}

--- a/api/v1beta1/azuremachine_validation.go
+++ b/api/v1beta1/azuremachine_validation.go
@@ -20,7 +20,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/google/uuid"
 	"golang.org/x/crypto/ssh"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -334,7 +334,7 @@ func validateManagedDisksUpdate(oldDiskParams, newDiskParams *ManagedDiskParamet
 func validateStorageAccountType(storageAccountType string, fieldPath *field.Path, isOSDisk bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if isOSDisk && storageAccountType == string(compute.StorageAccountTypesUltraSSDLRS) {
+	if isOSDisk && storageAccountType == string(armcompute.StorageAccountTypesUltraSSDLRS) {
 		allErrs = append(allErrs, field.Invalid(fieldPath.Child("managedDisks").Child("storageAccountType"), storageAccountType, "UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disks"))
 	}
 
@@ -343,12 +343,12 @@ func validateStorageAccountType(storageAccountType string, fieldPath *field.Path
 		return allErrs
 	}
 
-	for _, possibleStorageAccountType := range compute.PossibleDiskStorageAccountTypesValues() {
+	for _, possibleStorageAccountType := range armcompute.PossibleDiskStorageAccountTypesValues() {
 		if string(possibleStorageAccountType) == storageAccountType {
 			return allErrs
 		}
 	}
-	allErrs = append(allErrs, field.Invalid(fieldPath, "", fmt.Sprintf("allowed values are %v", compute.PossibleDiskStorageAccountTypesValues())))
+	allErrs = append(allErrs, field.Invalid(fieldPath, "", fmt.Sprintf("allowed values are %v", armcompute.PossibleDiskStorageAccountTypesValues())))
 	return allErrs
 }
 
@@ -356,19 +356,19 @@ func validateCachingType(cachingType string, fieldPath *field.Path, managedDisk 
 	allErrs := field.ErrorList{}
 	cachingTypeChildPath := fieldPath.Child("CachingType")
 
-	if managedDisk != nil && managedDisk.StorageAccountType == string(compute.StorageAccountTypesUltraSSDLRS) {
-		if cachingType != string(compute.CachingTypesNone) {
-			allErrs = append(allErrs, field.Invalid(cachingTypeChildPath, cachingType, fmt.Sprintf("cachingType '%s' is not supported when storageAccountType is '%s'. Allowed values are: '%s'", cachingType, compute.StorageAccountTypesUltraSSDLRS, compute.CachingTypesNone)))
+	if managedDisk != nil && managedDisk.StorageAccountType == string(armcompute.StorageAccountTypesUltraSSDLRS) {
+		if cachingType != string(armcompute.CachingTypesNone) {
+			allErrs = append(allErrs, field.Invalid(cachingTypeChildPath, cachingType, fmt.Sprintf("cachingType '%s' is not supported when storageAccountType is '%s'. Allowed values are: '%s'", cachingType, armcompute.StorageAccountTypesUltraSSDLRS, armcompute.CachingTypesNone)))
 		}
 	}
 
-	for _, possibleCachingType := range compute.PossibleCachingTypesValues() {
+	for _, possibleCachingType := range armcompute.PossibleCachingTypesValues() {
 		if string(possibleCachingType) == cachingType {
 			return allErrs
 		}
 	}
 
-	allErrs = append(allErrs, field.Invalid(cachingTypeChildPath, cachingType, fmt.Sprintf("allowed values are %v", compute.PossibleCachingTypesValues())))
+	allErrs = append(allErrs, field.Invalid(cachingTypeChildPath, cachingType, fmt.Sprintf("allowed values are %v", armcompute.PossibleCachingTypesValues())))
 	return allErrs
 }
 

--- a/api/v1beta1/azuremachine_validation_test.go
+++ b/api/v1beta1/azuremachine_validation_test.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/google/uuid"
 	. "github.com/onsi/gomega"
 	"golang.org/x/crypto/ssh"
@@ -105,7 +105,7 @@ func TestAzureMachine_ValidateOSDisk(t *testing.T) {
 				CachingType: "None",
 				OSType:      "blah",
 				DiffDiskSettings: &DiffDiskSettings{
-					Option: string(compute.DiffDiskOptionsLocal),
+					Option: string(armcompute.DiffDiskOptionsLocal),
 				},
 				ManagedDisk: &ManagedDiskParameters{
 					StorageAccountType: "Standard_LRS",
@@ -120,7 +120,7 @@ func TestAzureMachine_ValidateOSDisk(t *testing.T) {
 				CachingType: "None",
 				OSType:      "blah",
 				DiffDiskSettings: &DiffDiskSettings{
-					Option: string(compute.DiffDiskOptionsLocal),
+					Option: string(armcompute.DiffDiskOptionsLocal),
 				},
 				ManagedDisk: &ManagedDiskParameters{
 					StorageAccountType: "Standard_LRS",
@@ -193,7 +193,7 @@ func generateNegativeTestCases() []osDiskTestInput {
 				StorageAccountType: "Premium_LRS",
 			},
 			DiffDiskSettings: &DiffDiskSettings{
-				Option: string(compute.DiffDiskOptionsLocal),
+				Option: string(armcompute.DiffDiskOptionsLocal),
 			},
 		},
 	}
@@ -216,7 +216,7 @@ func generateValidOSDisk() OSDisk {
 		ManagedDisk: &ManagedDiskParameters{
 			StorageAccountType: "Premium_LRS",
 		},
-		CachingType: string(compute.PossibleCachingTypesValues()[0]),
+		CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 	}
 }
 
@@ -251,13 +251,13 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					NameSuffix:  "my_disk",
 					DiskSizeGB:  64,
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 				{
 					NameSuffix:  "my_other_disk",
 					DiskSizeGB:  64,
 					Lun:         ptr.To[int32](1),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			wantErr: false,
@@ -269,13 +269,13 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					NameSuffix:  "disk",
 					DiskSizeGB:  64,
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 				{
 					NameSuffix:  "disk",
 					DiskSizeGB:  64,
 					Lun:         ptr.To[int32](1),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			wantErr: true,
@@ -287,13 +287,13 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					NameSuffix:  "my_disk",
 					DiskSizeGB:  64,
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 				{
 					NameSuffix:  "my_other_disk",
 					DiskSizeGB:  64,
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			wantErr: true,
@@ -305,7 +305,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					NameSuffix:  "my_disk",
 					DiskSizeGB:  0,
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			wantErr: true,
@@ -317,7 +317,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					NameSuffix:  "",
 					DiskSizeGB:  0,
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			wantErr: true,
@@ -341,7 +341,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					NameSuffix:  "my_disk",
 					DiskSizeGB:  64,
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			wantErr: false,
@@ -356,7 +356,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 						StorageAccountType: "Premium_LRS",
 					},
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 				{
 					NameSuffix: "my_disk_2",
@@ -365,7 +365,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 						StorageAccountType: "Standard_LRS",
 					},
 					Lun:         ptr.To[int32](1),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			wantErr: false,
@@ -380,7 +380,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 						StorageAccountType: "invalid storage account",
 					},
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			wantErr: true,
@@ -392,10 +392,10 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					NameSuffix: "my_disk_1",
 					DiskSizeGB: 64,
 					ManagedDisk: &ManagedDiskParameters{
-						StorageAccountType: string(compute.StorageAccountTypesUltraSSDLRS),
+						StorageAccountType: string(armcompute.StorageAccountTypesUltraSSDLRS),
 					},
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.CachingTypesNone),
+					CachingType: string(armcompute.CachingTypesNone),
 				},
 			},
 			wantErr: false,
@@ -407,10 +407,10 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					NameSuffix: "my_disk_1",
 					DiskSizeGB: 64,
 					ManagedDisk: &ManagedDiskParameters{
-						StorageAccountType: string(compute.StorageAccountTypesUltraSSDLRS),
+						StorageAccountType: string(armcompute.StorageAccountTypesUltraSSDLRS),
 					},
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.CachingTypesReadWrite),
+					CachingType: string(armcompute.CachingTypesReadWrite),
 				},
 			},
 			wantErr: true,
@@ -422,10 +422,10 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 					NameSuffix: "my_disk_1",
 					DiskSizeGB: 64,
 					ManagedDisk: &ManagedDiskParameters{
-						StorageAccountType: string(compute.StorageAccountTypesUltraSSDLRS),
+						StorageAccountType: string(armcompute.StorageAccountTypesUltraSSDLRS),
 					},
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.CachingTypesReadOnly),
+					CachingType: string(armcompute.CachingTypesReadOnly),
 				},
 			},
 			wantErr: true,
@@ -680,7 +680,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 				{
 					NameSuffix: "my_other_disk",
@@ -689,7 +689,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			oldDisks: []DataDisk{
@@ -700,7 +700,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 				{
 					NameSuffix: "my_other_disk",
@@ -709,7 +709,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 					ManagedDisk: &ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			wantErr: false,
@@ -724,7 +724,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 						StorageAccountType: "Standard_LRS",
 					},
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			oldDisks: []DataDisk{
@@ -735,7 +735,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 						StorageAccountType: "Premium_LRS",
 					},
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			wantErr: true,
@@ -756,7 +756,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 				{
 					NameSuffix:  "my_disk_1",
 					DiskSizeGB:  128,
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			wantErr: true,
@@ -771,7 +771,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 						StorageAccountType: "Standard_LRS",
 					},
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			oldDisks: []DataDisk{
@@ -782,7 +782,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 						StorageAccountType: "Premium_LRS",
 					},
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 				{
 					NameSuffix: "my_disk_2",
@@ -791,7 +791,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 						StorageAccountType: "Premium_LRS",
 					},
 					Lun:         ptr.To[int32](2),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			wantErr: true,
@@ -806,7 +806,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 						StorageAccountType: "Standard_LRS",
 					},
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 				{
 					NameSuffix: "my_disk_2",
@@ -815,7 +815,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 						StorageAccountType: "Premium_LRS",
 					},
 					Lun:         ptr.To[int32](2),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			oldDisks: []DataDisk{
@@ -826,7 +826,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 						StorageAccountType: "Standard_LRS",
 					},
 					Lun:         ptr.To[int32](0),
-					CachingType: string(compute.PossibleCachingTypesValues()[0]),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 				},
 			},
 			wantErr: true,

--- a/api/v1beta1/azuremachine_webhook_test.go
+++ b/api/v1beta1/azuremachine_webhook_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -104,7 +104,7 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name:    "azuremachine with valid osDisk cache type",
-			machine: createMachineWithOsDiskCacheType(string(compute.PossibleCachingTypesValues()[1])),
+			machine: createMachineWithOsDiskCacheType(string(armcompute.PossibleCachingTypesValues()[1])),
 			wantErr: false,
 		},
 		{
@@ -863,7 +863,7 @@ func TestAzureMachine_Default(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(cacheTypeNotSpecifiedTest.machine.Spec.OSDisk.CachingType).To(Equal("None"))
 
-	for _, possibleCachingType := range compute.PossibleCachingTypesValues() {
+	for _, possibleCachingType := range armcompute.PossibleCachingTypesValues() {
 		cacheTypeSpecifiedTest := test{machine: &AzureMachine{ObjectMeta: testObjectMeta, Spec: AzureMachineSpec{OSDisk: OSDisk{CachingType: string(possibleCachingType)}}}}
 		err = mw.Default(context.Background(), cacheTypeSpecifiedTest.machine)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -1044,7 +1044,7 @@ func createMachineWithConfidentialCompute(securityEncryptionType SecurityEncrypt
 				SecurityEncryptionType: securityEncryptionType,
 			},
 		},
-		CachingType: string(compute.PossibleCachingTypesValues()[0]),
+		CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 	}
 
 	return &AzureMachine{

--- a/api/v1beta1/azuremachinetemplate_webhook_test.go
+++ b/api/v1beta1/azuremachinetemplate_webhook_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -119,7 +119,7 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 		{
 			name: "azuremachinetemplate with valid osDisk cache type",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				createMachineWithOsDiskCacheType(string(compute.PossibleCachingTypesValues()[1])),
+				createMachineWithOsDiskCacheType(string(armcompute.PossibleCachingTypesValues()[1])),
 			),
 			wantErr: false,
 		},

--- a/test/e2e/azure_machinepools.go
+++ b/test/e2e/azure_machinepools.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -86,7 +86,7 @@ func AzureMachinePoolsSpec(ctx context.Context, inputGetter func() AzureMachineP
 		Expect(amp.Status.Replicas).To(BeNumerically("==", len(amp.Spec.ProviderIDList)))
 		for _, providerID := range amp.Spec.ProviderIDList {
 			switch amp.Spec.OrchestrationMode {
-			case infrav1.OrchestrationModeType(compute.OrchestrationModeFlexible):
+			case infrav1.OrchestrationModeType(armcompute.OrchestrationModeFlexible):
 				Expect(providerID).To(MatchRegexp(regexpFlexibleVM))
 			default:
 				Expect(providerID).To(MatchRegexp(regexpUniformInstance))


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts references in the `/api` directory to azure-sdk-for-go version 2.

**Which issue(s) this PR fixes**:

Fixes #3984

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
