### PR TITLE
add spec.networkPluginMode to AzureManagedControlPlane

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_default.go
+++ b/api/v1beta1/azuremanagedcontrolplane_default.go
@@ -30,6 +30,10 @@ const (
 	defaultAKSVnetCIDR = "10.0.0.0/8"
 	// defaultAKSNodeSubnetCIDR is the default Node Subnet CIDR.
 	defaultAKSNodeSubnetCIDR = "10.240.0.0/16"
+	// defaultAKSVnetCIDRForOverlay is the default Vnet CIDR when Azure CNI overlay is enabled.
+	defaultAKSVnetCIDRForOverlay = "10.224.0.0/12"
+	// defaultAKSNodeSubnetCIDRForOverlay is the default Node Subnet CIDR when Azure CNI overlay is enabled.
+	defaultAKSNodeSubnetCIDRForOverlay = "10.224.0.0/16"
 )
 
 // setDefaultSSHPublicKey sets the default SSHPublicKey for an AzureManagedControlPlane.
@@ -60,6 +64,9 @@ func (m *AzureManagedControlPlane) setDefaultVirtualNetwork() {
 	}
 	if m.Spec.VirtualNetwork.CIDRBlock == "" {
 		m.Spec.VirtualNetwork.CIDRBlock = defaultAKSVnetCIDR
+		if ptr.Deref(m.Spec.NetworkPluginMode, "") == NetworkPluginModeOverlay {
+			m.Spec.VirtualNetwork.CIDRBlock = defaultAKSVnetCIDRForOverlay
+		}
 	}
 	if m.Spec.VirtualNetwork.ResourceGroup == "" {
 		m.Spec.VirtualNetwork.ResourceGroup = m.Spec.ResourceGroupName
@@ -73,6 +80,9 @@ func (m *AzureManagedControlPlane) setDefaultSubnet() {
 	}
 	if m.Spec.VirtualNetwork.Subnet.CIDRBlock == "" {
 		m.Spec.VirtualNetwork.Subnet.CIDRBlock = defaultAKSNodeSubnetCIDR
+		if ptr.Deref(m.Spec.NetworkPluginMode, "") == NetworkPluginModeOverlay {
+			m.Spec.VirtualNetwork.Subnet.CIDRBlock = defaultAKSNodeSubnetCIDRForOverlay
+		}
 	}
 }
 

--- a/api/v1beta1/azuremanagedcontrolplane_types.go
+++ b/api/v1beta1/azuremanagedcontrolplane_types.go
@@ -62,6 +62,18 @@ const (
 	ManagedControlPlaneIdentityTypeUserAssigned ManagedControlPlaneIdentityType = ManagedControlPlaneIdentityType(VMIdentityUserAssigned)
 )
 
+// NetworkPluginMode is the mode the network plugin should use.
+type NetworkPluginMode string
+
+const (
+	// NetworkPluginModeOverlay is used with networkPlugin=azure, pods are given IPs from the PodCIDR address space but use Azure
+	// Routing Domains rather than Kubenet's method of route tables.
+	// See also [AKS doc].
+	//
+	// [AKS doc]: https://aka.ms/aks/azure-cni-overlay
+	NetworkPluginModeOverlay NetworkPluginMode = "overlay"
+)
+
 // AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane.
 type AzureManagedControlPlaneSpec struct {
 	// Version defines the desired Kubernetes version.
@@ -109,6 +121,12 @@ type AzureManagedControlPlaneSpec struct {
 	// +kubebuilder:validation:Enum=azure;kubenet
 	// +optional
 	NetworkPlugin *string `json:"networkPlugin,omitempty"`
+
+	// NetworkPluginMode is the mode the network plugin should use.
+	// Allowed value is "overlay".
+	// +kubebuilder:validation:Enum=overlay
+	// +optional
+	NetworkPluginMode *NetworkPluginMode `json:"networkPluginMode,omitempty"`
 
 	// NetworkPolicy used for building Kubernetes network.
 	// Allowed values are "azure", "calico".

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1165,6 +1165,11 @@ func (in *AzureManagedControlPlaneSpec) DeepCopyInto(out *AzureManagedControlPla
 		*out = new(string)
 		**out = **in
 	}
+	if in.NetworkPluginMode != nil {
+		in, out := &in.NetworkPluginMode, &out.NetworkPluginMode
+		*out = new(NetworkPluginMode)
+		**out = **in
+	}
 	if in.NetworkPolicy != nil {
 		in, out := &in.NetworkPolicy, &out.NetworkPolicy
 		*out = new(string)

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -484,6 +484,7 @@ func (s *ManagedControlPlaneScope) ManagedClusterSpec() azure.ResourceSpecGetter
 		OutboundType:                s.ControlPlane.Spec.OutboundType,
 		Identity:                    s.ControlPlane.Spec.Identity,
 		KubeletUserAssignedIdentity: s.ControlPlane.Spec.KubeletUserAssignedIdentity,
+		NetworkPluginMode:           s.ControlPlane.Spec.NetworkPluginMode,
 	}
 
 	if s.ControlPlane.Spec.SSHPublicKey != nil {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -375,6 +375,12 @@ spec:
                 - azure
                 - kubenet
                 type: string
+              networkPluginMode:
+                description: NetworkPluginMode is the mode the network plugin should
+                  use. Allowed value is "overlay".
+                enum:
+                - overlay
+                type: string
               networkPolicy:
                 description: NetworkPolicy used for building Kubernetes network. Allowed
                   values are "azure", "calico". Immutable.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
/area managedclusters

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR exposes the `networkProfile.networkPluginMode` AKS API field from CAPZ at AzureManagedControlPlane's `spec.networkPluginMode`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3678

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added `spec.networkPluginMode` to AzureManagedControlPlane
```
