### PR TITLE
[release-1.10] fix endless reconciliation on AKS system node labels

### DIFF
--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -240,10 +240,8 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (p
 		// We do a just-in-time merge of existent kubernetes.azure.com-prefixed labels
 		// So that we don't unintentionally delete them
 		// See https://github.com/Azure/AKS/issues/3152
-		if normalizedProfile.NodeLabels != nil {
-			nodeLabels = mergeSystemNodeLabels(normalizedProfile.NodeLabels, existingPool.NodeLabels)
-			normalizedProfile.NodeLabels = nodeLabels
-		}
+		nodeLabels = mergeSystemNodeLabels(normalizedProfile.NodeLabels, existingPool.NodeLabels)
+		normalizedProfile.NodeLabels = nodeLabels
 
 		// Compute a diff to check if we require an update
 		diff := cmp.Diff(normalizedProfile, existingProfile)
@@ -371,11 +369,18 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (p
 // into the local capz label set.
 func mergeSystemNodeLabels(capz, aks map[string]*string) map[string]*string {
 	ret := capz
+	if ret == nil {
+		ret = make(map[string]*string)
+	}
 	// Look for labels returned from the AKS node pool API that begin with kubernetes.azure.com
 	for aksNodeLabelKey := range aks {
 		if azureutil.IsAzureSystemNodeLabelKey(aksNodeLabelKey) {
 			ret[aksNodeLabelKey] = aks[aksNodeLabelKey]
 		}
+	}
+	// Preserve nil-ness of capz
+	if capz == nil && len(ret) == 0 {
+		ret = nil
 	}
 	return ret
 }

--- a/azure/services/agentpools/spec_test.go
+++ b/azure/services/agentpools/spec_test.go
@@ -282,6 +282,24 @@ func TestParameters(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "difference in system node labels with empty labels shouldn't trigger update",
+			spec: fakeAgentPool(
+				func(pool *AgentPoolSpec) {
+					pool.NodeLabels = nil
+				},
+			),
+			existing: sdkFakeAgentPool(
+				func(pool *containerservice.AgentPool) {
+					pool.NodeLabels = map[string]*string{
+						"kubernetes.azure.com/scalesetpriority": pointer.String("spot"),
+					}
+				},
+				sdkWithProvisioningState("Succeeded"),
+			),
+			expected:      nil,
+			expectedError: nil,
+		},
+		{
 			name: "parameters with an existing agent pool and update needed on node taints",
 			spec: fakeAgentPool(),
 			existing: sdkFakeAgentPool(
@@ -368,6 +386,15 @@ func TestMergeSystemNodeLabels(t *testing.T) {
 				"hello": pointer.String("world"),
 			},
 			expected: map[string]*string{},
+		},
+		{
+			name:       "delete labels from nil",
+			capzLabels: nil,
+			aksLabels: map[string]*string{
+				"foo":   pointer.String("bar"),
+				"hello": pointer.String("world"),
+			},
+			expected: nil,
 		},
 		{
 			name: "delete one label",


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
/area managedclusters

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Manual cherry-pick of #3975.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug where AzureManagedMachinePools using Spot instances would endlessly reconcile without any user-specified node labels
```
