### PR TITLE
Convert groups service to SDKv2

### DIFF
--- a/azure/services/groups/groups_test.go
+++ b/azure/services/groups/groups_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -41,16 +41,16 @@ var (
 	}
 	internalError      = autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error")
 	notFoundError      = autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusNotFound}, "Not Found")
-	sampleManagedGroup = resources.Group{
+	sampleManagedGroup = armresources.ResourceGroup{
 		Name:       ptr.To("test-group"),
 		Location:   ptr.To("test-location"),
-		Properties: &resources.GroupProperties{},
+		Properties: &armresources.ResourceGroupProperties{},
 		Tags:       map[string]*string{"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": ptr.To("owned")},
 	}
-	sampleBYOGroup = resources.Group{
+	sampleBYOGroup = armresources.ResourceGroup{
 		Name:       ptr.To("test-group"),
 		Location:   ptr.To("test-location"),
-		Properties: &resources.GroupProperties{},
+		Properties: &armresources.ResourceGroupProperties{},
 		Tags:       map[string]*string{"foo": ptr.To("bar")},
 	}
 )
@@ -157,7 +157,7 @@ func TestDeleteGroups(t *testing.T) {
 			expectedError: "could not get resource group management state",
 			expect: func(s *mock_groups.MockGroupScopeMockRecorder, m *mock_groups.MockclientMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				s.GroupSpec().AnyTimes().Return(&fakeGroupSpec)
-				m.Get(gomockinternal.AContext(), &fakeGroupSpec).Return(resources.Group{}, internalError)
+				m.Get(gomockinternal.AContext(), &fakeGroupSpec).Return(armresources.ResourceGroup{}, internalError)
 			},
 		},
 		{
@@ -165,7 +165,7 @@ func TestDeleteGroups(t *testing.T) {
 			expectedError: "",
 			expect: func(s *mock_groups.MockGroupScopeMockRecorder, m *mock_groups.MockclientMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				s.GroupSpec().AnyTimes().Return(&fakeGroupSpec)
-				m.Get(gomockinternal.AContext(), &fakeGroupSpec).Return(resources.Group{}, notFoundError)
+				m.Get(gomockinternal.AContext(), &fakeGroupSpec).Return(armresources.ResourceGroup{}, notFoundError)
 				s.DeleteLongRunningOperationState("test-group", ServiceName, infrav1.DeleteFuture)
 				s.UpdateDeleteStatus(infrav1.ResourceGroupReadyCondition, ServiceName, nil)
 			},

--- a/azure/services/groups/mock_groups/client_mock.go
+++ b/azure/services/groups/mock_groups/client_mock.go
@@ -24,9 +24,10 @@ import (
 	context "context"
 	reflect "reflect"
 
-	azure "github.com/Azure/go-autorest/autorest/azure"
+	runtime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	armresources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	gomock "go.uber.org/mock/gomock"
-	azure0 "sigs.k8s.io/cluster-api-provider-azure/azure"
+	azure "sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
 // Mockclient is a mock of client interface.
@@ -53,38 +54,38 @@ func (m *Mockclient) EXPECT() *MockclientMockRecorder {
 }
 
 // CreateOrUpdateAsync mocks base method.
-func (m *Mockclient) CreateOrUpdateAsync(ctx context.Context, spec azure0.ResourceSpecGetter, parameters interface{}) (interface{}, azure.FutureAPI, error) {
+func (m *Mockclient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (interface{}, *runtime.Poller[armresources.ResourceGroupsClientCreateOrUpdateResponse], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", ctx, spec, parameters)
+	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", ctx, spec, resumeToken, parameters)
 	ret0, _ := ret[0].(interface{})
-	ret1, _ := ret[1].(azure.FutureAPI)
+	ret1, _ := ret[1].(*runtime.Poller[armresources.ResourceGroupsClientCreateOrUpdateResponse])
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
 // CreateOrUpdateAsync indicates an expected call of CreateOrUpdateAsync.
-func (mr *MockclientMockRecorder) CreateOrUpdateAsync(ctx, spec, parameters interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) CreateOrUpdateAsync(ctx, spec, resumeToken, parameters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*Mockclient)(nil).CreateOrUpdateAsync), ctx, spec, parameters)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*Mockclient)(nil).CreateOrUpdateAsync), ctx, spec, resumeToken, parameters)
 }
 
 // DeleteAsync mocks base method.
-func (m *Mockclient) DeleteAsync(ctx context.Context, spec azure0.ResourceSpecGetter) (azure.FutureAPI, error) {
+func (m *Mockclient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string) (*runtime.Poller[armresources.ResourceGroupsClientDeleteResponse], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAsync", ctx, spec)
-	ret0, _ := ret[0].(azure.FutureAPI)
+	ret := m.ctrl.Call(m, "DeleteAsync", ctx, spec, resumeToken)
+	ret0, _ := ret[0].(*runtime.Poller[armresources.ResourceGroupsClientDeleteResponse])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DeleteAsync indicates an expected call of DeleteAsync.
-func (mr *MockclientMockRecorder) DeleteAsync(ctx, spec interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) DeleteAsync(ctx, spec, resumeToken interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAsync", reflect.TypeOf((*Mockclient)(nil).DeleteAsync), ctx, spec)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAsync", reflect.TypeOf((*Mockclient)(nil).DeleteAsync), ctx, spec, resumeToken)
 }
 
 // Get mocks base method.
-func (m *Mockclient) Get(arg0 context.Context, arg1 azure0.ResourceSpecGetter) (interface{}, error) {
+func (m *Mockclient) Get(arg0 context.Context, arg1 azure.ResourceSpecGetter) (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(interface{})
@@ -96,34 +97,4 @@ func (m *Mockclient) Get(arg0 context.Context, arg1 azure0.ResourceSpecGetter) (
 func (mr *MockclientMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockclient)(nil).Get), arg0, arg1)
-}
-
-// IsDone mocks base method.
-func (m *Mockclient) IsDone(ctx context.Context, future azure.FutureAPI) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsDone", ctx, future)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsDone indicates an expected call of IsDone.
-func (mr *MockclientMockRecorder) IsDone(ctx, future interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDone", reflect.TypeOf((*Mockclient)(nil).IsDone), ctx, future)
-}
-
-// Result mocks base method.
-func (m *Mockclient) Result(ctx context.Context, future azure.FutureAPI, futureType string) (interface{}, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Result", ctx, future, futureType)
-	ret0, _ := ret[0].(interface{})
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Result indicates an expected call of Result.
-func (mr *MockclientMockRecorder) Result(ctx, future, futureType interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Result", reflect.TypeOf((*Mockclient)(nil).Result), ctx, future, futureType)
 }

--- a/azure/services/groups/mock_groups/groups_mock.go
+++ b/azure/services/groups/mock_groups/groups_mock.go
@@ -21,6 +21,7 @@ limitations under the License.
 package mock_groups
 
 import (
+	context "context"
 	reflect "reflect"
 
 	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -138,6 +139,21 @@ func (mr *MockGroupScopeMockRecorder) ClusterName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterName", reflect.TypeOf((*MockGroupScope)(nil).ClusterName))
 }
 
+// CreateOrUpdateResource mocks base method.
+func (m *MockGroupScope) CreateOrUpdateResource(ctx context.Context, spec azure.ResourceSpecGetter, serviceName string) (interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrUpdateResource", ctx, spec, serviceName)
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateOrUpdateResource indicates an expected call of CreateOrUpdateResource.
+func (mr *MockGroupScopeMockRecorder) CreateOrUpdateResource(ctx, spec, serviceName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateResource", reflect.TypeOf((*MockGroupScope)(nil).CreateOrUpdateResource), ctx, spec, serviceName)
+}
+
 // DeleteLongRunningOperationState mocks base method.
 func (m *MockGroupScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
@@ -148,6 +164,20 @@ func (m *MockGroupScope) DeleteLongRunningOperationState(arg0, arg1, arg2 string
 func (mr *MockGroupScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockGroupScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
+}
+
+// DeleteResource mocks base method.
+func (m *MockGroupScope) DeleteResource(ctx context.Context, spec azure.ResourceSpecGetter, serviceName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteResource", ctx, spec, serviceName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteResource indicates an expected call of DeleteResource.
+func (mr *MockGroupScopeMockRecorder) DeleteResource(ctx, spec, serviceName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResource", reflect.TypeOf((*MockGroupScope)(nil).DeleteResource), ctx, spec, serviceName)
 }
 
 // GetLongRunningOperationState mocks base method.

--- a/azure/services/groups/spec.go
+++ b/azure/services/groups/spec.go
@@ -19,7 +19,7 @@ package groups
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
@@ -56,7 +56,7 @@ func (s *GroupSpec) Parameters(ctx context.Context, existing interface{}) (param
 		// Note that rg tags are updated separately using tags service.
 		return nil, nil
 	}
-	return resources.Group{
+	return armresources.ResourceGroup{
 		Location: ptr.To(s.Location),
 		// User defined additional tags are created with the resource group and updated using tags service.
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -74,7 +74,10 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 	}
 	var groupsSvc azure.ServiceReconciler = asogroups.New(scope)
 	if scope.UseLegacyGroups {
-		groupsSvc = groups.New(scope)
+		groupsSvc, err = groups.New(scope)
+		if err != nil {
+			return nil, err
+		}
 	}
 	natGatewaysSvc, err := natgateways.New(scope)
 	if err != nil {

--- a/controllers/azuremanagedcontrolplane_reconciler.go
+++ b/controllers/azuremanagedcontrolplane_reconciler.go
@@ -47,7 +47,11 @@ type azureManagedControlPlaneService struct {
 func newAzureManagedControlPlaneReconciler(scope *scope.ManagedControlPlaneScope) (*azureManagedControlPlaneService, error) {
 	var groupsService azure.ServiceReconciler = asogroups.New(scope)
 	if scope.UseLegacyGroups {
-		groupsService = groups.New(scope)
+		svc, err := groups.New(scope)
+		if err != nil {
+			return nil, err
+		}
+		groupsService = svc
 	}
 	managedClustersSvc, err := managedclusters.New(scope)
 	if err != nil {

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -608,7 +608,10 @@ func ShouldDeleteIndividualResources(ctx context.Context, clusterScope *scope.Cl
 		return true
 	}
 	if clusterScope.UseLegacyGroups {
-		grpSvc := groups.New(clusterScope)
+		grpSvc, err := groups.New(clusterScope)
+		if err != nil {
+			return false
+		}
 		managed, err := grpSvc.IsManaged(ctx)
 		// Since this is a best effort attempt to speed up delete, we don't fail the delete if we can't get the RG status.
 		// Instead, take the long way and delete all resources one by one.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the groups service to azure-sdk-for-go version 2 and the `asyncpoller` framework.

**Which issue(s) this PR fixes**:

Fixes #3891

**Special notes for your reviewer**:

We had left this off the list of services to convert since ASO has it covered. But given that it's still an option, let's convert the "old" implementation to SDKv2 as well so we're not referring to Azure SDK for Go v1 anywhere.

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
